### PR TITLE
BifurcatedGraphicsContext fails to apply image masks to the secondary context

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -289,6 +289,14 @@ void BifurcatedGraphicsContext::clipPath(const Path& path, WindRule windRule)
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
+void BifurcatedGraphicsContext::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect)
+{
+    m_primaryContext.clipToImageBuffer(imageBuffer, destRect);
+    m_secondaryContext.clipToImageBuffer(imageBuffer, destRect);
+
+    VERIFY_STATE_SYNCHRONIZATION();
+}
+
 IntRect BifurcatedGraphicsContext::clipBounds() const
 {
     return m_primaryContext.clipBounds();

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -89,6 +89,8 @@ public:
 
     void clipPath(const Path&, WindRule = WindRule::EvenOdd) final;
 
+    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+
     IntRect clipBounds() const final;
 
     void setLineCap(LineCap) final;

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -404,11 +404,6 @@ void GraphicsContext::clipOutRoundedRect(const FloatRoundedRect& rect)
     clipOut(path);
 }
 
-void GraphicsContext::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destinationRect)
-{
-    imageBuffer.clipToMask(*this, destinationRect);
-}
-
 IntRect GraphicsContext::clipBounds() const
 {
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -294,7 +294,7 @@ public:
     virtual void clipOut(const Path&) = 0;
     WEBCORE_EXPORT virtual void clipOutRoundedRect(const FloatRoundedRect&);
     virtual void clipPath(const Path&, WindRule = WindRule::EvenOdd) = 0;
-    WEBCORE_EXPORT virtual void clipToImageBuffer(ImageBuffer&, const FloatRect&);
+    WEBCORE_EXPORT virtual void clipToImageBuffer(ImageBuffer&, const FloatRect&) = 0;
     WEBCORE_EXPORT virtual IntRect clipBounds() const;
 
     // Text

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -460,14 +460,6 @@ void ImageBuffer::drawConsuming(RefPtr<ImageBuffer> imageBuffer, GraphicsContext
     imageBuffer->drawConsuming(context, destRect, srcRect, options);
 }
 
-void ImageBuffer::clipToMask(GraphicsContext& destContext, const FloatRect& destRect)
-{
-    if (auto* backend = ensureBackendCreated()) {
-        flushContext();
-        backend->clipToMask(destContext, destRect);
-    }
-}
-
 void ImageBuffer::convertToLuminanceMask()
 {
     if (auto* backend = ensureBackendCreated()) {

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -189,8 +189,6 @@ public:
 
     static void drawConsuming(RefPtr<ImageBuffer>, GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions& = { });
 
-    void clipToMask(GraphicsContext& destContext, const FloatRect& destRect);
-
     WEBCORE_EXPORT virtual void convertToLuminanceMask();
     WEBCORE_EXPORT virtual void transformToColorSpace(const DestinationColorSpace& newColorSpace);
 

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -117,8 +117,6 @@ public:
     WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImageForDrawing(GraphicsContext& destination);
     WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
 
-    virtual void clipToMask(GraphicsContext&, const FloatRect&) { }
-
     WEBCORE_EXPORT void convertToLuminanceMask();
     virtual void transformToColorSpace(const DestinationColorSpace&) { }
 

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp
@@ -42,12 +42,6 @@
 
 namespace WebCore {
 
-void ImageBufferCairoBackend::clipToMask(GraphicsContext& destContext, const FloatRect& destRect)
-{
-    if (auto image = copyNativeImage(DontCopyBackingStore))
-        Cairo::clipToImageBuffer(*destContext.platformContext(), image->platformImage().get(), destRect);
-}
-
 void ImageBufferCairoBackend::transformToColorSpace(const DestinationColorSpace& newColorSpace)
 {
 #if ENABLE(DESTINATION_COLOR_SPACE_LINEAR_SRGB)

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h
@@ -37,8 +37,6 @@ namespace WebCore {
 
 class ImageBufferCairoBackend : public ImageBufferBackend {
 public:
-    WEBCORE_EXPORT void clipToMask(GraphicsContext&, const FloatRect& destRect) override;
-
     WEBCORE_EXPORT void transformToColorSpace(const DestinationColorSpace&) override;
 
 protected:

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1001,6 +1001,22 @@ void GraphicsContextCG::clipPath(const Path& path, WindRule clipRule)
     }
 }
 
+void GraphicsContextCG::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect)
+{
+    auto nativeImage = imageBuffer.copyNativeImage(DontCopyBackingStore);
+    if (!nativeImage)
+        return;
+
+    // FIXME: This image needs to be grayscale to be used as an alpha mask here.
+    CGContextRef context = platformContext();
+    CGContextTranslateCTM(context, destRect.x(), destRect.maxY());
+    CGContextScaleCTM(context, 1, -1);
+    CGContextClipToRect(context, { { }, destRect.size() });
+    CGContextClipToMask(context, { { }, destRect.size() }, nativeImage->platformImage().get());
+    CGContextScaleCTM(context, 1, -1);
+    CGContextTranslateCTM(context, -destRect.x(), -destRect.maxY());
+}
+
 IntRect GraphicsContextCG::clipBounds() const
 {
     return enclosingIntRect(CGContextGetClipBoundingBox(platformContext()));

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -87,6 +87,8 @@ public:
 
     void clipPath(const Path&, WindRule = WindRule::EvenOdd) final;
 
+    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+
     IntRect clipBounds() const final;
 
     void setLineCap(LineCap) final;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -62,23 +62,6 @@ unsigned ImageBufferCGBackend::calculateBytesPerRow(const IntSize& backendSize)
     return CheckedUint32(backendSize.width()) * 4;
 }
 
-void ImageBufferCGBackend::clipToMask(GraphicsContext& destContext, const FloatRect& destRect)
-{
-    auto nativeImage = copyNativeImage(DontCopyBackingStore);
-    if (!nativeImage)
-        return;
-    
-    CGContextRef cgContext = destContext.platformContext();
-
-    // FIXME: This image needs to be grayscale to be used as an alpha mask here.
-    CGContextTranslateCTM(cgContext, destRect.x(), destRect.maxY());
-    CGContextScaleCTM(cgContext, 1, -1);
-    CGContextClipToRect(cgContext, { { }, destRect.size() });
-    CGContextClipToMask(cgContext, { { }, destRect.size() }, nativeImage->platformImage().get());
-    CGContextScaleCTM(cgContext, 1, -1);
-    CGContextTranslateCTM(cgContext, -destRect.x(), -destRect.maxY());
-}
-
 std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlusher()
 {
     return makeUnique<ThreadSafeImageBufferFlusherCG>(context().platformContext());

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -45,8 +45,6 @@ protected:
     using ImageBufferBackend::ImageBufferBackend;
     void applyBaseTransform(GraphicsContextCG&) const;
 
-    void clipToMask(GraphicsContext&, const FloatRect& destRect) override;
-
     std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() override;
 
     bool originAtBottomLeftCorner() const override;


### PR DESCRIPTION
#### 91212e766452b51daeb83f508b642d72c99040b5
<pre>
BifurcatedGraphicsContext fails to apply image masks to the secondary context
<a href="https://bugs.webkit.org/show_bug.cgi?id=253340">https://bugs.webkit.org/show_bug.cgi?id=253340</a>
rdar://104488384

Reviewed by Said Abou-Hallawa.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::clipToImageBuffer):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
Add a BifurcatedGraphicsContext implementation of clipToImageBuffer.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::clipToImageBuffer): Deleted.
* Source/WebCore/platform/graphics/GraphicsContext.h:
Make clipToImageBuffer pure virtual instead of bouncing through ImageBuffer,
so that it is clear that it is implemented by the platform contexts (and not
in terms of other GraphicsContext commands), and thus must be overriden by
any GraphicsContext implementation.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::clipToMask): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::clipToMask): Deleted.
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp:
(WebCore::ImageBufferCairoBackend::clipToMask): Deleted.
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::clipToImageBuffer):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::ImageBufferCGBackend::clipToMask): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
Move ImageBufferBackend::clipToMask into the platform GraphicsContext implementations.

* Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp:
(TestWebKitAPI::TEST):
Add a test.

Canonical link: <a href="https://commits.webkit.org/261283@main">https://commits.webkit.org/261283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a42fa00de05295f6a41f77e35aeca980310daec3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/19890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/10994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2024 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103165 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12503 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86127 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9006 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18433 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7821 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15004 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->