### PR TITLE
Web Inspector: replace getCSSCanvasContext with canvas

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/Popover.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Popover.css
@@ -34,8 +34,12 @@
     --popover-background-color: var(--panel-background-color);
     --popover-border-color: hsla(0, 0%, 0%, 0.25);
     --popover-shadow-color: hsla(0, 0%, 0%, 0.5);
+}
 
-    background-image: -webkit-canvas(popover);
+.popover > .background-canvas {
+    position: absolute;
+    inset: 0;
+    z-index : -1;
 }
 
 .popover.arrow-up {

--- a/Source/WebInspectorUI/UserInterface/Views/Popover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Popover.js
@@ -203,6 +203,20 @@ WI.Popover = class Popover extends WI.Object
 
     // Private
 
+    static _getCanvasContext(width, height)
+    {
+        let context = WI.Popover._canvasContext?.deref();
+        if (!context) {
+            context = document.createElement("canvas").getContext("2d");
+            context.canvas.className = "background-canvas";
+            WI.Popover._canvasContext = new WeakRef(context);
+        }
+
+        context.canvas.width = width;
+        context.canvas.height = height;
+        return context;
+    }
+
     _update(shouldAnimate)
     {
         if (shouldAnimate)
@@ -425,7 +439,9 @@ WI.Popover = class Popover extends WI.Object
         bounds = bounds.inset(WI.Popover.ShadowEdgeInsets);
         let computedStyle = window.getComputedStyle(this._element, null);
 
-        let context = document.getCSSCanvasContext("2d", "popover", scaledWidth, scaledHeight);
+        let context = WI.Popover._getCanvasContext(scaledWidth, scaledHeight);
+        this._element.appendChild(context.canvas);
+
         context.clearRect(0, 0, scaledWidth, scaledHeight);
 
         function isolate(callback) {


### PR DESCRIPTION
#### c5ae28e2dee482dadf47c543f67e8f586aa81cbc
<pre>
Web Inspector: replace getCSSCanvasContext with canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=253414">https://bugs.webkit.org/show_bug.cgi?id=253414</a>

Reviewed by Patrick Angle and Devin Rousso.

The fix replaces unsupported on all browser function getCSSCanvasContext
with additional &quot;canvas&quot; element. This solves problem with missing popup
dialog, e.g.: to display details about hovered variable.

* Source/WebInspectorUI/UserInterface/Views/Popover.js:
(WI.Popover):

Canonical link: <a href="https://commits.webkit.org/261966@main">https://commits.webkit.org/261966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24541227aa3a2519a05b102f8f6a059fec74af7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120408 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3234 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105694 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46185 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13287 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/95314 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9628 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52180 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8344 "Build is in progress. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Checked out pull request; Reviewed by Devin Rousso and Patrick Angle; Running compile-webkit") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15767 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->