### PR TITLE
[ews] Send only important steps info to ews-app

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -372,10 +372,7 @@ class GitHubEWS(GitHub):
 
     def _steps_messages(self, build):
         # FIXME: figure out if it is possible to have multi-line hover-over messages in GitHub UI.
-        return '; '.join([step.state_string for step in build.step_set.all().order_by('uid') if self._should_display_step(step)])
-
-    def _should_display_step(self, step):
-        return not [step_to_hide for step_to_hide in StatusBubble.STEPS_TO_HIDE if re.search(step_to_hide, step.state_string)]
+        return '; '.join([step.state_string for step in build.step_set.all().order_by('uid')])
 
     def _does_build_contains_any_failed_step(self, build):
         for step in build.step_set.all():

--- a/Tools/CISupport/ews-app/ews/views/statusbubble.py
+++ b/Tools/CISupport/ews-app/ews/views/statusbubble.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2018-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,17 +47,6 @@ class StatusBubble(View):
                   'ios-wk2', 'mac-wk1', 'mac-wk2', 'mac-wk2-stress', 'mac-AS-debug-wk2', 'gtk-wk2', 'wpe-wk2', 'api-ios', 'api-mac', 'api-gtk',
                   'bindings', 'jsc', 'jsc-arm64', 'jsc-armv7', 'jsc-armv7-tests', 'jsc-mips', 'jsc-mips-tests', 'jsc-i386', 'webkitperl', 'webkitpy', 'services']
 
-    STEPS_TO_HIDE = ['^Archived built product$', '^Uploaded built product$', '^Transferred archive to S3$',
-                     '^Archived test results$', '^Uploaded test results$', '^Extracted test results$',
-                     '^Downloaded built product$', '^Extracted built product$',
-                     '^Crash collection has quiesced$', '^Triggered crash log submission$',
-                     '^Cleaned and updated working directory$', '^Checked out required revision$', '^Updated working directory$',
-                     '^Validated change$', '^Killed old processes$', '^Configured build$', '^OS:.*Xcode:', '(skipped)',
-                     '^Printed configuration$', '^Patch contains relevant changes$', '^Deleted .git/index.lock$',
-                     '^triggered.*$', '^Found modified ChangeLogs$', '^Created local git commit$', '^Set build summary$',
-                     '^Validated commiter$', '^Validated commiter and reviewer$', '^Validated ChangeLog and Reviewer$',
-                     '^Removed flags on bugzilla patch$', '^Checked change status on other queues$', '^Identifier:.*$',
-                     '^Updated branch information$', '^worker .* ready$']
     DAYS_TO_CHECK_QUEUE_POSITION = 0.5
     DAYS_TO_HIDE_BUBBLE = 7
     BUILDER_ICON = u'\U0001f6e0'
@@ -208,16 +197,13 @@ class StatusBubble(View):
         return '[[' + datetime.datetime.fromtimestamp(time).isoformat() + 'Z]]'
 
     def _steps_messages(self, build):
-        return '\n'.join([step.state_string for step in build.step_set.all().order_by('uid') if self._should_display_step(step)])
+        return '\n'.join([step.state_string for step in build.step_set.all().order_by('uid')])
 
     def _steps_messages_from_multiple_builds(self, builds):
         message = ''
         for build in reversed(builds):
             message += '\n\n' + self._steps_messages(build)
         return message
-
-    def _should_display_step(self, step):
-        return not [step_to_hide for step_to_hide in StatusBubble.STEPS_TO_HIDE if re.search(step_to_hide, step.state_string)]
 
     def _does_build_contains_any_failed_step(self, build):
         for step in build.step_set.all():

--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -45,6 +45,22 @@ class Events(service.BuildbotService):
 
     EVENT_SERVER_ENDPOINT = 'https://ews.webkit{}.org/results/'.format(custom_suffix)
     MAX_GITHUB_DESCRIPTION = 140
+    STEPS_TO_REPORT = [
+        'configuration', 'checkout-pull-request', 'apply-patch',
+        'compile-webkit', 'compile-webkit-without-change', 'compile-jsc', 'compile-jsc-without-change',
+        'layout-tests', 'layout-tests-repeat-failures', 're-run-layout-tests',
+        'run-layout-tests-without-change', 'layout-tests-repeat-failures-without-change',
+        'run-layout-tests-in-stress-mode', 'run-layout-tests-in-guard-malloc-stress-mode',
+        'run-api-tests', 'run-api-tests-without-change', 're-run-api-tests',
+        'jscore-test', 'jscore-test-without-change',
+        'add-reviewer-to-commit-message', 'commit-patch', 'push-commit-to-webkit-repo', 'canonicalize-commit',
+        'build-webkit-org-unit-tests', 'buildbot-check-config', 'buildbot-check-config-for-build-webkit', 'buildbot-check-config-for-ews',
+        'ews-unit-tests', 'resultsdbpy-unit-tests',
+        'upload-built-product', 'upload-test-results',
+        'apply-watch-list', 'bindings-tests', 'check-webkit-style',
+        'webkitperl-tests', 're-run-webkitperl-tests',
+        'webkitpy-tests-python2', 'webkitpy-tests-python3'
+    ]
 
     def __init__(self, master_hostname, type_prefix='', name='Events'):
         """
@@ -192,6 +208,8 @@ class Events(service.BuildbotService):
         self.sendDataToEWS(data)
 
     def stepStarted(self, key, step):
+        if step.get('name') not in self.STEPS_TO_REPORT:
+            return
         state_string = step.get('state_string')
         if state_string == 'pending':
             state_string = 'Running {}'.format(step.get('name'))
@@ -211,6 +229,8 @@ class Events(service.BuildbotService):
         self.sendDataToEWS(data)
 
     def stepFinished(self, key, step):
+        if step.get('name') not in self.STEPS_TO_REPORT:
+            return
         data = {
             "type": self.type_prefix + "step",
             "status": "finished",


### PR DESCRIPTION
#### 41910e61bbb5a7db89c0689a6e2819853b66fb88
<pre>
[ews] Send only important steps info to ews-app
<a href="https://bugs.webkit.org/show_bug.cgi?id=253341">https://bugs.webkit.org/show_bug.cgi?id=253341</a>

Reviewed by Ryan Haddad.

EWS (buildbot) should send only important steps info to ews-app. Currently it&apos;s
sending information of every step start/stop to ews django app. Then django app
filters out which steps info to use. Instead EWS should just filter out the step
and send only required info to ews-app.

Also, step information is only used to display status-bubble hover-over summary.
Step information in hover-over messages are less useful in GitHub as compared to bugzilla,
since there are limitations in Github on how we can display hover-over messages.
We should only display useful information in hover-over messages.

Therefore we should send step information for only the important steps (which we
really want to show in hover-over messages). This would save thousands of network
requests every hour from buildbot-server, and would help with load on buildbot server.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS._should_display_step): Deleted.
* Tools/CISupport/ews-app/ews/views/statusbubble.py:
(StatusBubble):
(StatusBubble._steps_messages_from_multiple_builds):
(StatusBubble._should_display_step): Deleted.
* Tools/CISupport/ews-build/events.py:
(Events): Added list of steps which should be reported to ews django app.
(Events.stepStarted):
(Events.stepFinished):

Canonical link: <a href="https://commits.webkit.org/261168@main">https://commits.webkit.org/261168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95876af8514b26048b73088dc7f390ccd975669d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110805 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/19891 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/2155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/114770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/21291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/10995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/2155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116555 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/21291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/21291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/103166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/10995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/109582 "Passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4218 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->