### PR TITLE
Optimize / Simplify HTMLFastPathParser::parseAttributes() a bit

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -827,24 +827,23 @@ private:
                 }
                 return didFail(HTMLFastPathResult::FailedParsingAttributes);
             }
-            if (attributeName.size() >= 2 && attributeName[0] == 'o' && attributeName[1] == 'n') {
+            if (attributeName.size() > 2 && attributeName[0] == 'o' && attributeName[1] == 'n') {
                 // These attributes likely contain script that may be executed at random
                 // points, which could cause problems if parsing via the fast path
                 // fails. For example, an image's onload event.
                 return didFail(HTMLFastPathResult::FailedOnAttribute);
             }
+            if (attributeName.size() == 2 && attributeName[0] == 'i' && attributeName[1] == 's')
+                return didFail(HTMLFastPathResult::FailedParsingAttributes);
             skipWhile<isHTMLSpace>(m_parsingBuffer);
             std::variant<LCharSpan, UCharSpan> attributeValue;
-            if (m_parsingBuffer.hasCharactersRemaining() && *m_parsingBuffer == '=') {
-                m_parsingBuffer.advance();
+            if (skipExactly(m_parsingBuffer, '=')) {
                 attributeValue = scanAttributeValue();
                 skipWhile<isHTMLSpace>(m_parsingBuffer);
             }
             auto attribute = processAttribute(attributeName, attributeValue);
-            m_attributeBuffer.append(attribute);
-            if (attribute.name() == HTMLNames::isAttr)
-                return didFail(HTMLFastPathResult::FailedParsingAttributes);
             m_attributeNames.append(attribute.localName().impl());
+            m_attributeBuffer.append(WTFMove(attribute));
         }
         std::sort(m_attributeNames.begin(), m_attributeNames.end());
         if (std::adjacent_find(m_attributeNames.begin(), m_attributeNames.end()) != m_attributeNames.end()) {


### PR DESCRIPTION
#### b9f99e9eaaa0a5fe071a66838744516070816501
<pre>
Optimize / Simplify HTMLFastPathParser::parseAttributes() a bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=253398">https://bugs.webkit.org/show_bug.cgi?id=253398</a>
rdar://106239527

Reviewed by Darin Adler.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseAttributes):

Canonical link: <a href="https://commits.webkit.org/261237@main">https://commits.webkit.org/261237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/696f8f9a2613d5c154b8e18e3dc149326f392380

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2394 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119812 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2058 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44385 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12625 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32137 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9118 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18583 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7796 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15119 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->