### PR TITLE
[GTK][WPE] Remote Web Inspector: context menu does not work

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/BrowserInspectorFrontendHost.js
+++ b/Source/WebInspectorUI/UserInterface/Base/BrowserInspectorFrontendHost.js
@@ -281,7 +281,7 @@ if (!window.InspectorFrontendHost) {
 
         showContextMenu(event, items)
         {
-            this._contextMenu = WI.SoftContextMenu(items);
+            this._contextMenu = new WI.SoftContextMenu(items);
             this._contextMenu.show(event);
         }
 


### PR DESCRIPTION
#### b1ff4ea8b21294251d503fa653bd8ae77ff37823
<pre>
[GTK][WPE] Remote Web Inspector: context menu does not work
<a href="https://bugs.webkit.org/show_bug.cgi?id=253428">https://bugs.webkit.org/show_bug.cgi?id=253428</a>

Reviewed by Tim Nguyen.

Context menu does not work in remote web inspector due to the error:
&apos;typeerror: Cannot call a class constructor without |new|&apos;.

This fix adds missing &apos;new&apos; when SoftContextMenu class is created.

* Source/WebInspectorUI/UserInterface/Base/BrowserInspectorFrontendHost.js:
(window.InspectorFrontendHost.WI.BrowserInspectorFrontendHost.prototype.showContextMenu):

Canonical link: <a href="https://commits.webkit.org/261425@main">https://commits.webkit.org/261425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0428e82cde1a8d28342d3b0350ad1c420fffe70f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119945 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2163 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103613 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98014 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44527 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12758 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86431 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9225 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18717 "Built successfully") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7950 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15250 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->