### PR TITLE
Use modern constexpr instead of traits in SelectorQuery.cpp

### DIFF
--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -56,6 +56,15 @@ enum class IdMatchingType : uint8_t {
     Filter
 };
 
+template<typename Output> static ALWAYS_INLINE void appendOutputForElement(Output& output, Element& element)
+{
+    if constexpr (std::is_same_v<Output, Element*>) {
+        ASSERT(!output);
+        output = &element;
+    } else
+        output.append(element);
+}
+
 static bool canBeUsedForIdFastPath(const CSSSelector& selector)
 {
     return selector.match() == CSSSelector::Id
@@ -159,34 +168,17 @@ Element* SelectorDataList::closest(Element& targetElement) const
     return nullptr;
 }
 
-struct AllElementExtractorSelectorQueryTrait {
-    typedef Vector<Ref<Element>> OutputType;
-    static const bool shouldOnlyMatchFirstElement = false;
-    ALWAYS_INLINE static void appendOutputForElement(OutputType& output, Element* element) { ASSERT(element); output.append(*element); }
-};
-
 Ref<NodeList> SelectorDataList::queryAll(ContainerNode& rootNode) const
 {
     Vector<Ref<Element>> result;
-    execute<AllElementExtractorSelectorQueryTrait>(rootNode, result);
+    execute(rootNode, result);
     return StaticElementList::create(WTFMove(result));
 }
-
-struct SingleElementExtractorSelectorQueryTrait {
-    typedef Element* OutputType;
-    static const bool shouldOnlyMatchFirstElement = true;
-    ALWAYS_INLINE static void appendOutputForElement(OutputType& output, Element* element)
-    {
-        ASSERT(element);
-        ASSERT(!output);
-        output = element;
-    }
-};
 
 Element* SelectorDataList::queryFirst(ContainerNode& rootNode) const
 {
     Element* result = nullptr;
-    execute<SingleElementExtractorSelectorQueryTrait>(rootNode, result);
+    execute(rootNode, result);
     return result;
 }
 
@@ -207,13 +199,8 @@ static const CSSSelector* selectorForIdLookup(const ContainerNode& rootNode, con
     return nullptr;
 }
 
-static inline bool isTreeScopeRoot(const ContainerNode& node)
-{
-    return node.isDocumentNode() || node.isShadowRoot();
-}
-
-template <typename SelectorQueryTrait>
-ALWAYS_INLINE void SelectorDataList::executeFastPathForIdSelector(const ContainerNode& rootNode, const SelectorData& selectorData, const CSSSelector* idSelector, typename SelectorQueryTrait::OutputType& output) const
+template<typename OutputType>
+ALWAYS_INLINE void SelectorDataList::executeFastPathForIdSelector(const ContainerNode& rootNode, const SelectorData& selectorData, const CSSSelector* idSelector, OutputType& output) const
 {
     ASSERT(m_selectors.size() == 1);
     ASSERT(idSelector);
@@ -222,11 +209,11 @@ ALWAYS_INLINE void SelectorDataList::executeFastPathForIdSelector(const Containe
     if (UNLIKELY(rootNode.treeScope().containsMultipleElementsWithId(idToMatch))) {
         const Vector<Element*>* elements = rootNode.treeScope().getAllElementsById(idToMatch);
         ASSERT(elements);
-        bool rootNodeIsTreeScopeRoot = isTreeScopeRoot(rootNode);
+        bool rootNodeIsTreeScopeRoot = rootNode.isTreeScope();
         for (auto& element : *elements) {
             if ((rootNodeIsTreeScopeRoot || element->isDescendantOf(rootNode)) && selectorMatches(selectorData, *element, rootNode)) {
-                SelectorQueryTrait::appendOutputForElement(output, element);
-                if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+                appendOutputForElement(output, *element);
+                if constexpr (std::is_same_v<OutputType, Element*>)
                     return;
             }
         }
@@ -234,10 +221,10 @@ ALWAYS_INLINE void SelectorDataList::executeFastPathForIdSelector(const Containe
     }
 
     Element* element = rootNode.treeScope().getElementById(idToMatch);
-    if (!element || !(isTreeScopeRoot(rootNode) || element->isDescendantOf(rootNode)))
+    if (!element || !(rootNode.isTreeScope() || element->isDescendantOf(rootNode)))
         return;
     if (selectorMatches(selectorData, *element, rootNode))
-        SelectorQueryTrait::appendOutputForElement(output, element);
+        appendOutputForElement(output, *element);
 }
 
 static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector& firstSelector)
@@ -265,17 +252,14 @@ static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector&
                 if (LIKELY(!rootNode.treeScope().containsMultipleElementsWithId(idToMatch))) {
                     if (inAdjacentChain)
                         searchRoot = searchRoot->parentNode();
-                    if (searchRoot && (isTreeScopeRoot(rootNode) || searchRoot == &rootNode || searchRoot->isDescendantOf(rootNode)))
+                    if (searchRoot && (rootNode.isTreeScope() || searchRoot == &rootNode || searchRoot->isDescendantOf(rootNode)))
                         return *searchRoot;
                 }
             }
         }
         if (selector->relation() == CSSSelector::Subselector)
             continue;
