### PR TITLE
bufferedchange event should be fired whenever the buffered range change.

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt
@@ -1,0 +1,18 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+Append a media segment.
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(bufferedchange)
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+Clean sourcebuffer of all content.
+RUN(sourceBuffer.remove(0, sourceBuffer.buffered.end(0)))
+EVENT(bufferedchange)
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-bufferedchange.html
+++ b/LayoutTests/media/media-source/media-managedmse-bufferedchange.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>managedmediasource</title>
+    <script src="../../media/media-source/media-source-loader.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        try {
+            findMediaElement();
+
+            let manifests = [ 'content/test-opus-manifest.json', 'content/test-vorbis-manifest.json', 'content/test-48khz-manifest.json', 'content/test-xhe-aac-manifest.json' ];
+            for (const manifest of manifests) {
+                loader = new MediaSourceLoader(manifest);
+                await loaderPromise(loader);
+                if (ManagedMediaSource.isTypeSupported(loader.type()))
+                    break;
+            }
+
+            source = new ManagedMediaSource();
+            run('video.src = URL.createObjectURL(source)');
+            await waitFor(source, 'sourceopen');
+            waitFor(video, 'error').then(failTest);
+
+            run('sourceBuffer = source.addSourceBuffer(loader.type())');
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+
+            consoleWrite('Append a media segment.')
+            run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+            await Promise.all([waitFor(sourceBuffer, 'bufferedchange'), waitFor(sourceBuffer, 'update')]);
+            testExpected('sourceBuffer.buffered.length', '1');
+
+            consoleWrite('Clean sourcebuffer of all content.');
+            run('sourceBuffer.remove(0, sourceBuffer.buffered.end(0))');
+            await Promise.all([waitFor(sourceBuffer, 'bufferedchange'), waitFor(sourceBuffer, 'update')]);
+            testExpected('sourceBuffer.buffered.length', '0');
+
+            endTest();
+        } catch (e) {
+            failTest(`Caught exception: "${e}"`);
+        }
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1350,6 +1350,8 @@ void SourceBuffer::sourceBufferPrivateBufferedDirtyChanged(bool flag)
     m_bufferedDirty = flag;
     if (!isRemoved())
         m_source->sourceBufferDidChangeBufferedDirty(*this, flag);
+    if (flag && isManaged())
+        scheduleEvent(eventNames().bufferedchangeEvent);
 }
 
 bool SourceBuffer::isBufferedDirty() const
@@ -1381,12 +1383,7 @@ void SourceBuffer::memoryPressure()
 {
     if (!isManaged())
         return;
-    m_private->memoryPressure(maximumBufferSize(), m_source->currentTime(), m_source->isEnded(), [this, protectedThis = Ref { *this }] (bool bufferedChange) {
-        if (!bufferedChange)
-            return;
-        scheduleEvent(eventNames().bufferedchangeEvent);
-        m_source->monitorSourceBuffers();
-    });
+    m_private->memoryPressure(maximumBufferSize(), m_source->currentTime(), m_source->isEnded());
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -1054,16 +1054,14 @@ void SourceBufferPrivate::append(Vector<unsigned char>&&)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void SourceBufferPrivate::memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded, CompletionHandler<void(bool)>&& completionHandler)
+void SourceBufferPrivate::memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded)
 {
-    auto oldBuffered = m_buffered->ranges();
-    if (isActive())
+    if (isActive()) {
         evictFrames(maximumBufferSize, maximumBufferSize, currentTime, isEnded);
-    else {
-        resetTrackBuffers();
-        clearTrackBuffers(true);
+        return;
     }
-    completionHandler(m_buffered->ranges() != oldBuffered);
+    resetTrackBuffers();
+    clearTrackBuffers(true);
 }
 
 bool SourceBufferPrivate::evictFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded)

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -118,7 +118,7 @@ public:
     virtual size_t platformMaximumBufferSize() const { return 0; }
 
     // Methods for ManagedSourceBuffer
