### PR TITLE
Block logd in WebContent

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/OSLogSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/OSLogSPI.h
@@ -40,8 +40,14 @@ OS_ENUM(_os_trace_commonmodes, os_trace_mode_t,
     OS_TRACE_MODE_DEBUG                         = 0x02,
     OS_TRACE_MODE_BACKTRACE                     = 0x04,
     OS_TRACE_MODE_STREAM_LIVE                   = 0x08,
+    OS_TRACE_MODE_DISABLE                       = 0x0100,
     OS_TRACE_MODE_OFF                           = 0x0400,
 );
+
+typedef struct os_log_message_s {
+    char padding[128];
+    const char *subsystem;
+} *os_log_message_t;
 
 #endif
 
@@ -52,5 +58,16 @@ void os_log_with_args(os_log_t oslog, os_log_type_t type, const char *format, va
 
 OS_EXPORT OS_NOTHROW
 void os_trace_set_mode(os_trace_mode_t mode);
+
+OS_EXPORT OS_NOTHROW
+os_trace_mode_t os_trace_get_mode();
+
+typedef void (^os_log_hook_t)(os_log_type_t type, os_log_message_t msg);
+
+OS_EXPORT OS_NOTHROW
+os_log_hook_t os_log_set_hook(os_log_type_t level, os_log_hook_t);
+
+OS_EXPORT OS_NOTHROW
+char* os_log_copy_message_string(os_log_message_t msg);
 
 WTF_EXTERN_C_END

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -202,7 +202,9 @@ public:
 #if ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     void installMockContentFilter(WebCore::MockContentFilterSettings&&);
 #endif
-
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    void logOnBehalfOfWebContent(const String& logChannel, const String& logString, uint8_t logType);
+#endif
 private:
     NetworkConnectionToWebProcess(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters, IPC::Connection::Identifier);
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -116,4 +116,7 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
 #if ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     InstallMockContentFilter(WebCore::MockContentFilterSettings settings)
 #endif
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    LogOnBehalfOfWebContent(String logChannel, String logString, uint8_t logType)
+#endif
 }

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -463,10 +463,10 @@
         (extension-class "com.apple.app-sandbox.read-write" "com.apple.app-sandbox.read")
         (extension "com.apple.fileprovider.read-write")))
 
-(allow mach-lookup
-    (global-name "com.apple.logd")
-    (global-name "com.apple.logd.events")
-)
+(with-filter (require-not (state-flag "DisableLogging"))
+    (allow mach-lookup (global-name
+        "com.apple.logd"
+        "com.apple.logd.events")))
 
 (deny mach-lookup (with no-report)
     (global-name "com.apple.distributed_notifications@1v3"))

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -178,12 +178,14 @@ function webcontent_sandbox_entitlements()
     plistbuddy Add :com.apple.private.security.mutable-state-flags:3 string BlockIOKitInWebContentSandbox
     plistbuddy Add :com.apple.private.security.mutable-state-flags:4 string LockdownModeEnabled
     plistbuddy Add :com.apple.private.security.mutable-state-flags:5 string WebContentProcessLaunched
+    plistbuddy Add :com.apple.private.security.mutable-state-flags:6 string DisableLogging
     plistbuddy Add :com.apple.private.security.enable-state-flags array
     plistbuddy Add :com.apple.private.security.enable-state-flags:0 string EnableExperimentalSandbox
     plistbuddy Add :com.apple.private.security.enable-state-flags:1 string EnableExperimentalSandboxWithProbability
     plistbuddy Add :com.apple.private.security.enable-state-flags:2 string BlockIOKitInWebContentSandbox
     plistbuddy Add :com.apple.private.security.enable-state-flags:3 string LockdownModeEnabled
     plistbuddy Add :com.apple.private.security.enable-state-flags:4 string WebContentProcessLaunched