-        if (selector->relation() == CSSSelector::DirectAdjacent || selector->relation() == CSSSelector::IndirectAdjacent)
-            inAdjacentChain = true;
-        else
-            inAdjacentChain = false;
+        inAdjacentChain = selector->relation() == CSSSelector::DirectAdjacent || selector->relation() == CSSSelector::IndirectAdjacent;
     }
     return rootNode;
 }
@@ -288,41 +272,41 @@ static ALWAYS_INLINE bool localNameMatches(const Element& element, const AtomStr
 
 }
 
-template <typename SelectorQueryTrait>
-static inline void elementsForLocalName(const ContainerNode& rootNode, const AtomString& localName, const AtomString& lowercaseLocalName, typename SelectorQueryTrait::OutputType& output)
+template<typename OutputType>
+static inline void elementsForLocalName(const ContainerNode& rootNode, const AtomString& localName, const AtomString& lowercaseLocalName, OutputType& output)
 {
     if (localName == lowercaseLocalName) {
         for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(rootNode))) {
             if (element.tagQName().localName() == localName) {
-                SelectorQueryTrait::appendOutputForElement(output, &element);
-                if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+                appendOutputForElement(output, element);
+                if constexpr (std::is_same_v<OutputType, Element*>)
                 return;
             }
         }
     } else {
         for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(rootNode))) {
             if (localNameMatches(element, localName, lowercaseLocalName)) {
-                SelectorQueryTrait::appendOutputForElement(output, &element);
-                if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+                appendOutputForElement(output, element);
+                if constexpr (std::is_same_v<OutputType, Element*>)
                 return;
             }
         }
     }
 }
 
-template <typename SelectorQueryTrait>
-static inline void anyElement(const ContainerNode& rootNode, typename SelectorQueryTrait::OutputType& output)
+template<typename OutputType>
+static inline void anyElement(const ContainerNode& rootNode, OutputType& output)
 {
     for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(rootNode))) {
-        SelectorQueryTrait::appendOutputForElement(output, &element);
-        if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+        appendOutputForElement(output, element);
+        if constexpr (std::is_same_v<OutputType, Element*>)
             return;
     }
 }
 
 
-template <typename SelectorQueryTrait>
-ALWAYS_INLINE void SelectorDataList::executeSingleTagNameSelectorData(const ContainerNode& rootNode, const SelectorData& selectorData, typename SelectorQueryTrait::OutputType& output) const
+template<typename OutputType>
+ALWAYS_INLINE void SelectorDataList::executeSingleTagNameSelectorData(const ContainerNode& rootNode, const SelectorData& selectorData, OutputType& output) const
 {
     ASSERT(m_selectors.size() == 1);
     ASSERT(isSingleTagNameSelector(*selectorData.selector));
@@ -335,25 +319,25 @@ ALWAYS_INLINE void SelectorDataList::executeSingleTagNameSelectorData(const Cont
     if (selectorNamespaceURI == starAtom()) {
         if (selectorLocalName != starAtom()) {
             // Common case: name defined, selectorNamespaceURI is a wildcard.
-            elementsForLocalName<SelectorQueryTrait>(rootNode, selectorLocalName, selectorLowercaseLocalName, output);
+            elementsForLocalName(rootNode, selectorLocalName, selectorLowercaseLocalName, output);
         } else {
             // Other fairly common case: both are wildcards.
-            anyElement<SelectorQueryTrait>(rootNode, output);
+            anyElement(rootNode, output);
         }
     } else {
         // Fallback: NamespaceURI is set, selectorLocalName may be starAtom().
         for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(rootNode))) {
             if (element.namespaceURI() == selectorNamespaceURI && localNameMatches(element, selectorLocalName, selectorLowercaseLocalName)) {
-                SelectorQueryTrait::appendOutputForElement(output, &element);
-                if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+                appendOutputForElement(output, element);
+                if constexpr (std::is_same_v<OutputType, Element*>)
                     return;
             }
         }
     }
 }
 
