### PR TITLE
ASSERTION FAILED: m_contextMenuPreventionState != EventPreventionState::Waiting when running ContextMenuTests

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
@@ -42,10 +42,6 @@
 - (NSString *)waitForConfirm;
 - (NSString *)waitForPromptWithReply:(NSString *)reply;
 
-#if PLATFORM(MAC)
-- (_WKContextMenuElementInfo *)waitForContextMenu;
-#endif
-
 @end
 
 @interface WKWebView (TestUIDelegateExtras)
@@ -53,7 +49,4 @@
 - (NSString *)_test_waitForConfirm;
 - (NSString *)_test_waitForPromptWithReply:(NSString *)reply;
 - (void)_test_waitForInspectorToShow;
-#if PLATFORM(MAC)
-- (_WKContextMenuElementInfo *)_test_waitForContextMenu;
-#endif
 @end

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
@@ -87,24 +87,6 @@
     if (_focusWebView)
         _focusWebView(webView);
 }
-
-- (_WKContextMenuElementInfo *)waitForContextMenu
-{
-    EXPECT_FALSE(self.getContextMenuFromProposedMenu);
-
-    __block bool finished = false;
-    __block RetainPtr<_WKContextMenuElementInfo> result;
-    self.getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
-        result = elementInfo;
-        finished = true;
-        completionHandler(nil);
-    };
-
-    TestWebKitAPI::Util::run(&finished);
-
-    self.getContextMenuFromProposedMenu = nil;
-    return result.autorelease();
-}
 #endif // PLATFORM(MAC)
 
 - (void)_webView:(WKWebView *)webView saveDataToFile:(NSData *)data suggestedFilename:(NSString *)suggestedFilename mimeType:(NSString *)mimeType originatingURL:(NSURL *)url
@@ -221,17 +203,5 @@
     [uiDelegate waitForInspectorToShow];
     self.UIDelegate = nil;
 }
-
-#if PLATFORM(MAC)
-- (_WKContextMenuElementInfo *)_test_waitForContextMenu
-{
-    EXPECT_FALSE(self.UIDelegate);
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
-    self.UIDelegate = uiDelegate.get();
-    _WKContextMenuElementInfo *result = [uiDelegate waitForContextMenu];
-    self.UIDelegate = nil;
-    return result;
-}
-#endif
 
 @end


### PR DESCRIPTION
#### 11b7c45306f25d65ee4762c0d0fb6c7d6c2f2bef
<pre>
ASSERTION FAILED: m_contextMenuPreventionState != EventPreventionState::Waiting when running ContextMenuTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=253402">https://bugs.webkit.org/show_bug.cgi?id=253402</a>
rdar://106209710

Reviewed by Wenson Hsieh.

255193@main added `m_contextMenuPreventionState` and the associated assertions to
ensure a consistent ordering between right clicking, contextmenu events, and
context menu display. The state is set to &quot;Waiting&quot; when the right click is first
received in the UI process, and is only reset when the Web process responds with
the result.

261019@main added multiple context menu tests that perform two successive right
clicks, while using SPI to prevent showing a context menu. This means that the
second right click is received by the UI process before the Web process has a
chance to handle the first event. Consequently, `m_contextMenuPreventionState`
is still &quot;Waiting&quot; when the second right click is received, and the assertion
is hit.

In real use cases, this scenario should never occur. Normally, menu presentation
is not suppressed at the UI process layer, so the second right click will only
be received in the UI process after the menu is presented, giving the web
process time to respond. The only way two right clicks could be received before
the Web process responds is if the Web process is hung, in which case there are
already minimal guarantees about event handling.

Consequently, fix the issue by updating the tests to wait for a presentation
update prior to sending the second right click. This ensures that the Web
process can handle the first right click before the second one is received.

* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(-[TestWKWebView rightClickAtPointAndWaitForContextMenu:]):

Move the all the context menu waiting logic into a common method to avoid code
duplication, and reduce future errors.

(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm:

Move the context menu helper code out of here since it needs to operate on a
`TestWKWebView`.

(-[WKWebView _test_waitForContextMenu]): Deleted.

Canonical link: <a href="https://commits.webkit.org/261294@main">https://commits.webkit.org/261294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1353061030fad71717086aeff5d6acecd702200b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120021 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11430 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116947 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103767 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44655 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12844 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32297 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18802 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7827 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15330 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->