### PR TITLE
CSS Text Underline Right Support

### DIFF
--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -616,7 +616,7 @@ void TextBoxPainter<TextBoxPath>::paintBackgroundDecorations(TextDecorationPaint
             };
         };
 
-        decorationPainter.paintBackgroundDecorations(textRun, computedBackgroundDecorationGeometry(), computedTextDecorationType, decoratingBox.textDecorationStyles);
+        decorationPainter.paintBackgroundDecorations(textRun, computedBackgroundDecorationGeometry(), computedTextDecorationType, decoratingBox.textDecorationStyles, decoratingBox.style);
     }
 
     if (m_isCombinedText)

--- a/Source/WebCore/rendering/TextDecorationPainter.h
+++ b/Source/WebCore/rendering/TextDecorationPainter.h
@@ -67,7 +67,7 @@ public:
         float clippingOffset { 0.f };
         WavyStrokeParameters wavyStrokeParameters;
     };
-    void paintBackgroundDecorations(const TextRun&, const BackgroundDecorationGeometry&, OptionSet<TextDecorationLine>, const Styles&);
+    void paintBackgroundDecorations(const TextRun&, const BackgroundDecorationGeometry&, OptionSet<TextDecorationLine>, const Styles&, const RenderStyle& style);
 
     struct ForegroundDecorationGeometry {
         FloatPoint boxOrigin;

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -181,6 +181,17 @@ static float computedUnderlineOffset(const UnderlineOffsetArguments& context)
         computedUnderlineOffset = std::max<float>(desiredOffset, fontMetrics.ascent());
         break;
     }
+    case TextUnderlinePosition::Left:
+    case TextUnderlinePosition::Right: {
+        if (context.lineStyle.isHorizontalWritingMode()) {
+            ASSERT(context.textUnderlinePositionUnder);
+            // Position underline relative to the bottom edge of the lowest element's content box.
+            auto desiredOffset = context.textUnderlinePositionUnder->textRunLogicalHeight + gap + std::max(context.textUnderlinePositionUnder->textRunOffsetFromBottomMost, 0.f) + underlineOffset.lengthOr(0.f);
+            computedUnderlineOffset = std::max<float>(desiredOffset, fontMetrics.ascent());
+        } else
+            computedUnderlineOffset = fontMetrics.ascent() + underlineOffset.lengthOr(gap);
+        break;
+    }
     default:
         ASSERT_NOT_REACHED();
         break;
@@ -271,7 +282,7 @@ GlyphOverflow visualOverflowForDecorations(const InlineIterator::LineBoxIterator
     auto underlinePositionValue = resolvedUnderlinePosition(style, lineBox->baselineType());
     auto textUnderlinePositionUnder = std::optional<TextUnderlinePositionUnder> { };
 
-    if (underlinePositionValue == TextUnderlinePosition::Under) {
+    if (underlinePositionValue == TextUnderlinePosition::Under || underlinePositionValue == TextUnderlinePosition::Left || underlinePositionValue == TextUnderlinePosition::Right) {
         auto textRunOffset = textRunOffsetFromBottomMost(lineBox, renderer, textBoxLogicalTop, textBoxLogicalBottom);
         textUnderlinePositionUnder = TextUnderlinePositionUnder { textBoxLogicalBottom - textBoxLogicalTop, textRunOffset };
     }
@@ -303,7 +314,7 @@ float underlineOffsetForTextBoxPainting(const InlineIterator::InlineBox& inlineB
     auto textUnderlinePositionUnder = std::optional<TextUnderlinePositionUnder> { };
     auto underlinePositionValue = resolvedUnderlinePosition(style, inlineBox.lineBox()->baselineType());
 
-    if (underlinePositionValue == TextUnderlinePosition::Under) {
+    if (underlinePositionValue == TextUnderlinePosition::Under || underlinePositionValue == TextUnderlinePosition::Left || underlinePositionValue == TextUnderlinePosition::Right) {
         auto textRunOffset = boxOffsetFromBottomMost(inlineBox.lineBox(), inlineBox.renderer(), inlineBox.logicalTop(), inlineBox.logicalBottom());
         auto inlineBoxContentBoxHeight = inlineBox.logicalHeight();
         if (!inlineBox.isRootInlineBox())


### PR DESCRIPTION
CSS Text Underline Right Support
https://bugs.webkit.org/show_bug.cgi?id=253328

Reviewed by NOBODY (OOPS!).

Add CSS Text Underline Right support handling. This will not show up in test cases based on how the flags work.

* Source/WebCore/rendering/TextBoxPainter.cpp: (WebCore::TextBoxPainter<TextBoxPath>::paintBackgroundDecorations):
* Source/WebCore/rendering/TextDecorationPainter.cpp: (WebCore::TextDecorationPainter::paintBackgroundDecorations):
* Source/WebCore/rendering/TextDecorationPainter.h:
* Source/WebCore/style/InlineTextBoxStyle.cpp: (WebCore::computedUnderlineOffset):
(WebCore::visualOverflowForDecorations):
(WebCore::underlineOffsetForTextBoxPainting):<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/498c50e7d18b494f4159e106f66590aafe66c99f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110786 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119601 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2018 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103141 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44222 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12465 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32109 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86102 "Found 2 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/8993 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51730 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14989 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->