### PR TITLE
[git-webkit] Add pre-push hook to prevent publication of security sensative commits

### DIFF
--- a/Tools/Scripts/hooks/pre-push
+++ b/Tools/Scripts/hooks/pre-push
@@ -1,0 +1,364 @@
+#!/usr/bin/env {{ python }}
+VERSION = '1.0'
+
+import io
+import os
+import re
+import subprocess
+import sys
+
+if sys.stdout.isatty() and os.path.exists('/dev/tty'):
+    TTY = io.TextIOWrapper(io.FileIO(os.open('/dev/tty', os.O_NOCTTY | os.O_RDWR), 'r+'))
+else:
+    TTY = None
+
+LOCATION = r'{{ location }}'
+SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
+sys.path.append(SCRIPTS)
+
+REMOTE_RE = re.compile(r'(?P<protcol>[^@:]+)(@|://)(?P<host>[^:/]+)(/|:)(?P<path>[^\.]+[^\./])(\.git)?/?')
+NULL_HASH = '0' * 40
+TRUNCATED_COMMIT_LEN = 12
+
+CLASS_1 = 1  # Commit exists on another remote
+CLASS_2 = 2  # Commit is a cherry-pick of one that exists on another remote
+CLASS_3 = 3  # Commit references a bug which requires redaction
+
+COMMIT_REF_BASE = r'r?R?[a-f0-9A-F]+.?\d*@?[0-9a-zA-z\-\/\.]*'
+COMPOUND_COMMIT_REF = r'(?P<primary>{})(?P<secondary> \({}\))?'.format(COMMIT_REF_BASE, COMMIT_REF_BASE)
+CHERRY_PICK_RE = [
+    re.compile(r'\S* ?[Cc]herry[- ][Pp]ick of {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'\S* ?[Cc]herry[- ][Pp]ick {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'\S* ?[Cc]herry[- ][Pp]icked {}'.format(COMPOUND_COMMIT_REF)),
+]
+UNPACK_SECONDARY_RE = re.compile(r' \(({})\)'.format(COMMIT_REF_BASE))
+
+DEV_BRANCHES = re.compile(r'.*[(eng)(dev)(bug)]/.+')
+PROD_BRANCHES = re.compile(r'\S+-[\d+\.]+-branch')
+DEFAULT_BRANCHES = ('master', 'main')
+
+ENCODING_KWARGS = dict()
+if sys.version_info >= (3, 6):
+    ENCODING_KWARGS = dict(encoding='utf-8')
+
+QUIET = -1
+VERBOSE = 1
+VERBOSITY = int(os.environ.get('VERBOSITY', '0'))
+
+SECURITY_LEVELS = { {% for key, value in security_levels.items() %}
+    '{{ key }}': {{ value }},{% endfor %}
+}
+MAX_LEVEL = max(SECURITY_LEVELS.values())
+
+
+def print_error(why):
+    if sys.stdout.isatty():
+        RED_TEXT_FORMAT = '\033[31m{}\033[0m\n'
+        (TTY or sys.stderr).write(RED_TEXT_FORMAT.format(why))
+        (TTY or sys.stderr).flush()
+    else:
+        sys.stderr.write('{}\n'.format(why))
+
+
+def print_tty(message):
+    (TTY or sys.stdout).write('{}\n'.format(message))
+    (TTY or sys.stdout).flush()
+
+
+DEFAULT_MODE = 'default' # Forbid class 1, prompt for class 2 and 3
+PUBLISH_MODE = 'publish' # Prompt for class 1, forbid class 2 and 3
+NO_RADAR_MODE = 'no-radar' # Forbid class 1 and 2, don't compute class 3
+MODE = os.environ.get('PUSH_HOOK_MODE', {{ default_pre_push_mode }})
+
+
+if MODE not in (DEFAULT_MODE, PUBLISH_MODE, NO_RADAR_MODE):
+    print_error("'{}' is not a recognized push mode".format(MODE))
+    sys.exit(1)
+
+
+REPOSITORY = None
+try:
+    import webkitpy
+    from webkitcorepy import Version
+    from webkitscmpy import local, Commit
+    from webkitbugspy import version
+
+    if MODE != NO_RADAR_MODE and version >= Version(0, 9, 8):
+        REPOSITORY = local.Git(os.getcwd())
+
+except:
+    pass
+
+if not REPOSITORY:
+    print_error('Checkout too out-of-date to check bug status of novel commits')
+
+
+def security_level_for_remote(remote):
+    match = REMOTE_RE.match(remote)
+    if not match:
+        return None
+    return SECURITY_LEVELS.get('{}:{}'.format(match.group('host'), match.group('path')), None)
+
+
+def security_level_for_remotes(remotes, name_to_remote=None):
+    if not name_to_remote:
+        _, name_to_remote = remote_name_mappings()
+    security_levels = [security_level_for_remote(name_to_remote.get(name, name)) for name in remotes]
+    if 0 in security_levels:
+        return 0
+    if None in security_levels:
+        return None
+    return min(security_levels)
+
+
+def commits_in(from_ref, to_ref):
+    command = ['git', 'rev-list']
+    if from_ref:
+        command.append('{}..{}'.format(from_ref, to_ref))
+    else:
+        command.append(to_ref)
+    proc = None
+    try:
+        proc = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            **ENCODING_KWARGS
+        )
+        line = proc.stdout.readline()
+        while line:
+            yield line.rstrip()[:TRUNCATED_COMMIT_LEN]
+            line = proc.stdout.readline()
+    finally:
+        if proc and proc.poll() is None:
+            proc.kill()
+
+
+def remote_name_mappings():
+    a, b = {}, {}
+    for line in subprocess.check_output(
+        ['git', 'remote', '-v'],
+        **ENCODING_KWARGS
+    ).splitlines():
+        remote = line.split()
+        if len(remote) < 2:
+            continue
+        b[remote[0]] = remote[1]
+        match = REMOTE_RE.match(remote[1])
+        if match:
+            a['{}:{}'.format(match.group('host'), match.group('path'))] = remote[0]
+    return a, b
+
+
+def remotes_for(commit):
+    try:
+        result = set()
+        for line in subprocess.check_output(
+            ['git', 'branch', '-r', '--contains', commit],
+            stderr=subprocess.STDOUT,
+            **ENCODING_KWARGS
+        ).splitlines():
+            result.add(line.lstrip().split('/')[0])
+        return list(result)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def branch_for(commit):
+    try:
+        candidate = None
+        for line in subprocess.check_output(
+            ['git', 'branch', '-a', '--contains', commit],
+            stderr=subprocess.STDOUT,
+            **ENCODING_KWARGS
+        ).splitlines():
+            if line[0] == '*':
+                line = line[1:]
+            line = line.lstrip().rstrip()
+            is_remote = line.startswith('remotes')
+            if is_remote:
+                line = line.split('/', 2)[-1]
+            if not candidate:
+                candidate = line
+                continue
+            if candidate in DEFAULT_BRANCHES or PROD_BRANCHES.match(candidate):
+                continue
+            if PROD_BRANCHES.match(line) or DEV_BRANCHES.match(candidate):
+                candidate = line
+
+        return candidate
+    except subprocess.CalledProcessError:
+        return None
+
+
+def message_for(commit):
+    return subprocess.check_output(
+        ['git', 'log', '--format=%B', '-n', '1', commit],
+        **ENCODING_KWARGS
+    )
+
+
+def security_level_for_commit(commit, remotes, name_to_remote=None):
+    if not name_to_remote:
+        _, name_to_remote = remote_name_mappings()
+
+    # Class 1: the commit we're pushing exists on a remote already
+    if remotes:
+        return security_level_for_remotes(remotes, name_to_remote), CLASS_1
+
+    message = message_for(commit)
+    title = message.splitlines()[0]
+
+    # Class 2: The commit we're pushing is a cherry-pick of something that exists on a remote already
+    for r in CHERRY_PICK_RE:
+        match = r.match(title)
+        if not match:
+            continue
+        primary = match.group('primary')
+        secondary = match.group('secondary')
+        if secondary:
+            secondary = UNPACK_SECONDARY_RE.match(secondary).groups()[0]
+        for candidate in [primary, secondary]:
+            original_remotes = remotes_for(candidate)
+            if not original_remotes:
+                continue
+            return security_level_for_remotes(original_remotes, name_to_remote), CLASS_2
+        break
+
+    # Class 3: We must inspect the commit for bug references
+    if REPOSITORY:
+        obj = Commit(hash=commit, message=message)
+        for issue in obj.issues:
+            if issue.redacted:
+                return 1, CLASS_3
+        return 0, CLASS_3
+
+    return None, None
+
+
+def main(name, remote):
+    target_security_level = security_level_for_remote(remote)
+    if VERBOSITY > QUIET:
+        if target_security_level:
+            print_tty('Pushing to {}, which is classified as a secure remote'.format(name or remote))
+        elif target_security_level == 0:
+            print_tty('Pushing to {}, which is classified as a public remote'.format(name or remote))
+        else:
+            print_tty('Pushing to {}, which has not classification. Treating it as a public remote'.format(name or remote))
+
+    to_push = []
+    for push in sys.stdin.readlines():
+        _, local_ref, _, remote_ref = push.split()
+        # Deletes are always safe
+        if local_ref == NULL_HASH:
+            continue
+        if remote_ref == NULL_HASH:
+            remote_ref = None
+        to_push.append((remote_ref, local_ref))
+    if not to_push:
+        if VERBOSITY > QUIET:
+            print_tty('No novel content being pushed')
+        return 0
+
+    remote_to_name, name_to_remote = remote_name_mappings()
+    if name == remote:
+        match = REMOTE_RE.match(remote)
+        if not match:
+            print_error("'{}' does not conform to a recognized target remote".format(remote))
+            return 255
+        name = remote_to_name.get('{}:{}'.format(match.group('host'), match.group('path')), None)
+        if not name:
+            print_error("Failed to map '{}' to an existing remote".format(remote))
+            return 1
+
+
+    remotes_with = {}
+    for from_ref, to_ref in to_push:
+        for commit in commits_in(from_ref, to_ref):
+            if commit not in remotes_with:
+                remotes_with[commit] = remotes_for(commit) or []
+            if remotes_with.get(commit):
+                # Any future commits (being ancestors of this one) will nessesarily be on the same remote this commit is
+                break
+    remotes_with = dict(filter(lambda pair: name not in pair[1], remotes_with.items()))
+
+    print_tty("Verifying commits in '{}' mode".format(MODE))
+    if VERBOSITY > QUIET:
+        print_tty('Attempting to push {} batch{} of commits to {}...'.format(len(to_push), '' if len(to_push) == 1 else 'es', name))
+
+    prompt_for = []
+    for commit, remotes in remotes_with.items():
+        security_level, categorization_class = security_level_for_commit(commit, remotes, name_to_remote=name_to_remote)
+
+        # Unkown security level of source
+        if categorization_class == 1 and security_level is None and not target_security_level:
+            print_error("'{}' comes from an uncategorized remote, it's not safe to push it publically".format(commit))
+            return 1
+        # Security level of source exceeds security level of target
+        if categorization_class == 1 and security_level > (target_security_level or 0):
+            print_error("'{}' comes from a more secure remote than '{}'".format(commit, name))
+            if MODE == PUBLISH_MODE:
+                prompt_for.append(commit)
+            else:
+                return 1
+
+        # Unknown security level from original of cherry-pick
+        if categorization_class == 2 and security_level is None and not target_security_level:
+            print_error("'{}' cherry-picks a change from an uncategorized remote, it's not safe to push it publically".format(commit))
+            return 1
+        # Security level of original of a cherry-pick exceeds security level of target
+        if categorization_class == 2 and security_level > (target_security_level or 0):
+            print_error("'{}' cherry-picks a change from a more secure remote than '{}'".format(commit, name))
+            if MODE == DEFAULT_MODE:
+                prompt_for.append(commit)
+            else:
+                return 1
+
+        # Commit is redacted, but we're pushing it publically
+        if categorization_class == 3 and (MAX_LEVEL if security_level is None else security_level) > (target_security_level or 0):
+            print_error("'{}' fixes a redacted issue, but '{}' is a public remote".format(commit, name))
+            if MODE == DEFAULT_MODE:
+                prompt_for.append(commit)
+            else:
+                return 1
+
+        if VERBOSITY >= VERBOSE:
+            print_tty('    {} is security level {} by class {}'.format(commit, security_level, categorization_class))
+
+    if prompt_for and not TTY:
+        print_tty('No TTY available for prompting user, rejecting push')
+        return 1
+
+    if prompt_for:
+        branches = sorted({[branch_for(commit) for commit in prompt_for]})
+        expected_response = 'publicize {}'.format(
+            branches[0] if len(branches) == 1
+            else '{}, and {}'.format(', '.join(branches[:-1]), branches[-1]),
+        )
+        print_tty('')
+        print_tty('We have detected you are about to publish security content to a public remote')
+        print_tty('Unless you are engaged in merge-back or fixing a security bug which has not shipped, you are likely making a mistake')
+        print_tty('')
+        sys.stdout.write('Type "{}" to continue with publication: '.format(expected_response))
+        sys.stdout.flush()
+        response = TTY.readline().rstrip()
+        if response != expected_response:
+            if response:
+                print_error('Response does not match prompt')
+            print_error('User failed to explicitly approve potentially dangerous push')
+            return 1
+        print_tty("User has explicitly approved potentially dangerous push, continuing...")
+
+    elif VERBOSITY > QUIET:
+        print_tty('Verified {} novel commit{} to {} are safe to push'.format(len(remotes_with), '' if len(remotes_with) == 1 else 's', name))
+
+    return 0
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main(*sys.argv[1:]))
+    except KeyboardInterrupt:
+        print_tty('')
+        print_error('User has canceled push')
+        sys.exit(1)
+

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.14.5',
+    version='6.0.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 14, 5)
+version = Version(6, 0, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -28,6 +28,7 @@ import time
 
 from datetime import datetime
 from mock import patch
+from collections import OrderedDict
 
 from webkitcorepy import decorators, mocks, string_utils, OutputCapture, StringIO
 from webkitscmpy import local, Commit, Contributor
@@ -54,7 +55,7 @@ class Git(mocks.Subprocess):
     ):
         self.path = path
         self.default_branch = default_branch
