### PR TITLE
DFG should support tuples

### DIFF
--- a/JSTests/stress/for-in-redefine-enumerable.js
+++ b/JSTests/stress/for-in-redefine-enumerable.js
@@ -5,7 +5,7 @@ function assert(x) {
 
 function shouldBe(actual, expected) {
     if (actual !== expected)
-        throw new Error(`Bad value: ${actual}.`);
+        throw new Error(`Bad value: ${actual} expected ${expected}.`);
 }
 
 const enumDesc = { value: 0, writable: true, enumerable: true, configurable: true };
@@ -15,13 +15,16 @@ const dontEnumDesc = { value: 0, writable: true, enumerable: false, configurable
 (() => {
     function test() {
         var arr = Object.defineProperties([0, 0, 0], { 1: dontEnumDesc });
+        var count = 0;
         for (var i in arr) {
+            count++;
             assert(i in arr);
             shouldBe(arr[i], 0);
             ++arr[i];
             if (i === "0")
                 Object.defineProperties(arr, { 1: enumDesc, 2: dontEnumDesc });
         }
+        shouldBe(count, 1);
         shouldBe(arr[0], 1);
         shouldBe(arr[1], 0);
         shouldBe(arr[2], 0);

--- a/Source/JavaScriptCore/b3/B3Type.h
+++ b/Source/JavaScriptCore/b3/B3Type.h
@@ -135,11 +135,18 @@ inline bool Type::isVector() const
     return kind() == V128;
 }
 
-inline Type pointerType()
+constexpr Type pointerType()
 {
     if (is32Bit())
         return Int32;
     return Int64;
+}
+
+constexpr Type registerType()
+{
+    if (isRegister64Bit())
+        return Int64;
+    return Int32;
 }
 
 inline size_t sizeofType(Type type)

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -674,6 +674,14 @@ public:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() >= 1, ("At ", *value));
                 VALIDATE(value->child(0)->type() == pointerType(), ("At ", *value));
+                if (value->type().isTuple()) {
+                    // FIXME: Right now we only support a pair of register sized values since on every calling
+                    // convention we support that's returned in returnValueGPR/returnValueGPR2, respectively.
+                    VALIDATE(m_procedure.resultCount(value->type()) == 2, ("At ", *value));
+                    VALIDATE(m_procedure.typeAtOffset(value->type(), 0) == registerType(), ("At ", *value));
+                    VALIDATE(m_procedure.typeAtOffset(value->type(), 1) == registerType(), ("At ", *value));
+                }
+
                 break;
             case Patchpoint:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));

--- a/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
@@ -56,7 +56,7 @@ void marshallCCallArgumentImpl(Vector<Arg>& result, unsigned& argumentCount, uns
         // In the rare case when the Arg width does not match the argument width
         // (32-bit arm passing a 64-bit argument), we respect the width needed
         // for each stack access:
-        slotSize = bytesForWidth(cCallArgumentRegisterWidth(child));
+        slotSize = bytesForWidth(cCallArgumentRegisterWidth(child->type()));
 
         // but the logical stack slot uses the natural alignment of the argument
         slotAlignment = sizeofType(child->type());
@@ -103,7 +103,7 @@ Vector<Arg> computeCCallingConvention(Code& code, CCallValue* value)
     return result;
 }
 
-size_t cCallResultCount(CCallValue* value)
+size_t cCallResultCount(Code& code, CCallValue* value)
 {
     switch (value->type().kind()) {
     case Void:
@@ -113,7 +113,12 @@ size_t cCallResultCount(CCallValue* value)
             return 2;
         return 1;
     case Tuple:
-        RELEASE_ASSERT_NOT_REACHED();
+        // We only support tuples that return exactly two register sized ints.
+        UNUSED_PARAM(code);
+        ASSERT(code.proc().resultCount(value->type()) == 2);
+        ASSERT(code.proc().typeAtOffset(value->type(), 0) == pointerType());
+        ASSERT(code.proc().typeAtOffset(value->type(), 1) == pointerType());
+        return 2;
     default:
         return 1;
 
@@ -136,19 +141,19 @@ size_t cCallArgumentRegisterCount(const Value* value)
     }
 }
 
-Width cCallArgumentRegisterWidth(const Value* value)
+Width cCallArgumentRegisterWidth(Type type)
 {
     if constexpr (is32Bit()) {
-        if (value->type() == Int64)
+        if (type == Int64)
             return Width32;
     }
 
-    return widthForType(value->type());
+    return widthForType(type);
 }
 
-Tmp cCallResult(CCallValue* value, unsigned index)
+Tmp cCallResult(Code& code, CCallValue* value, unsigned index)
 {
-    ASSERT_UNUSED(index, index <= (is64Bit() ? 1 : 2));
+    ASSERT(index < 2);
     switch (value->type().kind()) {
     case Void:
         return Tmp();
@@ -160,9 +165,15 @@ Tmp cCallResult(CCallValue* value, unsigned index)
         return Tmp(GPRInfo::returnValueGPR);
     case Float:
     case Double:
+        ASSERT(!index);
         return Tmp(FPRInfo::returnValueFPR);
-    case V128:
     case Tuple:
+        ASSERT_UNUSED(code, code.proc().resultCount(value->type()) == 2);
+        // We only support functions that return each parameter in its own register for now.
+        ASSERT(code.proc().typeAtOffset(value->type(), 0) == registerType());
+        ASSERT(code.proc().typeAtOffset(value->type(), 1) == registerType());
+        return index ? Tmp(GPRInfo::returnValueGPR2) : Tmp(GPRInfo::returnValueGPR);
+    case V128:
         break;
     }
 

--- a/Source/JavaScriptCore/b3/air/AirCCallingConvention.h
+++ b/Source/JavaScriptCore/b3/air/AirCCallingConvention.h
@@ -42,7 +42,7 @@ class Code;
 
 Vector<Arg> computeCCallingConvention(Code&, CCallValue*);
 
-size_t cCallResultCount(CCallValue*);
+size_t cCallResultCount(Code&, CCallValue*);
 
 /*
  * On some platforms (well, on 32-bit platforms,) C functions can take arguments
@@ -54,9 +54,9 @@ size_t cCallResultCount(CCallValue*);
 // Return the number of Air::Args needed to marshall this Value to the C function
 size_t cCallArgumentRegisterCount(const Value*);
 // Return the width of the individual Air::Args needed to marshall this value
-Width cCallArgumentRegisterWidth(const Value*);
+Width cCallArgumentRegisterWidth(Type);
 
-Tmp cCallResult(CCallValue*, unsigned);
+Tmp cCallResult(Code&, CCallValue*, unsigned);
 
 Inst buildCCall(Code&, Value* origin, const Vector<Arg>&);
 

--- a/Source/JavaScriptCore/b3/air/AirCustom.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCustom.cpp
@@ -31,6 +31,7 @@
 #include "AirCCallingConvention.h"
 #include "AirInstInlines.h"
 #include "B3CCallValue.h"
+#include "B3ProcedureInlines.h"
 #include "B3ValueInlines.h"
 #include "CCallHelpers.h"
 
@@ -65,8 +66,14 @@ bool CCallCustom::isValidForm(Inst& inst)
     if (!value)
         return false;
 
-    size_t resultCount = cCallResultCount(value);
-    size_t expectedArgCount = resultCount;
+    if (!inst.args[0].isSpecial())
+        return false;
+
+    Special* special = inst.args[0].special();
+    Code& code = special->code();
+
+    size_t resultCount = cCallResultCount(code, value);
+    size_t expectedArgCount = resultCount + 1; // first Arg is always CCallSpecial.
     for (Value* child : value->children()) {
         ASSERT(child->type() != Tuple);
         expectedArgCount += cCallArgumentRegisterCount(child);
@@ -76,22 +83,28 @@ bool CCallCustom::isValidForm(Inst& inst)
         return false;
 
     // The arguments can only refer to the stack, tmps, or immediates.
-    for (Arg& arg : inst.args) {
+    for (unsigned i = inst.args.size() - 1; i; --i) {
+        Arg arg = inst.args[i];
         if (!arg.isTmp() && !arg.isStackMemory() && !arg.isSomeImm())
             return false;
     }
 
     // Callee
-    if (!inst.args[0].isGP())
+    if (!inst.args[1].isGP())
         return false;
 
-    unsigned offset = 1;
+    unsigned offset = 2;
 
     // If there is a result then it cannot be an immediate.
-    for (size_t i = 0 ; i < resultCount; ++i) {
+    for (size_t i = 0; i < resultCount; ++i) {
         if (inst.args[offset].isSomeImm())
             return false;
-        if (!inst.args[offset].canRepresent(value))
+
+        if (value->type().isTuple()) {
+            Type type = code.proc().typeAtOffset(value->type(), i);
+            if (!inst.args[offset].canRepresent(type))
+                return false;
+        } else if (!inst.args[offset].canRepresent(value))
             return false;
         offset++;
     }

--- a/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
@@ -34,6 +34,7 @@
 #include "AirInsertionSet.h"
 #include "AirPhaseScope.h"
 #include "B3CCallValue.h"
+#include "B3ProcedureInlines.h"
 #include "B3ValueInlines.h"
 
 namespace JSC { namespace B3 { namespace Air {
@@ -53,14 +54,14 @@ void lowerMacros(Code& code)
 
                 Vector<Arg> destinations = computeCCallingConvention(code, value);
 
-                unsigned resultCount = cCallResultCount(value);
-                ASSERT_IMPLIES(is64Bit(), resultCount <= 1);
+                unsigned resultCount = cCallResultCount(code, value);
                 
                 Vector<ShufflePair, 16> shufflePairs;
                 bool hasRegisterSource = false;
                 unsigned offset = 1;
                 auto addNextPair = [&](Width width) {
-                    ShufflePair pair(inst.args[offset + resultCount], destinations[offset], width);
+                    // Skip the special Arg in CCall
+                    ShufflePair pair(inst.args[offset + resultCount + 1], destinations[offset], width);
                     shufflePairs.append(pair);
                     hasRegisterSource |= pair.src().isReg();
                     ++offset;
@@ -68,7 +69,7 @@ void lowerMacros(Code& code)
                 for (unsigned i = 1; i < value->numChildren(); ++i) {
                     Value* child = value->child(i);
                     for (unsigned j = 0; j < cCallArgumentRegisterCount(child); j++)
-                        addNextPair(cCallArgumentRegisterWidth(child));
+                        addNextPair(cCallArgumentRegisterWidth(child->type()));
                 }
                 ASSERT(offset = inst.args.size());
                 
@@ -97,13 +98,11 @@ void lowerMacros(Code& code)
                 }
 
                 // Indicate that we're using our original callee argument.
-                destinations[0] = inst.args[0];
+                destinations[0] = inst.args[1];
 
                 // Save where the original instruction put its result.
-                Arg resultDst0 = resultCount >= 1 ? inst.args[1] : Arg();
-#if USE(JSVALUE32_64)
-                Arg resultDst1 = resultCount >= 2 ? inst.args[2] : Arg();
-#endif
+                Arg resultDst0 = resultCount >= 1 ? inst.args[2] : Arg();
+                Arg resultDst1 = resultCount >= 2 ? inst.args[3] : Arg();
 
                 inst = buildCCall(code, inst.origin, destinations);
                 if (oldKind.effects)
@@ -111,26 +110,29 @@ void lowerMacros(Code& code)
 
                 switch (value->type().kind()) {
                 case Void:
+                    break;
                 case Tuple:
+                    insertionSet.insert(instIndex + 1, Move, value, cCallResult(code, value, 0), resultDst0);
+                    insertionSet.insert(instIndex + 1, Move, value, cCallResult(code, value, 1), resultDst1);
                     break;
                 case Float:
-                    insertionSet.insert(instIndex + 1, MoveFloat, value, cCallResult(value, 0), resultDst0);
+                    insertionSet.insert(instIndex + 1, MoveFloat, value, cCallResult(code, value, 0), resultDst0);
                     break;
                 case Double:
-                    insertionSet.insert(instIndex + 1, MoveDouble, value, cCallResult(value, 0), resultDst0);
+                    insertionSet.insert(instIndex + 1, MoveDouble, value, cCallResult(code, value, 0), resultDst0);
                     break;
                 case Int32:
-                    insertionSet.insert(instIndex + 1, Move32, value, cCallResult(value, 0), resultDst0);
+                    insertionSet.insert(instIndex + 1, Move32, value, cCallResult(code, value, 0), resultDst0);
                     break;
                 case Int64:
-                    insertionSet.insert(instIndex + 1, Move, value, cCallResult(value, 0), resultDst0);
+                    insertionSet.insert(instIndex + 1, Move, value, cCallResult(code, value, 0), resultDst0);
 #if USE(JSVALUE32_64)
-                    insertionSet.insert(instIndex + 1, Move, value, cCallResult(value, 1), resultDst1);
+                    insertionSet.insert(instIndex + 1, Move, value, cCallResult(code, value, 1), resultDst1);
 #endif
                     break;
                 case V128:
                     ASSERT(is64Bit());
-                    insertionSet.insert(instIndex + 1, MoveVector, value, cCallResult(value, 0), resultDst0);
+                    insertionSet.insert(instIndex + 1, MoveVector, value, cCallResult(code, value, 0), resultDst0);
                     break;
                 }
             };

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -2034,7 +2034,7 @@ custom Shuffle
 custom Patch
 
 # Instructions used for lowering C calls. These don't make it to Air generation. They get lowered to
-# something else first. The origin Value must be a CCallValue.
+# CCallSpecials first. The origin Value must be a CCallValue.
 custom CCall
 custom ColdCCall
 

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -959,6 +959,8 @@ void testCallSimplePure(int, int);
 void testCallFunctionWithHellaArguments();
 void testCallFunctionWithHellaArguments2();
 void testCallFunctionWithHellaArguments3();
+void testCallPairResult(int, int);
+void testCallPairResultRare(int, int);
 void testReturnDouble(double value);
 void testReturnFloat(float value);
 void testMulNegArgArg(int, int);

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -3999,7 +3999,10 @@ void addCallTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
     RUN(testCallFunctionWithHellaArguments());
     RUN(testCallFunctionWithHellaArguments2());
     RUN(testCallFunctionWithHellaArguments3());
-    
+
+    RUN(testCallPairResult(1, 100));
+    RUN(testCallPairResultRare(1, 100));
+
     RUN(testReturnDouble(0.0));
     RUN(testReturnDouble(negativeZero()));
     RUN(testReturnDouble(42.5));

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
@@ -248,6 +248,14 @@ private:
         m_state.setShouldTryConstantFolding(true);
     }
     
+    void setTupleConstant(Node* node, unsigned index, FrozenValue value)
+    {
+        AbstractValue& abstractValue = m_state.forTupleNode(node, index);
+        abstractValue.set(m_graph, value, m_state.structureClobberState());
+        abstractValue.fixTypeForRepresentation(m_graph, node);
+        m_state.setShouldTryConstantFolding(true);
+    }
+
     ALWAYS_INLINE void filterByType(Edge& edge, SpeculatedType type);
     
     void verifyEdge(Node*, Edge);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -389,6 +389,13 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             m_state.setShouldTryConstantFolding(true);
         break;
     }
+
+    case ExtractFromTuple: {
+        setForNode(node, m_state.forTupleNode(node->child1(), node->extractOffset()));
+        if (forNode(node).value())
+            m_state.setShouldTryConstantFolding(true);
+        break;
+    }
         
     case ExtractCatchLocal:
     case ExtractOSREntryLocal: {
@@ -4524,11 +4531,13 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case EnumeratorNextUpdateIndexAndMode: {
         ArrayMode arrayMode = node->arrayMode();
-        if (node->enumeratorMetadata() == JSPropertyNameEnumerator::OwnStructureMode && m_graph.varArgChild(node, 0).useKind() == CellUse) {
-            // Do nothing.
-        } else if (node->enumeratorMetadata() != JSPropertyNameEnumerator::IndexedMode)
+        if (node->enumeratorMetadata() == JSPropertyNameEnumerator::OwnStructureMode && m_graph.varArgChild(node, 0).useKind() == CellUse)
+            setTupleConstant(node, 1, jsNumber(static_cast<uint8_t>(JSPropertyNameEnumerator::OwnStructureMode)));
+        else if (node->enumeratorMetadata() != JSPropertyNameEnumerator::IndexedMode) {
+            m_state.setNonCellTypeForTupleNode(node, 1, SpecInt32Only);
             clobberWorld();
-        else {
+        } else {
+            setTupleConstant(node, 1, jsNumber(static_cast<uint8_t>(JSPropertyNameEnumerator::IndexedMode)));
             switch (arrayMode.type()) {
             case Array::Int32:
             case Array::Double:
@@ -4544,25 +4553,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             }
             }
         }
-        setNonCellTypeForNode(node, SpecBytecodeNumber);
-        break;
-    }
-
-    case EnumeratorNextExtractMode: {
-        if (node->child1()->enumeratorMetadata() == JSPropertyNameEnumerator::IndexedMode) {
-            setConstant(node, jsNumber(static_cast<uint8_t>(JSPropertyNameEnumerator::IndexedMode)));
-            break;
-        }
-
-        if (node->child1()->enumeratorMetadata() == JSPropertyNameEnumerator::OwnStructureMode && m_graph.varArgChild(node->child1().node(), 0).useKind() == CellUse) {
-            setConstant(node, jsNumber(static_cast<uint8_t>(JSPropertyNameEnumerator::OwnStructureMode)));
-            break;
-        }
-
-        FALLTHROUGH;
-    }
-    case EnumeratorNextExtractIndex: {
-        setNonCellTypeForNode(node, SpecInt32Only);
+        m_state.setNonCellTypeForTupleNode(node, 0, SpecInt32Only);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp
@@ -36,12 +36,14 @@ namespace JSC { namespace DFG {
 AtTailAbstractState::AtTailAbstractState(Graph& graph)
     : m_graph(graph)
     , m_valuesAtTailMap(m_graph)
+    , m_tupleAbstractValues(m_graph)
 {
     for (BasicBlock* block : graph.blocksInNaturalOrder()) {
         auto& valuesAtTail = m_valuesAtTailMap.at(block);
         valuesAtTail.clear();
         for (auto& valueAtTailPair : block->ssa->valuesAtTail)
             valuesAtTail.add(valueAtTailPair.node, valueAtTailPair.value);
+        m_tupleAbstractValues.at(block).grow(m_graph.m_tupleData.size());
     }
 }
 

--- a/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h
@@ -136,6 +136,83 @@ public:
     {
         makeHeapTopForNode(edge.node());
     }
+
+    ALWAYS_INLINE AbstractValue& forTupleNode(NodeFlowProjection node, unsigned index)
+    {
+        ASSERT(index < node->tupleSize());
+        return m_tupleAbstractValues.at(m_block).at(node->tupleOffset() + index);
+    }
+
+    ALWAYS_INLINE AbstractValue& forTupleNode(Edge edge, unsigned index)
+    {
+        return forTupleNode(edge.node(), index);
+    }
+
+    ALWAYS_INLINE void clearForTupleNode(NodeFlowProjection node, unsigned index)
+    {
+        forTupleNode(node, index).clear();
+    }
+
+    ALWAYS_INLINE void clearForTupleNode(Edge edge, unsigned index)
+    {
+        clearForTupleNode(edge.node(), index);
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setForTupleNode(NodeFlowProjection node, unsigned index, Arguments&&... arguments)
+    {
+        forTupleNode(node, index).set(m_graph, std::forward<Arguments>(arguments)...);
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setForTupleNode(Edge edge, unsigned index, Arguments&&... arguments)
+    {
+        setForTupleNode(edge.node(), index, std::forward<Arguments>(arguments)...);
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setTypeForTupleNode(NodeFlowProjection node, unsigned index, Arguments&&... arguments)
+    {
+        forTupleNode(node, index).setType(m_graph, std::forward<Arguments>(arguments)...);
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setTypeForTupleNode(Edge edge, unsigned index, Arguments&&... arguments)
+    {
+        setTypeForTupleNode(edge.node(), index, std::forward<Arguments>(arguments)...);
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setNonCellTypeForTupleNode(NodeFlowProjection node, unsigned index, Arguments&&... arguments)
+    {
+        forTupleNode(node, index).setNonCellType(std::forward<Arguments>(arguments)...);
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setNonCellTypeForTupleNode(Edge edge, unsigned index, Arguments&&... arguments)
+    {
+        setNonCellTypeForTupleNode(edge.node(), index, std::forward<Arguments>(arguments)...);
+    }
+
+    ALWAYS_INLINE void makeBytecodeTopForTupleNode(NodeFlowProjection node, unsigned index)
+    {
+        forTupleNode(node, index).makeBytecodeTop();
+    }
+
+    ALWAYS_INLINE void makeBytecodeTopForTupleNode(Edge edge, unsigned index)
+    {
+        makeBytecodeTopForTupleNode(edge.node(), index);
+    }
+
+    ALWAYS_INLINE void makeHeapTopForTupleNode(NodeFlowProjection node, unsigned index)
+    {
+        forTupleNode(node, index).makeHeapTop();
+    }
+
+    ALWAYS_INLINE void makeHeapTopForTupleNode(Edge edge, unsigned index)
+    {
+        makeHeapTopForTupleNode(edge.node(), index);
+    }
     
     unsigned size() const { return m_block->valuesAtTail.size(); }
     unsigned numberOfArguments() const { return m_block->valuesAtTail.numberOfArguments(); }
@@ -181,6 +258,7 @@ public:
 private:
     Graph& m_graph;
     BlockMap<HashMap<NodeFlowProjection, AbstractValue>> m_valuesAtTailMap;
+    BlockMap<Vector<AbstractValue>> m_tupleAbstractValues;
     BasicBlock* m_block { nullptr };
     bool m_trustEdgeProofs { false };
 };

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -359,9 +359,8 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
     }
 
-    case EnumeratorNextExtractMode:
-    case EnumeratorNextExtractIndex: {
-        def(PureValue(node));
+    case ExtractFromTuple: {
+        def(PureValue(node, node->extractOffset()));
         return;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -519,8 +519,7 @@ bool doesGC(Graph& graph, Node* node)
     case ResolveRope:
         return true;
 
-    case EnumeratorNextExtractMode:
-    case EnumeratorNextExtractIndex:
+    case ExtractFromTuple:
         return false;
 
     case PutByValDirect:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2418,11 +2418,15 @@ private:
             fixEdge<KnownInt32Use>(index);
             fixEdge<KnownInt32Use>(m_graph.varArgChild(node, 2));
             fixEdge<KnownCellUse>(m_graph.varArgChild(node, 3));
+
+            m_graph.m_tupleData.at(node->tupleOffset()).resultFlags = NodeResultInt32;
+            m_graph.m_tupleData.at(node->tupleOffset() + 1).resultFlags = NodeResultInt32;
             break;
         }
 
-        case EnumeratorNextExtractIndex:
-        case EnumeratorNextExtractMode: {
+        case ExtractFromTuple: {
+            node->setResult(m_graph.m_tupleData.at(node->tupleIndex()).resultFlags);
+            ASSERT(node->hasResult());
             break;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGGenerationInfo.h
+++ b/Source/JavaScriptCore/dfg/DFGGenerationInfo.h
@@ -147,6 +147,14 @@ public:
 
     // Get the node that produced this value.
     Node* node() { return m_node; }
+
+    void initFromTupleResult(Node* newNode)
+    {
+        ASSERT(m_useCount == 1);
+        ASSERT(newNode->child1().node() == m_node);
+        m_node = newNode;
+        m_useCount = m_node->refCount();
+    }
     
     void noticeOSRBirth(VariableEventStreamBuilder& stream, Node* node, VirtualRegister virtualRegister)
     {

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -391,6 +391,8 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
         out.print(comma, *node->putByStatus());
     if (node->hasEnumeratorMetadata())
         out.print(comma, "enumeratorModes = ", node->enumeratorMetadata().toRaw());
+    if (node->hasExtractOffset())
+        out.print(comma, "<<", node->extractOffset());
     if (node->isJump())
         out.print(comma, "T:", *node->targetBlock());
     if (node->isBranch())
@@ -765,7 +767,9 @@ public:
             for (unsigned phiIndex = block->phis.size(); phiIndex--;)
                 block->phis[phiIndex]->setRefCount(0);
         }
-    
+        for (auto& tupleData : m_graph.m_tupleData)
+            tupleData.refCount = 0;
+
         // Now find the roots:
         // - Nodes that are must-generate.
         // - Nodes that are reachable from type checks.
@@ -820,8 +824,7 @@ private:
         // will just not have gotten around to it.
         if (edge.isProved() || edge.willNotHaveCheck())
             return;
-        if (!edge->postfixRef())
-            m_worklist.append(edge.node());
+        countNode(edge.node());
     }
     
     void countNode(Node* node)
@@ -831,11 +834,14 @@ private:
         m_worklist.append(node);
     }
     
-    void countEdge(Node*, Edge edge)
+    void countEdge(Node* node, Edge edge)
     {
         // Don't count edges that are already counted for their type checks.
         if (!(edge.isProved() || edge.willNotHaveCheck()))
             return;
+        // Tuples are special and have a reference count for each result.
+        if (node->op() == ExtractFromTuple)
+            m_graph.m_tupleData.at(node->tupleIndex()).refCount++;
         countNode(edge.node());
     }
     

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -221,13 +221,14 @@ public:
     template<typename... Params>
     Node* addNode(Params... params)
     {
-        return m_nodes.addNew(params...);
+        Node* node = m_nodes.addNew(params...);
+        return node;
     }
 
     template<typename... Params>
     Node* addNode(SpeculatedType type, Params... params)
     {
-        Node* node = m_nodes.addNew(params...);
+        Node* node = addNode(params...);
         node->predict(type);
         return node;
     }
@@ -1175,6 +1176,14 @@ public:
     Vector<RefPtr<BasicBlock>, 8> m_blocks;
     Vector<BasicBlock*, 1> m_roots;
     Vector<Edge, 16> m_varArgChildren;
+
+    struct TupleData {
+        uint16_t refCount { 0 };
+        uint16_t resultFlags { 0 };
+        VirtualRegister virtualRegister;
+    };
+
+    Vector<TupleData> m_tupleData;
 
     // UnlinkedSimpleJumpTable/UnlinkedStringJumpTable are kept by UnlinkedCodeBlocks retained by baseline CodeBlocks handled by DFG / FTL.
     Vector<const UnlinkedSimpleJumpTable*> m_unlinkedSwitchJumpTables;

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
@@ -41,6 +41,7 @@ InPlaceAbstractState::InPlaceAbstractState(Graph& graph)
     : m_graph(graph)
     , m_abstractValues(*graph.m_abstractValuesCache)
     , m_variables(OperandsLike, graph.block(0)->variablesAtHead)
+    , m_tupleAbstractValues(graph.m_tupleData.size())
     , m_block(nullptr)
 {
 }

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
@@ -156,6 +156,101 @@ public:
         makeHeapTopForNode(edge.node());
     }
     
+    ALWAYS_INLINE AbstractValue& forTupleNode(NodeFlowProjection node, unsigned index)
+    {
+        ASSERT(index < node->tupleSize());
+        return fastForward(m_tupleAbstractValues.at(node->tupleOffset() + index));
+    }
+
+    ALWAYS_INLINE AbstractValue& forTupleNode(Edge edge, unsigned index)
+    {
+        return forTupleNode(edge.node(), index);
+    }
+
+    ALWAYS_INLINE void clearForTupleNode(NodeFlowProjection node, unsigned index)
+    {
+        ASSERT(index < node->tupleSize());
+        AbstractValue& value = m_tupleAbstractValues.at(node->tupleOffset() + index);
+        value.clear();
+        value.m_effectEpoch = m_effectEpoch;
+    }
+
+    ALWAYS_INLINE void clearForTupleNode(Edge edge, unsigned index)
+    {
+        clearForTupleNode(edge.node(), index);
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setForTupleNode(NodeFlowProjection node, unsigned index, Arguments&&... arguments)
+    {
+        ASSERT(index < node->tupleSize());
+        AbstractValue& value = m_tupleAbstractValues.at(node->tupleOffset() + index);
+        value.set(m_graph, std::forward<Arguments>(arguments)...);
+        value.m_effectEpoch = m_effectEpoch;
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setForTupleNode(Edge edge, unsigned index, Arguments&&... arguments)
+    {
+        setForTupleNode(edge.node(), index, std::forward<Arguments>(arguments)...);
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setTypeForTupleNode(NodeFlowProjection node, unsigned index, Arguments&&... arguments)
+    {
+        ASSERT(index < node->tupleSize());
+        AbstractValue& value = m_tupleAbstractValues.at(node->tupleOffset() + index);
+        value.setType(m_graph, std::forward<Arguments>(arguments)...);
+        value.m_effectEpoch = m_effectEpoch;
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setTypeForTupleNode(Edge edge, unsigned index, Arguments&&... arguments)
+    {
+        setTypeForTupleNode(edge.node(), index, std::forward<Arguments>(arguments)...);
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setNonCellTypeForTupleNode(NodeFlowProjection node, unsigned index, Arguments&&... arguments)
+    {
+        ASSERT(index < node->tupleSize());
+        AbstractValue& value = m_tupleAbstractValues.at(node->tupleOffset() + index);
+        value.setNonCellType(std::forward<Arguments>(arguments)...);
+        value.m_effectEpoch = m_effectEpoch;
+    }
+
+    template<typename... Arguments>
+    ALWAYS_INLINE void setNonCellTypeForTupleNode(Edge edge, unsigned index, Arguments&&... arguments)
+    {
+        setNonCellTypeForTupleNode(edge.node(), index, std::forward<Arguments>(arguments)...);
+    }
+
+    ALWAYS_INLINE void makeBytecodeTopForTupleNode(NodeFlowProjection node, unsigned index)
+    {
+        ASSERT(index < node->tupleSize());
+        AbstractValue& value = m_tupleAbstractValues.at(node->tupleOffset() + index);
+        value.makeBytecodeTop();
+        value.m_effectEpoch = m_effectEpoch;
+    }
+
+    ALWAYS_INLINE void makeBytecodeTopForTupleNode(Edge edge, unsigned index)
+    {
+        makeBytecodeTopForTupleNode(edge.node(), index);
+    }
+
+    ALWAYS_INLINE void makeHeapTopForTupleNode(NodeFlowProjection node, unsigned index)
+    {
+        ASSERT(index < node->tupleSize());
+        AbstractValue& value = m_tupleAbstractValues.at(node->tupleOffset() + index);
+        value.makeHeapTop();
+        value.m_effectEpoch = m_effectEpoch;
+    }
+
+    ALWAYS_INLINE void makeHeapTopForTupleNode(Edge edge, unsigned index)
+    {
+        makeHeapTopForTupleNode(edge.node(), index);
+    }
+
     Operands<AbstractValue>& variablesForDebugging();
 
     unsigned size() const { return m_variables.size(); }
@@ -280,6 +375,7 @@ private:
 
     FlowMap<AbstractValue>& m_abstractValues;
     Operands<AbstractValue> m_variables;
+    Vector<AbstractValue> m_tupleAbstractValues;
     FastBitVector m_activeVariables;
     BasicBlock* m_block;
 

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -111,8 +111,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case FilterDeleteByStatus:
     case FilterCheckPrivateBrandStatus:
     case FilterSetPrivateBrandStatus:
-    case EnumeratorNextExtractMode:
-    case EnumeratorNextExtractIndex:
+    case ExtractFromTuple:
         break;
 
     case EnumeratorNextUpdatePropertyName:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -90,6 +90,7 @@ namespace JSC { namespace DFG {
     macro(Phi, 0) \
     macro(Flush, NodeMustGenerate) \
     macro(PhantomLocal, NodeMustGenerate) \
+    macro(ExtractFromTuple, 0) \
     \
     /* Hint that this is where bytecode thinks is a good place to OSR. Note that this */\
     /* will exist even in inlined loops. This has no execution semantics but it must */\
@@ -517,9 +518,7 @@ namespace JSC { namespace DFG {
     macro(HasIndexedProperty, NodeMustGenerate | NodeResultBoolean | NodeHasVarArgs) \
     /* For-in enumeration opcodes */\
     macro(GetPropertyEnumerator, NodeMustGenerate | NodeResultJS) \
-    macro(EnumeratorNextUpdateIndexAndMode, NodeResultJS | NodeHasVarArgs) \
-    macro(EnumeratorNextExtractMode, NodeResultInt32) \
-    macro(EnumeratorNextExtractIndex, NodeResultInt32) \
+    macro(EnumeratorNextUpdateIndexAndMode, NodeHasVarArgs) \
     macro(EnumeratorNextUpdatePropertyName, NodeResultJS) \
     macro(EnumeratorGetByVal, NodeResultJS | NodeHasVarArgs | NodeMustGenerate) \
     macro(EnumeratorInByVal, NodeResultBoolean | NodeHasVarArgs | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2353,7 +2353,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetPropertyEnumeratorCell, JSCell*, (JSGlobalO
     RELEASE_AND_RETURN(scope, propertyNameEnumerator(globalObject, base));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationEnumeratorNextUpdateIndexAndMode, EncodedJSValue, (JSGlobalObject* globalObject, EncodedJSValue baseValue, uint32_t index, int32_t modeNumber, JSPropertyNameEnumerator* enumerator))
+JSC_DEFINE_JIT_OPERATION(operationEnumeratorNextUpdateIndexAndMode, UGPRPair, (JSGlobalObject* globalObject, EncodedJSValue baseValue, uint32_t index, int32_t modeNumber, JSPropertyNameEnumerator* enumerator))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
@@ -2375,13 +2375,7 @@ JSC_DEFINE_JIT_OPERATION(operationEnumeratorNextUpdateIndexAndMode, EncodedJSVal
         RETURN_IF_EXCEPTION(scope, { });
     }
 
-#if USE(JSVALUE64)
-    JSValue result = bitwise_cast<JSValue>(static_cast<uint64_t>(mode) << 32 | index | JSValue::DoubleEncodeOffset);
-#else
-    JSValue result = JSValue(mode, index);
-#endif
-    ASSERT(result.isDouble());
-    return JSValue::encode(result);
+    return makeUGPRPair(index, static_cast<uint32_t>(mode));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationEnumeratorNextUpdatePropertyName, JSString*, (JSGlobalObject* globalObject, uint32_t index, int32_t modeNumber, JSPropertyNameEnumerator* enumerator))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -50,6 +50,20 @@ namespace DFG {
 
 struct OSRExitBase;
 
+
+#if USE(JSVALUE64)
+struct UGPRPair {
+    // We carefully use UCPURegister so both parameters are returned in their own registers.
+    UCPURegister first;
+    UCPURegister second;
+};
+constexpr UGPRPair makeUGPRPair(UCPURegister first, UCPURegister second) { return { first, second }; }
+#else
+using UGPRPair = uint64_t;
+constexpr UGPRPair makeUGPRPair(UCPURegister first, UCPURegister second) { return static_cast<uint64_t>(second) << 32 | first; }
+#endif
+
+
 JSC_DECLARE_JIT_OPERATION(operationStringFromCharCode, JSCell*, (JSGlobalObject*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringFromCharCodeUntyped, EncodedJSValue, (JSGlobalObject*, EncodedJSValue));
 
@@ -118,7 +132,7 @@ JSC_DECLARE_JIT_OPERATION(operationHasIndexedProperty, size_t, (JSGlobalObject*,
 JSC_DECLARE_JIT_OPERATION(operationHasEnumerableIndexedProperty, size_t, (JSGlobalObject*, JSCell*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationGetPropertyEnumerator, JSCell*, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationGetPropertyEnumeratorCell, JSCell*, (JSGlobalObject*, JSCell*));
-JSC_DECLARE_JIT_OPERATION(operationEnumeratorNextUpdateIndexAndMode, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, uint32_t, int32_t, JSPropertyNameEnumerator*));
+JSC_DECLARE_JIT_OPERATION(operationEnumeratorNextUpdateIndexAndMode, UGPRPair, (JSGlobalObject*, EncodedJSValue, uint32_t, int32_t, JSPropertyNameEnumerator*));
 JSC_DECLARE_JIT_OPERATION(operationEnumeratorNextUpdatePropertyName, JSString*, (JSGlobalObject*, uint32_t, int32_t, JSPropertyNameEnumerator*));
 JSC_DECLARE_JIT_OPERATION(operationEnumeratorInByVal, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, EncodedJSValue, uint32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationEnumeratorHasOwnProperty, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, EncodedJSValue, uint32_t, int32_t));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -42,7 +42,9 @@ class PredictionPropagationPhase : public Phase {
 public:
     PredictionPropagationPhase(Graph& graph)
         : Phase(graph, "prediction propagation")
+        , m_tupleSpeculations(graph.m_tupleData.size())
     {
+        m_tupleSpeculations.fill(SpecNone);
     }
     
     bool run()
@@ -127,6 +129,37 @@ private:
         ASSERT(m_currentNode->hasResult());
         
         return m_currentNode->predict(prediction);
+    }
+
+    bool setTuplePrediction(SpeculatedType prediction, unsigned index)
+    {
+        ASSERT(index < m_currentNode->tupleSize());
+
+        SpeculatedType& speculation = m_tupleSpeculations[m_currentNode->tupleOffset() + index];
+        // setTuplePrediction() is used when we know that there is no way that we can change
+        // our minds about what the prediction is going to be. There is no semantic
+        // difference between setTuplePrediction() and mergeTupleSpeculation() other than the
+        // increased checking to validate this property.
+        ASSERT(speculation == SpecNone || speculation == prediction);
+        return mergeSpeculation(speculation, prediction);
+    }
+
+    bool mergeTuplePrediction(SpeculatedType prediction, unsigned index)
+    {
+        ASSERT(index < m_currentNode->tupleSize());
+
+        SpeculatedType& speculation = m_tupleSpeculations[m_currentNode->tupleOffset() + index];
+        return mergeSpeculation(speculation, prediction);
+    }
+
+    template<typename... SpeculatedTypes>
+    bool setTuplePredictions(SpeculatedTypes... predictions)
+    {
+        unsigned index = 0;
+        bool updatedPrediction = false;
+        for (SpeculatedType prediction : { predictions... })
+            updatedPrediction |= setTuplePrediction(prediction, index++);
+        return updatedPrediction;
     }
     
     SpeculatedType speculatedDoubleTypeForPrediction(SpeculatedType value)
@@ -1250,9 +1283,9 @@ private:
             setPrediction(SpecObjectOther);
             break;
 
-        case EnumeratorNextExtractMode:
-        case EnumeratorNextExtractIndex: {
-            setPrediction(SpecInt32Only);
+        case ExtractFromTuple: {
+            // Use mergePrediction because ExtractFromTuple doesn't know if the prediction could change.
+            mergePrediction(m_tupleSpeculations[m_currentNode->tupleIndex()]);
             break;
         }
 
@@ -1273,7 +1306,7 @@ private:
         }
 
         case EnumeratorNextUpdateIndexAndMode: {
-            setPrediction(SpecFullNumber);
+            setTuplePredictions(SpecInt32Only, SpecInt32Only);
             break;
         }
 
@@ -1559,6 +1592,7 @@ private:
     }
 
     Vector<Node*> m_dependentNodes;
+    Vector<SpeculatedType, 16> m_tupleSpeculations;
     Node* m_currentNode;
     bool m_changed { false };
     PredictionPass m_pass { PrimaryPass }; // We use different logic for considering predictions depending on how far along we are in propagation.

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -501,9 +501,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     }
 
     case EnumeratorNextUpdateIndexAndMode:
-    // These technically don't have effects but they'll only ever follow a EnumeratorNextUpdateIndexAndMode so we might as well return false.
-    case EnumeratorNextExtractMode:
-    case EnumeratorNextExtractIndex:
+    case ExtractFromTuple:
     case EnumeratorNextUpdatePropertyName:
     case ToThis:
     case CreateThis:

--- a/Source/JavaScriptCore/dfg/DFGScoreBoard.h
+++ b/Source/JavaScriptCore/dfg/DFGScoreBoard.h
@@ -103,6 +103,7 @@ public:
         if (!child)
             return;
 
+        ASSERT(!child->isTuple());
         // Find the virtual register number for this child, increment its use count.
         uint32_t index = child->virtualRegister().toLocal();
         ASSERT(m_used[index] != max());

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2161,6 +2161,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ExtractFromTuple: {
+        compileExtractFromTuple(node);
+        break;
+    }
+
     case Inc:
     case Dec:
         compileIncOrDec(node);
@@ -4038,16 +4043,6 @@ void SpeculativeJIT::compile(Node* node)
 
     case EnumeratorNextUpdateIndexAndMode: {
         compileEnumeratorNextUpdateIndexAndMode(node);
-        break;
-    }
-
-    case EnumeratorNextExtractMode: {
-        compileEnumeratorNextExtractMode(node);
-        break;
-    }
-
-    case EnumeratorNextExtractIndex: {
-        compileEnumeratorNextExtractIndex(node);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3036,6 +3036,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ExtractFromTuple: {
+        compileExtractFromTuple(node);
+        break;
+    }
+
     case Inc:
     case Dec:
         compileIncOrDec(node);
@@ -5593,16 +5598,6 @@ void SpeculativeJIT::compile(Node* node)
 
     case EnumeratorNextUpdateIndexAndMode: {
         compileEnumeratorNextUpdateIndexAndMode(node);
-        break;
-    }
-
-    case EnumeratorNextExtractMode: {
-        compileEnumeratorNextExtractMode(node);
-        break;
-    }
-
-    case EnumeratorNextExtractIndex: {
-        compileEnumeratorNextExtractIndex(node);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -47,7 +47,9 @@ public:
         : m_graph(graph)
         , m_graphDumpMode(graphDumpMode)
         , m_graphDumpBeforePhase(graphDumpBeforePhase)
+        , m_myTupleRefCounts(m_graph.m_tupleData.size())
     {
+        m_myTupleRefCounts.fill(0);
     }
     
     #define VALIDATE(context, assertion) do { \
@@ -138,6 +140,14 @@ public:
                     
                     m_myRefCounts.find(edge.node())->value++;
 
+                    if (node->op() == ExtractFromTuple) {
+                        VALIDATE((node, edge), edge->isTuple());
+                        VALIDATE((node, edge), node->child1() == edge);
+                        m_myTupleRefCounts.at(node->tupleIndex())++;
+                        // Tuples edges don't obey the normal hasResult() rules for nodes so skip that logic below.
+                        continue;
+                    }
+
                     validateEdgeWithDoubleResultIfNecessary(node, edge);
                     validateEdgeWithInt52ResultIfNecessary(node, edge);
                     
@@ -179,8 +189,13 @@ public:
                 continue;
             for (size_t i = 0; i < block->numNodes(); ++i) {
                 Node* node = block->node(i);
-                if (m_graph.m_refCountState == ExactRefCount)
+                if (m_graph.m_refCountState == ExactRefCount) {
                     V_EQUAL((node), m_myRefCounts.get(node), node->adjustedRefCount());
+                    if (node->isTuple()) {
+                        for (unsigned j = 0; j < node->tupleSize(); ++j)
+                            V_EQUAL((node), m_myTupleRefCounts.at(node->tupleOffset() + j), m_graph.m_tupleData.at(node->tupleOffset() + j).refCount);
+                    }
+                }
             }
             
             bool foundTerminal = false;
@@ -488,13 +503,6 @@ public:
     }
     
 private:
-    Graph& m_graph;
-    GraphDumpMode m_graphDumpMode;
-    CString m_graphDumpBeforePhase;
-    
-    HashMap<Node*, unsigned> m_myRefCounts;
-    HashSet<Node*> m_acceptableNodes;
-    
     void validateCPS()
     {
         VALIDATE((), !m_graph.m_rootToArguments.isEmpty()); // We should have at least one root.
@@ -1086,6 +1094,14 @@ private:
         dataLog("At time of failure:\n");
         m_graph.dump();
     }
+
+    Graph& m_graph;
+    GraphDumpMode m_graphDumpMode;
+    CString m_graphDumpBeforePhase;
+
+    HashMap<Node*, unsigned> m_myRefCounts;
+    Vector<uint32_t> m_myTupleRefCounts;
+    HashSet<Node*> m_acceptableNodes;
 };
 
 } // End anonymous namespace.

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -55,6 +55,7 @@ inline CapabilityLevel canCompile(Node* node)
     case Phantom:
     case Flush:
     case PhantomLocal:
+    case ExtractFromTuple:
     case SetArgumentDefinitely:
     case SetArgumentMaybe:
     case Return:
@@ -299,8 +300,6 @@ inline CapabilityLevel canCompile(Node* node)
     case ResolveRope:
     case GetPropertyEnumerator:
     case EnumeratorNextUpdateIndexAndMode:
-    case EnumeratorNextExtractMode:
-    case EnumeratorNextExtractIndex:
     case EnumeratorNextUpdatePropertyName:
     case EnumeratorGetByVal:
     case EnumeratorInByVal:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -159,6 +159,7 @@ public:
         , m_ftlState(state)
         , m_out(state)
         , m_proc(*state.proc)
+        , m_tupleValues(m_graph.m_tupleData.size())
         , m_availabilityCalculator(m_graph)
         , m_state(state.graph)
         , m_interpreter(state.graph, m_state)
@@ -735,6 +736,9 @@ private:
             break;
         case DFG::Phi:
             compilePhi();
+            break;
+        case ExtractFromTuple:
+            compileExtractFromTuple();
             break;
         case JSConstant:
             break;
@@ -1571,12 +1575,6 @@ private:
             break;
         case EnumeratorNextUpdateIndexAndMode:
             compileEnumeratorNextUpdateIndexAndMode();
-            break;
-        case EnumeratorNextExtractIndex:
-            compileEnumeratorNextExtractIndex();
-            break;
-        case EnumeratorNextExtractMode:
-            compileEnumeratorNextExtractMode();
             break;
         case EnumeratorNextUpdatePropertyName:
             compileEnumeratorNextUpdatePropertyName();
@@ -14228,7 +14226,8 @@ IGNORE_CLANG_WARNINGS_END
 
             m_out.appendTo(continuation);
             LValue finalIndex = m_out.phi(Int32, finalIncrementedIndex, finalPropertyIndex);
-            setJSValue(m_out.bitOr(m_out.zeroExt(finalIndex, Int64), m_out.constInt64(JSValue::NumberTag | static_cast<uint64_t>(JSPropertyNameEnumerator::IndexedMode) << 32)));
+            setTuple(0, finalIndex);
+            setTuple(1, m_out.constInt32(static_cast<uint32_t>(JSPropertyNameEnumerator::IndexedMode)));
             return;
         }
 
@@ -14251,27 +14250,47 @@ IGNORE_CLANG_WARNINGS_END
 
             m_out.appendTo(continuation);
             index = m_out.phi(Int32, initialIndex, incrementedIndex);
-            setJSValue(m_out.bitOr(m_out.zeroExt(index, Int64), m_out.constInt64(JSValue::DoubleEncodeOffset | static_cast<uint64_t>(JSPropertyNameEnumerator::OwnStructureMode) << 32)));
+            setTuple(0, index);
+            setTuple(1, m_out.constInt32(static_cast<uint32_t>(JSPropertyNameEnumerator::OwnStructureMode)));
             return;
         }
 
         LValue base = lowJSValue(baseEdge);
-        setJSValue(vmCall(Int64, operationEnumeratorNextUpdateIndexAndMode, weakPointer(globalObject), base, index, mode, enumerator));
+        LValue tuple = vmCall(registerPair(), operationEnumeratorNextUpdateIndexAndMode, weakPointer(globalObject), base, index, mode, enumerator);
+
+        setTuple(0, m_out.castToInt32(m_out.extract(tuple, 0)));
+        setTuple(1, m_out.castToInt32(m_out.extract(tuple, 1)));
     }
 
-    void compileEnumeratorNextExtractIndex()
+    void compileExtractFromTuple()
     {
-        LValue boxedPair = lowJSValue(m_node->child1());
+        auto& loweredNodeValue = m_tupleValues.at(m_node->tupleIndex());
+        ASSERT(isValid(loweredNodeValue));
+        LValue result = loweredNodeValue.value();
 
-        setInt32(m_out.castToInt32(boxedPair));
-    }
+        switch (m_graph.m_tupleData.at(m_node->tupleIndex()).resultFlags) {
+        case NodeResultJS:
+        case NodeResultNumber:
+            setJSValue(result);
+            break;
+        case NodeResultDouble:
+            setDouble(result);
+            break;
+        case NodeResultInt32:
+            setInt32(result);
+            break;
+        case NodeResultBoolean:
+            setBoolean(result);
+            break;
+        case NodeResultStorage:
+            setStorage(result);
+            break;
 
-    void compileEnumeratorNextExtractMode()
-    {
-        LValue boxedPair = lowJSValue(m_node->child1());
-
-        LValue highBits = m_out.castToInt32(m_out.lShr(boxedPair, m_out.constInt32(32)));
-        setInt32(m_out.bitAnd(highBits, m_out.constInt32(JSPropertyNameEnumerator::enumerationModeMask)));
+        // FIXME: These are not supported because it wasn't exactly clear how to implement them and they are not currently used.
+        case NodeResultInt52:
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
     }
 
     // FIXME: We should probably have a method of value recovery for this node since it's "effect" free but always live in bytecode.
@@ -21645,6 +21664,11 @@ IGNORE_CLANG_WARNINGS_END
     {
         m_doubleValues.set(node, LoweredNodeValue(value, m_highBlock));
     }
+    void setTuple(Node* tuple, unsigned index, LValue value)
+    {
+        ASSERT(index < tuple->tupleSize());
+        m_tupleValues.at(tuple->tupleOffset() + index) = LoweredNodeValue(value, m_highBlock);
+    }
 
     void setInt32(LValue value)
     {
@@ -21677,6 +21701,10 @@ IGNORE_CLANG_WARNINGS_END
     void setDouble(LValue value)
     {
         setDouble(m_node, value);
+    }
+    void setTuple(unsigned index, LValue value)
+    {
+        setTuple(m_node, index, value);
     }
     
     bool isValid(const LoweredNodeValue& value)
@@ -21831,6 +21859,13 @@ IGNORE_CLANG_WARNINGS_END
         return abstractStructure(edge.node());
     }
 
+    LType registerPair()
+    {
+        if (!m_registerPair.isTuple())
+            m_registerPair = m_proc.addTuple({ registerType(), registerType() });
+        return m_registerPair;
+    }
+
     void crash()
     {
         crash(m_highBlock, m_node);
@@ -21917,6 +21952,8 @@ IGNORE_CLANG_WARNINGS_END
     HashMap<Node*, LoweredNodeValue> m_storageValues;
     HashMap<Node*, LoweredNodeValue> m_doubleValues;
     
+    Vector<LoweredNodeValue> m_tupleValues;
+
     HashMap<Node*, LValue> m_phis;
     
     LocalOSRAvailabilityCalculator m_availabilityCalculator;
@@ -21935,6 +21972,8 @@ IGNORE_CLANG_WARNINGS_END
     HashMap<Node*, NodeSet> m_liveInToNode;
     HashMap<Node*, AbstractValue> m_aiCheckedNodes;
     String m_graphDump;
+
+    LType m_registerPair;
 };
 
 } // anonymous namespace

--- a/Source/JavaScriptCore/ftl/FTLOutput.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOutput.cpp
@@ -128,6 +128,11 @@ LValue Output::opaque(LValue value)
     return m_block->appendNew<Value>(m_proc, Opaque, origin(), value);
 }
 
