### PR TITLE
[UI-side compositing] fast/scrolling/mac/async-scroll-overflow-top-inset.html fails

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
@@ -53,11 +53,10 @@ public:
     float frameScaleFactor() const { return m_frameScaleFactor; }
     int headerHeight() const { return m_headerHeight; }
     int footerHeight() const { return m_footerHeight; }
+    float topContentInset() const { return m_topContentInset; }
 
 protected:
     ScrollingTreeFrameScrollingNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
-
-    float topContentInset() const { return m_topContentInset; }
 
     FloatPoint minLayoutViewportOrigin() const { return m_minLayoutViewportOrigin; }
     FloatPoint maxLayoutViewportOrigin() const { return m_maxLayoutViewportOrigin; }

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp
@@ -49,17 +49,17 @@ FloatPoint ScrollingTreeScrollingNodeDelegate::lastCommittedScrollPosition() con
     return m_scrollingNode.lastCommittedScrollPosition();
 }
 
-const FloatSize& ScrollingTreeScrollingNodeDelegate::totalContentsSize()
+FloatSize ScrollingTreeScrollingNodeDelegate::totalContentsSize()
 {
     return m_scrollingNode.totalContentsSize();
 }
 
-const FloatSize& ScrollingTreeScrollingNodeDelegate::reachableContentsSize()
+FloatSize ScrollingTreeScrollingNodeDelegate::reachableContentsSize()
 {
     return m_scrollingNode.reachableContentsSize();
 }
 
-const IntPoint& ScrollingTreeScrollingNodeDelegate::scrollOrigin() const
+IntPoint ScrollingTreeScrollingNodeDelegate::scrollOrigin() const
 {
     return m_scrollingNode.scrollOrigin();
 }

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -59,10 +59,11 @@ public:
 
 protected:
     WEBCORE_EXPORT ScrollingTree& scrollingTree() const;
+
     WEBCORE_EXPORT FloatPoint lastCommittedScrollPosition() const;
-    WEBCORE_EXPORT const FloatSize& totalContentsSize();
-    WEBCORE_EXPORT const FloatSize& reachableContentsSize();
-    WEBCORE_EXPORT const IntPoint& scrollOrigin() const;
+    WEBCORE_EXPORT FloatSize totalContentsSize();
+    WEBCORE_EXPORT FloatSize reachableContentsSize();
+    WEBCORE_EXPORT IntPoint scrollOrigin() const;
 
     FloatPoint currentScrollPosition() const { return m_scrollingNode.currentScrollPosition(); }
     FloatPoint minimumScrollPosition() const { return m_scrollingNode.minimumScrollPosition(); }


### PR DESCRIPTION
#### c942c1f76a75b0149b02c6b2a14caed460fa167d
<pre>
[UI-side compositing] fast/scrolling/mac/async-scroll-overflow-top-inset.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=253382">https://bugs.webkit.org/show_bug.cgi?id=253382</a>
rdar://106115858

Reviewed by Tim Horton.

RemoteScrollingTreeMac::scrollingNodeForPoint() mistakenly offset the hit-testing point by
the scroll position because of a bug where RemoteScrollingTreeMac::scrollingTreeNodeDidScroll()
failed to call the base class, leaving m_mainFrameScrollPosition stale (the caller maps the
point through m_mainFrameScrollPosition) before we get here.

In addition, we have to do the same math used to position the root layer, which takes top
content inset and header height into account, so use `FrameView::positionForRootContentLayer()`
to do that.

Fixes fast/scrolling/mac/async-scroll-overflow-top-inset.html.

* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.cpp:
(WebCore::ScrollingTreeScrollingNodeDelegate::totalContentsSize):
(WebCore::ScrollingTreeScrollingNodeDelegate::reachableContentsSize):
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollOrigin const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingTreeMac::scrollingNodeForPoint):

Canonical link: <a href="https://commits.webkit.org/261289@main">https://commits.webkit.org/261289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ed4c878faff0c2ca57018155d5f199736ec47a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110981 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2410 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2068 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103465 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30814 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44403 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12638 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86311 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9130 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18598 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7825 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15131 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->