### PR TITLE
Move mainFrame, isMainFrame, and settings from Frame to AbstractFrame

### DIFF
--- a/Source/WebCore/page/AbstractFrame.cpp
+++ b/Source/WebCore/page/AbstractFrame.cpp
@@ -45,6 +45,8 @@ AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, HTMLFrameOwner
     , m_treeNode(*this, parentFrame(ownerElement))
     , m_windowProxy(WindowProxy::create(*this))
     , m_ownerElement(ownerElement)
+    , m_mainFrame(ownerElement ? page.mainFrame() : *this)
+    , m_settings(page.settings())
 {
     if (auto* parent = parentFrame(ownerElement))
         parent->tree().appendChild(*this);

--- a/Source/WebCore/page/AbstractFrame.h
+++ b/Source/WebCore/page/AbstractFrame.h
@@ -37,6 +37,7 @@ class AbstractDOMWindow;
 class AbstractFrameView;
 class HTMLFrameOwnerElement;
 class Page;
+class Settings;
 class WeakPtrImplWithEventTargetData;
 class WindowProxy;
 
@@ -54,6 +55,10 @@ public:
     FrameTree& tree() const { return m_treeNode; }
     FrameIdentifier frameID() const { return m_frameID; }
     inline Page* page() const; // Defined in Page.h.
+    Settings& settings() const { return m_settings.get(); }
+    AbstractFrame& mainFrame() const { return m_mainFrame; }
+    bool isMainFrame() const { return this == &m_mainFrame; }
+
     WEBCORE_EXPORT void detachFromPage();
     inline HTMLFrameOwnerElement* ownerElement() const; // Defined in HTMLFrameOwnerElement.h.
     WEBCORE_EXPORT void disconnectOwnerElement();
@@ -74,6 +79,8 @@ private:
     mutable FrameTree m_treeNode;
     Ref<WindowProxy> m_windowProxy;
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
+    AbstractFrame& m_mainFrame;
+    const Ref<Settings> m_settings;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -95,7 +95,6 @@ class RenderView;
 class RenderWidget;
 class ScriptController;
 class SecurityOrigin;
-class Settings;
 class VisiblePosition;
 class Widget;
 
@@ -138,9 +137,6 @@ public:
     void removeDestructionObserver(FrameDestructionObserver&);
 
     WEBCORE_EXPORT void willDetachPage();
-
-    AbstractFrame& mainFrame() const;
-    bool isMainFrame() const { return this == static_cast<void*>(&m_mainFrame); }
 
     Document* document() const;
     FrameView* view() const;
@@ -186,8 +182,6 @@ public:
     WEBCORE_EXPORT String trackedRepaintRectsAsText() const;
 
     WEBCORE_EXPORT static Frame* frameForWidget(const Widget&);
-
-    Settings& settings() const { return *m_settings; }
 
     WEBCORE_EXPORT void setPrinting(bool printing, const FloatSize& pageSize, const FloatSize& originalPageSize, float maximumShrinkRatio, AdjustViewSizeOrNot);
     bool shouldUsePrintingLayout() const;
@@ -313,8 +307,6 @@ private:
 
     Vector<std::pair<Ref<DOMWrapperWorld>, UniqueRef<UserScript>>> m_userScriptsAwaitingNotification;
 
-    AbstractFrame& m_mainFrame;
-    const RefPtr<Settings> m_settings;
     UniqueRef<FrameLoader> m_loader;
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;
 
@@ -374,11 +366,6 @@ inline FrameView* Frame::view() const
 inline Document* Frame::document() const
 {
     return m_doc.get();
-}
-
-inline AbstractFrame& Frame::mainFrame() const
-{
-    return m_mainFrame;
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, const Frame&);


### PR DESCRIPTION
#### e1a6b42e11b6d0b94a78c5a5bc391be355e79591
<pre>
Move mainFrame, isMainFrame, and settings from Frame to AbstractFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=253378">https://bugs.webkit.org/show_bug.cgi?id=253378</a>

Reviewed by Mark Lam.

Preparation for the main frame being a RemoteFrame in iframe processes.

* Source/WebCore/page/AbstractFrame.cpp:
(WebCore::AbstractFrame::AbstractFrame):
* Source/WebCore/page/AbstractFrame.h:
(WebCore::AbstractFrame::settings const):
(WebCore::AbstractFrame::mainFrame const):
(WebCore::AbstractFrame::isMainFrame const):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
(WebCore::Frame::~Frame):
(WebCore::Frame::requestDOMPasteAccess):
* Source/WebCore/page/Frame.h:
(WebCore::Frame::mainFrame const): Deleted.

Canonical link: <a href="https://commits.webkit.org/261223@main">https://commits.webkit.org/261223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ce7ee7dc0452374f2c64fa34ab7e6ca685f0027

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2342 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114875 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11156 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116666 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103393 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12574 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32102 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9075 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18533 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15072 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4252 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->