### PR TITLE
[CoordinatedGraphics] Initialize WebCore::DisplayUpdate in ThreadedDisplayRefreshMonitor

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -56,7 +56,7 @@ ThreadedCompositor::ThreadedCompositor(Client& client, ThreadedDisplayRefreshMon
     : m_client(client)
     , m_paintFlags(paintFlags)
     , m_compositingRunLoop(makeUnique<CompositingRunLoop>([this] { renderLayerTree(); }))
-    , m_displayRefreshMonitor(ThreadedDisplayRefreshMonitor::create(displayID, displayRefreshMonitorClient))
+    , m_displayRefreshMonitor(ThreadedDisplayRefreshMonitor::create(displayID, displayRefreshMonitorClient, WebCore::DisplayUpdate { 0, c_defaultRefreshRate / 1000 }))
 {
     {
         // Locking isn't really necessary here, but it's done for consistency.

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.cpp
@@ -37,10 +37,11 @@
 
 namespace WebKit {
 
-ThreadedDisplayRefreshMonitor::ThreadedDisplayRefreshMonitor(WebCore::PlatformDisplayID displayID, Client& client)
+ThreadedDisplayRefreshMonitor::ThreadedDisplayRefreshMonitor(WebCore::PlatformDisplayID displayID, Client& client, WebCore::DisplayUpdate displayUpdate)
     : WebCore::DisplayRefreshMonitor(displayID)
     , m_displayRefreshTimer(RunLoop::main(), this, &ThreadedDisplayRefreshMonitor::displayRefreshCallback)
     , m_client(&client)
+    , m_displayUpdate(displayUpdate)
 {
 #if USE(GLIB_EVENT_LOOP)
     m_displayRefreshTimer.setPriority(RunLoopSourcePriority::DisplayRefreshMonitorTimer);

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.h
@@ -42,9 +42,9 @@ public:
         virtual void handleDisplayRefreshMonitorUpdate(bool) = 0;
     };
 
-    static Ref<ThreadedDisplayRefreshMonitor> create(WebCore::PlatformDisplayID displayID, Client& client)
+    static Ref<ThreadedDisplayRefreshMonitor> create(WebCore::PlatformDisplayID displayID, Client& client, WebCore::DisplayUpdate displayUpdate)
     {
-        return adoptRef(*new ThreadedDisplayRefreshMonitor(displayID, client));
+        return adoptRef(*new ThreadedDisplayRefreshMonitor(displayID, client, displayUpdate));
     }
     virtual ~ThreadedDisplayRefreshMonitor() = default;
 
@@ -55,7 +55,7 @@ public:
     void invalidate();
 
 private:
-    ThreadedDisplayRefreshMonitor(WebCore::PlatformDisplayID, Client&);
+    ThreadedDisplayRefreshMonitor(WebCore::PlatformDisplayID, Client&, WebCore::DisplayUpdate);
 
     bool startNotificationMechanism() final { return true; }
     void stopNotificationMechanism() final { }


### PR DESCRIPTION
#### 563893ba617934cdf2147bb814a0c2e40030f413
<pre>
[CoordinatedGraphics] Initialize WebCore::DisplayUpdate in ThreadedDisplayRefreshMonitor
<a href="https://bugs.webkit.org/show_bug.cgi?id=253393">https://bugs.webkit.org/show_bug.cgi?id=253393</a>

Unreviewed follow-up to 261124@main.

Construct the DisplayUpdate object in ThreadedCompositor based off of the
default refresh rate, and pass it on to the ThreadedDisplayRefreshMonitor
constructor where it&apos;s used to initialize the member variable, avoiding
division issues in certain cases where the object is left uninitialized but then
gets used during invalidation.

* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::m_displayRefreshMonitor):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.cpp:
(WebKit::ThreadedDisplayRefreshMonitor::ThreadedDisplayRefreshMonitor):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.h:
(WebKit::ThreadedDisplayRefreshMonitor::create):

Canonical link: <a href="https://commits.webkit.org/261228@main">https://commits.webkit.org/261228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c466921692b9044b2dc3354561ca7eac5ac06ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110960 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20099 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43527 "Failed to checkout and rebase branch from PR 11070") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2387 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119807 "Failed to checkout and rebase branch from PR 11070") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11200 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116712 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/15953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/43527 "Failed to checkout and rebase branch from PR 11070") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103439 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/97914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/43527 "Failed to checkout and rebase branch from PR 11070") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12619 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/43527 "Failed to checkout and rebase branch from PR 11070") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18577 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/43527 "Failed to checkout and rebase branch from PR 11070") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15113 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4257 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->