### PR TITLE
[JSC] VectorExtractLane+0 for f32x4 / f64x2 is nop

### DIFF
--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1215,5 +1215,7 @@ void testVectorXorAndAllOnesConstantToVectorOrXor(v128_t);
 void testVectorAndConstantConstant(v128_t, v128_t);
 void testVectorFmulByElementFloat();
 void testVectorFmulByElementDouble();
+void testVectorExtractLane0Float();
+void testVectorExtractLane0Double();
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -871,6 +871,8 @@ void run(const char* filter)
         RUN(testVectorOrSelf());
         RUN(testVectorAndSelf());
         RUN(testVectorXorSelf());
+        RUN(testVectorExtractLane0Float());
+        RUN(testVectorExtractLane0Double());
         RUN_UNARY(testVectorXorOrAllOnesConstantToVectorAndXor, v128Operands());
         RUN_UNARY(testVectorXorAndAllOnesConstantToVectorOrXor, v128Operands());
         RUN_BINARY(testVectorOrConstants, v128Operands(), v128Operands());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -2471,4 +2471,64 @@ void testVectorFmulByElementDouble()
     }
 }
 
+void testVectorExtractLane0Float()
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+
+    Value* address0 = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* input0 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address0);
+    root->appendNewControlValue(proc, Return, Origin(), root->appendNew<SIMDValue>(proc, Origin(), VectorExtractLane, B3::Float, SIMDLane::f32x4, SIMDSignMode::None, static_cast<uint8_t>(0), input0));
+
+    auto code = compileProc(proc);
+
+    auto checkFloat = [&](float a, float b) {
+        if (std::isnan(a))
+            CHECK(std::isnan(b));
+        else
+            CHECK(a == b);
+    };
+
+    for (auto& operand0 : floatingPointOperands<float>()) {
+        alignas(16) v128_t vector0;
+
+        vector0.f32x4[0] = operand0.value;
+        vector0.f32x4[1] = 1;
+        vector0.f32x4[2] = 2;
+        vector0.f32x4[3] = 3;
+
+        float result = invoke<float>(*code, &vector0);
+        checkFloat(result, operand0.value);
+    }
+}
+
+void testVectorExtractLane0Double()
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+
+    Value* address0 = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* input0 = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address0);
+    root->appendNewControlValue(proc, Return, Origin(), root->appendNew<SIMDValue>(proc, Origin(), VectorExtractLane, B3::Double, SIMDLane::f64x2, SIMDSignMode::None, static_cast<uint8_t>(0), input0));
+
+    auto code = compileProc(proc);
+
+    auto checkDouble = [&](double a, double b) {
+        if (std::isnan(a))
+            CHECK(std::isnan(b));
+        else
+            CHECK(a == b);
+    };
+
+    for (auto& operand0 : floatingPointOperands<double>()) {
+        alignas(16) v128_t vector0;
+
+        vector0.f64x2[0] = operand0.value;
+        vector0.f64x2[1] = 32;
+
+        double result = invoke<double>(*code, &vector0);
+        checkDouble(result, operand0.value);
+    }
+}
+
 #endif // ENABLE(B3_JIT)


### PR DESCRIPTION
#### bcf7195164fcec6f7da447a343d3adf2dcce7ecd
<pre>
[JSC] VectorExtractLane+0 for f32x4 / f64x2 is nop
<a href="https://bugs.webkit.org/show_bug.cgi?id=253381">https://bugs.webkit.org/show_bug.cgi?id=253381</a>
rdar://106226855

Reviewed by Mark Lam.

VectorExtractLane f32x4 / f64x2 for 0th lane is just Trunc operation.
Since both are FPReg, this is nop. We handle this in the same way to Trunc.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testVectorExtractLane0Float):
(testVectorExtractLane0Double):

Canonical link: <a href="https://commits.webkit.org/261227@main">https://commits.webkit.org/261227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/801b2b296671118d7f170887d7caec6b562e1a18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110912 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2340 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119764 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11153 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44346 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99528 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12572 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32101 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10690 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13125 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9073 "Found 1 new test failure: http/tests/misc/heic-accept-header.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100640 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18531 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31377 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15070 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108676 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4256 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26781 "Passed tests") | 
<!--EWS-Status-Bubble-End-->