-        self.remote = remote or 'git@example.org:/mock/{}'.format(os.path.basename(path))
+        self.remote = remote or 'git@example.org:mock/{}'.format(os.path.basename(path))
         self.detached = detached or False
 
         self.tags = tags or {}
@@ -477,6 +478,14 @@ nothing to commit, working tree clean
                     mocks.ProcessCompletion(
                         returncode=0,
                         stdout='\n'.join(['{}={}'.format(key, value) for key, value in self.config().items()])
+                    ),
+            ), mocks.Subprocess.Route(
+                self.executable, 'config', '--get-regexp', re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs:
+                    mocks.ProcessCompletion(
+                        returncode=0,
+                        stdout='\n'.join(['{} {}'.format(key, value) for key, value in self.config().items() if key.startswith(args[3])])
                     ),
             ), mocks.Subprocess.Route(
                 self.executable, 'config', '-l', '--file', re.compile(r'.+'),
@@ -919,11 +928,11 @@ nothing to commit, working tree clean
     @decorators.hybridmethod
     def config(context, path=None):
         if isinstance(context, type):
-            return {
+            return OrderedDict({
                 'user.name': 'Tim Apple',
                 'user.email': 'tapple@webkit.org',
                 'sendemail.transferencoding': 'base64',
-            }
+            })
 
         top = None
         result = Git.config()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/publish.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/publish.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import collections
+import os
 import re
 import sys
 
@@ -225,6 +226,10 @@ class Publish(Command):
             sys.stderr.write("Publication canceled\n")
             return 1
 
+        push_env = os.environ.copy()
+        push_env['VERBOSITY'] = str(args.verbose)
+        push_env['PUSH_HOOK_MODE'] = 'publish'
+
         return_code = 0
         print('Pushing branches to {}...'.format(args.remote))
         command = [repository.executable(), 'push', '--atomic', args.remote] + [
@@ -235,6 +240,7 @@ class Publish(Command):
             command,
             cwd=repository.root_path,
             encoding='utf-8',
+            env=push_env,
         ).returncode:
             sys.stderr.write('Failed to push branches to {}\n'.format(args.remote))
             return_code += 1
@@ -247,6 +253,7 @@ class Publish(Command):
                 command,
                 cwd=repository.root_path,
                 encoding='utf-8',
+                env=push_env,
             ).returncode:
                 sys.stderr.write('Failed to push tags to {}\n'.format(args.remote))
                 return_code += 1

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -527,8 +527,11 @@ class PullRequest(Command):
             if did_remove:
                 pr_issue.set_labels(labels)
 