+    plistbuddy Add :com.apple.private.security.enable-state-flags:5 string DisableLogging
 }
 
 function mac_process_webcontent_shared_entitlements()

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -30,6 +30,7 @@
 #import "WKCrashReporter.h"
 #import "XPCServiceEntryPoint.h"
 #import <CoreFoundation/CoreFoundation.h>
+#import <mach/mach.h>
 #import <pal/spi/cf/CFUtilitiesSPI.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <sys/sysctl.h>
@@ -37,6 +38,8 @@
 #import <wtf/Language.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/spi/cocoa/OSLogSPI.h>
+#import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 
 namespace WebKit {
@@ -60,6 +63,52 @@ static void setAppleLanguagesPreference()
         }
     } else
         LOG(Language, "Bootstrap message does not contain OverrideLanguages");
+}
+
+static void initializeCFPrefs()
+{
+#if ENABLE(CFPREFS_DIRECT_MODE)
+    // Enable CFPrefs direct mode to avoid unsuccessfully attempting to connect to the daemon and getting blocked by the sandbox.
+    _CFPrefsSetDirectModeEnabled(YES);
+#if HAVE(CF_PREFS_SET_READ_ONLY)
+    _CFPrefsSetReadOnly(YES);
+#endif
+#endif // ENABLE(CFPREFS_DIRECT_MODE)
+}
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+static void blockLogdInSandbox()
+{
+    audit_token_t auditToken = { 0 };
+    mach_msg_type_number_t info_size = TASK_AUDIT_TOKEN_COUNT;
+    if (KERN_SUCCESS == task_info(mach_task_self(), TASK_AUDIT_TOKEN, reinterpret_cast<integer_t *>(&auditToken), &info_size))
+        sandbox_enable_state_flag("DisableLogging", auditToken);
+}
+#endif
+
+static void initializeLogd(bool disableLogging)
+{
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    if (disableLogging) {
+#if PLATFORM(IOS_FAMILY)
+        blockLogdInSandbox();
+#endif
+        os_trace_set_mode(OS_TRACE_MODE_OFF);
+        return;
+    }
+#else
+    UNUSED_PARAM(disableLogging);
+#endif
+
+    os_trace_set_mode(OS_TRACE_MODE_INFO | OS_TRACE_MODE_DEBUG);
+
+    // Log a long message to make sure the XPC connection to the log daemon for oversized messages is opened.
+    // This is needed to block launchd after the WebContent process has launched, since access to launchd is
+    // required when opening new XPC connections.
+    char stringWithSpaces[1024];
+    memset(stringWithSpaces, ' ', sizeof(stringWithSpaces));
+    stringWithSpaces[sizeof(stringWithSpaces) - 1] = 0;
+    RELEASE_LOG(Process, "Initialized logd %s", stringWithSpaces);
 }
 
 static void XPCServiceEventHandler(xpc_connection_t peer)
