### PR TITLE
Blue boxes appear at ends of selection for live text for images with vertical writing mode

### DIFF
--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2342,7 +2342,7 @@ static inline void adjustLineHeightOfSelectionGeometries(Vector<SelectionGeometr
         --i;
         if (geometries[i].lineNumber())
             break;
-        if (geometries[i].behavior() == SelectionRenderingBehavior::UseIndividualQuads)
+        if (geometries[i].behavior() == SelectionRenderingBehavior::UseIndividualQuads && geometries[i].isHorizontal())
             continue;
         geometries[i].setLineNumber(lineNumber);
         geometries[i].setLogicalTop(lineTop);
@@ -2499,7 +2499,7 @@ auto RenderObject::collectSelectionGeometriesInternal(const SimpleRange& range) 
     for (size_t j = 1; j < numberOfGeometries; ++j) {
         if (geometries[j].lineNumber() != geometries[j - 1].lineNumber())
             continue;
-        if (geometries[j].behavior() == SelectionRenderingBehavior::UseIndividualQuads)
+        if (geometries[j].behavior() == SelectionRenderingBehavior::UseIndividualQuads && geometries[j].isHorizontal())
             continue;
         auto& previousRect = geometries[j - 1];
         bool previousRectMayNotReachRightEdge = (previousRect.direction() == TextDirection::LTR && previousRect.containsEnd()) || (previousRect.direction() == TextDirection::RTL && previousRect.containsStart());
@@ -2517,7 +2517,7 @@ auto RenderObject::collectSelectionGeometriesInternal(const SimpleRange& range) 
         auto& selectionGeometry = geometries[i];
         if (!selectionGeometry.isLineBreak() && selectionGeometry.lineNumber() >= maxLineNumber)
             continue;
-        if (selectionGeometry.behavior() == SelectionRenderingBehavior::UseIndividualQuads)
+        if (selectionGeometry.behavior() == SelectionRenderingBehavior::UseIndividualQuads && selectionGeometry.isHorizontal())
             continue;
         if (selectionGeometry.direction() == TextDirection::RTL && selectionGeometry.isFirstOnLine()) {
             selectionGeometry.setLogicalWidth(selectionGeometry.logicalWidth() + selectionGeometry.logicalLeft() - selectionGeometry.minX());
@@ -2569,7 +2569,7 @@ Vector<SelectionGeometry> RenderObject::collectSelectionGeometries(const SimpleR
     IntRect interiorUnionRect;
     for (size_t i = 0; i < numberOfGeometries; ++i) {
         auto& currentGeometry = result.geometries[i];
-        if (currentGeometry.behavior() == SelectionRenderingBehavior::UseIndividualQuads) {
+        if (currentGeometry.behavior() == SelectionRenderingBehavior::UseIndividualQuads && currentGeometry.isHorizontal()) {
             if (currentGeometry.quad().isEmpty())
                 continue;
 


### PR DESCRIPTION
#### aa1b9db26fd093f7d590af2d65ea4352289eac4f
<pre>
Blue boxes appear at ends of selection for live text for images with vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=253335">https://bugs.webkit.org/show_bug.cgi?id=253335</a>
rdar://106106328

Reviewed by Wenson Hsieh.

`SelectionRenderingBehavior::UseIndividualQuads` doesn&apos;t currently work well for images
with a vertical writing mode, so this PR works around it by only using that behavior for
horizontal writing modes.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::adjustLineHeightOfSelectionGeometries):
(WebCore::RenderObject::collectSelectionGeometriesInternal):
(WebCore::RenderObject::collectSelectionGeometries):

Canonical link: <a href="https://commits.webkit.org/261209@main">https://commits.webkit.org/261209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c40baa28976547ca276d6b05a5d569e9a4eb741d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43329 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/2233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119595 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10970 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1831 "layout-tests (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103161 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44237 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12459 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32012 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8988 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18409 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7774 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14987 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->