### PR TITLE
Revert [261125@main] [JSC] Stop eagerly emitting wide32 opcodes

### DIFF
--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -1526,9 +1526,9 @@ void BytecodeGenerator::emitJumpIfSentinelString(RegisterID* cond, Label& target
     OpJeqPtr::emit(this, cond, moveLinkTimeConstant(nullptr, LinkTimeConstant::sentinelString), target.bind(this));
 }
 
-unsigned BytecodeGenerator::emitJumpIfNotFunctionHasOwnProperty(RegisterID* cond, Label& target)
+unsigned BytecodeGenerator::emitWideJumpIfNotFunctionHasOwnProperty(RegisterID* cond, Label& target)
 {
-    OpJneqPtr::emit(this, cond, moveLinkTimeConstant(nullptr, LinkTimeConstant::hasOwnPropertyFunction), target.bind(this));
+    OpJneqPtr::emit<OpcodeSize::Wide32>(this, cond, moveLinkTimeConstant(nullptr, LinkTimeConstant::hasOwnPropertyFunction), target.bind(this));
     return m_lastInstruction.offset();
 }
 
@@ -1536,7 +1536,6 @@ void BytecodeGenerator::recordHasOwnPropertyInForInLoop(ForInContext& context, u
 {
     RELEASE_ASSERT(genericPath.isBound());
     RELEASE_ASSERT(!genericPath.isForward());
-    RELEASE_ASSERT((Fits<unsigned, OpcodeSize::Narrow>::check(genericPath.location() - branchOffset)));
     context.addHasOwnPropertyJump(branchOffset, genericPath.location());
 }
 
@@ -2607,21 +2606,13 @@ RegisterID* BytecodeGenerator::emitInstanceOfCustom(RegisterID* dst, RegisterID*
 
 RegisterID* BytecodeGenerator::emitInByVal(RegisterID* dst, RegisterID* property, RegisterID* base)
 {
-    kill(dst);
     for (size_t i = m_forInContextStack.size(); i--; ) {
         ForInContext& context = m_forInContextStack[i].get();
         if (context.local() != property)
             continue;
 
-        // Reserve a metadata ID if we need to de-optimize it later
-        auto metadataID = addMetadataFor(op_in_by_val);
-        if (Fits<unsigned, OpcodeSize::Narrow>::check(metadataID))
-            OpEnumeratorInByVal::emit(this, dst, base, context.mode(), property, context.propertyOffset(), context.enumerator());
-        else if (Fits<unsigned, OpcodeSize::Narrow>::check(metadataID))
-            OpEnumeratorInByVal::emitWithSmallestSizeRequirement<OpcodeSize::Wide16>(this, dst, base, context.mode(), property, context.propertyOffset(), context.enumerator());
-        else
-            OpEnumeratorInByVal::emit<OpcodeSize::Wide32>(this, dst, base, context.mode(), property, context.propertyOffset(), context.enumerator());
-        context.addInInst(m_lastInstruction.offset(), property->index(), metadataID);
+        OpEnumeratorInByVal::emit<OpcodeSize::Wide32>(this, dst, base, context.mode(), property, context.propertyOffset(), context.enumerator());
+        context.addInInst(m_lastInstruction.offset(), property->index());
         return dst;
     }
 
@@ -2769,15 +2760,9 @@ RegisterID* BytecodeGenerator::emitGetByVal(RegisterID* dst, RegisterID* base, R
         if (context.local() != property)
             continue;
 
-        // Reserve a metadata ID if we need to de-optimize it later
-        auto metadataID = addMetadataFor(op_get_by_val);
-        if (Fits<unsigned, OpcodeSize::Narrow>::check(metadataID))
-            OpEnumeratorGetByVal::emit(this, kill(dst), base, context.mode(), property, context.propertyOffset(), context.enumerator());
-        else if (Fits<unsigned, OpcodeSize::Narrow>::check(metadataID))
-            OpEnumeratorGetByVal::emitWithSmallestSizeRequirement<OpcodeSize::Wide16>(this, kill(dst), base, context.mode(), property, context.propertyOffset(), context.enumerator());
-        else
-            OpEnumeratorGetByVal::emit<OpcodeSize::Wide32>(this, kill(dst), base, context.mode(), property, context.propertyOffset(), context.enumerator());
-        context.addGetInst(m_lastInstruction.offset(), property->index(), metadataID);
+        // FIXME: We should have a better bytecode rewriter that can resize chunks.
+        OpEnumeratorGetByVal::emit<OpcodeSize::Wide32>(this, kill(dst), base, context.mode(), property, context.propertyOffset(), context.enumerator());
+        context.addGetInst(m_lastInstruction.offset(), property->index());
         return dst;
     }
 
@@ -5373,9 +5358,9 @@ ALWAYS_INLINE void rewriteOp(BytecodeGenerator& generator, TupleType& instTuple)
 {
     unsigned instIndex = std::get<0>(instTuple);
     int propertyRegIndex = std::get<1>(instTuple);
-    unsigned metadataID = std::get<2>(instTuple);
     auto instruction = generator.m_writer.ref(instIndex);
     auto end = instIndex + instruction->size();
+    ASSERT(instruction->isWide32());
 
     generator.m_writer.seek(instIndex);
 
@@ -5387,18 +5372,9 @@ ALWAYS_INLINE void rewriteOp(BytecodeGenerator& generator, TupleType& instTuple)
     // 1. dst stays the same.
     // 2. base stays the same.
     // 3. property gets switched to the original property.
+
     static_assert(sizeof(NewOpType) <= sizeof(OldOpType));
-    switch (instruction->width()) {
-    case OpcodeSize::Narrow:
-        NewOpType::template emit<OpcodeSize::Narrow, BytecodeGenerator>(&generator, bytecode.m_dst, bytecode.m_base, VirtualRegister(propertyRegIndex), metadataID);
-        break;
-    case OpcodeSize::Wide16:
-        NewOpType::template emit<OpcodeSize::Wide16, BytecodeGenerator>(&generator, bytecode.m_dst, bytecode.m_base, VirtualRegister(propertyRegIndex), metadataID);
-        break;
-    case OpcodeSize::Wide32:
-        NewOpType::template emit<OpcodeSize::Wide32, BytecodeGenerator>(&generator, bytecode.m_dst, bytecode.m_base, VirtualRegister(propertyRegIndex), metadataID);
-        break;
-    }
+    NewOpType::emit(&generator, bytecode.m_dst, bytecode.m_base, VirtualRegister(propertyRegIndex));
 
     // 4. nop out the remaining bytes
     while (generator.m_writer.position() < end)
@@ -5419,69 +5395,42 @@ void ForInContext::finalize(BytecodeGenerator& generator, UnlinkedCodeBlockGener
     // reassigned, or we'd have to resort to runtime checks to see if the variable had been
     // reassigned from its original value.
 
-    unsigned escaped = 0;
-    unsigned loopHintOffset = 0;
+    bool escaped = false;
     for (unsigned offset = bodyBytecodeStartOffset(); !escaped && offset < bodyBytecodeEndOffset;) {
         auto instruction = generator.instructions().at(offset);
         ASSERT(!instruction->is<OpEnter>());
-        if (instruction->is<OpLoopHint>()) {
-            if (!loopHintOffset)
-                loopHintOffset = offset;
-        } else {
-            for (Checkpoint checkpoint = instruction->numberOfCheckpoints(); checkpoint--;) {
-                computeDefsForBytecodeIndex(codeBlock, instruction.ptr(), checkpoint, [&] (VirtualRegister operand) {
-                    if (local()->virtualRegister() == operand)
-                        escaped = loopHintOffset ? loopHintOffset : offset;
-                });
-            }
-            if (escaped)
-                break;
+        for (Checkpoint checkpoint = instruction->numberOfCheckpoints(); checkpoint--;) {
+            computeDefsForBytecodeIndex(codeBlock, instruction.ptr(), checkpoint, [&] (VirtualRegister operand) {
+                if (local()->virtualRegister() == operand)
+                    escaped = true;
+            });
         }
         offset += instruction->size();
     }
 
-    for (const auto& instTuple : m_getInsts) {
-        unsigned offset = std::get<0>(instTuple);
-        if (escaped && offset < escaped)
-            continue;
-        rewriteOp<OpEnumeratorGetByVal, OpGetByVal>(generator, instTuple);
-    }
+    if (!escaped)
+        return;
 
-    for (const auto& instTuple : m_inInsts) {
-        unsigned offset = std::get<0>(instTuple);
-        if (escaped && offset < escaped)
-            continue;
+    for (const auto& instTuple : m_getInsts)
+        rewriteOp<OpEnumeratorGetByVal, OpGetByVal>(generator, instTuple);
+
+    for (const auto& instTuple : m_inInsts)
         rewriteOp<OpEnumeratorInByVal, OpInByVal>(generator, instTuple);
-    }
 
     for (const auto& hasOwnPropertyTuple : m_hasOwnPropertyJumpInsts) {
         static_assert(sizeof(OpJmp) <= sizeof(OpJneqPtr));
         unsigned branchInstIndex = std::get<0>(hasOwnPropertyTuple);
         unsigned newBranchTarget = std::get<1>(hasOwnPropertyTuple);
-        if (escaped && branchInstIndex < escaped)
-            continue;
 
         auto instruction = generator.m_writer.ref(branchInstIndex);
         RELEASE_ASSERT(instruction->is<OpJneqPtr>());
+        RELEASE_ASSERT(instruction->isWide32());
         auto end = branchInstIndex + instruction->size();
 
         generator.m_writer.seek(branchInstIndex);
         generator.disablePeepholeOptimization();
-        BoundLabel targetLabel(static_cast<int>(newBranchTarget) - static_cast<int>(branchInstIndex));
 
-#if ASSERT_ENABLED
-        bool didEmit = false;
-        OpcodeSize size = instruction->width();
-        if (static_cast<unsigned>(size) <= static_cast<unsigned>(OpcodeSize::Narrow))
-            didEmit = OpJmp::emit<OpcodeSize::Narrow, BytecodeGenerator, NoAssert, true>(&generator, targetLabel);
-        if (!didEmit && static_cast<unsigned>(size) <= static_cast<unsigned>(OpcodeSize::Wide16))
-            didEmit = OpJmp::emit<OpcodeSize::Wide16, BytecodeGenerator, NoAssert, true>(&generator, targetLabel);
-        if (!didEmit)
-            didEmit = OpJmp::emit<OpcodeSize::Wide32, BytecodeGenerator, Assert, true>(&generator, targetLabel);
-        ASSERT(didEmit);
-#else
-        OpJmp::emit(&generator, targetLabel);
-#endif
+        OpJmp::emit(&generator, BoundLabel(static_cast<int>(newBranchTarget) - static_cast<int>(branchInstIndex)));
 
         while (generator.m_writer.position() < end)
             OpNop::emit<OpcodeSize::Narrow>(&generator);

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -255,7 +255,7 @@ namespace JSC {
         WTF_MAKE_FAST_ALLOCATED;
         WTF_MAKE_NONCOPYABLE(ForInContext);
     public:
-        using GetInst = std::tuple<unsigned, int, unsigned>;
+        using GetInst = std::tuple<unsigned, int>;
         using InInst = GetInst;
         using HasOwnPropertyJumpInst = std::tuple<unsigned, unsigned>;
 
@@ -269,14 +269,14 @@ namespace JSC {
         RegisterID* mode() const { return m_mode.get(); }
         const std::optional<Variable>& baseVariable() const { return m_baseVariable; }
 
-        void addGetInst(unsigned instIndex, int propertyRegIndex, unsigned metadataID)
+        void addGetInst(unsigned instIndex, int propertyRegIndex)
         {
-            m_getInsts.append(GetInst { instIndex, propertyRegIndex, metadataID });
+            m_getInsts.append(GetInst { instIndex, propertyRegIndex });
         }
 
-        void addInInst(unsigned instIndex, int propertyRegIndex, unsigned metadataID)
+        void addInInst(unsigned instIndex, int propertyRegIndex)
         {
-            m_inInsts.append(InInst { instIndex, propertyRegIndex, metadataID });
+            m_inInsts.append(InInst { instIndex, propertyRegIndex });
         }
 
         void addHasOwnPropertyJump(unsigned branchInstIndex, unsigned genericPathTarget)
@@ -850,7 +850,7 @@ namespace JSC {
         void emitJumpIfNotFunctionApply(RegisterID* cond, Label& target);
         void emitJumpIfEmptyPropertyNameEnumerator(RegisterID* cond, Label& target);
         void emitJumpIfSentinelString(RegisterID* cond, Label& target);
-        unsigned emitJumpIfNotFunctionHasOwnProperty(RegisterID* cond, Label& target);
+        unsigned emitWideJumpIfNotFunctionHasOwnProperty(RegisterID* cond, Label& target);
         void recordHasOwnPropertyInForInLoop(ForInContext&, unsigned branchOffset, Label& genericPath);
 
         template<typename BinOp, typename JmpOp>

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -2297,7 +2297,7 @@ RegisterID* HasOwnPropertyFunctionCallDotNode::emitBytecode(BytecodeGenerator& g
         Ref<Label> realCall = generator.newLabel();
         Ref<Label> end = generator.newLabel();
 
-        unsigned branchInsnOffset = generator.emitJumpIfNotFunctionHasOwnProperty(function.get(), realCall.get());
+        unsigned branchInsnOffset = generator.emitWideJumpIfNotFunctionHasOwnProperty(function.get(), realCall.get());
         generator.emitEnumeratorHasOwnProperty(returnValue.get(), base.get(), context->mode(), generator.emitNode(argument), context->propertyOffset(), context->enumerator());
         generator.emitJump(end.get());
 


### PR DESCRIPTION
#### 42ab3c79e0cde0ef6dc5de5854d534d9c09587d7
<pre>
Revert [261125@main] [JSC] Stop eagerly emitting wide32 opcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=252891">https://bugs.webkit.org/show_bug.cgi?id=252891</a>
rdar://105876002

Unreviewed, revert 261125@main as it caused a 4% Speedometer regression.

* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitWideJumpIfNotFunctionHasOwnProperty):
(JSC::BytecodeGenerator::recordHasOwnPropertyInForInLoop):
(JSC::BytecodeGenerator::emitInByVal):
(JSC::BytecodeGenerator::emitGetByVal):
(JSC::rewriteOp):
(JSC::ForInContext::finalize):
(JSC::BytecodeGenerator::emitJumpIfNotFunctionHasOwnProperty): Deleted.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::ForInContext::addGetInst):
(JSC::ForInContext::addInInst):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::HasOwnPropertyFunctionCallDotNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/261229@main">https://commits.webkit.org/261229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df329303b439cc5b2d47c443adadcffeebf3d87e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2384 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119804 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11197 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103437 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99565 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12616 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/32130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10731 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9110 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100682 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18574 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31389 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/7791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15110 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108719 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4258 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26791 "Passed tests") | 
<!--EWS-Status-Bubble-End-->