+LValue Output::extract(LValue value, unsigned index)
+{
+    return m_block->appendNew<ExtractValue>(m_proc, origin(), m_proc.typeAtOffset(value->type(), index), value, index);
+}
+
 LValue Output::add(LValue left, LValue right)
 {
     if (Value* result = left->addConstant(m_proc, right)) {

--- a/Source/JavaScriptCore/ftl/FTLOutput.h
+++ b/Source/JavaScriptCore/ftl/FTLOutput.h
@@ -149,6 +149,7 @@ public:
     void addIncomingToPhiIfSet(LValue phi, Params... theRest);
     
     LValue opaque(LValue);
+    LValue extract(LValue tuple, unsigned index);
 
     LValue add(LValue, LValue);
     LValue sub(LValue, LValue);

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -30,6 +30,7 @@
 
 #if ENABLE(WEBASSEMBLY_B3JIT)
 
+#include "AirCCallSpecial.h"
 #include "AirCode.h"
 #include "AirGenerate.h"
 #include "AirHelpers.h"
@@ -834,7 +835,7 @@ protected:
         B3::Value* dummyFunc = m_proc.addConstant(B3::Origin(), B3::pointerType(), bitwise_cast<uintptr_t>(func));
         B3::Value* origin = m_proc.add<B3::CCallValue>(resultType, B3::Origin(), B3::Effects::none(), dummyFunc, makeDummyValue(theArgs)...);
 
-        Inst inst(CCall, origin);
+        Inst inst(CCall, origin, Arg::special(m_proc.code().cCallSpecial()));
 
         auto callee = self().gPtr();
         append(block, Move, Arg::immPtr(tagCFunctionPtr<void*, OperationPtrTag>(func)), callee);


### PR DESCRIPTION
#### f2f3c91fa89c2bef7d30bba0324cdba55aa3ae4f
<pre>
DFG should support tuples
<a href="https://bugs.webkit.org/show_bug.cgi?id=253413">https://bugs.webkit.org/show_bug.cgi?id=253413</a>

Reviewed by Yusuke Suzuki.

This change adds support for tuples in the DFG. It works similarly to how tuples
work in B3 where there is a side buffer which holds most of the metadata for a
tuple. In the DFG there are three pieces of information held here:
    1) The reference count
    2) The result flags
    3) The virtual register

