### PR TITLE
Include FetchMetadata on preflight requests

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any-expected.txt
@@ -1,8 +1,12 @@
-CONSOLE MESSAGE: Preflight response is not successful. Status code: 403
-CONSOLE MESSAGE: Fetch API cannot load https://www.web-platform.test:9443/fetch/metadata/resources/echo-as-json.py due to access control checks.
-CONSOLE MESSAGE: Preflight response is not successful. Status code: 403
-CONSOLE MESSAGE: Fetch API cannot load https://www.not-web-platform.test:9443/fetch/metadata/resources/echo-as-json.py due to access control checks.
 
-FAIL Same-site fetch with preflight promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Cross-site fetch with preflight promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Same-site fetch with preflight
+PASS Cross-site fetch with preflight
+PASS Same-site fetch with preflight: sec-fetch-dest
+PASS Same-site fetch with preflight: sec-fetch-mode
+PASS Same-site fetch with preflight: sec-fetch-site
+PASS Same-site fetch with preflight: sec-fetch-user
+PASS Cross-site fetch with preflight: sec-fetch-dest
+PASS Cross-site fetch with preflight: sec-fetch-mode
+PASS Cross-site fetch with preflight: sec-fetch-site
+PASS Cross-site fetch with preflight: sec-fetch-user
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.serviceworker-expected.txt
@@ -1,4 +1,12 @@
 
-FAIL Same-site fetch with preflight promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Cross-site fetch with preflight promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Same-site fetch with preflight
+PASS Cross-site fetch with preflight
+PASS Same-site fetch with preflight: sec-fetch-dest
+PASS Same-site fetch with preflight: sec-fetch-mode
+PASS Same-site fetch with preflight: sec-fetch-site
+PASS Same-site fetch with preflight: sec-fetch-user
+PASS Cross-site fetch with preflight: sec-fetch-dest
+PASS Cross-site fetch with preflight: sec-fetch-mode
+PASS Cross-site fetch with preflight: sec-fetch-site
+PASS Cross-site fetch with preflight: sec-fetch-user
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.sharedworker-expected.txt
@@ -1,4 +1,12 @@
 
-FAIL Same-site fetch with preflight promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Cross-site fetch with preflight promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Same-site fetch with preflight
+PASS Cross-site fetch with preflight
+PASS Same-site fetch with preflight: sec-fetch-dest
+PASS Same-site fetch with preflight: sec-fetch-mode
+PASS Same-site fetch with preflight: sec-fetch-site
+PASS Same-site fetch with preflight: sec-fetch-user
+PASS Cross-site fetch with preflight: sec-fetch-dest
+PASS Cross-site fetch with preflight: sec-fetch-mode
+PASS Cross-site fetch with preflight: sec-fetch-site
+PASS Cross-site fetch with preflight: sec-fetch-user
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.worker-expected.txt
@@ -1,6 +1,12 @@
-CONSOLE MESSAGE: Preflight response is not successful. Status code: 403
-CONSOLE MESSAGE: Preflight response is not successful. Status code: 403
 
-FAIL Same-site fetch with preflight promise_test: Unhandled rejection with value: object "TypeError: Load failed"
-FAIL Cross-site fetch with preflight promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Same-site fetch with preflight
+PASS Cross-site fetch with preflight
+PASS Same-site fetch with preflight: sec-fetch-dest
+PASS Same-site fetch with preflight: sec-fetch-mode
+PASS Same-site fetch with preflight: sec-fetch-site
+PASS Same-site fetch with preflight: sec-fetch-user
+PASS Cross-site fetch with preflight: sec-fetch-dest
+PASS Cross-site fetch with preflight: sec-fetch-mode
+PASS Cross-site fetch with preflight: sec-fetch-site
+PASS Cross-site fetch with preflight: sec-fetch-user
 

--- a/Source/WebCore/loader/CrossOriginAccessControl.h
+++ b/Source/WebCore/loader/CrossOriginAccessControl.h
@@ -58,7 +58,7 @@ void updateRequestReferrer(ResourceRequest&, ReferrerPolicy, const String&);
     
 WEBCORE_EXPORT void updateRequestForAccessControl(ResourceRequest&, SecurityOrigin&, StoredCredentialsPolicy);
 
-WEBCORE_EXPORT ResourceRequest createAccessControlPreflightRequest(const ResourceRequest&, SecurityOrigin&, const String&);
+WEBCORE_EXPORT ResourceRequest createAccessControlPreflightRequest(const ResourceRequest&, SecurityOrigin&, const String&, bool includeFetchMetadata);
 enum class SameOriginFlag { No, Yes };
 CachedResourceRequest createPotentialAccessControlRequest(ResourceRequest&&, ResourceLoaderOptions&&, Document&, const String& crossOriginAttribute, SameOriginFlag = SameOriginFlag::No);
 

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -42,6 +42,7 @@
 #include "FrameLoader.h"
 #include "InspectorInstrumentation.h"
 #include "NetworkLoadMetrics.h"