+        push_env = os.environ.copy()
+        push_env['VERBOSITY'] = str(args.verbose)
+
         log.info("Pushing '{}' to '{}'...".format(repository.branch, target))
-        if run([repository.executable(), 'push', '-f', target, repository.branch], cwd=repository.root_path).returncode:
+        if run([repository.executable(), 'push', '-f', target, repository.branch], cwd=repository.root_path, env=push_env).returncode:
             sys.stderr.write("Failed to push '{}' to '{}' (alias of '{}')\n".format(repository.branch, target, repository.url(name=target)))
             sys.stderr.write("Your checkout may be mis-configured, try re-running 'git-webkit setup' or\n")
             sys.stderr.write("your checkout may not have permission to push to '{}'\n".format(repository.url(name=target)))
@@ -536,7 +539,7 @@ class PullRequest(Command):
 
         if rebasing and target.endswith('fork') and repository.config().get('webkitscmpy.update-fork', 'false') == 'true':
             log.info("Syncing '{}' to remote '{}'".format(branch_point.branch, target))
-            if run([repository.executable(), 'push', target, '{branch}:{branch}'.format(branch=branch_point.branch)], cwd=repository.root_path).returncode:
+            if run([repository.executable(), 'push', target, '{branch}:{branch}'.format(branch=branch_point.branch)], cwd=repository.root_path, env=push_env).returncode:
                 sys.stderr.write("Failed to sync '{}' to '{}.' Error is non fatal, continuing...\n".format(branch_point.branch, target))
 
         if args.history or (target != source_remote and args.history is None and args.technique == 'overwrite'):