-template <typename SelectorQueryTrait>
-ALWAYS_INLINE void SelectorDataList::executeSingleClassNameSelectorData(const ContainerNode& rootNode, const SelectorData& selectorData, typename SelectorQueryTrait::OutputType& output) const
+template<typename OutputType>
+ALWAYS_INLINE void SelectorDataList::executeSingleClassNameSelectorData(const ContainerNode& rootNode, const SelectorData& selectorData, OutputType& output) const
 {
     ASSERT(m_selectors.size() == 1);
     ASSERT(isSingleClassNameSelector(*selectorData.selector));
@@ -361,35 +345,35 @@ ALWAYS_INLINE void SelectorDataList::executeSingleClassNameSelectorData(const Co
     const AtomString& className = selectorData.selector->value();
     for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(rootNode))) {
         if (element.hasClass() && element.classNames().contains(className)) {
-            SelectorQueryTrait::appendOutputForElement(output, &element);
-            if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+            appendOutputForElement(output, element);
+            if constexpr (std::is_same_v<OutputType, Element*>)
                 return;
         }
     }
 }
 
-template <typename SelectorQueryTrait>
-ALWAYS_INLINE void SelectorDataList::executeSingleSelectorData(const ContainerNode& rootNode, const ContainerNode& searchRootNode, const SelectorData& selectorData, typename SelectorQueryTrait::OutputType& output) const
+template<typename OutputType>
+ALWAYS_INLINE void SelectorDataList::executeSingleSelectorData(const ContainerNode& rootNode, const ContainerNode& searchRootNode, const SelectorData& selectorData, OutputType& output) const
 {
     ASSERT(m_selectors.size() == 1);
 
     for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(searchRootNode))) {
         if (selectorMatches(selectorData, element, rootNode)) {
-            SelectorQueryTrait::appendOutputForElement(output, &element);
-            if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+            appendOutputForElement(output, element);
+            if constexpr (std::is_same_v<OutputType, Element*>)
                 return;
         }
     }
 }
 
-template <typename SelectorQueryTrait>
-ALWAYS_INLINE void SelectorDataList::executeSingleMultiSelectorData(const ContainerNode& rootNode, typename SelectorQueryTrait::OutputType& output) const
+template<typename OutputType>
+ALWAYS_INLINE void SelectorDataList::executeSingleMultiSelectorData(const ContainerNode& rootNode, OutputType& output) const
 {
     for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(rootNode))) {
         for (auto& selector : m_selectors) {
             if (selectorMatches(selector, element, rootNode)) {
-                SelectorQueryTrait::appendOutputForElement(output, &element);
-                if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+                appendOutputForElement(output, element);
+                if constexpr (std::is_same_v<OutputType, Element*>)
                     return;
                 break;
             }
@@ -398,22 +382,22 @@ ALWAYS_INLINE void SelectorDataList::executeSingleMultiSelectorData(const Contai
 }
 
 #if ENABLE(CSS_SELECTOR_JIT)
-template <typename SelectorQueryTrait, typename Checker>
-ALWAYS_INLINE void SelectorDataList::executeCompiledSimpleSelectorChecker(const ContainerNode& searchRootNode, Checker selectorChecker, typename SelectorQueryTrait::OutputType& output, const SelectorData& selectorData) const
+template<typename Checker, typename OutputType>
+ALWAYS_INLINE void SelectorDataList::executeCompiledSimpleSelectorChecker(const ContainerNode& searchRootNode, Checker selectorChecker, OutputType& output, const SelectorData& selectorData) const
 {
     for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(searchRootNode))) {
         selectorData.compiledSelector.wasUsed();
 
         if (selectorChecker(&element)) {
-            SelectorQueryTrait::appendOutputForElement(output, &element);
-            if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+            appendOutputForElement(output, element);
+            if constexpr (std::is_same_v<OutputType, Element*>)
                 return;
         }
     }
 }
 
