### PR TITLE
Have functions that only require VMs take a VM reference https://bugs.webkit.org/show_bug.cgi?id=202392

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -74,7 +74,7 @@ public:
     PropertyNameForFunctionCall(PropertyName);
     PropertyNameForFunctionCall(unsigned);
 
-    JSValue value(JSGlobalObject*) const;
+    JSValue value(VM&) const;
 
 private:
     PropertyName m_propertyName;
@@ -209,10 +209,9 @@ inline PropertyNameForFunctionCall::PropertyNameForFunctionCall(unsigned number)
 {
 }
 
-JSValue PropertyNameForFunctionCall::value(JSGlobalObject* globalObject) const
+JSValue PropertyNameForFunctionCall::value(VM& vm) const
 {
     if (!m_value) {
-        VM& vm = globalObject->vm();
         if (!m_propertyName.isNull())
             m_value = jsString(vm, String { m_propertyName.uid() });
         else {
@@ -324,7 +323,7 @@ ALWAYS_INLINE JSValue Stringifier::toJSON(JSValue baseValue, const PropertyNameF
         return baseValue;
 
     MarkedArgumentBuffer args;
-    args.append(propertyName.value(m_globalObject));
+    args.append(propertyName.value(vm));
     ASSERT(!args.hasOverflowed());
     RELEASE_AND_RETURN(scope, call(m_globalObject, asObject(toJSONFunction), callData, baseValue, args));
 }
@@ -353,7 +352,7 @@ Stringifier::StringifyResult Stringifier::appendStringifiedValue(StringBuilder& 
     // Call the replacer function.
     if (isCallableReplacer()) {
         MarkedArgumentBuffer args;
-        args.append(propertyName.value(m_globalObject));
+        args.append(propertyName.value(vm));
         args.append(value);
         ASSERT(!args.hasOverflowed());
         ASSERT(holder.object());

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp
@@ -85,7 +85,7 @@ JSC::JSValue MediaKeyStatusMap::get(JSC::JSGlobalObject& state, const BufferSour
 
     if (it == statuses.end())
         return JSC::jsUndefined();
-    return convertEnumerationToJS(state, it->second);
+    return convertEnumerationToJS(state.vm(), it->second);
 }
 
 MediaKeyStatusMap::Iterator::Iterator(MediaKeyStatusMap& map)

--- a/Source/WebCore/bindings/js/JSDOMConvertEnumeration.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertEnumeration.h
@@ -38,8 +38,7 @@ template<typename T> std::optional<T> parseEnumeration(JSC::JSGlobalObject&, JSC
 template<typename T> const char* expectedEnumerationValues();
 
 // Specialized by generated code for IDL enumeration conversion.
-template<typename T> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, T);
-
+template<typename T> JSC::JSString* convertEnumerationToJS(JSC::VM&, T);
 
 template<typename T> struct Converter<IDLEnumeration<T>> : DefaultConverter<IDLEnumeration<T>> {
     template<typename ExceptionThrower = DefaultExceptionThrower>
@@ -65,7 +64,7 @@ template<typename T> struct JSConverter<IDLEnumeration<T>> {
 
     static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, T value)
     {
-        return convertEnumerationToJS(lexicalGlobalObject, value);
+        return convertEnumerationToJS(lexicalGlobalObject.vm(), value);
     }
 };
 

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2409,13 +2409,11 @@ sub GenerateEnumerationImplementationContent
     $result .= "}\n\n";
 
 
-    # FIXME: Change to take VM& instead of JSGlobalObject*.
-    $result .= "template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, $className enumerationValue)\n";
+    $result .= "template<> JSString* convertEnumerationToJS(VM& vm, $className enumerationValue)\n";
     $result .= "{\n";
-    $result .= "    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));\n";
+    $result .= "    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));\n";
     $result .= "}\n\n";
 
-    # FIXME: Change to take VM& instead of JSGlobalObject&.
     # FIXME: Consider using toStringOrNull to make exception checking faster.
     # FIXME: Consider finding a more efficient way to match against all the strings quickly.
     $result .= "template<> std::optional<$className> parseEnumerationFromString<${className}>(const String& stringValue)\n";
@@ -2480,7 +2478,7 @@ sub GenerateEnumerationHeaderContent
     my $exportMacro = GetExportMacroForJSClass($enumeration);
 
     $result .= "${exportMacro}String convertEnumerationToString($className);\n";
-    $result .= "template<> ${exportMacro}JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, $className);\n\n";
+    $result .= "template<> ${exportMacro}JSC::JSString* convertEnumerationToJS(JSC::VM&, $className);\n\n";
     $result .= "template<> ${exportMacro}std::optional<$className> parseEnumerationFromString<${className}>(const String&);\n";
     $result .= "template<> ${exportMacro}std::optional<$className> parseEnumeration<$className>(JSC::JSGlobalObject&, JSC::JSValue);\n";
     $result .= "template<> ${exportMacro}const char* expectedEnumerationValues<$className>();\n\n";

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -63,9 +63,9 @@ String convertEnumerationToString(TestCallbackInterface::Enum enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestCallbackInterface::Enum enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestCallbackInterface::Enum enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestCallbackInterface::Enum> parseEnumerationFromString<TestCallbackInterface::Enum>(const String& stringValue)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -66,7 +66,7 @@ JSC::JSValue toJS(TestCallbackInterface&);
 inline JSC::JSValue toJS(TestCallbackInterface* impl) { return impl ? toJS(*impl) : JSC::jsNull(); }
 
 String convertEnumerationToString(TestCallbackInterface::Enum);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestCallbackInterface::Enum);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestCallbackInterface::Enum);
 
 template<> std::optional<TestCallbackInterface::Enum> parseEnumerationFromString<TestCallbackInterface::Enum>(const String&);
 template<> std::optional<TestCallbackInterface::Enum> parseEnumeration<TestCallbackInterface::Enum>(JSC::JSGlobalObject&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp
@@ -42,9 +42,9 @@ String convertEnumerationToString(TestDefaultToJSONEnum enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestDefaultToJSONEnum enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestDefaultToJSONEnum enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestDefaultToJSONEnum> parseEnumerationFromString<TestDefaultToJSONEnum>(const String& stringValue)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.h
@@ -26,7 +26,7 @@
 namespace WebCore {
 
 String convertEnumerationToString(TestDefaultToJSONEnum);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestDefaultToJSONEnum);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestDefaultToJSONEnum);
 
 template<> std::optional<TestDefaultToJSONEnum> parseEnumerationFromString<TestDefaultToJSONEnum>(const String&);
 template<> std::optional<TestDefaultToJSONEnum> parseEnumeration<TestDefaultToJSONEnum>(JSC::JSGlobalObject&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -144,9 +144,9 @@ String convertEnumerationToString(TestObj::EnumType enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestObj::EnumType enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumType enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestObj::EnumType> parseEnumerationFromString<TestObj::EnumType>(const String& stringValue)
@@ -186,9 +186,9 @@ String convertEnumerationToString(TestObj::EnumTrailingComma enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestObj::EnumTrailingComma enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumTrailingComma enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestObj::EnumTrailingComma> parseEnumerationFromString<TestObj::EnumTrailingComma>(const String& stringValue)
@@ -229,9 +229,9 @@ String convertEnumerationToString(TestObj::Optional enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestObj::Optional enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::Optional enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestObj::Optional> parseEnumerationFromString<TestObj::Optional>(const String& stringValue)
@@ -271,9 +271,9 @@ String convertEnumerationToString(AlternateEnumName enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, AlternateEnumName enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, AlternateEnumName enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<AlternateEnumName> parseEnumerationFromString<AlternateEnumName>(const String& stringValue)
@@ -310,9 +310,9 @@ String convertEnumerationToString(TestObj::EnumA enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestObj::EnumA enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumA enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestObj::EnumA> parseEnumerationFromString<TestObj::EnumA>(const String& stringValue)
@@ -350,9 +350,9 @@ String convertEnumerationToString(TestObj::EnumB enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestObj::EnumB enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumB enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestObj::EnumB> parseEnumerationFromString<TestObj::EnumB>(const String& stringValue)
@@ -390,9 +390,9 @@ String convertEnumerationToString(TestObj::EnumC enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestObj::EnumC enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumC enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestObj::EnumC> parseEnumerationFromString<TestObj::EnumC>(const String& stringValue)
@@ -430,9 +430,9 @@ String convertEnumerationToString(TestObj::Kind enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestObj::Kind enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::Kind enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestObj::Kind> parseEnumerationFromString<TestObj::Kind>(const String& stringValue)
@@ -469,9 +469,9 @@ String convertEnumerationToString(TestObj::Size enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestObj::Size enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::Size enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestObj::Size> parseEnumerationFromString<TestObj::Size>(const String& stringValue)
@@ -508,9 +508,9 @@ String convertEnumerationToString(TestObj::Confidence enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestObj::Confidence enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestObj::Confidence enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestObj::Confidence> parseEnumerationFromString<TestObj::Confidence>(const String& stringValue)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
@@ -116,28 +116,28 @@ template<> struct JSDOMWrapperConverterTraits<TestObj> {
     using ToWrappedReturnType = TestObj*;
 };
 String convertEnumerationToString(TestObj::EnumType);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::EnumType);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumType);
 
 template<> std::optional<TestObj::EnumType> parseEnumerationFromString<TestObj::EnumType>(const String&);
 template<> std::optional<TestObj::EnumType> parseEnumeration<TestObj::EnumType>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::EnumType>();
 
 String convertEnumerationToString(TestObj::EnumTrailingComma);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::EnumTrailingComma);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumTrailingComma);
 
 template<> std::optional<TestObj::EnumTrailingComma> parseEnumerationFromString<TestObj::EnumTrailingComma>(const String&);
 template<> std::optional<TestObj::EnumTrailingComma> parseEnumeration<TestObj::EnumTrailingComma>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::EnumTrailingComma>();
 
 String convertEnumerationToString(TestObj::Optional);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::Optional);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::Optional);
 
 template<> std::optional<TestObj::Optional> parseEnumerationFromString<TestObj::Optional>(const String&);
 template<> std::optional<TestObj::Optional> parseEnumeration<TestObj::Optional>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::Optional>();
 
 String convertEnumerationToString(AlternateEnumName);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, AlternateEnumName);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, AlternateEnumName);
 
 template<> std::optional<AlternateEnumName> parseEnumerationFromString<AlternateEnumName>(const String&);
 template<> std::optional<AlternateEnumName> parseEnumeration<AlternateEnumName>(JSC::JSGlobalObject&, JSC::JSValue);
@@ -146,7 +146,7 @@ template<> const char* expectedEnumerationValues<AlternateEnumName>();
 #if ENABLE(Condition1)
 
 String convertEnumerationToString(TestObj::EnumA);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::EnumA);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumA);
 
 template<> std::optional<TestObj::EnumA> parseEnumerationFromString<TestObj::EnumA>(const String&);
 template<> std::optional<TestObj::EnumA> parseEnumeration<TestObj::EnumA>(JSC::JSGlobalObject&, JSC::JSValue);
@@ -157,7 +157,7 @@ template<> const char* expectedEnumerationValues<TestObj::EnumA>();
 #if ENABLE(Condition1) && ENABLE(Condition2)
 
 String convertEnumerationToString(TestObj::EnumB);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::EnumB);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumB);
 
 template<> std::optional<TestObj::EnumB> parseEnumerationFromString<TestObj::EnumB>(const String&);
 template<> std::optional<TestObj::EnumB> parseEnumeration<TestObj::EnumB>(JSC::JSGlobalObject&, JSC::JSValue);
@@ -168,7 +168,7 @@ template<> const char* expectedEnumerationValues<TestObj::EnumB>();
 #if ENABLE(Condition1) || ENABLE(Condition2)
 
 String convertEnumerationToString(TestObj::EnumC);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::EnumC);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::EnumC);
 
 template<> std::optional<TestObj::EnumC> parseEnumerationFromString<TestObj::EnumC>(const String&);
 template<> std::optional<TestObj::EnumC> parseEnumeration<TestObj::EnumC>(JSC::JSGlobalObject&, JSC::JSValue);
@@ -177,21 +177,21 @@ template<> const char* expectedEnumerationValues<TestObj::EnumC>();
 #endif
 
 String convertEnumerationToString(TestObj::Kind);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::Kind);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::Kind);
 
 template<> std::optional<TestObj::Kind> parseEnumerationFromString<TestObj::Kind>(const String&);
 template<> std::optional<TestObj::Kind> parseEnumeration<TestObj::Kind>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::Kind>();
 
 String convertEnumerationToString(TestObj::Size);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::Size);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::Size);
 
 template<> std::optional<TestObj::Size> parseEnumerationFromString<TestObj::Size>(const String&);
 template<> std::optional<TestObj::Size> parseEnumeration<TestObj::Size>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::Size>();
 
 String convertEnumerationToString(TestObj::Confidence);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::Confidence);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestObj::Confidence);
 
 template<> std::optional<TestObj::Confidence> parseEnumerationFromString<TestObj::Confidence>(const String&);
 template<> std::optional<TestObj::Confidence> parseEnumeration<TestObj::Confidence>(JSC::JSGlobalObject&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
@@ -343,9 +343,9 @@ String convertEnumerationToString(TestStandaloneDictionary::EnumInStandaloneDict
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestStandaloneDictionary::EnumInStandaloneDictionaryFile enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestStandaloneDictionary::EnumInStandaloneDictionaryFile enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFile> parseEnumerationFromString<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(const String& stringValue)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.h
@@ -33,7 +33,7 @@ template<> WEBCORE_EXPORT DictionaryImplName convertDictionary<DictionaryImplNam
 WEBCORE_EXPORT JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject&, JSDOMGlobalObject&, const DictionaryImplName&);
 
 String convertEnumerationToString(TestStandaloneDictionary::EnumInStandaloneDictionaryFile);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestStandaloneDictionary::EnumInStandaloneDictionaryFile);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestStandaloneDictionary::EnumInStandaloneDictionaryFile);
 
 template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFile> parseEnumerationFromString<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(const String&);
 template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFile> parseEnumeration<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(JSC::JSGlobalObject&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
@@ -45,9 +45,9 @@ String convertEnumerationToString(TestStandaloneEnumeration enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
-template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject, TestStandaloneEnumeration enumerationValue)
+template<> JSString* convertEnumerationToJS(VM& vm, TestStandaloneEnumeration enumerationValue)
 {
-    return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
+    return jsStringWithCache(vm, convertEnumerationToString(enumerationValue));
 }
 
 template<> std::optional<TestStandaloneEnumeration> parseEnumerationFromString<TestStandaloneEnumeration>(const String& stringValue)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.h
@@ -28,7 +28,7 @@
 namespace WebCore {
 
 String convertEnumerationToString(TestStandaloneEnumeration);
-template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestStandaloneEnumeration);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestStandaloneEnumeration);
 
 template<> std::optional<TestStandaloneEnumeration> parseEnumerationFromString<TestStandaloneEnumeration>(const String&);
 template<> std::optional<TestStandaloneEnumeration> parseEnumeration<TestStandaloneEnumeration>(JSC::JSGlobalObject&, JSC::JSValue);


