### PR TITLE
Inline ScopedEventQueue::incrementScopingLevel()

### DIFF
--- a/Source/WebCore/dom/ScopedEventQueue.cpp
+++ b/Source/WebCore/dom/ScopedEventQueue.cpp
@@ -68,11 +68,6 @@ void ScopedEventQueue::dispatchAllEvents()
         dispatchEvent(queuedEvent);
 }
 
-void ScopedEventQueue::incrementScopingLevel()
-{
-    ++m_scopingLevel;
-}
-
 void ScopedEventQueue::decrementScopingLevel()
 {
     ASSERT(m_scopingLevel);

--- a/Source/WebCore/dom/ScopedEventQueue.h
+++ b/Source/WebCore/dom/ScopedEventQueue.h
@@ -58,7 +58,7 @@ private:
 
     void dispatchEvent(const ScopedEvent&) const;
     void dispatchAllEvents();
-    void incrementScopingLevel();
+    void incrementScopingLevel() { ++m_scopingLevel; }
     void decrementScopingLevel();
 
     Vector<ScopedEvent> m_queuedEvents;


### PR DESCRIPTION
#### 9b67f253118ab2ee9feb585a0d3df2aac203b0aa
<pre>
Inline ScopedEventQueue::incrementScopingLevel()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253420">https://bugs.webkit.org/show_bug.cgi?id=253420</a>

Reviewed by Sihui Liu.

Inline ScopedEventQueue::incrementScopingLevel() since its implementation is
small and it shows on profiles.

* Source/WebCore/dom/ScopedEventQueue.cpp:
(WebCore::ScopedEventQueue::incrementScopingLevel): Deleted.

Canonical link: <a href="https://commits.webkit.org/261269@main">https://commits.webkit.org/261269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a7465c5febb3816a3a303c661dd4d7eae48b84e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2497 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119913 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2134 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103567 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/97985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44485 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12726 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86397 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9194 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18685 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7815 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15219 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->