### PR TITLE
Ensure that [PKDeferredPaymentRequest setFreeCancellationDateTimeZone] exists before using it

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -336,6 +336,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^PKCanMakePaymentsCompletion)(BOOL isValid, NSError *);
 
+#if HAVE(PASSKIT_DEFERRED_PAYMENTS)
+@interface PKDeferredPaymentRequest (Staging_104652810)
+@property (nonatomic, strong, nullable) NSTimeZone *freeCancellationDateTimeZone;
+@end
+#endif
+
 NS_ASSUME_NONNULL_END
 
 #define PAL_PASSKIT_SPI_GUARD_AGAINST_INDIRECT_INCLUSION

--- a/Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm
@@ -48,7 +48,8 @@ RetainPtr<PKDeferredPaymentRequest> platformDeferredPaymentRequest(const ApplePa
         if (auto& freeCancellationDateTimeZone = webDeferredPaymentRequest.freeCancellationDateTimeZone; !freeCancellationDateTimeZone.isNull()) {
             if (auto timeZone = [NSTimeZone timeZoneWithName:freeCancellationDateTimeZone]) {
                 [pkDeferredPaymentRequest setFreeCancellationDate:[NSDate dateWithTimeIntervalSince1970:freeCancellationDate.secondsSinceEpoch().value()]];
-                [pkDeferredPaymentRequest setFreeCancellationDateTimeZone:timeZone];
+                if ([pkDeferredPaymentRequest respondsToSelector:@selector(setFreeCancellationDateTimeZone:)])
+                    [pkDeferredPaymentRequest setFreeCancellationDateTimeZone:timeZone];
             }
         }
     }


### PR DESCRIPTION
#### 633a76e240244003717981bfde7facde69c63f32
<pre>
Ensure that [PKDeferredPaymentRequest setFreeCancellationDateTimeZone] exists before using it
<a href="https://bugs.webkit.org/show_bug.cgi?id=253395">https://bugs.webkit.org/show_bug.cgi?id=253395</a>
rdar://106239467

Reviewed by Aditya Keerthi.

[PKDeferredPaymentRequest setFreeCancellationDateTimeZone] was added in a recent SDK, so we should ensure it&apos;s present before trying to use it.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:
* Source/WebKit/Shared/ApplePay/cocoa/DeferredPaymentRequestCocoa.mm:
(WebKit::platformDeferredPaymentRequest):

Canonical link: <a href="https://commits.webkit.org/261230@main">https://commits.webkit.org/261230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50ce460ce769770a6b4f2e8e1345b49230ad1134

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119816 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/114929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11211 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116723 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44386 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12629 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13176 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18587 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15123 "Failed to checkout and rebase branch from PR 11073") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4259 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->