### PR TITLE
[GTK] Crash in WebCore::Cairo::drawGlyphs if threaded rendering is enabled

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -792,6 +792,9 @@ void clearRect(GraphicsContextCairo& platformContext, const FloatRect& rect)
 
 void drawGlyphs(GraphicsContextCairo& platformContext, const FillSource& fillSource, const StrokeSource& strokeSource, const ShadowState& shadowState, const FloatPoint& point, cairo_scaled_font_t* scaledFont, double syntheticBoldOffset, const Vector<cairo_glyph_t>& glyphs, float xOffset, TextDrawingModeFlags textDrawingMode, float strokeThickness, const FloatSize& shadowOffset, const Color& shadowColor, FontSmoothingMode fontSmoothingMode)
 {
+#if USE(FREETYPE)
+    Locker cairoFontLocker(cairoFontLock());
+#endif
     drawGlyphsShadow(platformContext, shadowState, textDrawingMode, shadowOffset, shadowColor, point, scaledFont, syntheticBoldOffset, glyphs, fontSmoothingMode);
 
     cairo_t* cr = platformContext.cr();

--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
@@ -48,6 +48,14 @@
 
 namespace WebCore {
 
+#if USE(FREETYPE)
+RecursiveLock& cairoFontLock()
+{
+    static RecursiveLock s_lock;
+    return s_lock;
+}
+#endif
+
 static cairo_font_options_t* defaultCairoFontOptions()
 {
     static cairo_font_options_t* s_defaultCairoFontOptions = cairo_font_options_create();

--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
@@ -35,6 +35,7 @@
 
 #if USE(FREETYPE)
 #include <cairo-ft.h>
+#include <wtf/RecursiveLockAdapter.h>
 #endif
 
 namespace WebCore {
@@ -48,18 +49,22 @@ class Path;
 class Region;
 
 #if USE(FREETYPE)
+RecursiveLock& cairoFontLock();
+
 class CairoFtFaceLocker {
 public:
-    CairoFtFaceLocker(cairo_scaled_font_t* scaledFont)
+    explicit CairoFtFaceLocker(cairo_scaled_font_t* scaledFont)
         : m_scaledFont(scaledFont)
-        , m_ftFace(cairo_ft_scaled_font_lock_face(scaledFont))
     {
+        cairoFontLock().lock();
+        m_ftFace = cairo_ft_scaled_font_lock_face(m_scaledFont);
     }
 
     ~CairoFtFaceLocker()
     {
         if (m_ftFace)
             cairo_ft_scaled_font_unlock_face(m_scaledFont);
+        cairoFontLock().unlock();
     }
 
     FT_Face ftFace() const { return m_ftFace; }


### PR DESCRIPTION
#### b59118c2ad0b788abe2a4bd5f4163fad0d8095bd
<pre>
[GTK] Crash in WebCore::Cairo::drawGlyphs if threaded rendering is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=247628">https://bugs.webkit.org/show_bug.cgi?id=247628</a>

Reviewed by Žan Doberšek.

We are now using a single rendering thread, but the main thread can
still use FreeType during the recording phase while laying out text. So,
we can try by using a global lock for FreeType.

* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::drawGlyphs):
* Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp:
(WebCore::cairoFontLock):
* Source/WebCore/platform/graphics/cairo/CairoUtilities.h:
(WebCore::CairoFtFaceLocker::CairoFtFaceLocker):
(WebCore::CairoFtFaceLocker::~CairoFtFaceLocker):

Canonical link: <a href="https://commits.webkit.org/261318@main">https://commits.webkit.org/261318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cfd645c5750f8376340a570731aabb866ae4768

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2533 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119950 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2169 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103618 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30908 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44530 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12763 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86434 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9227 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18722 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15254 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4296 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->