### PR TITLE
REGRESSION (STP 164): new failure in css/css-backgrounds/parsing/background-shorthand-serialization.html

### DIFF
--- a/LayoutTests/editing/deleting/paste-with-transparent-background-color-expected.txt
+++ b/LayoutTests/editing/deleting/paste-with-transparent-background-color-expected.txt
@@ -13,7 +13,7 @@ After cut and paste:
 | "hello "
 | <span>
 |   class="test"
-|   style="background-color: transparent;"
+|   style="background-image: none; background-color: transparent;"
 |   "world"
 | " WebKit<#selection-caret>"
 | <br>

--- a/LayoutTests/editing/deleting/paste-with-transparent-background-color-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/paste-with-transparent-background-color-live-range-expected.txt
@@ -13,7 +13,7 @@ After cut and paste:
 | "hello "
 | <span>
 |   class="test"
-|   style="background-color: transparent;"
+|   style="background-image: none; background-color: transparent;"
 |   "world"
 | " WebKit<#selection-caret>"
 | <br>

--- a/LayoutTests/fast/backgrounds/background-shorthand-after-set-backgroundSize-expected.txt
+++ b/LayoutTests/fast/backgrounds/background-shorthand-after-set-backgroundSize-expected.txt
@@ -3,7 +3,7 @@ Tests a flag to make background shorthand property not override background-size 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS e.style.background is 'red url("dummy://test.png") center center / cover no-repeat border-box'
+PASS e.style.background is 'url("dummy://test.png") center center / cover no-repeat border-box red'
 PASS e.style.backgroundSize is 'cover'
 
 PASS successfullyParsed is true

