### PR TITLE
Move uses of PlatformGamepad* to being WeakPtrs or containers that support WeakPtrs

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -63,7 +63,7 @@ void GamepadManager::platformGamepadConnected(PlatformGamepad& platformGamepad, 
         return;
 
     // Notify blind Navigators and Windows about all gamepads except for this one.
-    for (auto* gamepad : GamepadProvider::singleton().platformGamepads()) {
+    for (auto& gamepad : GamepadProvider::singleton().platformGamepads()) {
         if (!gamepad || gamepad == &platformGamepad)
             continue;
 
@@ -120,7 +120,7 @@ void GamepadManager::platformGamepadInputActivity(EventMakesGamepadsVisible even
     if (m_gamepadBlindNavigators.isEmptyIgnoringNullReferences() && m_gamepadBlindDOMWindows.isEmptyIgnoringNullReferences())
         return;
 
-    for (auto* gamepad : GamepadProvider::singleton().platformGamepads()) {
+    for (auto& gamepad : GamepadProvider::singleton().platformGamepads()) {
         if (gamepad)
             makeGamepadVisible(*gamepad, m_gamepadBlindNavigators, m_gamepadBlindDOMWindows);
     }

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -98,7 +98,7 @@ const Vector<RefPtr<Gamepad>>& NavigatorGamepad::gamepads()
     if (m_gamepads.isEmpty())
         return m_gamepads;
 
-    const Vector<PlatformGamepad*>& platformGamepads = GamepadProvider::singleton().platformGamepads();
+    auto& platformGamepads = GamepadProvider::singleton().platformGamepads();
 
     for (unsigned i = 0; i < platformGamepads.size(); ++i) {
         if (!platformGamepads[i]) {
@@ -115,7 +115,7 @@ const Vector<RefPtr<Gamepad>>& NavigatorGamepad::gamepads()
 
 void NavigatorGamepad::gamepadsBecameVisible()
 {
-    const Vector<PlatformGamepad*>& platformGamepads = GamepadProvider::singleton().platformGamepads();
+    auto& platformGamepads = GamepadProvider::singleton().platformGamepads();
     m_gamepads.resize(platformGamepads.size());
 
     for (unsigned i = 0; i < platformGamepads.size(); ++i) {

--- a/Source/WebCore/platform/gamepad/EmptyGamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/EmptyGamepadProvider.cpp
@@ -42,9 +42,9 @@ void EmptyGamepadProvider::stopMonitoringGamepads(GamepadProviderClient&)
 {
 }
 
-const Vector<PlatformGamepad*>& EmptyGamepadProvider::platformGamepads()
+const Vector<WeakPtr<PlatformGamepad>>& EmptyGamepadProvider::platformGamepads()
 {
-    static NeverDestroyed<Vector<PlatformGamepad*>> emptyGamepads;
+    static NeverDestroyed<Vector<WeakPtr<PlatformGamepad>>> emptyGamepads;
     return emptyGamepads;
 }
 

--- a/Source/WebCore/platform/gamepad/EmptyGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/EmptyGamepadProvider.h
@@ -38,7 +38,7 @@ public:
 private:
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<PlatformGamepad*>& platformGamepads() final;
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final;
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 };

--- a/Source/WebCore/platform/gamepad/GamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/GamepadProvider.cpp
@@ -53,7 +53,7 @@ void GamepadProvider::setSharedProvider(GamepadProvider& newProvider)
 void GamepadProvider::dispatchPlatformGamepadInputActivity()
 {
     for (auto& client : m_clients)
-        client->platformGamepadInputActivity(m_shouldMakeGamepadsVisible ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No);
+        client.platformGamepadInputActivity(m_shouldMakeGamepadsVisible ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No);
 
     m_shouldMakeGamepadsVisible = false;
 }

--- a/Source/WebCore/platform/gamepad/GamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/GamepadProvider.h
@@ -30,6 +30,7 @@
 #include "GamepadHapticEffectType.h"
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -46,7 +47,7 @@ public:
 
     virtual void startMonitoringGamepads(GamepadProviderClient&) = 0;
     virtual void stopMonitoringGamepads(GamepadProviderClient&) = 0;
-    virtual const Vector<PlatformGamepad*>& platformGamepads() = 0;
+    virtual const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() = 0;
     virtual bool isMockGamepadProvider() const { return false; }
 
     virtual void playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) = 0;
@@ -57,7 +58,7 @@ public:
 protected:
     WEBCORE_EXPORT void dispatchPlatformGamepadInputActivity();
     void setShouldMakeGamepadsVisibile() { m_shouldMakeGamepadsVisible = true; }
-    HashSet<GamepadProviderClient*> m_clients;
+    WeakHashSet<GamepadProviderClient> m_clients;
 
 private:
     bool m_shouldMakeGamepadsVisible { false };

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h
@@ -48,7 +48,7 @@ public:
 
     WEBCORE_EXPORT void startMonitoringGamepads(GamepadProviderClient&) final;
     WEBCORE_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
     void playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) final;
 
@@ -82,8 +82,8 @@ private:
     void inputNotificationTimerFired();
 
     HashMap<CFTypeRef, std::unique_ptr<GameControllerGamepad>> m_gamepadMap;
-    Vector<PlatformGamepad*> m_gamepadVector;
-    HashSet<PlatformGamepad*> m_invisibleGamepads;
+    Vector<WeakPtr<PlatformGamepad>> m_gamepadVector;
+    WeakHashSet<PlatformGamepad> m_invisibleGamepads;
 
     RetainPtr<NSObject> m_connectObserver;
     RetainPtr<NSObject> m_disconnectObserver;

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
@@ -79,10 +79,10 @@ void GamepadProviderLibWPE::startMonitoringGamepads(GamepadProviderClient& clien
     if (!m_provider)
         return;
 
-    bool shouldOpenAndScheduleManager = m_clients.isEmpty();
+    bool shouldOpenAndScheduleManager = m_clients.isEmptyIgnoringNullReferences();
 
-    ASSERT(!m_clients.contains(&client));
-    m_clients.add(&client);
+    ASSERT(!m_clients.contains(client));
+    m_clients.add(client);
 
     if (!shouldOpenAndScheduleManager)
         return;
@@ -104,9 +104,9 @@ void GamepadProviderLibWPE::stopMonitoringGamepads(GamepadProviderClient& client
     if (!m_provider)
         return;
 
-    ASSERT(m_clients.contains(&client));
+    ASSERT(m_clients.contains(client));
 
-    bool shouldCloseAndUnscheduleManager = m_clients.remove(&client) && m_clients.isEmpty();
+    bool shouldCloseAndUnscheduleManager = m_clients.remove(client) && m_clients.isEmptyIgnoringNullReferences();
     if (!shouldCloseAndUnscheduleManager)
         return;
 
@@ -146,7 +146,7 @@ void GamepadProviderLibWPE::gamepadConnected(uintptr_t id)
 
     auto eventVisibility = m_initialGamepadsConnected ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No;
     for (auto& client : m_clients)
-        client->platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
+        client.platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
 }
 
 void GamepadProviderLibWPE::gamepadDisconnected(uintptr_t id)
@@ -160,7 +160,7 @@ void GamepadProviderLibWPE::gamepadDisconnected(uintptr_t id)
         m_lastActiveGamepad = nullptr;
 
     for (auto& client : m_clients)
-        client->platformGamepadDisconnected(*removedGamepad);
+        client.platformGamepadDisconnected(*removedGamepad);
 }
 
 unsigned GamepadProviderLibWPE::indexForNewlyConnectedDevice()

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
@@ -51,7 +51,7 @@ public:
 
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 
@@ -72,7 +72,7 @@ private:
     void initialGamepadsConnectedTimerFired();
     void inputNotificationTimerFired();
 
-    Vector<PlatformGamepad*> m_gamepadVector;
+    Vector<WeakPtr<PlatformGamepad>> m_gamepadVector;
     HashMap<uintptr_t, std::unique_ptr<GamepadLibWPE>> m_gamepadMap;
     bool m_initialGamepadsConnected { false };
 

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
@@ -49,7 +49,7 @@ public:
 
     WEBCORE_EXPORT void startMonitoringGamepads(GamepadProviderClient&) final;
     WEBCORE_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 
@@ -77,7 +77,7 @@ private:
 
     unsigned indexForNewlyConnectedDevice();
 
-    Vector<PlatformGamepad*> m_gamepadVector;
+    Vector<WeakPtr<PlatformGamepad>> m_gamepadVector;
     HashMap<IOHIDDeviceRef, std::unique_ptr<HIDGamepad>> m_gamepadMap;
 
     RetainPtr<IOHIDManagerRef> m_manager;

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
@@ -165,19 +165,19 @@ void HIDGamepadProvider::closeAndUnscheduleManager()
 
 void HIDGamepadProvider::startMonitoringGamepads(GamepadProviderClient& client)
 {
-    bool shouldOpenAndScheduleManager = m_clients.isEmpty();
+    bool shouldOpenAndScheduleManager = m_clients.isEmptyIgnoringNullReferences();
 
-    ASSERT(!m_clients.contains(&client));
-    m_clients.add(&client);
+    ASSERT(!m_clients.contains(client));
+    m_clients.add(client);
 
     if (shouldOpenAndScheduleManager)
         openAndScheduleManager();
 }
 void HIDGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
 {
-    ASSERT(m_clients.contains(&client));
+    ASSERT(m_clients.contains(client));
 
-    bool shouldCloseAndUnscheduleManager = m_clients.remove(&client) && m_clients.isEmpty();
+    bool shouldCloseAndUnscheduleManager = m_clients.remove(client) && m_clients.isEmptyIgnoringNullReferences();
 
     if (shouldCloseAndUnscheduleManager)
         closeAndUnscheduleManager();
@@ -257,7 +257,7 @@ void HIDGamepadProvider::deviceAdded(IOHIDDeviceRef device)
 
     auto eventVisibility = m_initialGamepadsConnected ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No;
     for (auto& client : m_clients)
-        client->platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
+        client.platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
 
     // If we are working together with the GameController provider, let it know
     // that gamepads should now be visible.
@@ -281,7 +281,7 @@ void HIDGamepadProvider::deviceRemoved(IOHIDDeviceRef device)
     LOG(Gamepad, "HIDGamepadProvider device %p removed", device);
 
     for (auto& client : m_clients)
-        client->platformGamepadDisconnected(*removedGamepad);
+        client.platformGamepadDisconnected(*removedGamepad);
 }
 
 void HIDGamepadProvider::valuesChanged(IOHIDValueRef value)

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h
@@ -46,7 +46,7 @@ public:
     // GamepadProvider
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
     bool isMockGamepadProvider() const { return false; }
     void playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) final;
@@ -64,7 +64,7 @@ private:
 
     bool m_shouldMakeGamepadsVisible { false };
     size_t m_initialGamepadsCount { 0 };
-    Vector<PlatformGamepad*> m_gamepadVector;
+    Vector<WeakPtr<PlatformGamepad>> m_gamepadVector;
 
     // We create our own Gamepad type - to wrap both HID and GameController gamepads -
     // because MultiGamepadProvider needs to manage the indexes of its own gamepads
@@ -87,10 +87,10 @@ private:
         const char* source() const final { return m_platformGamepad->source(); }
 
     private:
-        PlatformGamepad* m_platformGamepad;
+        WeakPtr<PlatformGamepad> m_platformGamepad;
     };
 
-    HashMap<PlatformGamepad*, std::unique_ptr<PlatformGamepadWrapper>> m_gamepadMap;
+    WeakHashMap<PlatformGamepad, std::unique_ptr<PlatformGamepadWrapper>> m_gamepadMap;
     bool m_hidImportComplete { false };
     bool m_usesOnlyHIDProvider { false };
 };

--- a/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm
@@ -46,10 +46,10 @@ MultiGamepadProvider& MultiGamepadProvider::singleton()
 
 void MultiGamepadProvider::startMonitoringGamepads(GamepadProviderClient& client)
 {
-    bool monitorOtherProviders = m_clients.isEmpty();
+    bool monitorOtherProviders = m_clients.isEmptyIgnoringNullReferences();
 
-    ASSERT(!m_clients.contains(&client));
-    m_clients.add(&client);
+    ASSERT(!m_clients.contains(client));
+    m_clients.add(client);
 
     if (!m_usesOnlyHIDProvider) {
         HIDGamepadProvider::singleton().ignoreGameControllerFrameworkDevices();
@@ -65,9 +65,9 @@ void MultiGamepadProvider::startMonitoringGamepads(GamepadProviderClient& client
 
 void MultiGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
 {
-    ASSERT(m_clients.contains(&client));
+    ASSERT(m_clients.contains(client));
 
-    bool shouldStopMonitoringOtherProviders = m_clients.remove(&client) && m_clients.isEmpty();
+    bool shouldStopMonitoringOtherProviders = m_clients.remove(client) && m_clients.isEmptyIgnoringNullReferences();
 
     if (shouldStopMonitoringOtherProviders) {
         HIDGamepadProvider::singleton().stopMonitoringGamepads(*this);
@@ -110,19 +110,19 @@ void MultiGamepadProvider::platformGamepadConnected(PlatformGamepad& gamepad, Ev
 
     ASSERT(m_gamepadVector.size() > index);
 
-    auto addResult = m_gamepadMap.set(&gamepad, WTF::makeUnique<PlatformGamepadWrapper>(index, &gamepad));
+    auto addResult = m_gamepadMap.add(gamepad, WTF::makeUnique<PlatformGamepadWrapper>(index, &gamepad));
     ASSERT(addResult.isNewEntry);
     m_gamepadVector[index] = addResult.iterator->value.get();
 
     for (auto& client : m_clients)
-        client->platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
+        client.platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
 }
 
 void MultiGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
 {
     LOG(Gamepad, "MultiGamepadProvider disconnecting gamepad from a %s source", gamepad.source());
 
-    auto gamepadWrapper = m_gamepadMap.take(&gamepad);
+    auto gamepadWrapper = m_gamepadMap.take(gamepad);
 
     ASSERT(gamepadWrapper);
     ASSERT(gamepadWrapper->index() < m_gamepadVector.size());
@@ -131,7 +131,7 @@ void MultiGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
     m_gamepadVector[gamepadWrapper->index()] = nullptr;
 
     for (auto& client : m_clients)
-        client->platformGamepadDisconnected(*gamepadWrapper);
+        client.platformGamepadDisconnected(*gamepadWrapper);
 }
 
 void MultiGamepadProvider::platformGamepadInputActivity(EventMakesGamepadsVisible eventVisibility)
@@ -140,7 +140,7 @@ void MultiGamepadProvider::platformGamepadInputActivity(EventMakesGamepadsVisibl
         GameControllerGamepadProvider::singleton().makeInvisibleGamepadsVisible();
 
     for (auto& client : m_clients)
-        client->platformGamepadInputActivity(eventVisibility);
+        client.platformGamepadInputActivity(eventVisibility);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
@@ -72,10 +72,10 @@ ManetteGamepadProvider::~ManetteGamepadProvider()
 
 void ManetteGamepadProvider::startMonitoringGamepads(GamepadProviderClient& client)
 {
-    bool shouldOpenAndScheduleManager = m_clients.isEmpty();
+    bool shouldOpenAndScheduleManager = m_clients.isEmptyIgnoringNullReferences();
 
-    ASSERT(!m_clients.contains(&client));
-    m_clients.add(&client);
+    ASSERT(!m_clients.contains(client));
+    m_clients.add(client);
 
     if (!shouldOpenAndScheduleManager)
         return;
@@ -99,9 +99,9 @@ void ManetteGamepadProvider::startMonitoringGamepads(GamepadProviderClient& clie
 
 void ManetteGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
 {
-    ASSERT(m_clients.contains(&client));
+    ASSERT(m_clients.contains(client));
 
-    bool shouldCloseAndUnscheduleManager = m_clients.remove(&client) && m_clients.isEmpty();
+    bool shouldCloseAndUnscheduleManager = m_clients.remove(client) && m_clients.isEmptyIgnoringNullReferences();
     if (shouldCloseAndUnscheduleManager) {
         m_gamepadVector.clear();
         m_gamepadMap.clear();
@@ -145,7 +145,7 @@ void ManetteGamepadProvider::deviceConnected(ManetteDevice* device)
 
     auto eventVisibility = m_initialGamepadsConnected ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No;
     for (auto& client : m_clients)
-        client->platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
+        client.platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
 }
 
 void ManetteGamepadProvider::deviceDisconnected(ManetteDevice* device)
@@ -156,7 +156,7 @@ void ManetteGamepadProvider::deviceDisconnected(ManetteDevice* device)
     ASSERT(removedGamepad);
 
     for (auto& client : m_clients)
-        client->platformGamepadDisconnected(*removedGamepad);
+        client.platformGamepadDisconnected(*removedGamepad);
 }
 
 unsigned ManetteGamepadProvider::indexForNewlyConnectedDevice()

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h
@@ -48,7 +48,7 @@ public:
 
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<PlatformGamepad*>& platformGamepads() final { return m_gamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_gamepadVector; }
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 
@@ -67,7 +67,7 @@ private:
     void initialGamepadsConnectedTimerFired();
     void inputNotificationTimerFired();
 
-    Vector<PlatformGamepad*> m_gamepadVector;
+    Vector<WeakPtr<PlatformGamepad>> m_gamepadVector;
     HashMap<ManetteDevice*, std::unique_ptr<ManetteGamepad>> m_gamepadMap;
     bool m_initialGamepadsConnected { false };
 

--- a/Source/WebCore/testing/MockGamepadProvider.cpp
+++ b/Source/WebCore/testing/MockGamepadProvider.cpp
@@ -46,10 +46,10 @@ MockGamepadProvider::MockGamepadProvider() = default;
 
 void MockGamepadProvider::startMonitoringGamepads(GamepadProviderClient& client)
 {
-    ASSERT(!m_clients.contains(&client));
-    m_clients.add(&client);
+    ASSERT(!m_clients.contains(client));
+    m_clients.add(client);
     WeakHashSet<PlatformGamepad> invisibleGamepads;
-    for (PlatformGamepad *gamepad : m_connectedGamepadVector) {
+    for (auto& gamepad : m_connectedGamepadVector) {
         if (gamepad)
             invisibleGamepads.add(*gamepad);
     }
@@ -59,8 +59,8 @@ void MockGamepadProvider::startMonitoringGamepads(GamepadProviderClient& client)
 
 void MockGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
 {
-    ASSERT(m_clients.contains(&client));
-    m_clients.remove(&client);
+    ASSERT(m_clients.contains(client));
+    m_clients.remove(client);
     m_invisibleGamepadsForClient.remove(client);
 }
 
@@ -96,11 +96,11 @@ bool MockGamepadProvider::connectMockGamepad(unsigned index)
     m_connectedGamepadVector[index] = m_mockGamepadVector[index].get();
 
     for (auto& client : m_clients) {
-        client->platformGamepadConnected(*m_connectedGamepadVector[index], EventMakesGamepadsVisible::Yes);
-        auto gamepadsForClient = m_invisibleGamepadsForClient.find(*client);
+        client.platformGamepadConnected(*m_connectedGamepadVector[index], EventMakesGamepadsVisible::Yes);
+        auto gamepadsForClient = m_invisibleGamepadsForClient.find(client);
         if (gamepadsForClient != m_invisibleGamepadsForClient.end()) {
             for (auto& invisibleGamepad : gamepadsForClient->value)
-                client->platformGamepadConnected(invisibleGamepad, EventMakesGamepadsVisible::Yes);
+                client.platformGamepadConnected(invisibleGamepad, EventMakesGamepadsVisible::Yes);
             m_invisibleGamepadsForClient.remove(gamepadsForClient);
         }
     }
@@ -123,9 +123,9 @@ bool MockGamepadProvider::disconnectMockGamepad(unsigned index)
 
     auto gamepadToRemove = m_mockGamepadVector[index].get();
     for (auto& client : m_clients) {
-        auto gamepadsForClient = m_invisibleGamepadsForClient.find(*client);
+        auto gamepadsForClient = m_invisibleGamepadsForClient.find(client);
         if (gamepadsForClient == m_invisibleGamepadsForClient.end() || !gamepadsForClient->value.remove(*gamepadToRemove))
-            client->platformGamepadDisconnected(*m_mockGamepadVector[index]);
+            client.platformGamepadDisconnected(*m_mockGamepadVector[index]);
     }
 
     return true;

--- a/Source/WebCore/testing/MockGamepadProvider.h
+++ b/Source/WebCore/testing/MockGamepadProvider.h
@@ -43,7 +43,7 @@ public:
 
     WEBCORE_TESTSUPPORT_EXPORT void startMonitoringGamepads(GamepadProviderClient&) final;
     WEBCORE_TESTSUPPORT_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<PlatformGamepad*>& platformGamepads() final { return m_connectedGamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_connectedGamepadVector; }
     bool isMockGamepadProvider() const final { return true; }
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
@@ -60,7 +60,7 @@ private:
 
     void gamepadInputActivity();
 
-    Vector<PlatformGamepad*> m_connectedGamepadVector;
+    Vector<WeakPtr<PlatformGamepad>> m_connectedGamepadVector;
     WeakHashMap<GamepadProviderClient, WeakHashSet<PlatformGamepad>>  m_invisibleGamepadsForClient;
     Vector<std::unique_ptr<MockGamepad>> m_mockGamepadVector;
 

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
@@ -148,7 +148,7 @@ void WebGamepadProvider::stopMonitoringGamepads(GamepadProviderClient& client)
     });
 }
 
-const Vector<PlatformGamepad*>& WebGamepadProvider::platformGamepads()
+const Vector<WeakPtr<PlatformGamepad>>& WebGamepadProvider::platformGamepads()
 {
     return m_rawGamepads;
 }

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
@@ -60,14 +60,14 @@ private:
     
     void startMonitoringGamepads(WebCore::GamepadProviderClient&) final;
     void stopMonitoringGamepads(WebCore::GamepadProviderClient&) final;
-    const Vector<WebCore::PlatformGamepad*>& platformGamepads() final;
+    const Vector<WeakPtr<WebCore::PlatformGamepad>>& platformGamepads() final;
     void playEffect(unsigned gamepadIndex, const String& gamepadID, WebCore::GamepadHapticEffectType, const WebCore::GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&&) final;
 
     HashSet<WebCore::GamepadProviderClient*> m_clients;
 
     Vector<std::unique_ptr<WebGamepad>> m_gamepads;
-    Vector<WebCore::PlatformGamepad*> m_rawGamepads;
+    Vector<WeakPtr<WebCore::PlatformGamepad>> m_rawGamepads;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### f2c293349a71f5fd06594bf3a334e2e7a965ea74
<pre>
Move uses of PlatformGamepad* to being WeakPtrs or containers that support WeakPtrs
<a href="https://bugs.webkit.org/show_bug.cgi?id=253331">https://bugs.webkit.org/show_bug.cgi?id=253331</a>
rdar://106168221

Reviewed by Ryosuke Niwa and David Kilzer.

Now that GamepadProviderClient and PlatformGamepad inherit from
CanHaveWeakPtr, we should stop storing raw pointers where possible.

* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::platformGamepadConnected):
(WebCore::GamepadManager::platformGamepadInputActivity):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::gamepads):
(WebCore::NavigatorGamepad::gamepadsBecameVisible):
* Source/WebCore/platform/gamepad/EmptyGamepadProvider.cpp:
(WebCore::EmptyGamepadProvider::platformGamepads):
(): Deleted.
* Source/WebCore/platform/gamepad/EmptyGamepadProvider.h:
* Source/WebCore/platform/gamepad/GamepadProvider.cpp:
(WebCore::GamepadProvider::dispatchPlatformGamepadInputActivity):
* Source/WebCore/platform/gamepad/GamepadProvider.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepadProvider.mm:
(WebCore::GameControllerGamepadProvider::controllerDidConnect):
(WebCore::GameControllerGamepadProvider::controllerDidDisconnect):
(WebCore::GameControllerGamepadProvider::startMonitoringGamepads):
(WebCore::GameControllerGamepadProvider::stopMonitoringGamepads):
(WebCore::GameControllerGamepadProvider::makeInvisibleGamepadsVisible):
(WebCore::GameControllerGamepadProvider::playEffect):
(WebCore::GameControllerGamepadProvider::stopEffects):
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp:
(WebCore::GamepadProviderLibWPE::startMonitoringGamepads):
(WebCore::GamepadProviderLibWPE::stopMonitoringGamepads):
(WebCore::GamepadProviderLibWPE::gamepadConnected):
(WebCore::GamepadProviderLibWPE::gamepadDisconnected):
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm:
(WebCore::HIDGamepadProvider::startMonitoringGamepads):
(WebCore::HIDGamepadProvider::stopMonitoringGamepads):
(WebCore::HIDGamepadProvider::deviceAdded):
(WebCore::HIDGamepadProvider::deviceRemoved):
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.h:
* Source/WebCore/platform/gamepad/mac/MultiGamepadProvider.mm:
(WebCore::MultiGamepadProvider::startMonitoringGamepads):
(WebCore::MultiGamepadProvider::stopMonitoringGamepads):
(WebCore::MultiGamepadProvider::platformGamepadConnected):
(WebCore::MultiGamepadProvider::platformGamepadDisconnected):
(WebCore::MultiGamepadProvider::platformGamepadInputActivity):
* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp:
(WebCore::ManetteGamepadProvider::startMonitoringGamepads):
(WebCore::ManetteGamepadProvider::stopMonitoringGamepads):
(WebCore::ManetteGamepadProvider::deviceConnected):
(WebCore::ManetteGamepadProvider::deviceDisconnected):
* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.h:
* Source/WebCore/testing/MockGamepadProvider.cpp:
(WebCore::MockGamepadProvider::startMonitoringGamepads):
(WebCore::MockGamepadProvider::stopMonitoringGamepads):
(WebCore::MockGamepadProvider::connectMockGamepad):
(WebCore::MockGamepadProvider::disconnectMockGamepad):
* Source/WebCore/testing/MockGamepadProvider.h:
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::platformGamepads):
(): Deleted.
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h:

Canonical link: <a href="https://commits.webkit.org/261274@main">https://commits.webkit.org/261274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6744f67fc92a4d6e45b5dc14198e58e4c32d0d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119742 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1997 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103338 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44295 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12546 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86180 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9059 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18504 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7818 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15048 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->