@@ -89,6 +138,9 @@ static void XPCServiceEventHandler(xpc_connection_t peer)
             return;
         }
         if (!strcmp(messageName, "bootstrap")) {
+            bool disableLogging = xpc_dictionary_get_bool(event, "disable-logging");
+            initializeLogd(disableLogging);
+
             const char* serviceName = xpc_dictionary_get_string(event, "service-name");
             if (!serviceName) {
                 RELEASE_LOG_ERROR(IPC, "XPCServiceEventHandler: 'service-name' is not present in the XPC dictionary");
@@ -129,10 +181,21 @@ static void XPCServiceEventHandler(xpc_connection_t peer)
             if (fd != -1)
                 dup2(fd, STDERR_FILENO);
 
-            WorkQueue::main().dispatchSync([initializerFunctionPtr, event = OSObjectPtr<xpc_object_t>(event), retainedPeerConnection] {
+            WorkQueue::main().dispatchSync([initializerFunctionPtr, event = OSObjectPtr<xpc_object_t>(event), retainedPeerConnection, disableLogging] {
+                WTF::initializeMainThread();
+
+                initializeCFPrefs();
+
                 initializerFunctionPtr(retainedPeerConnection.get(), event.get());
 
                 setAppleLanguagesPreference();
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT) && PLATFORM(MAC)
+                if (disableLogging)
+                    blockLogdInSandbox();
+#else
+                UNUSED_PARAM(disableLogging);
+#endif
             });
 
             return;
@@ -155,16 +218,6 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void crashDueWebKitFrameworkVersionMi
 
 int XPCServiceMain(int, const char**)
 {
-#if ENABLE(CFPREFS_DIRECT_MODE)
-    // Enable CFPrefs direct mode to avoid unsuccessfully attempting to connect to the daemon and getting blocked by the sandbox.
-    _CFPrefsSetDirectModeEnabled(YES);
-#if HAVE(CF_PREFS_SET_READ_ONLY)
-    _CFPrefsSetReadOnly(YES);
-#endif
-#endif // ENABLE(CFPREFS_DIRECT_MODE)
-
-    WTF::initializeMainThread();
-
     auto bootstrap = adoptOSObject(xpc_copy_bootstrap());
 
     if (bootstrap) {

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -56,6 +56,10 @@
 #import "CodeSigning.h"
 #endif
 
+#if __has_include(<WebKitAdditions/InternalBuildAdditions.h>)
+#include <WebKitAdditions/InternalBuildAdditions.h>
+#endif
+
 namespace WebKit {
 
 static const char* webContentServiceName(bool nonValidInjectedCodeAllowed, ProcessLauncher::Client* client)
@@ -178,6 +182,15 @@ void ProcessLauncher::launchProcess()
     xpc_dictionary_set_string(bootstrapMessage.get(), "process-identifier", String::number(m_launchOptions.processIdentifier.toUInt64()).utf8().data());
     xpc_dictionary_set_string(bootstrapMessage.get(), "ui-process-name", [[[NSProcessInfo processInfo] processName] UTF8String]);
     xpc_dictionary_set_string(bootstrapMessage.get(), "service-name", name);
+
+    if (m_launchOptions.processType == ProcessLauncher::ProcessType::Web) {
+        bool disableLogging = true;
+#if __has_include(<WebKitAdditions/InternalBuildAdditions.h>)
+        if (isInternalBuild())
+            disableLogging = false;
+#endif
+        xpc_dictionary_set_bool(bootstrapMessage.get(), "disable-logging", disableLogging);
+    }
 
     bool isWebKitDevelopmentBuild = ![[[[NSBundle bundleWithIdentifier:@"com.apple.WebKit"] bundlePath] stringByDeletingLastPathComponent] hasPrefix:FileSystem::systemDirectoryPath()];
     if (isWebKitDevelopmentBuild) {

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -244,25 +244,10 @@ static void softlinkDataDetectorsFrameworks()
 #endif // ENABLE(DATA_DETECTION)
 }
 
-static void initializeLogd()
-{
-    os_trace_set_mode(OS_TRACE_MODE_INFO | OS_TRACE_MODE_DEBUG);
-
-    // Log a long message to make sure the XPC connection to the log daemon for oversized messages is opened.
-    // This is needed to block launchd after the WebContent process has launched, since access to launchd is
-    // required when opening new XPC connections.
-    char stringWithSpaces[1024];
-    memset(stringWithSpaces, ' ', sizeof(stringWithSpaces));
-    stringWithSpaces[sizeof(stringWithSpaces) - 1] = 0;
-    RELEASE_LOG(Process, "Initialized logd %s", stringWithSpaces);
-}
-
 void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& parameters)
 {
     WEBPROCESS_RELEASE_LOG(Process, "WebProcess::platformInitializeWebProcess");
 
-    initializeLogd();
-    
     applyProcessCreationParameters(parameters.auxiliaryProcessParameters);
 
     setQOS(parameters.latencyQOS, parameters.throughputQOS);
@@ -656,8 +641,33 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void deliberateCrashForTesting()
 }
 #endif
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+static void registerLogHook()
+{
+    if (os_trace_get_mode() != OS_TRACE_MODE_DISABLE && os_trace_get_mode() != OS_TRACE_MODE_OFF)
+        return;
+
+    os_log_set_hook(OS_LOG_TYPE_DEFAULT, ^(os_log_type_t type, os_log_message_t msg) {
+        char* messageString = os_log_copy_message_string(msg);
+        String logString = String::fromUTF8(messageString);
+        free(messageString);
+        String logChannel = String::fromUTF8(msg->subsystem);
+        callOnMainRunLoop([logChannel.isolatedCopy(), logString.isolatedCopy(), type] {
+            auto* connection = WebProcess::singleton().existingNetworkProcessConnection();
+            if (!connection)
+                return;
+            connection->connection().send(Messages::NetworkConnectionToWebProcess::LogOnBehalfOfWebContent(logChannel, logString, type), 0);
+        });
+    });
+}
+#endif
+
 void WebProcess::platformInitializeProcess(const AuxiliaryProcessInitializationParameters& parameters)
 {
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    registerLogHook();
+#endif
+
 #if PLATFORM(MAC)
     // Deny the WebContent process access to the WindowServer.
     // This call will not succeed if there are open WindowServer connections at this point.

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1387,10 +1387,16 @@
         (extension "com.apple.webkit.extension.mach")
         (global-name "com.apple.trustd.agent")))
 
-;; Various services required by AppKit and other frameworks
-(allow mach-lookup
-       (global-name "com.apple.logd")
-       (global-name "com.apple.logd.events"))
+#if HAVE(SANDBOX_STATE_FLAGS)
+(with-filter (require-not (state-flag "DisableLogging"))
+    (allow mach-lookup (global-name
+        "com.apple.logd"
+        "com.apple.logd.events")))
+#else
+(allow mach-lookup (global-name
+    "com.apple.logd"
+    "com.apple.logd.events"))
+#endif
 
 ; Needed for [CAContext remoteContextWithOptions]
 #if HAVE(SANDBOX_STATE_FLAGS)


### PR DESCRIPTION
#### ac186a8cd8aeb6525562dd59a3d5ba86a6734aae
<pre>
Block logd in WebContent
<a href="https://bugs.webkit.org/show_bug.cgi?id=253342">https://bugs.webkit.org/show_bug.cgi?id=253342</a>
rdar://105416416

Reviewed by John Wilander.

Block logging service in the WebContent process sandbox unless the build is internal. This requires
some tweaks at startup of the WebContent process to avoid opening up a Mach connection to the service
before determining if logging should be enabled. Logs will be forwarded to the Networking process for
logging there if logging is disabled in the WebContent process. This feature is off by default, and
will only be enabled by default after further discussion and review from a larger group of stake-
holders. Initial performance measurements indicate that this feature is neutral and possibly even a
progression on page load benchmarks.

* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WTF/wtf/spi/cocoa/OSLogSPI.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::logOnBehalfOfWebContent):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::initializeCFPrefs):
(WebKit::blockLogdInSandbox):
(WebKit::initializeLogd):
(WebKit::XPCServiceEventHandler):
(WebKit::XPCServiceMain):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):
(WebKit::registerLogHook):
(WebKit::WebProcess::platformInitializeProcess):
(WebKit::initializeLogd): Deleted.
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/261201@main">https://commits.webkit.org/261201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/932e0be09d422cac03fc5ec58ac84f446bb7d2a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110873 "3 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/19997 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/2223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/119744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/21379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/11090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/2223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116625 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/21379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/114295 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/21379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/103238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99499 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10651 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/11090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100604 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31375 "Passed tests") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108637 "Built successfully") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4241 "Failed to push commit to Webkit repository") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26779 "Passed tests") | 
<!--EWS-Status-Bubble-End-->