### PR TITLE
[Filters] Enable GraphicsContextFiltersEnabled for layout tests

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -137,6 +137,7 @@ private:
     void drawNativeImageInternal(NativeImage&, const FloatSize& selfSize, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions& = { }) final;
 
     void clearCGShadow();
+    void setCGStyle(const std::optional<GraphicsStyle>&);
 
     const RetainPtr<CGContextRef> m_cgContext;
     const RenderingMode m_renderingMode : 1; // NOLINT

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3140,8 +3140,13 @@ GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, 
     return filterContext;
 }
 
-void RenderLayer::applyFilters(GraphicsContext& originalContext, const LayerPaintingInfo& paintingInfo, OptionSet<PaintBehavior> behavior, const LayerFragments& layerFragments)
+void RenderLayer::applyFilters(GraphicsContext& originalContext, GraphicsContext& filterContext, const LayerPaintingInfo& paintingInfo, OptionSet<PaintBehavior> behavior, const LayerFragments& layerFragments)
 {
+    if (&originalContext == &filterContext) {
+        m_filters->applyFilterEffect(originalContext);
+        return;
+    }
+
     // FIXME: Handle more than one fragment.
     ClipRect backgroundRect = layerFragments.isEmpty() ? ClipRect() : layerFragments[0].backgroundRect;
 
@@ -3333,7 +3338,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
                 (localPaintFlags & PaintLayerFlag::TemporaryClipRects) ? TemporaryClipRects : PaintingClipRects, clipRectOptions, offsetFromRoot);
             updatePaintingInfoForFragments(layerFragments, paintingInfo, localPaintFlags, shouldPaintContent, offsetFromRoot);
 
-            applyFilters(context, paintingInfo, paintBehavior, layerFragments);
+            applyFilters(context, *filterContext, paintingInfo, paintBehavior, layerFragments);
         }
     }
     

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1084,7 +1084,7 @@ private:
 
     RenderLayerFilters* filtersForPainting(GraphicsContext&, OptionSet<PaintLayerFlag>) const;
     GraphicsContext* setupFilters(GraphicsContext& destinationContext, LayerPaintingInfo&, OptionSet<PaintLayerFlag>, const LayoutSize& offsetFromRoot);
-    void applyFilters(GraphicsContext& originalContext, const LayerPaintingInfo&, OptionSet<PaintBehavior>, const LayerFragments&);
+    void applyFilters(GraphicsContext& originalContext, GraphicsContext& filterContext, const LayerPaintingInfo&, OptionSet<PaintBehavior>, const LayerFragments&);
 
     void paintLayer(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>);
     void paintLayerWithEffects(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>);

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -77,6 +77,7 @@ const TestFeatures& TestOptions::defaults()
             { "EncryptedMediaAPIEnabled", true },
             { "FullScreenEnabled", true },
             { "GamepadsEnabled", true },
+            { "GraphicsContextFiltersEnabled", true },
             { "HiddenPageCSSAnimationSuspensionEnabled", false },
             { "InlineMediaPlaybackRequiresPlaysInlineAttribute", false },
             { "JavaScriptCanAccessClipboard", true },

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -96,6 +96,7 @@ const TestFeatures& TestOptions::defaults()
             { "FrameFlatteningEnabled", false },
             { "FullScreenEnabled", true },
             { "GenericCueAPIEnabled", false },
+            { "GraphicsContextFiltersEnabled", true },
             { "HiddenPageCSSAnimationSuspensionEnabled", false },
             { "HiddenPageDOMTimerThrottlingEnabled", false },
             { "InlineMediaPlaybackRequiresPlaysInlineAttribute", false },


### PR DESCRIPTION
#### 77c9e12a4e25febb66b7087938d5c513ae0af445
<pre>
[Filters] Enable GraphicsContextFiltersEnabled for layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=249753">https://bugs.webkit.org/show_bug.cgi?id=249753</a>
rdar://103616340

Reviewed by NOBODY (OOPS!).

Enable it for layout tests as a step towards enabling it by default.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::setCGStyle):
(WebCore::GraphicsContextCG::didUpdateState):
(WebCore::setCGStyle): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::applyFilters):
(WebCore::RenderLayer::paintLayerContents):
* Source/WebCore/rendering/RenderLayer.h:
* Tools/DumpRenderTree/TestOptions.cpp:
(WTR::TestOptions::defaults):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77c9e12a4e25febb66b7087938d5c513ae0af445

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120032 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2241 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116961 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16135 "Found 2 new test failures: fast/scrolling/keyboard-scrolling-distance-pageDown.html, imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-drop-shadow.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103777 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44663 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86538 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13389 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9302 "Found 2 new test failures: imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-drop-shadow.html, imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-003.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51900 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15341 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->