### PR TITLE
REGRESSION(260977@main) [Win] test-webkitpy is failing to install lupa-1.13.0!

### DIFF
--- a/Tools/Scripts/webkitpy/test/main.py
+++ b/Tools/Scripts/webkitpy/test/main.py
@@ -78,6 +78,7 @@ def main():
     if sys.platform.startswith('win'):
         tester.skip(('webkitpy.common.checkout', 'webkitpy.tool'), 'fail horribly on win32', 54526)
         tester.skip(('reporelaypy',), 'fail to install lupa and don\'t have to test on win32', 243316)
+        tester.skip(('webkitflaskpy',), 'fail to install lupa and don\'t have to test on win32', 253419)
 
     # Tests that are platform specific
     mac_only_tests = (
@@ -196,7 +197,8 @@ class Tester(object):
         # Force registration of all autoinstalled packages.
         if any([n.startswith('reporelaypy') for n in names]):
             import reporelaypy
-        import webkitflaskpy
+        if any([n.startswith('webkitflaskpy') for n in names]):
+            import webkitflaskpy
 
         AutoInstall.install_everything()
 


### PR DESCRIPTION
#### 718e5df6bfd617349c2c46b4753b7be320cc0b40
<pre>
REGRESSION(260977@main) [Win] test-webkitpy is failing to install lupa-1.13.0!
<a href="https://bugs.webkit.org/show_bug.cgi?id=253419">https://bugs.webkit.org/show_bug.cgi?id=253419</a>

Reviewed by Jonathan Bedard.

After 260977@main changed webkitflaskpy to use lupa, test-webkitpy was
failing to install lupa-1.13.0 on Windows. lupa-1.13.0 has a known
issue to install on Windows. &lt;<a href="https://webkit.org/b/243329#c2">https://webkit.org/b/243329#c2</a>&gt;

Skip webkitflaskpy tests on Windows because it&apos;s used only by web
services.

* Tools/Scripts/webkitpy/test/main.py:
(main):
(Tester._run_tests):

Canonical link: <a href="https://commits.webkit.org/261267@main">https://commits.webkit.org/261267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cca0f05a04ab5e680abb9e7a711669d27b38e0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2132 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103563 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/114488 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44477 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12722 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32209 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86394 "Found 1 new API test failure: /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9192 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18682 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7817 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15215 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->