### PR TITLE
[ iOS arm64 ] Multiple layout-tests need pixel tolerance adjustments for arm64 (253274)

### DIFF
--- a/LayoutTests/compositing/patterns/direct-pattern-compositing-add-text.html
+++ b/LayoutTests/compositing/patterns/direct-pattern-compositing-add-text.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=9-15" />
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=2-15" />
   <script type="text/javascript" charset="utf-8">
       function doTest()
       {

--- a/LayoutTests/compositing/patterns/direct-pattern-compositing-padding.html
+++ b/LayoutTests/compositing/patterns/direct-pattern-compositing-padding.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=45-80" />
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=11-80" />
   <style>
     .composited { -webkit-transform: translate3D(0, 0, 0); }
     .test {

--- a/LayoutTests/compositing/patterns/direct-pattern-compositing.html
+++ b/LayoutTests/compositing/patterns/direct-pattern-compositing.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=9-15" />
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=2-15" />
   <style>
     .composited { -webkit-transform: rotate3d(0, 0, 1, 0); }
     .test {

--- a/LayoutTests/fast/backgrounds/background-opaque-clipped-gradients.html
+++ b/LayoutTests/fast/backgrounds/background-opaque-clipped-gradients.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=7200-8000" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=7200-8400" />
 <style type="text/css" media="screen">
     #div1 {
         width: 100px;

--- a/LayoutTests/fast/backgrounds/scaled-gradient-background.html
+++ b/LayoutTests/fast/backgrounds/scaled-gradient-background.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=14500-15300" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=14500-16606" />
     <style>
     .box {
         position: absolute;

--- a/LayoutTests/fast/gradients/linear-two-hints.html
+++ b/LayoutTests/fast/gradients/linear-two-hints.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=14300-15100" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=14300-15400" />
     <style>
         #grad {
         	width: 200px;

--- a/LayoutTests/fast/gradients/radial-two-hints.html
+++ b/LayoutTests/fast/gradients/radial-two-hints.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=1500-1900" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=1500-2000" />
     <style>
     	div {
     		position: absolute;

--- a/LayoutTests/fast/images/async-image-background-image-repeated.html
+++ b/LayoutTests/fast/images/async-image-background-image-repeated.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=28300-29000" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=28300-31000" />
 <style>
     .box {
         height: 50px;

--- a/LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=115;totalPixels=28000-29000" />
     <style>
         video {
             position: absolute;

--- a/LayoutTests/fast/shadow-dom/svg-linear-gradient-dynamic-update-href-in-shadow-tree.html
+++ b/LayoutTests/fast/shadow-dom/svg-linear-gradient-dynamic-update-href-in-shadow-tree.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=3800-4000" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=3800-4400" />
 <style>
     #host {
         width: 100px;

--- a/LayoutTests/fast/shadow-dom/svg-linear-gradient-href-in-shadow-tree.html
+++ b/LayoutTests/fast/shadow-dom/svg-linear-gradient-href-in-shadow-tree.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=3800-4000" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=3800-4400" />
 <body>
 <p>Test passes if you see a single 100px by 100px green box below.</p>
 <div id="host" style="width: 100px; height: 100px;"></div>

--- a/LayoutTests/fast/shadow-dom/svg-radial-gradient-dynamic-update-href-in-shadow-tree.html
+++ b/LayoutTests/fast/shadow-dom/svg-radial-gradient-dynamic-update-href-in-shadow-tree.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=3800-4000" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=3800-4400" />
 <style>
     #host {
         width: 100px;

--- a/LayoutTests/fast/shadow-dom/svg-radial-gradient-href-in-shadow-tree.html
+++ b/LayoutTests/fast/shadow-dom/svg-radial-gradient-href-in-shadow-tree.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=3800-4000" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=3800-4400" />
 <body>
 <p>Test passes if you see a single 100px by 100px green box below.</p>
 <div id="host" style="width: 100px; height: 100px;"></div>

--- a/LayoutTests/imported/blink/fast/gradients/large-horizontal-gradient.html
+++ b/LayoutTests/imported/blink/fast/gradients/large-horizontal-gradient.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=30000-31500" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=30000-35000" />
     <title>Long horizontal gradient with left border.</title>
     <!-- This is a regression test for crbug.com/241486 -->
     <style>

--- a/LayoutTests/imported/blink/fast/gradients/large-vertical-gradient.html
+++ b/LayoutTests/imported/blink/fast/gradients/large-vertical-gradient.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=22700-23500" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=22700-26000" />
     <title>Long vertical gradient with top border.</title>
     <!-- This is a regression test for crbug.com/241486 -->
     <style>

--- a/LayoutTests/imported/blink/svg/custom/fill-fallback-currentcolor-1.svg
+++ b/LayoutTests/imported/blink/svg/custom/fill-fallback-currentcolor-1.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=3800-4000" />
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=3800-4400" />
   <linearGradient id="lg">
     <stop stop-color="#008000"/>
   </linearGradient>

--- a/LayoutTests/imported/blink/svg/text/obb-paintserver.html
+++ b/LayoutTests/imported/blink/svg/text/obb-paintserver.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-12411" />
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-12500" />
 <svg width="200" height="400">
   <linearGradient id="gradient" x1="0" x2="0" y1="0" y2="1">
     <stop offset="0" stop-color="green"/>

--- a/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-background-origin-text.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-background-origin-text.html
@@ -3,7 +3,7 @@
 <title>webkit-background-origin should not accept text as value</title>
 <link rel="author" title="Rob Buis" href="rob.buis@chromium.org">
 <link rel="match" href="webkit-background-origin-text-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
 <style>
 #target {
   width: 0px;

--- a/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-bottom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-bottom.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://compat.spec.whatwg.org/#css-gradients-webkit-linear-gradient">
 <meta name="assert" content="'bottom' in -webkit-linear-gradient is equivalent to 'to top' in modern syntax">
 <link rel="match" href="green-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
 <style>
   #outer {
     width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-left.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-left.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://compat.spec.whatwg.org/#css-gradients-webkit-linear-gradient">
 <meta name="assert" content="'left' in -webkit-linear-gradient is equivalent to 'to right' in modern syntax">
 <link rel="match" href="green-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
 <style>
   #outer {
     width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-4.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-4.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-4-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'repeat space' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7905">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8000">
     <style type="text/css">
       .outer {
         width: 96px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-5.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-5.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="background-repeat-space-5-ref.html">
     <meta name="assert" content="Test checks whether background-repeat: 'space repeat' works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-7950">
+    <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-8000">
     <style type="text/css">
       .outer {
         width: 106px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/linear-gradient-currentcolor-first-line.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/linear-gradient-currentcolor-first-line.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#first-line-background">
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#first-line-inheritance">
 <link rel="match" href="linear-gradient-currentcolor-first-line-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-244">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-300">
 <style>
   div { color: red; }
   div::first-line { color: green; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html
@@ -7,7 +7,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-images-3/#gradients">
     <meta name="assert" content="Correct placement and rendering of gradients inside elements with borders.">
     <link rel="match" href="gradients-with-border-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-10955">
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-11000">
     <style>
         .test {
             width: 200px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-mask-image.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-mask-image.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-mask-image-ref.html">
-<meta name=fuzzy content="1;22">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2">
 <style>
 div {
   width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#color-stop-syntax">
 <meta name="assert" content="A color stop with two positions create a hard transition">
 <link rel="match" href="reference/100x100-blue-green.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-3665">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
 <style>
 #target {
   width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-clip-exclude.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-clip-exclude.html
@@ -4,7 +4,7 @@
 <link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
 <link rel="author" href="https://mozilla.org" title="Mozilla">
 <link rel="match" href="mask-image-clip-exclude-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1764">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2000">
 <title>mask-image + mask-clip + mask-composite: exclude on different background boxes</title>
 <style>
 div {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html
@@ -9,7 +9,7 @@
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a
                                 simple linear gradient."/>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-8000"/>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-8700"/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
         .container {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html
@@ -9,7 +9,7 @@
     <meta name="flags" content="ahem"/>
     <meta name="assert" content="This test verifies that shape-outside respects a
                                 simple linear gradient on a right float."/>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-7917"/>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-8700"/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
         .container {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html
@@ -11,7 +11,7 @@
     <meta name="assert" content="This test verifies that shape-outside respects a
                                 simple linear gradient on a right float with
                                 shape-margin applied."/>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-7917"/>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-8700"/>
     <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
     <style type="text/css">
         .container {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/white-space-intrinsic-size-017.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/white-space-intrinsic-size-017.html
@@ -12,7 +12,7 @@
   <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-3958">
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
   <meta content="When 'white-space' is 'pre-wrap', preserved white spaces at the beginning and at the end of the line affect the intrinsic max-content size." name="assert">
 
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/white-space-intrinsic-size-018.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/white-space-intrinsic-size-018.html
@@ -12,7 +12,7 @@
   <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
 
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-3958">
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
   <meta content="When 'white-space' is 'pre', preserved white spaces at the beginning and at the end of the line affect the intrinsic max-content size." name="assert">
 
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/gradientTransform/svg-gradientTransform-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/gradientTransform/svg-gradientTransform-001.html
@@ -10,7 +10,7 @@
     <link rel="match" href="reference/svg-gradientTransform-ref.html">
     <meta name="flags" content="svg">
     <meta name="assert" content="The gradientTransform attribute must support functions with unit less arguments for translation-value. The gradient in the test should be moved 25 pixels in the X direction resulting in a solid green rect.">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
     <style type="text/css">
     svg {
         width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/gradientTransform/svg-gradientTransform-combination-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/gradientTransform/svg-gradientTransform-combination-001.html
@@ -9,7 +9,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-gradient-transform-pattern-transform">
     <meta name="flags" content="svg">
     <meta name="assert" content="The gradientTransform attribute must support multiple transform functions the same element. The gradient in the test should be moved 100 pixels in the X direction resulting in a solid green rect.">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-16000">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-18000">
     <style type="text/css">
     svg {
         width: 200px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/gradientTransform/svg-gradientTransform-combination-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/gradientTransform/svg-gradientTransform-combination-003.html
@@ -9,7 +9,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-gradient-transform-pattern-transform">
     <meta name="flags" content="svg">
     <meta name="assert" content="The gradientTransform attribute must support multiple transform functions in both directions. The gradient in the test should be moved 100 pixels in the X direction resulting in a solid green rect.">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-16000">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-18000">
     <style type="text/css">
     svg {
         width: 200px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-001.html
@@ -9,7 +9,7 @@
   <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 
   <meta name="flags" content="invalid">
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
 
   <style>
   div

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-002.html
@@ -9,7 +9,7 @@
   <link rel="help" href="https://www.w3.org/TR/CSS22/syndata.html#characters">
   <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
   <meta content="This test checks that 'deg' angle unit is case-insensitive." name="assert">
 
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-003.html
@@ -9,7 +9,7 @@
   <link rel="help" href="https://www.w3.org/TR/CSS22/syndata.html#characters">
   <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
   <meta content="This test checks that 'grad' angle unit is case-insensitive." name="assert">
 
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-004.html
@@ -9,7 +9,7 @@
   <link rel="help" href="https://www.w3.org/TR/CSS22/syndata.html#characters">
   <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
   <meta content="This test checks that 'rad' angle unit is case-insensitive." name="assert">
 
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-005.html
@@ -9,7 +9,7 @@
   <link rel="help" href="https://www.w3.org/TR/CSS22/syndata.html#characters">
   <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
   <meta content="This test checks that 'turn' angle unit is case-insensitive." name="assert">
 
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/vars-background-shorthand-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/vars-background-shorthand-001.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Lea Verou" href="mailto:lea@verou.me">
 <link rel="help" href="https://www.w3.org/TR/css-variables-1/#variables-in-shorthands">
 <link rel="match" href="reference/vars-background-shorthand-001-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-17900">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-20000">
 <style>
 div {
     width: 50px;

--- a/LayoutTests/platform/ios-simulator-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-simulator-wk2/TestExpectations
@@ -167,7 +167,3 @@ webkit.org/b/236926 webrtc/vp9-profile2.html [ Timeout Pass ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/adopt-from-image-document.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/242748 [ Release arm64 ] css3/color-filters/svg/color-filter-inline-svg.html [ ImageOnlyFailure ]
-
-#webkit.org/b/253274
-compositing/patterns/direct-pattern-compositing-add-text.html [ Pass ImageOnlyFailure ]
-compositing/patterns/direct-pattern-compositing-padding.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/svg/animations/animated-string-href.svg
+++ b/LayoutTests/svg/animations/animated-string-href.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-    <meta name="fuzzy" content="maxDifference=1; totalPixels=3800-4000" />
+    <meta name="fuzzy" content="maxDifference=1; totalPixels=3800-4400" />
     <desc>Test that the 'href' attribute is animated correctly.</desc>
     <defs>
         <linearGradient id="red-fill">

--- a/LayoutTests/svg/clip-path/clip-path-objectboundingbox-003.svg
+++ b/LayoutTests/svg/clip-path/clip-path-objectboundingbox-003.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-26" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-30" />
 <clipPath id="clip1" clipPathUnits="objectBoundingBox">
   <circle cx="0.25" cy="0.25" r="0.25"/>
 </clipPath>

--- a/LayoutTests/svg/custom/href-svg-namespace-static.svg
+++ b/LayoutTests/svg/custom/href-svg-namespace-static.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4000" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4400" />
     <defs>
         <linearGradient id="gradient1">
             <stop offset="0%" stop-color="green" />

--- a/LayoutTests/svg/custom/href-xlink-href-gradient-element.svg
+++ b/LayoutTests/svg/custom/href-xlink-href-gradient-element.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=30500-32000" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=30500-35000" />
     <defs>
         <linearGradient id="red-gradient">
             <stop offset="0%"  stop-color="red" />

--- a/LayoutTests/svg/custom/local-url-reference-fill.html
+++ b/LayoutTests/svg/custom/local-url-reference-fill.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=7650-7950" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=7650-8700" />
 <base href="http://www.example.com/">
 <svg>
     <linearGradient id="paint">

--- a/LayoutTests/svg/custom/local-url-reference-radial-gradient.html
+++ b/LayoutTests/svg/custom/local-url-reference-radial-gradient.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4000" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4400" />
 <base href="http://www.example.com/">
 <svg>
   <radialGradient id="radial">

--- a/LayoutTests/svg/custom/local-url-reference-srcdoc.html
+++ b/LayoutTests/svg/custom/local-url-reference-srcdoc.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4000" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4400" />
 <iframe srcdoc="
   <!DOCTYPE html>
   <style>body { margin: 0; }</style>

--- a/LayoutTests/svg/custom/local-url-reference-stroke.html
+++ b/LayoutTests/svg/custom/local-url-reference-stroke.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=1; totalPixels=7600-8000">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=7600-8700">
 <base href="http://www.example.com/">
 <svg>
     <linearGradient id="paint">

--- a/LayoutTests/svg/dynamic-updates/SVGLinearGradientElement-svgdom-href-prop.html
+++ b/LayoutTests/svg/dynamic-updates/SVGLinearGradientElement-svgdom-href-prop.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4000" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4400" />
 <style>
     #container {
         width: 100px;

--- a/LayoutTests/svg/dynamic-updates/SVGRadialGradientElement-svgdom-href-prop.html
+++ b/LayoutTests/svg/dynamic-updates/SVGRadialGradientElement-svgdom-href-prop.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4000" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4400" />
 <style>
     #container {
         width: 100px;

--- a/LayoutTests/svg/gradients/spreadMethod.svg
+++ b/LayoutTests/svg/gradients/spreadMethod.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=26000-28000" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=26000-30000" />
     <linearGradient id="base-grad" x1="0" y1="0" x2="50%" y2="0">
         <stop stop-color="green" offset="0"/>
         <stop stop-color="green" offset="0.5"/>

--- a/LayoutTests/svg/gradients/spreadMethodDiagonal.svg
+++ b/LayoutTests/svg/gradients/spreadMethodDiagonal.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=1;totalPixels=24900-25700" />
+    <meta name="fuzzy" content="maxDifference=1;totalPixels=24900-27000" />
     <linearGradient id="base-grad" x1="0" y1="0" x2="50%" y2="0">
         <stop stop-color="green" offset="0"/>
         <stop stop-color="green" offset="0.5"/>

--- a/LayoutTests/svg/gradients/spreadMethodDiagonal2.svg
+++ b/LayoutTests/svg/gradients/spreadMethodDiagonal2.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=1;totalPixels=24900-25700" />
+    <meta name="fuzzy" content="maxDifference=1;totalPixels=24900-27000" />
     <linearGradient id="base-grad" x1="0" y1="0" x2="0" y2="50%">
         <stop stop-color="green" offset="0"/>
         <stop stop-color="green" offset="0.5"/>

--- a/LayoutTests/svg/gradients/spreadMethodDuplicateStop.svg
+++ b/LayoutTests/svg/gradients/spreadMethodDuplicateStop.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=26000-27700" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=26000-30000" />
     <linearGradient id="base-grad" x1="0" y1="0" x2="0.5" y2="0">
         <stop stop-color="green" offset="0"/>
         <stop stop-color="green" offset="0.5"/>

--- a/LayoutTests/svg/gradients/spreadMethodReversed.svg
+++ b/LayoutTests/svg/gradients/spreadMethodReversed.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=27700-28100" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=27700-31000" />
     <linearGradient id="base-grad" x1="50%" y1="0" x2="0" y2="0">
         <stop stop-color="green" offset="0"/>
         <stop stop-color="green" offset="0.5"/>

--- a/LayoutTests/svg/gradients/stopAlpha.svg
+++ b/LayoutTests/svg/gradients/stopAlpha.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=18900-23500" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=18900-24000" />
     <linearGradient id="base-grad" x1="0" y1="0" x2="50%" y2="0">
         <stop stop-color="rgba(0,255,0,0.5)" offset="0" stop-opacity="0.5" />
         <stop stop-color="rgba(0,255,0,0.5)" offset="0.5" stop-opacity="0.5" />


### PR DESCRIPTION
#### 3ba1cd78db7a3e27f9552de26935afc8c1a02306
<pre>
[ iOS arm64 ] Multiple layout-tests need pixel tolerance adjustments for arm64 (253274)
<a href="https://bugs.webkit.org/show_bug.cgi?id=253274">https://bugs.webkit.org/show_bug.cgi?id=253274</a>
rdar://106167726

Unreviewed test gardening. Pixel tolerance adjustment for ASi Macs.

* LayoutTests/compositing/patterns/direct-pattern-compositing-add-text.html:
* LayoutTests/compositing/patterns/direct-pattern-compositing-padding.html:
* LayoutTests/compositing/patterns/direct-pattern-compositing.html:
* LayoutTests/fast/backgrounds/background-opaque-clipped-gradients.html:
* LayoutTests/fast/backgrounds/scaled-gradient-background.html:
* LayoutTests/fast/gradients/linear-two-hints.html:
* LayoutTests/fast/gradients/radial-two-hints.html:
* LayoutTests/fast/images/async-image-background-image-repeated.html:
* LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled.html:
* LayoutTests/fast/shadow-dom/svg-linear-gradient-dynamic-update-href-in-shadow-tree.html:
* LayoutTests/fast/shadow-dom/svg-linear-gradient-href-in-shadow-tree.html:
* LayoutTests/fast/shadow-dom/svg-radial-gradient-dynamic-update-href-in-shadow-tree.html:
* LayoutTests/fast/shadow-dom/svg-radial-gradient-href-in-shadow-tree.html:
* LayoutTests/imported/blink/fast/gradients/large-horizontal-gradient.html:
* LayoutTests/imported/blink/fast/gradients/large-vertical-gradient.html:
* LayoutTests/imported/blink/svg/custom/fill-fallback-currentcolor-1.svg:
* LayoutTests/imported/blink/svg/text/obb-paintserver.html:
* LayoutTests/imported/w3c/web-platform-tests/compat/webkit-background-origin-text.html:
* LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-bottom.html:
* LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-left.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-4.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-5.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/linear-gradient-currentcolor-first-line.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-mask-image.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-image-clip-exclude.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/white-space-intrinsic-size-017.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/white-space-intrinsic-size-018.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/gradientTransform/svg-gradientTransform-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/gradientTransform/svg-gradientTransform-combination-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/gradientTransform/svg-gradientTransform-combination-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/angle-units-005.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/vars-background-shorthand-001.html:
* LayoutTests/platform/ios-simulator-wk2/TestExpectations:
* LayoutTests/svg/animations/animated-string-href.svg:
* LayoutTests/svg/clip-path/clip-path-objectboundingbox-003.svg:
* LayoutTests/svg/custom/href-svg-namespace-static.svg:
* LayoutTests/svg/custom/href-xlink-href-gradient-element.svg:
* LayoutTests/svg/custom/local-url-reference-fill.html:
* LayoutTests/svg/custom/local-url-reference-radial-gradient.html:
* LayoutTests/svg/custom/local-url-reference-srcdoc.html:
* LayoutTests/svg/custom/local-url-reference-stroke.html:
* LayoutTests/svg/dynamic-updates/SVGLinearGradientElement-svgdom-href-prop.html:
* LayoutTests/svg/dynamic-updates/SVGRadialGradientElement-svgdom-href-prop.html:
* LayoutTests/svg/gradients/spreadMethod.svg:
* LayoutTests/svg/gradients/spreadMethodDiagonal.svg:
* LayoutTests/svg/gradients/spreadMethodDiagonal2.svg:
* LayoutTests/svg/gradients/spreadMethodDuplicateStop.svg:
* LayoutTests/svg/gradients/spreadMethodReversed.svg:
* LayoutTests/svg/gradients/stopAlpha.svg:

Canonical link: <a href="https://commits.webkit.org/261277@main">https://commits.webkit.org/261277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5706a393bc3a0125f1adb29aeb212093063eed0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119738 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/1996 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44293 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12542 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86176 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9079 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18500 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15044 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4275 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->