### PR TITLE
Implement ManagedMediaSource startstreaming/endstreaming event

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-streaming-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-streaming-expected.txt
@@ -1,0 +1,11 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+EVENT(startstreaming)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+EVENT(endstreaming)
+EVENT(startstreaming)
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-streaming.html
+++ b/LayoutTests/media/media-source/media-managedmse-streaming.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>managedmediasource-memoryPressure</title>
+    <script src="../../media/media-source/media-source-loader.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script src="../../media/utilities.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+    var gotBufferedChange = false;
+    var bufferedStart;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        try {
+            findMediaElement();
+
+            let manifests = [ 'content/test-opus-manifest.json', 'content/test-vorbis-manifest.json', 'content/test-48khz-manifest.json', 'content/test-xhe-aac-manifest.json' ];
+            for (const manifest of manifests) {
+                loader = new MediaSourceLoader(manifest);
+                await loaderPromise(loader);
+                if (ManagedMediaSource.isTypeSupported(loader.type()))
+                    break;
+            }
+
+            source = new ManagedMediaSource();
+            run('video.src = URL.createObjectURL(source)');
+            await Promise.all([waitFor(source, 'sourceopen'), waitFor(source, 'startstreaming') ]);
+            waitFor(video, 'error').then(failTest);
+
+            run('sourceBuffer = source.addSourceBuffer(loader.type())');
+
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+
+            var done = false;
+            waitForEventOnceOn(source, 'endstreaming', () => { done = true; });
+
+            do {
+                sourceBuffer.appendBuffer(loader.mediaSegment(0));
+                await once(sourceBuffer, 'update');
+                sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1);
+            } while (!done);
+
+            waitForEventOnceOn(source, 'startstreaming', endTest);
+
+            sourceBuffer.remove(video.currentTime, video.currentTime + 5);
+        } catch (e) {
+            failTest(`Caught exception: "${e}"`);
+        }
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -46,8 +46,14 @@ public:
     static bool isTypeSupported(ScriptExecutionContext&, const String& type);
 
     bool isManaged() const final { return true; }
+
 private:
     explicit ManagedMediaSource(ScriptExecutionContext&);
+    void monitorSourceBuffers() final;
+    bool isBuffered(const PlatformTimeRanges&) const;
+    void startStreaming();
+    void endStreaming();
+    bool m_streaming { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -209,6 +209,9 @@ void MediaSource::seekToTime(const MediaTime& time)
         // frame processing algorithm to set the HTMLMediaElement.readyState attribute to a value greater
         // than HAVE_METADATA.
         m_private->waitForSeekCompleted();
+
+        monitorSourceBuffers();
+
         return;
     }
     // ↳ Otherwise
@@ -1046,16 +1049,20 @@ void MediaSource::onReadyStateChange(ReadyState oldState, ReadyState newState)
 
     if (isOpen()) {
         scheduleEvent(eventNames().sourceopenEvent);
+        monitorSourceBuffers();
         return;
     }
 
     if (oldState == ReadyState::Open && newState == ReadyState::Ended) {
         scheduleEvent(eventNames().sourceendedEvent);
+        monitorSourceBuffers();
         return;
     }
 
     ASSERT(isClosed());
     scheduleEvent(eventNames().sourcecloseEvent);
+
+    monitorSourceBuffers();
 }
 
 Vector<PlatformTimeRanges> MediaSource::activeRanges() const

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -85,11 +85,7 @@ public:
 
     bool attachToElement(HTMLMediaElement&);
     void detachFromElement(HTMLMediaElement&);
-#if USE(GSTREAMER)
-    void monitorSourceBuffers() final;
-#else
-    void monitorSourceBuffers();
-#endif
+    void monitorSourceBuffers() override;
     bool isSeeking() const { return m_pendingSeekTime.isValid(); }
     Ref<TimeRanges> seekable();
     ExceptionOr<void> setLiveSeekableRange(double start, double end);
@@ -135,6 +131,12 @@ public:
 protected:
     explicit MediaSource(ScriptExecutionContext&);
 
+    bool hasBufferedTime(const MediaTime&);
+    bool hasCurrentTime();
+    bool hasFutureTime();
+
+    void scheduleEvent(const AtomString& eventName);
+
 private:
     // ActiveDOMObject.
     void stop() final;