1) tells us if the ExtractFromTuple Node for a given tuple result still exists
(e.g. it could have been constant folded or dead code eliminated). From that we
will decide to fill (3) the virtual register when allocating registers. If we
didn&apos;t have the reference count then we would have no way to know that the
virtual registers isn&apos;t going to be consumed thus we will leak it. Lastly we
have (2) the result flags for the node. This tells the ExtractFromTuple and
theoretically (as right now the only ExtractFromTuple users produce Int32s) any
 consumers of the ExtractFromTuple what value format the tuple&apos;s result will
 be in. For the DFG, we don&apos;t need this because we know there&apos;s at most one
 ExtractFromTuple for any given tuple index since we don&apos;t duplicate code.

When dumping the DFG graph ExtractFromTuple follows the same pattern as B3
and uses `&lt;&lt;X` to denote the offset we are extracting from. So it will look
something like:

  6  1  0:  D@101:&lt; 1:-&gt;    EnumeratorNextUpdateIndexAndMode(Check:Untyped:D@97, Check:Untyped:D@98, Check:Untyped:D@100, Check:Untyped:D@99, VarArgs, SelectUsingPredictions+NonArray+InBounds+AsIs+Read, enumeratorModes = 4, R:World, W:Heap, Exits, ClobbersExit, bc#115, ExitValid)
  7  1  0:  D@102:&lt; 1:-&gt;    ExtractFromTuple(Check:Untyped:D@101, Int32|UseAsOther, &lt;&lt;0, bc#115, ExitInvalid)
  8  1  0:  D@103:&lt;!0:-&gt;    MovHint(Check:Untyped:D@102, MustGen, loc10, W:SideState, ClobbersExit, bc#115, ExitInvalid)
  9  1  0:  D@104:&lt; 1:-&gt;    ExtractFromTuple(Check:Untyped:D@101, Int32|UseAsOther, &lt;&lt;1, bc#115, ExitInvalid)

This patch also adds support for calling operations in both the FTL/B3 via
CCall. CCall can take exactly the tuple of `{ pointerType(), pointerType() }`,
which, for every calling conevention we support, should be returned in both
the return value registers. As the only way to look into a tuple is via the
B3 prodecure, the first Air::Arg of any CCall/ColdCCall Inst is now the
CCallSpecial for the compiling Air::Code. This gives us access to Air::Code
inside CCallCustom::forEachArg and isValidForm.

* JSTests/stress/for-in-redefine-enumerable.js:
(shouldBe):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Type.h:
(JSC::B3::pointerType):
(JSC::B3::registerType):
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp:
(JSC::B3::Air::cCallResultCount):
(JSC::B3::Air::cCallArgumentRegisterWidth):
(JSC::B3::Air::cCallResult):
* Source/JavaScriptCore/b3/air/AirCCallingConvention.h:
* Source/JavaScriptCore/b3/air/AirCustom.cpp:
(JSC::B3::Air::CCallCustom::isValidForm):
* Source/JavaScriptCore/b3/air/AirCustom.h:
(JSC::B3::Air::CCallCustom::forEachArg):
* Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp:
(JSC::B3::Air::lowerAfterRegAlloc):
* Source/JavaScriptCore/b3/air/AirLowerMacros.cpp:
(JSC::B3::Air::lowerMacros):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_3.cpp:
(addCallTests):
* Source/JavaScriptCore/b3/testb3_5.cpp:
(JSC_DEFINE_JIT_OPERATION):
(testCallPairResult):
(testCallPairResultRare):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h:
(JSC::DFG::AbstractInterpreter::setTupleConstant):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp:
(JSC::DFG::AtTailAbstractState::AtTailAbstractState):
* Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h:
(JSC::DFG::AtTailAbstractState::forTupleNode):
(JSC::DFG::AtTailAbstractState::clearForTupleNode):
(JSC::DFG::AtTailAbstractState::setForTupleNode):
(JSC::DFG::AtTailAbstractState::setTypeForTupleNode):
(JSC::DFG::AtTailAbstractState::setNonCellTypeForTupleNode):
(JSC::DFG::AtTailAbstractState::makeBytecodeTopForTupleNode):
(JSC::DFG::AtTailAbstractState::makeHeapTopForTupleNode):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::addToGraph):
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGGenerationInfo.h:
(JSC::DFG::GenerationInfo::initFromTupleResult):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dump):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp:
(JSC::DFG::InPlaceAbstractState::InPlaceAbstractState):
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h:
(JSC::DFG::InPlaceAbstractState::forTupleNode):
(JSC::DFG::InPlaceAbstractState::clearForTupleNode):
(JSC::DFG::InPlaceAbstractState::setForTupleNode):
(JSC::DFG::InPlaceAbstractState::setTypeForTupleNode):
(JSC::DFG::InPlaceAbstractState::setNonCellTypeForTupleNode):
(JSC::DFG::InPlaceAbstractState::makeBytecodeTopForTupleNode):
(JSC::DFG::InPlaceAbstractState::makeHeapTopForTupleNode):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::isTuple const):
(JSC::DFG::Node::setTupleOffset):
(JSC::DFG::Node::tupleOffset const):
(JSC::DFG::Node::hasExtractOffset const):
(JSC::DFG::Node::extractOffset const):
(JSC::DFG::Node::tupleIndex const):
(JSC::DFG::Node::tupleSize const):
(JSC::DFG::Node::hasVirtualRegister):
(JSC::DFG::Node::virtualRegister):
(JSC::DFG::Node::setVirtualRegister):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
(JSC::DFG::makeUGPRPair):
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGScoreBoard.h:
(JSC::DFG::ScoreBoard::use):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
(JSC::DFG::SpeculativeJIT::strictInt32TupleResultWithoutUsingChildren):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGValidate.cpp:
* Source/JavaScriptCore/dfg/DFGVirtualRegisterAllocationPhase.cpp:
(JSC::DFG::VirtualRegisterAllocationPhase::run):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::LowerDFGToB3):
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOutput.cpp:
(JSC::FTL::Output::extract):
* Source/JavaScriptCore/ftl/FTLOutput.h:
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::AirIRGeneratorBase::emitCCall):

Canonical link: <a href="https://commits.webkit.org/262068@main">https://commits.webkit.org/262068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab3884c0eee7246644afa330096caa5fe6815207

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/350 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/328 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/570 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/378 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/365 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/400 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/317 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/307 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/347 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/357 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/331 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/365 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/342 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/109 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/335 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/364 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/49 "Passed tests") | 
<!--EWS-Status-Bubble-End-->