@@ -552,7 +555,7 @@ class PullRequest(Command):
                 repository.executable(), 'branch', history_branch, repository.branch,
             ], cwd=repository.root_path).returncode or run([
                 repository.executable(), 'push', '-f', target, history_branch,
-            ], cwd=repository.root_path).returncode:
+            ], cwd=repository.root_path, env=push_env).returncode:
                 sys.stderr.write("Failed to create and push '{}' to '{}'\n".format(history_branch, target))
                 return 1
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -413,7 +413,7 @@ CommitDate: {time_c}
 
             self.assertEqual(repo.config()['user.name'], 'Tim Apple')
             self.assertEqual(repo.config()['core.filemode'], 'true')
-            self.assertEqual(repo.config()['remote.origin.url'], 'git@example.org:/mock/repository')
+            self.assertEqual(repo.config()['remote.origin.url'], 'git@example.org:mock/repository')
             self.assertEqual(repo.config()['svn-remote.svn.url'], 'https://svn.example.org/repository/webkit')
             self.assertEqual(repo.config()['svn-remote.svn.fetch'], 'trunk:refs/remotes/origin/main')
             self.assertEqual(repo.config()['webkitscmpy.history'], 'when-user-owned')


### PR DESCRIPTION
#### 604395a516c13cff80d4b0400e43a4c322dbb32f
<pre>
[git-webkit] Add pre-push hook to prevent publication of security sensative commits
<a href="https://bugs.webkit.org/show_bug.cgi?id=253354">https://bugs.webkit.org/show_bug.cgi?id=253354</a>
rdar://106216593