-template <typename SelectorQueryTrait, typename Checker>
-ALWAYS_INLINE void SelectorDataList::executeCompiledSelectorCheckerWithCheckingContext(const ContainerNode& rootNode, const ContainerNode& searchRootNode, Checker selectorChecker, typename SelectorQueryTrait::OutputType& output, const SelectorData& selectorData) const
+template<typename Checker, typename OutputType>
+ALWAYS_INLINE void SelectorDataList::executeCompiledSelectorCheckerWithCheckingContext(const ContainerNode& rootNode, const ContainerNode& searchRootNode, Checker selectorChecker, OutputType& output, const SelectorData& selectorData) const
 {
     SelectorChecker::CheckingContext checkingContext(SelectorChecker::Mode::QueryingRules);
     checkingContext.scope = rootNode.isDocumentNode() ? nullptr : &rootNode;
@@ -422,15 +406,15 @@ ALWAYS_INLINE void SelectorDataList::executeCompiledSelectorCheckerWithCheckingC
         selectorData.compiledSelector.wasUsed();
 
         if (selectorChecker(&element, &checkingContext)) {
-            SelectorQueryTrait::appendOutputForElement(output, &element);
-            if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+            appendOutputForElement(output, element);
+            if constexpr (std::is_same_v<OutputType, Element*>)
                 return;
         }
     }
 }
 