-    WEBCORE_EXPORT virtual void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded, CompletionHandler<void(bool)>&&);
+    WEBCORE_EXPORT virtual void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded);
 
     // Internals Utility methods
     WEBCORE_EXPORT virtual void bufferedSamplesForTrackId(const AtomString&, CompletionHandler<void(Vector<String>&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -368,10 +368,9 @@ void RemoteSourceBufferProxy::enqueuedSamplesForTrackID(TrackPrivateRemoteIdenti
 
 void RemoteSourceBufferProxy::memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded, CompletionHandler<void(WebCore::PlatformTimeRanges&&, uint64_t)>&& completionHandler)
 {
-    m_sourceBufferPrivate->memoryPressure(maximumBufferSize, currentTime, isEnded, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool) mutable {
-        auto buffered = m_sourceBufferPrivate->buffered()->ranges();
-        completionHandler(WTFMove(buffered), m_sourceBufferPrivate->totalTrackBufferSizeInBytes());
-    });
+    m_sourceBufferPrivate->memoryPressure(maximumBufferSize, currentTime, isEnded);
+    auto buffered = m_sourceBufferPrivate->buffered()->ranges();
+    completionHandler(WTFMove(buffered), m_sourceBufferPrivate->totalTrackBufferSizeInBytes());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -476,17 +476,15 @@ uint64_t SourceBufferPrivateRemote::totalTrackBufferSizeInBytes() const
     return m_totalTrackBufferSizeInBytes;
 }
 
-void SourceBufferPrivateRemote::memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded, CompletionHandler<void(bool)>&& completionHandler)
+void SourceBufferPrivateRemote::memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded)
 {
     if (!m_gpuProcessConnection)
         return;
 
     m_gpuProcessConnection->connection().sendWithAsyncReply(
-        Messages::RemoteSourceBufferProxy::MemoryPressure(maximumBufferSize, currentTime, isEnded), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](auto&& buffer, uint64_t totalTrackBufferSizeInBytes) mutable {
-            auto oldBuffered = buffered()->ranges();
+        Messages::RemoteSourceBufferProxy::MemoryPressure(maximumBufferSize, currentTime, isEnded), [this, protectedThis = Ref { *this }](auto&& buffer, uint64_t totalTrackBufferSizeInBytes) mutable {
             setBufferedRanges(WTFMove(buffer));
             m_totalTrackBufferSizeInBytes = totalTrackBufferSizeInBytes;
-            completionHandler(oldBuffered != buffered()->ranges());
         },
         m_remoteSourceBufferIdentifier);
 }

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -101,7 +101,7 @@ private:
     void updateTrackIds(Vector<std::pair<AtomString, AtomString>>&&) final;
     uint64_t totalTrackBufferSizeInBytes() const final;
 
-    void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded, CompletionHandler<void(bool)>&&) final;
+    void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded) final;
 
     bool isActive() const final { return m_isActive; }
 


### PR DESCRIPTION
#### b76e6ffa9afd5ea49f144a0a3423f8fc31e07e8e
<pre>
bufferedchange event should be fired whenever the buffered range change.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253277">https://bugs.webkit.org/show_bug.cgi?id=253277</a>
rdar://106168510

Reviewed by Eric Carlson.

We emit the event whenever the buffered range changes.
We re-use the infrastructure of SourceBufferPrivate&apos;s sourceBufferPrivateBufferedDirtyChanged

* LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-bufferedchange.html: Added.
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateBufferedDirtyChanged):
(WebCore::SourceBuffer::memoryPressure):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::memoryPressure):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::memoryPressure):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::memoryPressure):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/261263@main">https://commits.webkit.org/261263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bbc0b47a02cda500500c944faeda488faf5251a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2516 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119933 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2153 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44516 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12746 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86419 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9212 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18705 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7814 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15239 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->