Reviewed by Elliott Williams.

Write a pre-push hook to block or prompt the user in 3 situations to prevent the
inadvertent publication of security sensative commits:
- Class 1: A commit exists on a remote more secure than the one a contributor is pushing to
- Class 2: A commit is a cherry-pick of a commit from a more secure remote
- Class 3: The commit references a security bug the target remote is public

The goal of this hook is to prevent class 1 and 2 without relying on code in the checkout, while
class 3 relies on webkitbugspy to determine if a linked issue is redacted.

* Tools/Scripts/hooks/pre-push: Added.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git): Add `git config --get-regexp`
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clean.py:
(Clean.cleanup): Forward verbosity into `git push`.
(Clean.main): Ditto.
(DeletePRBranches.main): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py:
(Land.main): Forward verbosity into `git push`.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/publish.py:
(Publish.main): Change operating mode of our pre-push hook to allow class-1 security
publication with a prompt.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_pull_request): Forward verbosity into `git push`.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup._security_levels): Provide a security level for source and fork remotes based on
the order of our source remotes.
(Setup.git): Pass arguments to template for our pre-push hook.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:

Canonical link: <a href="https://commits.webkit.org/261526@main">https://commits.webkit.org/261526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3321a758674f10c12f603a1cc70a0546307ee061

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111964 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/21092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3728 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22441 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117724 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104985 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/115393 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/110715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/16006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4373 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->