### PR DESCRIPTION
#### 7a682381645f03d8fc7f2fa58c134d45b5b59c2d
<pre>
Have functions that only require VMs take a VM reference <a href="https://bugs.webkit.org/show_bug.cgi?id=202392">https://bugs.webkit.org/show_bug.cgi?id=202392</a>

Reviewed by Darin Adler.

We can have the .vm() method be called before these functions,
and pass the result VM reference instead of passing the pointer to the JSGlobalObject, potentially calling the .vm() methods redundantly in each method to which said JSGlobalObject pointer is passed, and dereferencing the pointers to the VM.

* Source/JavaScriptCore/runtime/JSONObject.cpp:(value): Change argument
  type from JSGlobalObject* to VM&amp;.

* Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp:
  (get): Pass the VM of the state object to convertEnumerationToJS
  rather than the whole object.

* Source/WebCore/bindings/js/JSDOMConvertEnumeration.h:
  (convertEnumerationToJS): Change argument type from JSGlobalObject to
  VM.
  (convert): Pass the VM of lexicalGlobalObject instead of the entire
  global object.

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm: Ditto.

* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
  Ditto.

* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h:
  Ditto.

* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp:
  Ditto.

* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.h:
  Ditto.

* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp: Ditto.

* Source/WebCore/bindings/scripts/test/JS/JSTestObj.h: Ditto.

* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp:
  Ditto.

* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.h:
  Ditto.

* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp:
  Ditto.

* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.h:
  Ditto.

Canonical link: <a href="https://commits.webkit.org/262166@main">https://commits.webkit.org/262166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bfa4bb763403077e3966f26e50d9a9513b298e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/932 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/765 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1038 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/752 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/706 "Failed to checkout and rebase branch from PR 11084") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/727 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/775 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/793 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/764 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/832 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/712 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/760 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/172 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/180 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/777 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/834 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/166 "Passed tests") | 
<!--EWS-Status-Bubble-End-->