--- a/LayoutTests/fast/backgrounds/background-shorthand-after-set-backgroundSize.html
+++ b/LayoutTests/fast/backgrounds/background-shorthand-after-set-backgroundSize.html
@@ -12,7 +12,7 @@ if (window.internals) {
 
     e.style.backgroundSize = "cover";
     e.style.background = "center red url(dummy://test.png) no-repeat border-box";
-    shouldBe("e.style.background", "'red url(\"dummy://test.png\") center center / cover no-repeat border-box'")
+    shouldBe("e.style.background", "'url(\"dummy://test.png\") center center / cover no-repeat border-box red'")
     shouldBe("e.style.backgroundSize", "'cover'");
     debug("")
 

--- a/LayoutTests/fast/backgrounds/background-shorthand-with-backgroundSize-style-expected.txt
+++ b/LayoutTests/fast/backgrounds/background-shorthand-with-backgroundSize-style-expected.txt
@@ -3,56 +3,56 @@ Tests background shortand property with background-size
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS e.style.background is 'red url("dummy://test.png") center center / cover no-repeat border-box'
+PASS e.style.background is 'url("dummy://test.png") center center / cover no-repeat border-box red'
 PASS e.style.backgroundSize is 'cover'
 PASS checkStyle() is true
 PASS computedStyle.getPropertyValue("background") is 'rgb(255, 0, 0) url("dummy://test.png") no-repeat scroll 50% 50% / cover border-box border-box'
 PASS computedStyle.getPropertyValue("background-size") is 'cover'
 PASS checkComputedStyleValue() is true
 
-PASS e.style.background is 'red url("dummy://test.png") 20px center / contain no-repeat padding-box'
+PASS e.style.background is 'url("dummy://test.png") 20px center / contain no-repeat padding-box red'
 PASS e.style.backgroundSize is 'contain'
 PASS checkStyle() is true
 PASS computedStyle.getPropertyValue("background") is 'rgb(255, 0, 0) url("dummy://test.png") no-repeat scroll 20px 50% / contain padding-box padding-box'
 PASS computedStyle.getPropertyValue("background-size") is 'contain'
 PASS checkComputedStyleValue() is true
 
-PASS e.style.background is 'red url("dummy://test.png") 50px 60px / 50% 75% no-repeat'
+PASS e.style.background is 'url("dummy://test.png") 50px 60px / 50% 75% no-repeat red'
 PASS e.style.backgroundSize is '50% 75%'
 PASS checkStyle() is true
 PASS computedStyle.getPropertyValue("background") is 'rgb(255, 0, 0) url("dummy://test.png") no-repeat scroll 50px 60px / 50% 75% padding-box border-box'
 PASS computedStyle.getPropertyValue("background-size") is '50% 75%'
 PASS checkComputedStyleValue() is true
 
-PASS e.style.background is 'red url("dummy://test.png") left top / 100px 200px repeat border-box content-box'
+PASS e.style.background is 'url("dummy://test.png") left top / 100px 200px repeat border-box content-box red'
 PASS e.style.backgroundSize is '100px 200px'
 PASS checkStyle() is true
 PASS computedStyle.getPropertyValue("background") is 'rgb(255, 0, 0) url("dummy://test.png") repeat scroll 0% 0% / 100px 200px border-box content-box'
 PASS computedStyle.getPropertyValue("background-size") is '100px 200px'
 PASS checkComputedStyleValue() is true
 
-PASS e.style.background is 'red url("dummy://test.png") 50% repeat content-box padding-box'
+PASS e.style.background is 'url("dummy://test.png") 50% repeat content-box padding-box red'
 PASS e.style.backgroundSize is 'auto'
 PASS checkStyle() is true
 PASS computedStyle.getPropertyValue("background") is 'rgb(255, 0, 0) url("dummy://test.png") repeat scroll 50% 50% / auto content-box padding-box'
 PASS computedStyle.getPropertyValue("background-size") is 'auto'
 PASS checkComputedStyleValue() is true
 
-PASS e.style.background is 'red url("dummy://test.png") 50px 60px / 50% auto no-repeat fixed'
+PASS e.style.background is 'url("dummy://test.png") 50px 60px / 50% auto no-repeat fixed red'
 PASS e.style.backgroundSize is '50% auto'
 PASS checkStyle() is true
 PASS computedStyle.getPropertyValue("background") is 'rgb(255, 0, 0) url("dummy://test.png") no-repeat fixed 50px 60px / 50% auto padding-box border-box'
 PASS computedStyle.getPropertyValue("background-size") is '50% auto'
 PASS checkComputedStyleValue() is true
 
-PASS e.style.background is 'red url("dummy://test.png") left top / 100px auto repeat'
+PASS e.style.background is 'url("dummy://test.png") left top / 100px auto repeat red'
 PASS e.style.backgroundSize is '100px auto'
 PASS checkStyle() is true
 PASS computedStyle.getPropertyValue("background") is 'rgb(255, 0, 0) url("dummy://test.png") repeat scroll 0% 0% / 100px auto padding-box border-box'
 PASS computedStyle.getPropertyValue("background-size") is '100px auto'
 PASS checkComputedStyleValue() is true
 
-PASS e.style.background is 'red url("dummy://test.png") 50% repeat fixed content-box'
+PASS e.style.background is 'url("dummy://test.png") 50% repeat fixed content-box red'
 PASS e.style.backgroundSize is 'auto'
 PASS checkStyle() is true
 PASS computedStyle.getPropertyValue("background") is 'rgb(255, 0, 0) url("dummy://test.png") repeat fixed 50% 50% / auto content-box content-box'
@@ -66,7 +66,7 @@ PASS computedStyle.getPropertyValue("background") is 'rgba(0, 0, 0, 0) none repe
 PASS computedStyle.getPropertyValue("background-size") is '50% auto'
 PASS checkComputedStyleValue() is true
 
-PASS e.style.background is 'red fixed'
+PASS e.style.background is 'fixed red'
 PASS e.style.backgroundSize is 'auto'
 PASS checkStyle() is true
 PASS computedStyle.getPropertyValue("background") is 'rgb(255, 0, 0) none repeat fixed 0% 0% / auto padding-box border-box'

--- a/LayoutTests/fast/backgrounds/background-shorthand-with-backgroundSize-style.html
+++ b/LayoutTests/fast/backgrounds/background-shorthand-with-backgroundSize-style.html
@@ -23,7 +23,7 @@ function checkComputedStyleValue() {
 }
 
 e.style.background = "center / cover red url(dummy://test.png) no-repeat border-box";
-shouldBe("e.style.background", "'red url(\"dummy://test.png\") center center / cover no-repeat border-box'");
+shouldBe("e.style.background", "'url(\"dummy://test.png\") center center / cover no-repeat border-box red'");
 shouldBe("e.style.backgroundSize", "'cover'");
 shouldBe("checkStyle()", "true");
 shouldBe('computedStyle.getPropertyValue("background")', "'rgb(255, 0, 0) url(\"dummy://test.png\") no-repeat scroll 50% 50% / cover border-box border-box'");
@@ -32,7 +32,7 @@ shouldBe("checkComputedStyleValue()", "true");
 debug("")
 
 e.style.background = "red 20px / contain url(dummy://test.png) no-repeat padding-box";
-shouldBe("e.style.background", "'red url(\"dummy://test.png\") 20px center / contain no-repeat padding-box'");
+shouldBe("e.style.background", "'url(\"dummy://test.png\") 20px center / contain no-repeat padding-box red'");
 shouldBe("e.style.backgroundSize", "'contain'");
 shouldBe("checkStyle()", "true");
 shouldBe('computedStyle.getPropertyValue("background")', "'rgb(255, 0, 0) url(\"dummy://test.png\") no-repeat scroll 20px 50% / contain padding-box padding-box'");
@@ -41,7 +41,7 @@ shouldBe("checkComputedStyleValue()", "true");
 debug("")
 
 e.style.background = "red url(dummy://test.png) 50px 60px / 50% 75% no-repeat";
-shouldBe("e.style.background", "'red url(\"dummy://test.png\") 50px 60px / 50% 75% no-repeat'");
+shouldBe("e.style.background", "'url(\"dummy://test.png\") 50px 60px / 50% 75% no-repeat red'");
 shouldBe("e.style.backgroundSize", "'50% 75%'");
 shouldBe("checkStyle()", "true");
 shouldBe('computedStyle.getPropertyValue("background")', "'rgb(255, 0, 0) url(\"dummy://test.png\") no-repeat scroll 50px 60px / 50% 75% padding-box border-box'");
@@ -50,7 +50,7 @@ shouldBe("checkComputedStyleValue()", "true");
 debug("")
 
 e.style.background = "red url(dummy://test.png) repeat top left / 100px 200px border-box content-box";
-shouldBe("e.style.background", "'red url(\"dummy://test.png\") left top / 100px 200px repeat border-box content-box'");
+shouldBe("e.style.background", "'url(\"dummy://test.png\") left top / 100px 200px repeat border-box content-box red'");
 shouldBe("e.style.backgroundSize", "'100px 200px'");
 shouldBe("checkStyle()", "true");
 shouldBe('computedStyle.getPropertyValue("background")', "'rgb(255, 0, 0) url(\"dummy://test.png\") repeat scroll 0% 0% / 100px 200px border-box content-box'");
@@ -59,7 +59,7 @@ shouldBe("checkComputedStyleValue()", "true");
 debug("")
 
 e.style.background = "red url(dummy://test.png) repeat 50% / auto auto content-box padding-box";
-shouldBe("e.style.background", "'red url(\"dummy://test.png\") 50% repeat content-box padding-box'");
+shouldBe("e.style.background", "'url(\"dummy://test.png\") 50% repeat content-box padding-box red'");
 shouldBe("e.style.backgroundSize", "'auto'");
 shouldBe("checkStyle()", "true");
 shouldBe('computedStyle.getPropertyValue("background")', "'rgb(255, 0, 0) url(\"dummy://test.png\") repeat scroll 50% 50% / auto content-box padding-box'");
@@ -68,7 +68,7 @@ shouldBe("checkComputedStyleValue()", "true");
 debug("")
 
 e.style.background = "url(dummy://test.png) red 50px 60px / 50% no-repeat fixed";
-shouldBe("e.style.background", "'red url(\"dummy://test.png\") 50px 60px / 50% auto no-repeat fixed'");
+shouldBe("e.style.background", "'url(\"dummy://test.png\") 50px 60px / 50% auto no-repeat fixed red'");
 shouldBe("e.style.backgroundSize", "'50% auto'");
 shouldBe("checkStyle()", "true");
 shouldBe('computedStyle.getPropertyValue("background")', "'rgb(255, 0, 0) url(\"dummy://test.png\") no-repeat fixed 50px 60px / 50% auto padding-box border-box'");
@@ -77,7 +77,7 @@ shouldBe("checkComputedStyleValue()", "true");
 debug("")
 
 e.style.background = "red repeat scroll padding-box border-box top left / 100px url(dummy://test.png)";
-shouldBe("e.style.background", "'red url(\"dummy://test.png\") left top / 100px auto repeat'");
+shouldBe("e.style.background", "'url(\"dummy://test.png\") left top / 100px auto repeat red'");
 shouldBe("e.style.backgroundSize", "'100px auto'");
 shouldBe("checkStyle()", "true");
 shouldBe('computedStyle.getPropertyValue("background")', "'rgb(255, 0, 0) url(\"dummy://test.png\") repeat scroll 0% 0% / 100px auto padding-box border-box'");
@@ -86,7 +86,7 @@ shouldBe("checkComputedStyleValue()", "true");
 debug("")
 
 e.style.background = "50% / auto fixed url(dummy://test.png) repeat content-box red";
-shouldBe("e.style.background", "'red url(\"dummy://test.png\") 50% repeat fixed content-box'");
+shouldBe("e.style.background", "'url(\"dummy://test.png\") 50% repeat fixed content-box red'");
 shouldBe("e.style.backgroundSize", "'auto'");
 shouldBe("checkStyle()", "true");
 shouldBe('computedStyle.getPropertyValue("background")', "'rgb(255, 0, 0) url(\"dummy://test.png\") repeat fixed 50% 50% / auto content-box content-box'");
@@ -104,7 +104,7 @@ shouldBe("checkComputedStyleValue()", "true");
 debug("")
 
 e.style.background = "red fixed";
-shouldBe("e.style.background", "'red fixed'");
+shouldBe("e.style.background", "'fixed red'");
 shouldBe("e.style.backgroundSize", "'auto'");
 shouldBe("checkStyle()", "true");
 shouldBe('computedStyle.getPropertyValue("background")', "'rgb(255, 0, 0) none repeat fixed 0% 0% / auto padding-box border-box'");

--- a/LayoutTests/fast/css/remove-shorthand-expected.txt
+++ b/LayoutTests/fast/css/remove-shorthand-expected.txt
@@ -7,7 +7,7 @@ removes "background"
 and adds "".
 Removing background-position
 removes "background"
-and adds "background-color, background-image, background-size, background-repeat, background-attachment, background-origin, background-clip".
+and adds "background-image, background-size, background-repeat, background-attachment, background-origin, background-clip, background-color".
 Removing border
 removes "border"
 and adds "".

--- a/LayoutTests/fast/dom/background-shorthand-csstext-expected.txt
+++ b/LayoutTests/fast/dom/background-shorthand-csstext-expected.txt
@@ -2,5 +2,5 @@ This page tests whether or not the background shorthand properly omits initial v
 
 PASS: document.body.style.background should be green and is.
 PASS: document.getElementById('div1').style.background should be and is.
-PASS: document.getElementById('div2').style.background should be blue 50% 50% and is.
-PASS: document.getElementById('div3').style.background should be rgb(255, 255, 255) repeat and is.
+PASS: document.getElementById('div2').style.background should be 50% 50% blue and is.
+PASS: document.getElementById('div3').style.background should be repeat rgb(255, 255, 255) and is.

--- a/LayoutTests/fast/dom/background-shorthand-csstext.html
+++ b/LayoutTests/fast/dom/background-shorthand-csstext.html
@@ -33,8 +33,8 @@ function test()
     
     shouldBe("document.body.style.background", "green");
     shouldBe("document.getElementById('div1').style.background", "");
-    shouldBe("document.getElementById('div2').style.background", "blue 50% 50%");
-    shouldBe("document.getElementById('div3').style.background", "rgb(255, 255, 255) repeat");
+    shouldBe("document.getElementById('div2').style.background", "50% 50% blue");
+    shouldBe("document.getElementById('div3').style.background", "repeat rgb(255, 255, 255)");
 }
 </script>
 </head>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1548,7 +1548,6 @@
         "background": {
             "codegen-properties": {
                 "longhands": [
-                    "background-color",
                     "background-image",
                     "background-position-x",
                     "background-position-y",
@@ -1556,7 +1555,8 @@
                     "background-repeat",
                     "background-attachment",
                     "background-origin",
-                    "background-clip"
+                    "background-clip",
+                    "background-color"
                 ]
             },
             "specification": {


### PR DESCRIPTION
#### bec59bdd1e2679d403d84c3aefcd42618e3bc2cb
<pre>
REGRESSION (STP 164): new failure in css/css-backgrounds/parsing/background-shorthand-serialization.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=252925">https://bugs.webkit.org/show_bug.cgi?id=252925</a>
rdar://problem/106208628

Reviewed by Tim Nguyen.

Revert the change from <a href="https://commits.webkit.org/260157@main">https://commits.webkit.org/260157@main</a> that made background-color
serialize first. This is being discussed in <a href="https://github.com/w3c/csswg-drafts/issues/8496">https://github.com/w3c/csswg-drafts/issues/8496</a>,
but while it&apos;s discussed, it seems good to change the behavior back since that matches
other browsers and some WPT test expectations.

* LayoutTests/editing/deleting/paste-with-transparent-background-color-expected.txt:
Change expectations back to expect background-color to be serialized last, after the other
longhands that are part of the background shorthand
* LayoutTests/editing/deleting/paste-with-transparent-background-color-live-range-expected.txt: Ditto.
* LayoutTests/fast/backgrounds/background-shorthand-after-set-backgroundSize-expected.txt: Ditto.
* LayoutTests/fast/backgrounds/background-shorthand-after-set-backgroundSize.html: Ditto.
* LayoutTests/fast/backgrounds/background-shorthand-with-backgroundSize-style-expected.txt: Ditto.
* LayoutTests/fast/backgrounds/background-shorthand-with-backgroundSize-style.html: Ditto.
* LayoutTests/fast/css/remove-shorthand-expected.txt: Ditto.
* LayoutTests/fast/dom/background-shorthand-csstext-expected.txt: Ditto.
* LayoutTests/fast/dom/background-shorthand-csstext.html: Ditto.

* Source/WebCore/css/CSSProperties.json: Move background-color to the end of the list of longhands
for the background shorthand.

Canonical link: <a href="https://commits.webkit.org/261250@main">https://commits.webkit.org/261250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5165dcecb7af3697158dfa32932034fed2c5deb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119901 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2124 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103553 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44469 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12713 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32199 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86377 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9182 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18673 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7802 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15206 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->