### PR TITLE
Reduce unnecessary work in VMEntryScope to speed up first VM entry.

### DIFF
--- a/JSTests/microbenchmarks/cpp-to-js-cached-call.js
+++ b/JSTests/microbenchmarks/cpp-to-js-cached-call.js
@@ -1,0 +1,2 @@
+function test() { }
+$vm.cachedCallFromCPP(test, 4e6);

--- a/JSTests/microbenchmarks/cpp-to-js-call-as-first-entry.js
+++ b/JSTests/microbenchmarks/cpp-to-js-call-as-first-entry.js
@@ -1,0 +1,2 @@
+function test() { }
+$vm.callFromCPPAsFirstEntry(test, 4e6);

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -411,6 +411,7 @@ CodePtr<ExceptionHandlerPtrTag> prepareCatchOSREntry(VM& vm, CallFrame* callFram
 
     // The active length of catchOSREntryBuffer will be zeroed by ClearCatchLocals node.
     dfgCommon->catchOSREntryBuffer->setActiveLength(sizeof(JSValue) * index);
+    vm.requestEntryScopeService(VM::EntryScopeService::ClearScratchBuffers);
 
     // At this point, we're committed to triggering an OSR entry immediately after we return. Hence, it is safe to modify stack here.
     callFrame->setCodeBlock(optimizedCodeBlock);

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1883,7 +1883,7 @@ JSC_DEFINE_JIT_OPERATION(operationOptimize, SlowPathReturnType, (VM* vmPointer, 
         return encodeResult(nullptr, nullptr);
     }
     
-    if (UNLIKELY(vm.terminationInProgress())) {
+    if (UNLIKELY(vm.hasTerminationRequest())) {
         // If termination of the current stack of execution is in progress,
         // then we need to hold off on optimized compiles so that termination
         // checks will be called, and we can unwind out of the current stack.

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Google Inc. All rights reserved.
  * Copyright (C) 2010 Research In Motion Limited. All rights reserved.
  *
@@ -81,10 +81,19 @@ public:
     DateCache();
     ~DateCache();
 
+    bool hasTimeZoneChange()
+    {
+#if PLATFORM(COCOA)
+        return m_cachedTimezoneID != lastTimeZoneID;
+#else
+        return true; // always force a time zone check.
+#endif
+    }
+
     void resetIfNecessary()
     {
 #if PLATFORM(COCOA)
-        if (LIKELY(m_cachedTimezoneID == lastTimeZoneID))
+        if (LIKELY(!hasTimeZoneChange()))
             return;
         m_cachedTimezoneID = lastTimeZoneID;
 #endif

--- a/Source/JavaScriptCore/runtime/VMEntryScope.cpp
+++ b/Source/JavaScriptCore/runtime/VMEntryScope.cpp
@@ -33,7 +33,6 @@
 #include "WasmCapabilities.h"
 #include "WasmMachineThreads.h"
 #include "Watchdog.h"
-#include <wtf/SystemTracing.h>
 #include <wtf/WTFConfig.h>
 
 namespace JSC {
@@ -54,53 +53,18 @@ void VMEntryScope::setUpSlow()
 #endif
     }
 
-    m_vm.firePrimitiveGigacageEnabledIfNecessary();
-
-    // Reset the date cache between JS invocations to force the VM to
-    // observe time zone changes.
-    m_vm.resetDateCacheIfNecessary();
-
-    if (UNLIKELY(m_vm.watchdog()))
-        m_vm.watchdog()->enteredVM();
-
-#if ENABLE(SAMPLING_PROFILER)
-    {
-        SamplingProfiler* samplingProfiler = m_vm.samplingProfiler();
-        if (UNLIKELY(samplingProfiler))
-            samplingProfiler->noticeVMEntry();
-    }
-#endif
-    if (UNLIKELY(Options::useTracePoints()))
-        tracePoint(VMEntryScopeStart);
+    if (UNLIKELY(m_vm.hasAnyEntryScopeServiceRequest() || m_vm.hasTimeZoneChange()))
+        m_vm.executeEntryScopeServicesOnEntry();
 }
 
 void VMEntryScope::tearDownSlow()
 {
     ASSERT_WITH_MESSAGE(!m_vm.hasCheckpointOSRSideState(), "Exitting the VM but pending checkpoint side state still available");
 
-    if (UNLIKELY(Options::useTracePoints()))
-        tracePoint(VMEntryScopeEnd);
-    
-    if (UNLIKELY(m_vm.watchdog()))
-        m_vm.watchdog()->exitedVM();
-
     m_vm.entryScope = nullptr;
-    m_vm.invokeDidPopListeners();
 
-    // If the trap bit is still set at this point, then it means that VMTraps::handleTraps()
-    // has not yet been called for this termination request. As a result, we've not thrown a
-    // TerminationException yet. Some client code relies on detecting the presence of the
-    // TerminationException in order to signal that a termination was requested. As a result,
-    // we want to stay in the TerminationInProgress state until VMTraps::handleTraps() (which
-    // clears the trap bit) gets called, and the TerminationException gets thrown.
-    //
-    // Note: perhaps there's a better way for the client to know that a termination was
-    // requested (after all, the request came from the client). However, this is how the
-    // client code currently works. Changing that will take some significant effort to hunt
-    // down all the places in client code that currently rely on this behavior.
-    if (!m_vm.traps().needHandling(VMTraps::NeedTermination))
-        m_vm.setTerminationInProgress(false);
-    m_vm.clearScratchBuffers();
+    if (UNLIKELY(m_vm.hasAnyEntryScopeServiceRequest()))
+        m_vm.executeEntryScopeServicesOnExit();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -401,11 +401,11 @@ void VMTraps::handleTraps(VMTraps::BitField mask)
             ASSERT(vm.watchdog());
             if (LIKELY(!vm.watchdog()->isActive() || !vm.watchdog()->shouldTerminate(vm.entryScope->globalObject())))
                 continue;
-            vm.setTerminationInProgress(true);
+            vm.setHasTerminationRequest();
             FALLTHROUGH;
 
         case NeedTermination:
-            ASSERT(vm.terminationInProgress());
+            ASSERT(vm.hasTerminationRequest());
             scope.release();
             if (!isDeferringTermination())
                 vm.throwTerminationException();
@@ -441,7 +441,7 @@ void VMTraps::deferTerminationSlow(DeferAction)
 
     VM& vm = this->vm();
     if (vm.hasPendingTerminationException()) {
-        ASSERT(vm.terminationInProgress());
+        ASSERT(vm.hasTerminationRequest());
         vm.clearException();
         m_suspendedTerminationException = true;
     }
@@ -452,7 +452,7 @@ void VMTraps::undoDeferTerminationSlow(DeferAction deferAction)
     ASSERT(m_deferTerminationCount == 0);
 
     VM& vm = this->vm();
-    ASSERT(vm.terminationInProgress());
+    ASSERT(vm.hasTerminationRequest());
     if (m_suspendedTerminationException || (deferAction == DeferAction::DeferUntilEndOfScope)) {
         vm.throwTerminationException();
         m_suspendedTerminationException = false;

--- a/Source/JavaScriptCore/runtime/VMTrapsInlines.h
+++ b/Source/JavaScriptCore/runtime/VMTrapsInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,8 +45,8 @@ inline void VMTraps::deferTermination(DeferAction deferAction)
 inline void VMTraps::undoDeferTermination(DeferAction deferAction)
 {
     ASSERT(m_deferTerminationCount > 0);
-    ASSERT(!m_suspendedTerminationException || vm().terminationInProgress());
-    if (UNLIKELY(--m_deferTerminationCount == 0 && vm().terminationInProgress()))
+    ASSERT(!m_suspendedTerminationException || vm().hasTerminationRequest());
+    if (UNLIKELY(--m_deferTerminationCount == 0 && vm().hasTerminationRequest()))
         undoDeferTerminationSlow(deferAction);
 }
 

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2221,6 +2221,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionEnsureArrayStorage);
 static JSC_DECLARE_HOST_FUNCTION(functionSetCrashLogMessage);
 #endif
 static JSC_DECLARE_HOST_FUNCTION(functionAssertFrameAligned);
+static JSC_DECLARE_HOST_FUNCTION(functionCallFromCPPAsFirstEntry);
 static JSC_DECLARE_HOST_FUNCTION(functionCallFromCPP);
 static JSC_DECLARE_HOST_FUNCTION(functionCachedCallFromCPP);
 
@@ -3988,6 +3989,20 @@ JSC_DEFINE_HOST_FUNCTION(functionAssertFrameAligned, (JSGlobalObject*, CallFrame
     return JSValue::encode(jsUndefined());
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionCallFromCPPAsFirstEntry, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    VM& vm = globalObject->vm();
+    VMEntryScope* origEntryScope = vm.entryScope;
+    vm.entryScope = nullptr;
+
+    auto restoreEntryScope = makeScopeExit([&] {
+        vm.entryScope = origEntryScope;
+    });
+
+    return functionCallFromCPP(globalObject, callFrame);
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionCallFromCPP, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
@@ -4239,6 +4254,7 @@ void JSDollarVM::finishCreation(VM& vm)
 
     addFunction(vm, "assertFrameAligned"_s, functionAssertFrameAligned, 0);
 
+    addFunction(vm, "callFromCPPAsFirstEntry"_s, functionCallFromCPPAsFirstEntry, 2);
     addFunction(vm, "callFromCPP"_s, functionCallFromCPP, 2);
     addFunction(vm, "cachedCallFromCPP"_s, functionCachedCallFromCPP, 2);
 


### PR DESCRIPTION
#### 3b78627af7fadf9e392d0eb8a7bcdfa96e01a20d
<pre>
Reduce unnecessary work in VMEntryScope to speed up first VM entry.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253412">https://bugs.webkit.org/show_bug.cgi?id=253412</a>
rdar://106258354

Reviewed by Yusuke Suzuki.

1. VMEntryScope entry and exit current check for the need to do a lot of work that are usually not needed.
   Instead of doing all these checks, we introduce a new VM::EntryScopeService concept where if one of
   these checks are needed, their sources will request an EntryScopeService.  With this, the VMEntryScope
   will only check if any such services have been requested (with a single bitfield), and can will only
   incur the cost of the check if at least one such services have been requested.

   The only exception to using these service requests is the resetting of the VM DateCache.  That is
   dependent on a global lastTimeZoneID because there is one DateCache per VM, and there can be multiple
   VMs.  Hence, lastTimeZoneID needs to be updated in an atomic way.  We also don&apos;t want the EntryScope
   service request to require a lock of any sort, nor have to deal with iterating all VMs to request a
   DateCache reset.  So, we&apos;ll just do a hasTimeZoneChange() check instead in addition to the service
   request check on entry.

2. Moved the servicing of the &quot;EntryScopeService&quot;s out to VM::executeEntryScopeServicesOnEntry() and
   VM::executeEntryScopeServicesOnExit() instead of keeping them inlined in VMEntryScope.

   This appears to have improved the microbenchmark result by ~2-4%.  Might be due to improved cache
   locality from moving the rare case out.

3. Rename VM::m_terminationInProgress to VM::m_hasTerminationRequest to better describe what it represents.
   I wrote this code, and I found even myself confused by it.  So, I&apos;m renaming it for clarity, and
   updating the comment about its treatment on VM exit for added clarity as well.

4. Added cpp-to-js-cached-call.js and cpp-to-js-call-as-first-entry.js microbenchmarks which tests
   repeated calls using CachedCall, and repeated calls at the first entry boundary.

The microbenchmark results are all follows,  As expected, only first entry is improved by this change.

                                          base                      new

    cpp-to-js-call-as-first-entry       96.8583+-0.1895     ^     75.9927+-0.6285        ^ definitely 1.2746x faster
    cpp-to-js-call                      69.6459+-0.1565           69.5432+-0.0586
    cpp-to-js-cached-call               79.8228+-0.5376     ?     80.4139+-0.6115        ?

* JSTests/microbenchmarks/cpp-to-js-cached-call.js: Added.
(test):
* JSTests/microbenchmarks/cpp-to-js-call-as-first-entry.js: Added.
(test):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/JSDateMath.h:
(JSC::DateCache::hasTimeZoneChange):
(JSC::DateCache::resetIfNecessary):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::primitiveGigacageDisabled):
(JSC::VM::ensureWatchdog):
(JSC::VM::ensureSamplingProfiler):
(JSC::VM::whenIdle):
(JSC::VM::setException):
(JSC::VM::throwTerminationException):
(JSC::VM::assertScratchBuffersAreEmpty):
(JSC::VM::executeEntryScopeServicesOnEntry):
(JSC::VM::executeEntryScopeServicesOnExit):
(JSC::VM::clearScratchBuffers): Deleted.
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::hasTerminationRequest const):
(JSC::VM::clearHasTerminationRequest):
(JSC::VM::setHasTerminationRequest):
(JSC::VM::hasAnyEntryScopeServiceRequest):
(JSC::VM::isValidEntryScopeService):
(JSC::VM::hasEntryScopeServiceRequest):
(JSC::VM::clearEntryScopeService):
(JSC::VM::requestEntryScopeService):
(JSC::VM::hasTimeZoneChange):
(JSC::VM::notifyNeedTermination):
(JSC::VM::terminationInProgress const): Deleted.
(JSC::VM::setTerminationInProgress): Deleted.
(JSC::VM::firePrimitiveGigacageEnabledIfNecessary): Deleted.
(JSC::VM::invokeDidPopListeners): Deleted.
(JSC::VM::resetDateCacheIfNecessary): Deleted.
* Source/JavaScriptCore/runtime/VMEntryScope.cpp:
(JSC::VMEntryScope::setUpSlow):
(JSC::VMEntryScope::tearDownSlow):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::handleTraps):
(JSC::VMTraps::deferTerminationSlow):
(JSC::VMTraps::undoDeferTerminationSlow):
* Source/JavaScriptCore/runtime/VMTrapsInlines.h:
(JSC::VMTraps::undoDeferTermination):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):

Canonical link: <a href="https://commits.webkit.org/261260@main">https://commits.webkit.org/261260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cb041d26a62e6b9ddc1b443c59b04c4dbff539a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2144 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103584 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44505 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99658 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12736 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86407 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10841 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9202 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100802 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18695 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31436 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7809 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15229 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108839 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26838 "Passed tests") | 
<!--EWS-Status-Bubble-End-->