-template <typename SelectorQueryTrait>
-ALWAYS_INLINE void SelectorDataList::executeCompiledSingleMultiSelectorData(const ContainerNode& rootNode, typename SelectorQueryTrait::OutputType& output) const
+template<typename OutputType>
+ALWAYS_INLINE void SelectorDataList::executeCompiledSingleMultiSelectorData(const ContainerNode& rootNode, OutputType& output) const
 {
     SelectorChecker::CheckingContext checkingContext(SelectorChecker::Mode::QueryingRules);
     checkingContext.scope = rootNode.isDocumentNode() ? nullptr : &rootNode;
@@ -446,8 +430,8 @@ ALWAYS_INLINE void SelectorDataList::executeCompiledSingleMultiSelectorData(cons
                 matched = SelectorCompiler::querySelectorSelectorCheckerWithCheckingContext(selector.compiledSelector, &element, &checkingContext);
             }
             if (matched) {
-                SelectorQueryTrait::appendOutputForElement(output, &element);
-                if (SelectorQueryTrait::shouldOnlyMatchFirstElement)
+                appendOutputForElement(output, element);
+                if constexpr (std::is_same_v<OutputType, Element*>)
                     return;
                 break;
             }
@@ -467,8 +451,8 @@ bool SelectorDataList::compileSelector(const SelectorData& selectorData)
 
 #endif // ENABLE(CSS_SELECTOR_JIT)
 
-template <typename SelectorQueryTrait>
-ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, typename SelectorQueryTrait::OutputType& output) const
+template<typename OutputType>
+ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, OutputType& output) const
 {
     ContainerNode* searchRootNode = &rootNode;
     switch (m_matchType) {
@@ -476,7 +460,7 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, typename S
         {
         const SelectorData& selectorData = m_selectors.first();
         if (const CSSSelector* idSelector = selectorForIdLookup(*searchRootNode, *selectorData.selector)) {
-            executeFastPathForIdSelector<SelectorQueryTrait>(*searchRootNode, m_selectors.first(), idSelector, output);
+            executeFastPathForIdSelector(*searchRootNode, m_selectors.first(), idSelector, output);
             break;
         }
 #if ENABLE(CSS_SELECTOR_JIT)
@@ -524,12 +508,12 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, typename S
         CompiledSingleCase:
         const SelectorData& selectorData = m_selectors.first();
         if (selectorData.compiledSelector.status == SelectorCompilationStatus::SimpleSelectorChecker) {
-            executeCompiledSimpleSelectorChecker<SelectorQueryTrait>(*searchRootNode, [&] (const Element* element) {
+            executeCompiledSimpleSelectorChecker(*searchRootNode, [&] (const Element* element) {
                 return SelectorCompiler::querySelectorSimpleSelectorChecker(selectorData.compiledSelector, element);
             }, output, selectorData);
         } else {
             ASSERT(selectorData.compiledSelector.status == SelectorCompilationStatus::SelectorCheckerWithCheckingContext);
-            executeCompiledSelectorCheckerWithCheckingContext<SelectorQueryTrait>(rootNode, *searchRootNode, [&] (const Element* element, const SelectorChecker::CheckingContext* context) {
+            executeCompiledSelectorCheckerWithCheckingContext(rootNode, *searchRootNode, [&] (const Element* element, const SelectorChecker::CheckingContext* context) {
                 return SelectorCompiler::querySelectorSelectorCheckerWithCheckingContext(selectorData.compiledSelector, element, context);
             }, output, selectorData);
         }
@@ -550,14 +534,14 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, typename S
         FALLTHROUGH;
     case SingleSelector:
         SingleSelectorCase:
-        executeSingleSelectorData<SelectorQueryTrait>(rootNode, *searchRootNode, m_selectors.first(), output);
+        executeSingleSelectorData(rootNode, *searchRootNode, m_selectors.first(), output);
         break;
 
     case TagNameMatch:
-        executeSingleTagNameSelectorData<SelectorQueryTrait>(*searchRootNode, m_selectors.first(), output);
+        executeSingleTagNameSelectorData(*searchRootNode, m_selectors.first(), output);
         break;
     case ClassNameMatch:
-        executeSingleClassNameSelectorData<SelectorQueryTrait>(*searchRootNode, m_selectors.first(), output);
+        executeSingleClassNameSelectorData(*searchRootNode, m_selectors.first(), output);
         break;
     case CompilableMultipleSelectorMatch:
 #if ENABLE(CSS_SELECTOR_JIT)
@@ -577,7 +561,7 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, typename S
     case CompiledMultipleSelectorMatch:
 #if ENABLE(CSS_SELECTOR_JIT)
         CompiledMultipleSelectorMatch:
-        executeCompiledSingleMultiSelectorData<SelectorQueryTrait>(*searchRootNode, output);
+        executeCompiledSingleMultiSelectorData(*searchRootNode, output);
         break;
 #else
         FALLTHROUGH;
@@ -586,7 +570,7 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, typename S
 #if ENABLE(CSS_SELECTOR_JIT)
         MultipleSelectorMatch:
 #endif
-        executeSingleMultiSelectorData<SelectorQueryTrait>(*searchRootNode, output);
+        executeSingleMultiSelectorData(*searchRootNode, output);
         break;
     }
 }
@@ -611,7 +595,7 @@ ExceptionOr<SelectorQuery&> SelectorQueryCache::add(const String& selectors, Doc
     if (selectorList->selectorsNeedNamespaceResolution())
         return Exception { SyntaxError };
 
-    const int maximumSelectorQueryCacheSize = 256;
+    constexpr int maximumSelectorQueryCacheSize = 256;
     if (m_entries.size() == maximumSelectorQueryCacheSize)
         m_entries.remove(m_entries.random());
 

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -59,16 +59,16 @@ private:
     bool selectorMatches(const SelectorData&, Element&, const ContainerNode& rootNode) const;
     Element* selectorClosest(const SelectorData&, Element&, const ContainerNode& rootNode) const;
 
-    template <typename SelectorQueryTrait> void execute(ContainerNode& rootNode, typename SelectorQueryTrait::OutputType&) const;
-    template <typename SelectorQueryTrait> void executeFastPathForIdSelector(const ContainerNode& rootNode, const SelectorData&, const CSSSelector* idSelector, typename SelectorQueryTrait::OutputType&) const;
-    template <typename SelectorQueryTrait> void executeSingleTagNameSelectorData(const ContainerNode& rootNode, const SelectorData&, typename SelectorQueryTrait::OutputType&) const;
-    template <typename SelectorQueryTrait> void executeSingleClassNameSelectorData(const ContainerNode& rootNode, const SelectorData&, typename SelectorQueryTrait::OutputType&) const;
-    template <typename SelectorQueryTrait> void executeSingleSelectorData(const ContainerNode& rootNode, const ContainerNode& searchRootNode, const SelectorData&, typename SelectorQueryTrait::OutputType&) const;
-    template <typename SelectorQueryTrait> void executeSingleMultiSelectorData(const ContainerNode& rootNode, typename SelectorQueryTrait::OutputType&) const;
+    template <typename OutputType> void execute(ContainerNode& rootNode, OutputType&) const;
+    template <typename OutputType> void executeFastPathForIdSelector(const ContainerNode& rootNode, const SelectorData&, const CSSSelector* idSelector, OutputType&) const;
+    template <typename OutputType> void executeSingleTagNameSelectorData(const ContainerNode& rootNode, const SelectorData&, OutputType&) const;
+    template <typename OutputType> void executeSingleClassNameSelectorData(const ContainerNode& rootNode, const SelectorData&, OutputType&) const;
+    template <typename OutputType> void executeSingleSelectorData(const ContainerNode& rootNode, const ContainerNode& searchRootNode, const SelectorData&, OutputType&) const;
+    template <typename OutputType> void executeSingleMultiSelectorData(const ContainerNode& rootNode, OutputType&) const;
 #if ENABLE(CSS_SELECTOR_JIT)
-    template <typename SelectorQueryTrait, typename Checker> void executeCompiledSimpleSelectorChecker(const ContainerNode& searchRootNode, Checker, typename SelectorQueryTrait::OutputType&, const SelectorData&) const;
-    template <typename SelectorQueryTrait, typename Checker> void executeCompiledSelectorCheckerWithCheckingContext(const ContainerNode& rootNode, const ContainerNode& searchRootNode, Checker, typename SelectorQueryTrait::OutputType&, const SelectorData&) const;
-    template <typename SelectorQueryTrait> void executeCompiledSingleMultiSelectorData(const ContainerNode& rootNode, typename SelectorQueryTrait::OutputType&) const;
+    template <typename Checker, typename OutputType> void executeCompiledSimpleSelectorChecker(const ContainerNode& searchRootNode, Checker, OutputType&, const SelectorData&) const;
+    template <typename Checker, typename OutputType> void executeCompiledSelectorCheckerWithCheckingContext(const ContainerNode& rootNode, const ContainerNode& searchRootNode, Checker, OutputType&, const SelectorData&) const;
+    template <typename OutputType> void executeCompiledSingleMultiSelectorData(const ContainerNode& rootNode, OutputType&) const;
     static bool compileSelector(const SelectorData&);
 #endif // ENABLE(CSS_SELECTOR_JIT)
 


### PR DESCRIPTION
#### d7ba779272595d0402d94e8eaa74d7657d678a41
<pre>
Use modern constexpr instead of traits in SelectorQuery.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=253400">https://bugs.webkit.org/show_bug.cgi?id=253400</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::appendOutputForElement):
(WebCore::SelectorDataList::queryAll const):
(WebCore::SelectorDataList::queryFirst const):
(WebCore::SelectorDataList::executeFastPathForIdSelector const):
(WebCore::filterRootById):
(WebCore::elementsForLocalName):
(WebCore::anyElement):
(WebCore::SelectorDataList::executeSingleTagNameSelectorData const):
(WebCore::SelectorDataList::executeSingleClassNameSelectorData const):
(WebCore::SelectorDataList::executeSingleSelectorData const):
(WebCore::SelectorDataList::executeSingleMultiSelectorData const):
(WebCore::SelectorDataList::executeCompiledSimpleSelectorChecker const):
(WebCore::SelectorDataList::executeCompiledSelectorCheckerWithCheckingContext const):
(WebCore::SelectorDataList::executeCompiledSingleMultiSelectorData const):
(WebCore::SelectorDataList::execute const):
(WebCore::AllElementExtractorSelectorQueryTrait::appendOutputForElement): Deleted.
(WebCore::SingleElementExtractorSelectorQueryTrait::appendOutputForElement): Deleted.
(WebCore::isTreeScopeRoot): Deleted.
* Source/WebCore/dom/SelectorQuery.h:

Canonical link: <a href="https://commits.webkit.org/261236@main">https://commits.webkit.org/261236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92be2d8d069e63904866132369fb397b02091104

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/110971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2399 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119817 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/114930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2061 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/15960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103455 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44389 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12630 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32139 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9123 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18588 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7795 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15124 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->