### PR TITLE
Safari doesn't translate iframe content

### DIFF
--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -25,7 +25,6 @@
 
 #include "config.h"
 #include "TextManipulationController.h"
-#include "TextManipulationItem.h"
 
 #include "AccessibilityObject.h"
 #include "CharacterData.h"
@@ -49,6 +48,7 @@
 #include "ShadowRoot.h"
 #include "Text.h"
 #include "TextIterator.h"
+#include "TextManipulationItem.h"
 #include "VisibleUnits.h"
 
 namespace WebCore {
@@ -642,6 +642,9 @@ void TextManipulationController::addItem(ManipulationItemData&& itemData)
     ASSERT(!itemData.tokens.isEmpty());
     auto newID = m_itemIdentifier.generate();
     m_pendingItemsForCallback.append(TextManipulationItem {
+        m_document->frame()->frameID(),
+        !m_document->frame()->isMainFrame(),
+        !m_document->topOrigin().isSameSiteAs(m_document->securityOrigin()),
         newID,
         itemData.tokens.map([](auto& token) { return token; })
     });
@@ -666,15 +669,21 @@ auto TextManipulationController::completeManipulation(const Vector<WebCore::Text
     HashSet<Ref<Node>> containersWithoutVisualOverflowBeforeReplacement;
     for (unsigned i = 0; i < completionItems.size(); ++i) {
         auto& itemToComplete = completionItems[i];
-        auto identifier = itemToComplete.identifier;
-        if (!identifier) {
-            failures.append(ManipulationFailure { identifier, i, ManipulationFailure::Type::InvalidItem });
+        auto frameID = itemToComplete.frameID;
+        auto itemID = itemToComplete.identifier;
+        if (!frameID || !m_document || !m_document->frame() || frameID != m_document->frame()->frameID()) {
+            failures.append(ManipulationFailure { frameID, itemID, i, ManipulationFailure::Type::NotAvailable });
             continue;
         }
 
-        auto itemDataIterator = m_items.find(identifier);
+        if (!itemID) {
+            failures.append(ManipulationFailure { frameID, itemID, i, ManipulationFailure::Type::InvalidItem });
+            continue;
+        }
+
+        auto itemDataIterator = m_items.find(itemID);
         if (itemDataIterator == m_items.end()) {
-            failures.append(ManipulationFailure { identifier, i, ManipulationFailure::Type::InvalidItem });
+            failures.append(ManipulationFailure { frameID, itemID, i, ManipulationFailure::Type::InvalidItem });
             continue;
         }
 
@@ -682,9 +691,8 @@ auto TextManipulationController::completeManipulation(const Vector<WebCore::Text
         std::exchange(itemData, itemDataIterator->value);
         m_items.remove(itemDataIterator);
 
-        auto failureOrNullopt = replace(itemData, itemToComplete.tokens, containersWithoutVisualOverflowBeforeReplacement);
-        if (failureOrNullopt)
-            failures.append(ManipulationFailure { identifier, i, *failureOrNullopt });
+        if (auto failureOrNullopt = replace(itemData, itemToComplete.tokens, containersWithoutVisualOverflowBeforeReplacement))
+            failures.append(ManipulationFailure { frameID, itemID, i, *failureOrNullopt });
     }
 
     if (!containersWithoutVisualOverflowBeforeReplacement.isEmpty()) {

--- a/Source/WebCore/editing/TextManipulationControllerManipulationFailure.h
+++ b/Source/WebCore/editing/TextManipulationControllerManipulationFailure.h
@@ -25,18 +25,21 @@
 
 #pragma once
 
+#include "FrameIdentifier.h"
 #include "TextManipulationItem.h"
 
 namespace WebCore {
 
 struct TextManipulationControllerManipulationFailure {
     enum class Type : uint8_t {
+        NotAvailable,
         ContentChanged,
         InvalidItem,
         InvalidToken,
         ExclusionViolation,
     };
-    
+
+    FrameIdentifier frameID;
     TextManipulationItemIdentifier identifier;
     uint64_t index;
     Type type;

--- a/Source/WebCore/editing/TextManipulationItem.h
+++ b/Source/WebCore/editing/TextManipulationItem.h
@@ -24,12 +24,17 @@
  */
 
 #pragma once
+
+#include "FrameIdentifier.h"
 #include "TextManipulationItemIdentifier.h"
 #include "TextManipulationToken.h"
 
 namespace WebCore {
 
 struct TextManipulationItem {
+    FrameIdentifier frameID;
+    bool isSubframe { false };
+    bool isCrossSiteSubframe { false };
     TextManipulationItemIdentifier identifier;
     Vector<TextManipulationToken> tokens;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1783,6 +1783,9 @@ struct WebCore::EventTrackingRegions {
 enum class WebCore::HasInsecureContent : bool
 
 struct WebCore::TextManipulationItem {
+    WebCore::FrameIdentifier frameID;
+    bool isSubframe;
+    bool isCrossSiteSubframe;
     WebCore::TextManipulationItemIdentifier identifier;
     Vector<WebCore::TextManipulationToken> tokens;
 }
@@ -3131,6 +3134,7 @@ header: <WebCore/TextManipulationController.h>
 
 header: <WebCore/TextManipulationController.h>
 [Nested, CustomHeader] enum class WebCore::TextManipulationControllerManipulationFailure::Type : uint8_t {
+    NotAvailable,
     ContentChanged,
     InvalidItem,
     InvalidToken,
@@ -3139,6 +3143,7 @@ header: <WebCore/TextManipulationController.h>
 
 header: <WebCore/TextManipulationController.h>
 [CustomHeader] struct WebCore::TextManipulationControllerManipulationFailure {
+    WebCore::FrameIdentifier frameID;
     WebCore::TextManipulationItemIdentifier identifier;
     uint64_t index;
     WebCore::TextManipulationControllerManipulationFailure::Type type;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -152,6 +152,7 @@
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/spi/darwin/dyldSPI.h>
+#import <wtf/text/StringToIntegerConversion.h>
 #import <wtf/text/TextStream.h>
 
 #if ENABLE(APPLICATION_MANIFEST)
@@ -2204,8 +2205,15 @@ static RetainPtr<NSDictionary<NSString *, id>> createUserInfo(const std::optiona
 {
     THROW_IF_SUSPENDED;
     using ExclusionRule = WebCore::TextManipulationController::ExclusionRule;
+    bool includeSubframes = configuration.includeSubframes;
 
     if (!_textManipulationDelegate || !_page) {
+        completionHandler();
+        return;
+    }
+
+    auto* frame = _page->mainFrame();
+    if (!frame) {
         completionHandler();
         return;
     }
@@ -2223,7 +2231,7 @@ static RetainPtr<NSDictionary<NSString *, id>> createUserInfo(const std::optiona
         }
     }
 
-    _page->startTextManipulations(exclusionRules, [weakSelf = WeakObjCPtr<WKWebView>(self)] (const Vector<WebCore::TextManipulationItem>& itemReferences) {
+    _page->startTextManipulations(exclusionRules, includeSubframes, [weakSelf = WeakObjCPtr<WKWebView>(self)] (const Vector<WebCore::TextManipulationItem>& itemReferences) {
         if (!weakSelf)
             return;
 
@@ -2241,7 +2249,8 @@ static RetainPtr<NSDictionary<NSString *, id>> createUserInfo(const std::optiona
                 [wkToken setUserInfo:createUserInfo(token.info).get()];
                 return wkToken;
             });
-            return adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:String::number(item.identifier.toUInt64()) tokens:tokens.get()]);
+            auto identifier = makeString(item.frameID.processIdentifier(), '-', item.frameID.object(), '-', item.identifier);
+            return adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:identifier tokens:tokens.get() isSubframe:item.isSubframe isCrossSiteSubframe:item.isCrossSiteSubframe]);
         };
 
         if ([delegate respondsToSelector:@selector(_webView:didFindTextManipulationItems:)])
@@ -2255,9 +2264,40 @@ static RetainPtr<NSDictionary<NSString *, id>> createUserInfo(const std::optiona
     });
 }
 
-static WebCore::TextManipulationItemIdentifier coreTextManipulationItemIdentifierFromString(NSString *identifier)
+struct ItemIdentifiers {
+    WebCore::FrameIdentifier frameID;
+    WebCore::TextManipulationItemIdentifier itemID;
+};
+
+static std::optional<ItemIdentifiers> coreTextManipulationItemIdentifierFromString(NSString *identifier)
 {
-    return makeObjectIdentifier<WebCore::TextManipulationItemIdentifierType>(identifier.longLongValue);
+    String identifierString { identifier };
+    unsigned index = 0;
+    std::optional<uint64_t> processID;
+    std::optional<uint64_t> frameID;
+    std::optional<uint64_t> itemID;
+    for (auto token : StringView(identifierString).split('-')) {
+        switch (index) {
+        case 0:
+            processID = parseInteger<uint64_t>(token);
+            break;
+        case 1:
+            frameID = parseInteger<uint64_t>(token);
+            break;
+        case 2:
+            itemID = parseInteger<uint64_t>(token);
+            break;
+        default:
+            return std::nullopt;
+        }
+        ++index;
+    }
+    if (!processID || !*processID || !frameID || !*frameID || !itemID || !*itemID)
+        return std::nullopt;
+
+    return ItemIdentifiers { WebCore::ProcessQualified(makeObjectIdentifier<WebCore::FrameIdentifierType>(*frameID),
+        makeObjectIdentifier<WebCore::ProcessIdentifierType>(*processID)),
+        makeObjectIdentifier<WebCore::TextManipulationItemIdentifierType>(*itemID) };
 }
 
 static WebCore::TextManipulationTokenIdentifier coreTextManipulationTokenIdentifierFromString(NSString *identifier)
@@ -2273,7 +2313,11 @@ static WebCore::TextManipulationTokenIdentifier coreTextManipulationTokenIdentif
         return;
     }
 
-    auto itemID = coreTextManipulationItemIdentifierFromString(item.identifier);
+    auto identifiers = coreTextManipulationItemIdentifierFromString(item.identifier);
+    if (!identifiers) {
+        completionHandler(false);
+        return;
+    }
 
     Vector<WebCore::TextManipulationToken> tokens;
     for (_WKTextManipulationToken *wkToken in item.tokens)
@@ -2281,7 +2325,7 @@ static WebCore::TextManipulationTokenIdentifier coreTextManipulationTokenIdentif
 
     Vector<WebCore::TextManipulationItem> coreItems;
     coreItems.reserveInitialCapacity(1);
-    coreItems.uncheckedAppend(WebCore::TextManipulationItem { itemID, WTFMove(tokens) });
+    coreItems.uncheckedAppend(WebCore::TextManipulationItem { identifiers->frameID, false, false, identifiers->itemID, WTFMove(tokens) });
     _page->completeTextManipulation(coreItems, [capturedCompletionBlock = makeBlockPtr(completionHandler)] (bool allFailed, auto& failures) {
         capturedCompletionBlock(!allFailed && failures.isEmpty());
     });
@@ -2307,6 +2351,8 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
         auto errorCode = static_cast<NSInteger>(([&coreFailure] {
             using Type = WebCore::TextManipulationController::ManipulationFailure::Type;
             switch (coreFailure.type) {
+            case Type::NotAvailable:
+                return _WKTextManipulationItemErrorNotAvailable;
             case Type::ContentChanged:
                 return _WKTextManipulationItemErrorContentChanged;
             case Type::InvalidItem:
@@ -2318,7 +2364,12 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
             }
         })());
         auto item = items[coreFailure.index];
-        ASSERT(coreTextManipulationItemIdentifierFromString(item.identifier) == coreFailure.identifier);
+#if ASSERT_ENABLED
+        auto identifiers = coreTextManipulationItemIdentifierFromString(item.identifier);
+        ASSERT(identifiers);
+        ASSERT(identifiers->frameID == coreFailure.frameID);
+        ASSERT(identifiers->itemID == coreFailure.identifier);
+#endif
         return [NSError errorWithDomain:_WKTextManipulationItemErrorDomain code:errorCode userInfo:@{_WKTextManipulationItemErrorItemKey: item}];
     });
 }
@@ -2338,7 +2389,14 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
         coreTokens.reserveInitialCapacity(wkItem.tokens.count);
         for (_WKTextManipulationToken *wkToken in wkItem.tokens)
             coreTokens.uncheckedAppend(WebCore::TextManipulationToken { coreTextManipulationTokenIdentifierFromString(wkToken.identifier), wkToken.content, std::nullopt });
-        coreItems.uncheckedAppend(WebCore::TextManipulationItem { coreTextManipulationItemIdentifierFromString(wkItem.identifier), WTFMove(coreTokens) });
+        auto identifiers = coreTextManipulationItemIdentifierFromString(wkItem.identifier);
+        WebCore::FrameIdentifier frameID;
+        WebCore::TextManipulationItemIdentifier itemID;
+        if (identifiers) {
+            frameID = identifiers->frameID;
+            itemID = identifiers->itemID;
+        }
+        coreItems.uncheckedAppend(WebCore::TextManipulationItem { frameID, false, false, itemID, WTFMove(coreTokens) });
     }
 
     RetainPtr<NSArray<_WKTextManipulationItem *>> retainedItems = items;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationConfiguration.h
@@ -32,5 +32,6 @@ WK_CLASS_AVAILABLE(macos(10.15.4), ios(13.4))
 @interface _WKTextManipulationConfiguration : NSObject
 
 @property (nonatomic, copy) NSArray<_WKTextManipulationExclusionRule *> *exclusionRules;
+@property (nonatomic) BOOL includeSubframes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.h
@@ -35,9 +35,12 @@ WK_CLASS_AVAILABLE(macos(10.15.4), ios(13.4))
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithIdentifier:(nullable NSString *)identifier tokens:(NSArray<_WKTextManipulationToken *> *)tokens;
+- (instancetype)initWithIdentifier:(nullable NSString *)identifier tokens:(NSArray<_WKTextManipulationToken *> *)tokens isSubframe:(BOOL)isSubframe isCrossSiteSubframe:(BOOL)isCrossSiteSubframe WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @property (nonatomic, readonly, nullable, copy) NSString *identifier;
 @property (nonatomic, readonly, copy) NSArray<_WKTextManipulationToken *> *tokens;
+@property (nonatomic, readonly) BOOL isSubframe WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, readonly) BOOL isCrossSiteSubframe WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 - (BOOL)isEqualToTextManipulationItem:(nullable _WKTextManipulationItem *)otherItem includingContentEquality:(BOOL)includingContentEquality;
 @property (nonatomic, readonly, copy) NSString *debugDescription;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.mm
@@ -47,6 +47,18 @@ NSString * const _WKTextManipulationItemErrorItemKey = @"item";
     return self;
 }
 
+- (instancetype)initWithIdentifier:(NSString *)identifier tokens:(NSArray<_WKTextManipulationToken *> *)tokens isSubframe:(BOOL)isSubframe isCrossSiteSubframe:(BOOL)isCrossSiteSubframe
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _identifier = identifier;
+    _tokens = tokens;
+    _isSubframe = isSubframe;
+    _isCrossSiteSubframe = isCrossSiteSubframe;
+    return self;
+}
+
 - (NSString *)identifier
 {
     return _identifier.get();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11375,7 +11375,7 @@ void WebPageProxy::setMockWebAuthenticationConfiguration(MockWebAuthenticationCo
 }
 #endif
 
-void WebPageProxy::startTextManipulations(const Vector<WebCore::TextManipulationController::ExclusionRule>& exclusionRules,
+void WebPageProxy::startTextManipulations(const Vector<WebCore::TextManipulationController::ExclusionRule>& exclusionRules, bool includeSubframes,
     TextManipulationItemCallback&& callback, WTF::CompletionHandler<void()>&& completionHandler)
 {
     if (!hasRunningProcess()) {
@@ -11383,7 +11383,7 @@ void WebPageProxy::startTextManipulations(const Vector<WebCore::TextManipulation
         return;
     }
     m_textManipulationItemCallback = WTFMove(callback);
-    sendWithAsyncReply(Messages::WebPage::StartTextManipulations(exclusionRules), WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::WebPage::StartTextManipulations(exclusionRules, includeSubframes), WTFMove(completionHandler));
 }
 
 void WebPageProxy::didFindTextManipulationItems(const Vector<WebCore::TextManipulationItem>& items)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1959,7 +1959,7 @@ public:
 #endif
 
     using TextManipulationItemCallback = WTF::Function<void(const Vector<WebCore::TextManipulationItem>&)>;
-    void startTextManipulations(const Vector<WebCore::TextManipulationController::ExclusionRule>&, TextManipulationItemCallback&&, WTF::CompletionHandler<void()>&&);
+    void startTextManipulations(const Vector<WebCore::TextManipulationController::ExclusionRule>&, bool includeSubframes, TextManipulationItemCallback&&, WTF::CompletionHandler<void()>&&);
     void didFindTextManipulationItems(const Vector<WebCore::TextManipulationItem>&);
     void completeTextManipulation(const Vector<WebCore::TextManipulationItem>&, WTF::Function<void(bool allFailed, const Vector<WebCore::TextManipulationController::ManipulationFailure>&)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1429,7 +1429,7 @@ public:
     RefPtr<WebCore::Element> elementForContext(const WebCore::ElementContext&) const;
     std::optional<WebCore::ElementContext> contextForElement(WebCore::Element&) const;
 
-    void startTextManipulations(Vector<WebCore::TextManipulationController::ExclusionRule>&&, CompletionHandler<void()>&&);
+    void startTextManipulations(Vector<WebCore::TextManipulationController::ExclusionRule>&&, bool includesSubframes, CompletionHandler<void()>&&);
     void completeTextManipulation(const Vector<WebCore::TextManipulationItem>&, CompletionHandler<void(bool allFailed, const Vector<WebCore::TextManipulationController::ManipulationFailure>&)>&&);
 
 #if ENABLE(APPLE_PAY)
@@ -1725,6 +1725,8 @@ private:
     void tryMarkLayersVolatileCompletionHandler(MarkLayersVolatileDontRetryReason, bool didSucceed);
 
     String sourceForFrame(WebFrame*);
+
+    void startTextManipulationForFrame(WebCore::Frame&);
 
     void loadDataImpl(uint64_t navigationID, WebCore::ShouldTreatAsContinuingLoad, std::optional<WebsitePoliciesData>&&, Ref<WebCore::FragmentedSharedBuffer>&&, WebCore::ResourceRequest&&, WebCore::ResourceResponse&&, const URL& failingURL, const UserData&, std::optional<NavigatingToAppBoundDomain>, WebCore::SubstituteData::SessionHistoryVisibility, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
 
@@ -2539,6 +2541,9 @@ private:
 #if HAVE(SCENEKIT)
     bool m_useSceneKitForModel { false };
 #endif
+
+    bool m_textManipulationIncludesSubframes { false };
+    std::optional<Vector<WebCore::TextManipulationController::ExclusionRule>> m_textManipulationExclusionRules;
 
     Vector<String> m_corsDisablingPatterns;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -656,7 +656,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     SendMessageToWebProcessExtensionWithReply(struct WebKit::UserMessage userMessage) -> (struct WebKit::UserMessage replyMessage)
 #endif
 
-    StartTextManipulations(Vector<WebCore::TextManipulationController::ExclusionRule> exclusionRules) -> ()
+    StartTextManipulations(Vector<WebCore::TextManipulationController::ExclusionRule> exclusionRules, bool includeSubframes) -> ()
     CompleteTextManipulation(Vector<WebCore::TextManipulationItem> items) -> (bool allFailed, Vector<WebCore::TextManipulationController::ManipulationFailure> failures)
 
     SetOverriddenMediaType(String mediaType)


### PR DESCRIPTION
#### 09c4983c5bd980390426e4b15d18f32457a0aabc
<pre>
Safari doesn&apos;t translate iframe content
<a href="https://bugs.webkit.org/show_bug.cgi?id=253353">https://bugs.webkit.org/show_bug.cgi?id=253353</a>
&lt;rdar://59693219&gt;

Reviewed by Darin Adler, Sihui Liu and Wenson Hsieh.

Optionally translate contents within each frame when includeSubframes is set in
_WKTextManipulationConfiguration. To do this, each TextManipulationItem and
TextManipulationControllerManipulationFailure are augmented with a frame identifier.
These IDs are serialized with &quot;-&quot; as delimiter for _WKTextManipulationItem.

_WKTextManipulationItem now exposes two new booleans: isSubframe and isCrossSiteSubframe.
These two booleans are ignored when completing items.

WebPage::startTextManipulations now invokes startTextManipulationForFrame on each frame.
We also detect when a new frame is inserted in WebPage::didCommitLoad.

Finally, in WebPage::completeTextManipulation, we aggregate and complete items per frame.

* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::addItem): Add the frame identifier.
(WebCore::TextManipulationController::completeManipulation): Check the frame identifier.

* Source/WebCore/editing/TextManipulationControllerManipulationFailure.h:
* Source/WebCore/editing/TextManipulationItem.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _startTextManipulationsWithConfiguration:completion:]):
(coreTextManipulationItemIdentifierFromString):
(-[WKWebView _completeTextManipulation:completion:]):
(wkTextManipulationErrors):
(-[WKWebView _completeTextManipulationForItems:completion:]):

* Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationItem.mm:
(-[_WKTextManipulationItem initWithIdentifier:tokens:isSubframe:isCrossSiteSubframe:]): Added.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCommitLoad):
(WebKit::WebPage::startTextManipulations):
(WebKit::WebPage::startTextManipulationForFrame): Extracted out of startTextManipulations.
(WebKit::WebPage::completeTextManipulation): Complete per frame and aggregate the results.

* Source/WebKit/WebProcess/WebPage/WebPage.h:

* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm:
(TextManipulation.StartTextManipulationDoesNotFindContentInIframeIfIncludeSubframeIsNotSet): Added.
(TextManipulation.StartTextManipulationFindsContentInIframeIfIncludeSubframeIsSet): Added.
(TextManipulation.StartTextManipulationFindsContentInIframeInsertedLater): Added.
(TextManipulation.CompleteTextManipulationReplaceContentInIframe): Added.
(TextManipulation.CompleteTextManipulationFailWhenContentIsChangedInIframe): Added.

Canonical link: <a href="https://commits.webkit.org/261671@main">https://commits.webkit.org/261671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f33cd3084cbd8987f39f2c8b70aae0a171250a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4259 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121057 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5400 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118247 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105536 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/804 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13976 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/837 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14668 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52842 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16490 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4454 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->