### PR TITLE
Add null checks needed to get site-isolated iframe to load with RemoteFrame as a Page's main frame

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -692,8 +692,6 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
     auto* topFrame = dynamicDowncast<LocalFrame>(m_frame->tree().top());
 
     ASSERT(m_frame->document());
-    ASSERT(topFrame);
-    ASSERT(topFrame->document());
     
     // Update cookie policy base URL as URL changes, except for subframes, which use the
     // URL of the main frame which doesn't change when we redirect.
@@ -715,7 +713,9 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
     if (isRedirectToGetAfterPost(m_request, newRequest))
         newRequest.clearHTTPOrigin();
 
-    if (topFrame != m_frame) {
+    // FIXME: Get mixed content checking working when the top frame is a RemoteFrame.
+    if (topFrame && topFrame != m_frame) {
+        ASSERT(topFrame->document());
         if (!MixedContentChecker::canDisplayInsecureContent(*m_frame, m_frame->document()->securityOrigin(), MixedContentChecker::ContentType::Active, newRequest.url(), MixedContentChecker::AlwaysDisplayInNonStrictMode::Yes)) {
             cancelMainResourceLoad(frameLoader()->cancelledError(newRequest));
             return completionHandler(WTFMove(newRequest));

--- a/Source/WebCore/loader/NavigationDisabler.h
+++ b/Source/WebCore/loader/NavigationDisabler.h
@@ -45,9 +45,10 @@ public:
     ~NavigationDisabler()
     {
         if (m_frame) {
-            auto& mainFrame = *dynamicDowncast<LocalFrame>(m_frame->mainFrame());
-            ASSERT(mainFrame.m_navigationDisableCount);
-            --mainFrame.m_navigationDisableCount;
+            if (auto* mainFrame = dynamicDowncast<LocalFrame>(m_frame->mainFrame())) {
+                ASSERT(mainFrame->m_navigationDisableCount);
+                --mainFrame->m_navigationDisableCount;
+            }
         } else {
             ASSERT(s_globalNavigationDisableCount);
             --s_globalNavigationDisableCount;
@@ -56,10 +57,9 @@ public:
 
     static bool isNavigationAllowed(Frame& frame)
     {
-        auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
-        if (localFrame)
+        if (auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame()))
             return !localFrame->m_navigationDisableCount && !s_globalNavigationDisableCount;
-        return false;
+        return true;
     }
 
 private:

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -416,7 +416,7 @@ void FocusController::setFocusedInternal(bool focused)
             setFocusedFrame(localMainFrame);
     }
 
-    if (m_focusedFrame->view()) {
+    if (m_focusedFrame && m_focusedFrame->view()) {
         m_focusedFrame->selection().setFocused(focused);
         dispatchEventsOnWindowAndFocusedElement(m_focusedFrame->document(), focused);
     }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1906,18 +1906,19 @@ auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
         document.prepareCanvasesForDisplayIfNeeded();
     });
 
-    ASSERT(localMainFrame);
-    ASSERT(!localMainFrame->view() || !localMainFrame->view()->needsLayout());
+    if (localMainFrame) {
+        ASSERT(!localMainFrame->view() || !localMainFrame->view()->needsLayout());
 #if ASSERT_ENABLED
-    for (AbstractFrame* child = localMainFrame->tree().firstRenderedChild(); child; child = child->tree().traverseNextRendered()) {
-        auto* localFrame = dynamicDowncast<LocalFrame>(child);
-        auto* frameView = localFrame->view();
-        ASSERT(!frameView || !frameView->needsLayout());
-    }
+        for (AbstractFrame* child = localMainFrame->tree().firstRenderedChild(); child; child = child->tree().traverseNextRendered()) {
+            auto* localFrame = dynamicDowncast<LocalFrame>(child);
+            auto* frameView = localFrame->view();
+            ASSERT(!frameView || !frameView->needsLayout());
+        }
 #endif
 
-    if (auto* view = localMainFrame->view())
-        view->notifyAllFramesThatContentAreaWillPaint();
+        if (auto* view = localMainFrame->view())
+            view->notifyAllFramesThatContentAreaWillPaint();
+    }
 
     if (!m_sampledPageTopColor) {
         m_sampledPageTopColor = PageColorSampler::sampleTop(*this);

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -108,12 +108,11 @@ WebLoaderStrategy::~WebLoaderStrategy()
 void WebLoaderStrategy::loadResource(Frame& frame, CachedResource& resource, ResourceRequest&& request, const ResourceLoaderOptions& options, CompletionHandler<void(RefPtr<SubresourceLoader>&&)>&& completionHandler)
 {
     if (resource.type() != CachedResource::Type::MainResource || !frame.isMainFrame()) {
-        auto* localMainFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
-        if (!localMainFrame)
-            return;
-        if (auto* document = localMainFrame->document()) {
-            if (document && document->loader())
-                request.setIsAppInitiated(document->loader()->lastNavigationWasAppInitiated());
+        if (auto* localMainFrame = dynamicDowncast<LocalFrame>(frame.mainFrame())) {
+            if (auto* document = localMainFrame->document()) {
+                if (document && document->loader())
+                    request.setIsAppInitiated(document->loader()->lastNavigationWasAppInitiated());
+            }
         }
     }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -297,8 +297,10 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
     auto size = m_webPage.size();
     FloatRect visibleRect(FloatPoint(), size);
-    if (auto exposedRect = m_webPage.mainFrameView()->viewExposedRect())
-        visibleRect.intersect(*exposedRect);
+    if (auto* mainFrameView = m_webPage.mainFrameView()) {
+        if (auto exposedRect = mainFrameView->viewExposedRect())
+            visibleRect.intersect(*exposedRect);
+    }
 
     OptionSet<FinalizeRenderingUpdateFlags> flags;
     if (m_nextRenderingUpdateRequiresSynchronousImageDecoding)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -112,7 +112,7 @@ static uint64_t generateListenerID()
     return uniqueListenerID++;
 }
 
-void WebFrame::initWithCoreMainFrame(WebPage& page, Frame& coreFrame, bool receivedMainFrameIdentifierFromUIProcess)
+void WebFrame::initWithCoreMainFrame(WebPage& page, AbstractFrame& coreFrame, bool receivedMainFrameIdentifierFromUIProcess)
 {
     ASSERT(!m_frameID);
     m_frameID = coreFrame.frameID();
@@ -124,7 +124,8 @@ void WebFrame::initWithCoreMainFrame(WebPage& page, Frame& coreFrame, bool recei
 
     m_coreFrame = coreFrame;
     m_coreFrame->tree().setName(nullAtom());
-    coreFrame.init();
+    if (auto* localFrame = dynamicDowncast<LocalFrame>(coreFrame))
+        localFrame->init();
 }
 
 Ref<WebFrame> WebFrame::createSubframe(WebPage& page, WebFrame& parent, const AtomString& frameName, HTMLFrameOwnerElement& ownerElement)
@@ -531,11 +532,7 @@ bool WebFrame::isFrameSet() const
 
 bool WebFrame::isMainFrame() const
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-    if (!localFrame)
-        return false;
-
-    return localFrame->isMainFrame();
+    return m_coreFrame && m_coreFrame->isMainFrame();
 }
 
 String WebFrame::name() const

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -79,7 +79,7 @@ public:
     static Ref<WebFrame> createSubframe(WebPage&, WebFrame& parent, const AtomString& frameName, WebCore::HTMLFrameOwnerElement&);
     ~WebFrame();
 
-    void initWithCoreMainFrame(WebPage&, WebCore::Frame&, bool receivedMainFrameIdentifierFromUIProcess);
+    void initWithCoreMainFrame(WebPage&, WebCore::AbstractFrame&, bool receivedMainFrameIdentifierFromUIProcess);
 
     // Called when the FrameLoaderClient (and therefore the WebCore::Frame) is being torn down.
     void invalidate();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -745,8 +745,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     // in modern WebKit.
     m_page->settings().setBackForwardCacheExpirationInterval(Seconds::infinity());
 
-    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
-        m_mainFrame->initWithCoreMainFrame(*this, *localMainFrame, receivedMainFrameIdentifierFromUIProcess);
+    m_mainFrame->initWithCoreMainFrame(*this, m_page->mainFrame(), receivedMainFrameIdentifierFromUIProcess);
 
     m_drawingArea->updatePreferences(parameters.store);
 
@@ -1983,6 +1982,10 @@ void WebPage::setSize(const WebCore::IntSize& viewSize)
     m_viewSize = viewSize;
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     FrameView* view = localMainFrame ? localMainFrame->view() : nullptr;
+    if (!view) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
 
     view->resize(viewSize);
     m_drawingArea->setNeedsDisplay();
@@ -6175,6 +6178,9 @@ static bool hasEnabledHorizontalScrollbar(ScrollableArea* scrollableArea)
 
 static bool pageContainsAnyHorizontalScrollbars(Frame* mainFrame)
 {
+    if (!mainFrame)
+        return false;
+
     if (FrameView* frameView = mainFrame->view()) {
         if (hasEnabledHorizontalScrollbar(frameView))
             return true;


### PR DESCRIPTION
#### 197b2532f73e0cdc0b14a23bbe28f7384a760eba
<pre>
Add null checks needed to get site-isolated iframe to load with RemoteFrame as a Page&apos;s main frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=253391">https://bugs.webkit.org/show_bug.cgi?id=253391</a>

Reviewed by Chris Dumez.

This is a bunch of seemingly randomly-located null checks that don&apos;t change behaviour
when site isolation is not turned on, and also don&apos;t do anything until a change I&apos;m about
to make comes and makes the main frame a RemoteFrame in an iframe&apos;s process.  Then,
these changes allow the load to happen and get to the drawing code, which still needs a
little work.  All calls to dynamicDowncast&lt;LocalFrame&gt; indicate code that needs to be
audited later.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/NavigationDisabler.h:
(WebCore::NavigationDisabler::~NavigationDisabler):
(WebCore::NavigationDisabler::isNavigationAllowed):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedInternal):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::doAfterUpdateRendering):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResource):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::initWithCoreMainFrame):
(WebKit::WebFrame::isMainFrame const):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::setSize):
(WebKit::pageContainsAnyHorizontalScrollbars):

Canonical link: <a href="https://commits.webkit.org/261271@main">https://commits.webkit.org/261271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e7cf3ff22147f376945586b741c2b98a0afccb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2383 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2050 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103432 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97909 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44371 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12615 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32129 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86294 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9108 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18573 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15109 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4270 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->