### PR TITLE
image-decoders code fails to compile with -Wthread-safety-analysis

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -496,6 +496,7 @@ platform/graphics/mac/controls/WebControlView.mm
 platform/graphics/opentype/OpenTypeCG.cpp
 platform/image-decoders/avif/AVIFImageDecoder.cpp
 platform/image-decoders/avif/AVIFImageReader.cpp
+platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
 platform/image-decoders/ScalableImageDecoder.cpp
 platform/image-decoders/ScalableImageDecoderFrame.cpp
 platform/ios/ColorIOS.mm

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -348,7 +349,14 @@ JxlDecoderStatus JPEGXLImageDecoder::processInput(Query query)
 
 void JPEGXLImageDecoder::imageOutCallback(void* that, size_t x, size_t y, size_t numPixels, const void* pixels)
 {
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
     static_cast<JPEGXLImageDecoder*>(that)->imageOut(x, y, numPixels, static_cast<const uint8_t*>(pixels));
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 }
 
 void JPEGXLImageDecoder::imageOut(size_t x, size_t y, size_t numPixels, const uint8_t* pixels)
@@ -396,7 +404,7 @@ void JPEGXLImageDecoder::prepareColorTransform()
         return; // TODO(bugs.webkit.org/show_bug.cgi?id=234222): We should try to use encoded color profile if ICC profile is not available.
 
     // TODO(bugs.webkit.org/show_bug.cgi?id=234221): We should handle CMYK color but it may require two extra channels (Alpha and K)
-    // and libjxl has yet to support it. 
+    // and libjxl has yet to support it.
     if (cmsGetColorSpace(profile.get()) == cmsSigRgbData && cmsGetColorSpace(displayProfile) == cmsSigRgbData)
         m_iccTransform = LCMSTransformPtr(cmsCreateTransform(profile.get(), TYPE_BGRA_8, displayProfile, TYPE_BGRA_8, INTENT_RELATIVE_COLORIMETRIC, 0));
 }

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +30,7 @@
 
 #if USE(JPEGXL)
 
-#include <jxl/decode_cxx.h>
+#include "JxlDecoderPtr.h"
 
 #if USE(LCMS)
 #include "LCMSUniquePtr.h"
@@ -49,10 +50,10 @@ public:
 
     // ScalableImageDecoder
     String filenameExtension() const override { return "jxl"_s; }
-    size_t frameCount() const override;
+    size_t frameCount() const override WTF_REQUIRES_LOCK(m_lock);
     RepetitionCount repetitionCount() const override;
-    ScalableImageDecoderFrame* frameBufferAtIndex(size_t index) override;
-    void clearFrameBufferCache(size_t clearBeforeFrame) override;
+    ScalableImageDecoderFrame* frameBufferAtIndex(size_t index) override WTF_REQUIRES_LOCK(m_lock);
+    void clearFrameBufferCache(size_t clearBeforeFrame) override WTF_REQUIRES_LOCK(m_lock);
 
     bool setFailed() override;
 
@@ -72,7 +73,7 @@ private:
 
     void clear();
 
-    void tryDecodeSize(bool allDataReceived) override;
+    void tryDecodeSize(bool allDataReceived) override WTF_REQUIRES_LOCK(m_lock);
 
     bool hasAlpha() const;
     bool hasAnimation() const;
@@ -80,12 +81,12 @@ private:
     void ensureDecoderInitialized();
     bool shouldRewind(Query , size_t frameIndex) const;
     void rewind();
-    void updateFrameCount();
+    void updateFrameCount() WTF_REQUIRES_LOCK(m_lock);
 
-    void decode(Query, size_t frameIndex, bool allDataReceived);
-    JxlDecoderStatus processInput(Query);
+    void decode(Query, size_t frameIndex, bool allDataReceived) WTF_REQUIRES_LOCK(m_lock);
+    JxlDecoderStatus processInput(Query) WTF_REQUIRES_LOCK(m_lock);
     static void imageOutCallback(void*, size_t x, size_t y, size_t numPixels, const void* pixels);
-    void imageOut(size_t x, size_t y, size_t numPixels, const uint8_t* pixels);
+    void imageOut(size_t x, size_t y, size_t numPixels, const uint8_t* pixels) WTF_REQUIRES_LOCK(m_lock);
 
 #if USE(LCMS)
     void clearColorTransform();

--- a/Source/WebCore/platform/image-decoders/jpegxl/JxlDecoderPtr.h
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JxlDecoderPtr.h
@@ -1,0 +1,90 @@
+/*
+* Copyright (C) 2021 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#if USE(JPEGXL)
+
+#include <algorithm>
+#include <jxl/decode.h>
+
+class JxlDecoderPtr {
+public:
+    JxlDecoderPtr() = default;
+
+    JxlDecoderPtr(JxlDecoder* decoder)
+        : m_decoder(decoder)
+    {
+    }
+
+    JxlDecoderPtr(const JxlDecoderPtr&) = delete;
+
+    JxlDecoderPtr(JxlDecoderPtr&& other)
+        : m_decoder(other.m_decoder)
+    {
+        other.m_decoder = nullptr;
+    }
+
+    JxlDecoderPtr& operator=(const JxlDecoderPtr&) = delete;
+
+    JxlDecoderPtr& operator=(JxlDecoderPtr&& other)
+    {
+        reset();
+        std::swap(m_decoder, other.m_decoder);
+        return *this;
+    }
+
+    ~JxlDecoderPtr()
+    {
+        reset();
+    }
+
+    void reset()
+    {
+        if (m_decoder)
+            JxlDecoderDestroy(m_decoder);
+        m_decoder = nullptr;
+    }
+
+    operator bool() const
+    {
+        return m_decoder;
+    }
+
+    JxlDecoder* get() const
+    {
+        return m_decoder;
+    }
+
+private:
+    JxlDecoder* m_decoder { nullptr };
+};
+
+static inline JxlDecoderPtr JxlDecoderMake(const JxlMemoryManager* memoryManager)
+{
+    return JxlDecoderPtr(JxlDecoderCreate(memoryManager));
+}
+
+#endif // USE(JPEGXL)


### PR DESCRIPTION
#### 121ab62cae80a9f4b937c0cc4c3633ae52502dad
<pre>
image-decoders code fails to compile with -Wthread-safety-analysis
<a href="https://bugs.webkit.org/show_bug.cgi?id=253397">https://bugs.webkit.org/show_bug.cgi?id=253397</a>
rdar://106239523

Reviewed by Simon Fraser.

This patch mostly adds WTF_REQUIRES_LOCK() annotations to places that need it.

It also switches out use of C++ API to C API, for binary compatibility.

No test because there is no behavior change.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp:
(WebCore::JPEGXLImageDecoder::imageOutCallback):
(WebCore::JPEGXLImageDecoder::prepareColorTransform):
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h:
* Source/WebCore/platform/image-decoders/jpegxl/JxlDecoderRAII.h: Added.
(JxlDecoderPtr::JxlDecoderPtr):
(JxlDecoderPtr::operator=):
(JxlDecoderPtr::~JxlDecoderPtr):
(JxlDecoderPtr::reset):
(JxlDecoderPtr::operator bool const):
(JxlDecoderPtr::get const):
(JxlDecoderMake):

Canonical link: <a href="https://commits.webkit.org/261240@main">https://commits.webkit.org/261240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65f964e5c917c50a293a01637963c3402b63d2df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2413 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2071 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44405 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12642 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32151 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9133 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18602 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7798 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15135 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->