+#include "Quirks.h"
 #include "SharedBuffer.h"
 
 namespace WebCore {
@@ -122,7 +123,8 @@ void CrossOriginPreflightChecker::startPreflight()
     options.serviceWorkersMode = ServiceWorkersMode::None;
     options.initiatorContext = m_loader.options().initiatorContext;
 
-    CachedResourceRequest preflightRequest(createAccessControlPreflightRequest(m_request, m_loader.securityOrigin(), m_loader.referrer()), options);
+    bool includeFetchMetadata = m_loader.document().settings().fetchMetadataEnabled() && !m_loader.document().quirks().shouldDisableFetchMetadata();
+    CachedResourceRequest preflightRequest(createAccessControlPreflightRequest(m_request, m_loader.securityOrigin(), m_loader.referrer(), includeFetchMetadata), options);
     preflightRequest.setInitiatorType(AtomString { m_loader.options().initiatorType });
 
     ASSERT(!m_resource);
@@ -136,7 +138,8 @@ void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, 
     if (!loader.document().frame())
         return;
 
-    ResourceRequest preflightRequest = createAccessControlPreflightRequest(request, loader.securityOrigin(), loader.referrer());
+    bool includeFetchMetadata = loader.document().settings().fetchMetadataEnabled() && !loader.document().quirks().shouldDisableFetchMetadata();
+    ResourceRequest preflightRequest = createAccessControlPreflightRequest(request, loader.securityOrigin(), loader.referrer(), includeFetchMetadata);
     ResourceError error;
     ResourceResponse response;
     RefPtr<SharedBuffer> data;

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -67,7 +67,7 @@ void NetworkCORSPreflightChecker::startPreflight()
     CORS_CHECKER_RELEASE_LOG("startPreflight");
 
     NetworkLoadParameters loadParameters;
-    loadParameters.request = createAccessControlPreflightRequest(m_parameters.originalRequest, m_parameters.sourceOrigin, m_parameters.referrer);
+    loadParameters.request = createAccessControlPreflightRequest(m_parameters.originalRequest, m_parameters.sourceOrigin, m_parameters.referrer, m_parameters.includeFetchMetadata);
     loadParameters.networkConnectionIntegrityPolicy = m_parameters.networkConnectionIntegrityPolicy;
     if (!m_parameters.userAgent.isNull())
         loadParameters.request.setHTTPHeaderField(HTTPHeaderName::UserAgent, m_parameters.userAgent);

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
@@ -60,6 +60,7 @@ public:
         WebCore::StoredCredentialsPolicy storedCredentialsPolicy;
         bool allowPrivacyProxy { true };
         OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy;
+        bool includeFetchMetadata { false };
     };
     using CompletionCallback = CompletionHandler<void(WebCore::ResourceError&&)>;
 

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -427,7 +427,8 @@ void NetworkLoadChecker::checkCORSRequestWithPreflight(ResourceRequest&& request
         m_webPageProxyID,
         m_storedCredentialsPolicy,
         m_allowPrivacyProxy,
-        m_networkConnectionIntegrityPolicy
+        m_networkConnectionIntegrityPolicy,
+        request.hasHTTPHeaderField(HTTPHeaderName::SecFetchSite)
     };
     m_corsPreflightChecker = makeUnique<NetworkCORSPreflightChecker>(m_networkProcess.get(), m_networkResourceLoader.get(), WTFMove(parameters), m_shouldCaptureExtraNetworkLoadMetrics, [this, request = WTFMove(request), handler = WTFMove(handler), isRedirected = isRedirected()](auto&& error) mutable {
         LOAD_CHECKER_RELEASE_LOG("checkCORSRequestWithPreflight - makeCrossOriginAccessRequestWithPreflight preflight complete, success=%d forRedirect=%d", error.isNull(), isRedirected);


### PR DESCRIPTION
#### fc63906f700d09fba0a4050e192bfa64848d7290
<pre>
Include FetchMetadata on preflight requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=253300">https://bugs.webkit.org/show_bug.cgi?id=253300</a>

Reviewed by Brent Fulgham and Youenn Fablet.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.serviceworker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.sharedworker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.worker-expected.txt:
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::createAccessControlPreflightRequest):
* Source/WebCore/loader/CrossOriginAccessControl.h:
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::startPreflight):
(WebCore::CrossOriginPreflightChecker::doPreflight):
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp:
(WebKit::NetworkCORSPreflightChecker::startPreflight):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):

Canonical link: <a href="https://commits.webkit.org/261587@main">https://commits.webkit.org/261587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf35a6938add59c4bacb875c9a7ffd5415f7d47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4029 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22714 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/4796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117994 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/100058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105291 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/641 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14448 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52643 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8076 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16244 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->