@@ -157,11 +159,6 @@ private:
     Vector<PlatformTimeRanges> activeRanges() const;
 
     ExceptionOr<Ref<SourceBufferPrivate>> createSourceBufferPrivate(const ContentType&);
-    void scheduleEvent(const AtomString& eventName);
-
-    bool hasBufferedTime(const MediaTime&);
-    bool hasCurrentTime();
-    bool hasFutureTime();
 
     void regenerateActiveSourceBuffers();
     void updateBufferedIfNeeded();

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -629,6 +629,8 @@ void SourceBuffer::removeTimerFired()
 
         // 9. Queue a task to fire a simple event named updateend at this SourceBuffer object.
         scheduleEvent(eventNames().updateendEvent);
+
+        m_source->monitorSourceBuffers();
     });
 }
 
@@ -1380,8 +1382,10 @@ void SourceBuffer::memoryPressure()
     if (!isManaged())
         return;
     m_private->memoryPressure(maximumBufferSize(), m_source->currentTime(), m_source->isEnded(), [this, protectedThis = Ref { *this }] (bool bufferedChange) {
-        if (bufferedChange)
-            scheduleEvent(eventNames().bufferedchangeEvent);
+        if (!bufferedChange)
+            return;
+        scheduleEvent(eventNames().bufferedchangeEvent);
+        m_source->monitorSourceBuffers();
     });
 }
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -43,9 +43,7 @@ public:
     virtual MediaTime duration() const = 0;
     virtual std::unique_ptr<PlatformTimeRanges> buffered() const = 0;
     virtual void seekToTime(const MediaTime&) = 0;
-#if USE(GSTREAMER)
     virtual void monitorSourceBuffers() = 0;
-#endif
 
 #if !RELEASE_LOG_DISABLED
     virtual void setLogIdentifier(const void*) = 0;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -81,12 +81,10 @@ void RemoteMediaSourceProxy::seekToTime(const MediaTime& time)
     m_connectionToWebProcess->connection().send(Messages::MediaSourcePrivateRemote::SeekToTime(time), m_identifier);
 }
 
-#if USE(GSTREAMER)
 void RemoteMediaSourceProxy::monitorSourceBuffers()
 {
     notImplemented();
 }
-#endif
 
 #if !RELEASE_LOG_DISABLED
 void RemoteMediaSourceProxy::setLogIdentifier(const void*)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -66,9 +66,7 @@ public:
     MediaTime duration() const final;
     std::unique_ptr<WebCore::PlatformTimeRanges> buffered() const final;
     void seekToTime(const MediaTime&) final;
-#if USE(GSTREAMER)
     void monitorSourceBuffers() final;
-#endif
 
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(const void*) final;


### PR DESCRIPTION
#### 77fc3174bf28cd77b65c93acbdf27e622bc2fb3b
<pre>
Implement ManagedMediaSource startstreaming/endstreaming event
<a href="https://bugs.webkit.org/show_bug.cgi?id=253295">https://bugs.webkit.org/show_bug.cgi?id=253295</a>
rdar://106182027

Reviewed by Jer Noble and Youenn Fablet.

We set a low and high watermarks of respectively 10 and 30s ; we continuously
monitor currentTime progress to ensure that buffering is within those
two thresholds.
Upcoming change would make those configurable.

* LayoutTests/media/media-source/media-managedmse-streaming-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-streaming.html: Added.
* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::startStreaming):
(WebCore::ManagedMediaSource::endStreaming):
(WebCore::ManagedMediaSource::isBuffered const):
(WebCore::ManagedMediaSource::monitorSourceBuffers):
* Source/WebCore/Modules/mediasource/ManagedMediaSource.h:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::seekToTime):
(WebCore::MediaSource::onReadyStateChange):
(WebCore::MediaSource::updateBufferedIfNeeded):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::removeTimerFired):
(WebCore::SourceBuffer::memoryPressure):
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::monitorSourceBuffers):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:

Canonical link: <a href="https://commits.webkit.org/261232@main">https://commits.webkit.org/261232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6edd2fac8f27325731d049f2be9ea2238fec5043

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2026 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103361 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44308 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12576 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32104 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9086 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18534 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7794 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15073 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->