### PR TITLE
[GTK][WPE] Remove conditional includes of epoxy in files that are only used by GTK and WPE

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -94,12 +94,6 @@ list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
     ${UPOWERGLIB_INCLUDE_DIRS}
 )
 
-if (USE_OPENGL AND NOT USE_LIBEPOXY)
-    list(APPEND WebCore_SOURCES
-        platform/graphics/OpenGLShims.cpp
-    )
-endif ()
-
 if (ENABLE_WAYLAND_TARGET)
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
         platform/graphics/wayland/PlatformDisplayWayland.h

--- a/Source/WebCore/platform/graphics/egl/GLContextEGLWayland.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextEGLWayland.cpp
@@ -26,11 +26,7 @@
 // These includes need to be in this order because wayland-egl.h defines WL_EGL_PLATFORM
 // and egl.h checks that to decide whether it's Wayland platform.
 #include <wayland-egl.h>
-#if USE(LIBEPOXY)
 #include <epoxy/egl.h>
-#else
-#include <EGL/egl.h>
-#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/egl/GLContextEGLX11.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextEGLX11.cpp
@@ -25,12 +25,7 @@
 #include "XErrorTrapper.h"
 #include "XUniquePtr.h"
 #include <X11/Xlib.h>
-
-#if USE(LIBEPOXY)
 #include <epoxy/egl.h>
-#else
-#include <EGL/egl.h>
-#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -51,11 +51,8 @@
 typedef struct _GstMpegtsSection GstMpegtsSection;
 
 #if USE(GSTREAMER_GL)
-#if USE(LIBEPOXY)
 // Include the <epoxy/gl.h> header before <gst/gl/gl.h>.
 #include <epoxy/gl.h>
-#endif // USE(LIBEPOXY)
-
 #define GST_USE_UNSTABLE_API
 #include <gst/gl/gl.h>
 #undef GST_USE_UNSTABLE_API

--- a/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.cpp
@@ -39,10 +39,7 @@
 #include "TextureMapperPlatformLayerBuffer.h"
 #include "TextureMapperPlatformLayerProxyDMABuf.h"
 #include "TextureMapperPlatformLayerProxyGL.h"
-
-#if USE(LIBEPOXY)
 #include <epoxy/gl.h>
-#endif
 
 namespace Nicosia {
 

--- a/Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.cpp
+++ b/Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.cpp
@@ -35,12 +35,7 @@
 // These includes need to be in this order because wayland-egl.h defines WL_EGL_PLATFORM
 // and egl.h checks that to decide whether it's Wayland platform.
 #include <wayland-egl.h>
-#if USE(LIBEPOXY)
 #include <epoxy/egl.h>
-#else
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
-#endif
 
 #if PLATFORM(GTK)
 #if USE(GTK4)
@@ -128,21 +123,13 @@ void PlatformDisplayWayland::initialize()
     wl_registry_add_listener(m_registry.get(), &s_registryListener, this);
     wl_display_roundtrip(m_display);
 
-#if defined(EGL_KHR_platform_wayland) || defined(EGL_EXT_platform_wayland)
     const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
-#if defined(EGL_KHR_platform_wayland)
-    if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base")) {
-        if (auto* getPlatformDisplay = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(eglGetProcAddress("eglGetPlatformDisplay")))
-            m_eglDisplay = getPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR, m_display, nullptr);
-    }
-#endif
-#if defined(EGL_EXT_platform_wayland)
-    if (m_eglDisplay == EGL_NO_DISPLAY && GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base")) {
-        if (auto* getPlatformDisplay = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(eglGetProcAddress("eglGetPlatformDisplayEXT")))
-            m_eglDisplay = getPlatformDisplay(EGL_PLATFORM_WAYLAND_EXT, m_display, nullptr);
-    }
-#endif
-#endif
+    if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
+        m_eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR, m_display, nullptr);
+
+    if (m_eglDisplay == EGL_NO_DISPLAY && GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
+        m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_WAYLAND_EXT, m_display, nullptr);
+
     if (m_eglDisplay == EGL_NO_DISPLAY)
         m_eglDisplay = eglGetDisplay(m_display);
 

--- a/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp
+++ b/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp
@@ -45,20 +45,11 @@
 #endif
 
 #if USE(EGL)
-#if USE(LIBEPOXY)
 #include <epoxy/egl.h>
-#else
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
-#endif
 #endif
 
 #if USE(GLX)
-#if USE(LIBEPOXY)
 #include <epoxy/glx.h>
-#else
-#include <GL/glx.h>
-#endif
 #endif
 
 namespace WebCore {
@@ -136,16 +127,12 @@ void PlatformDisplayX11::sharedDisplayDidClose()
 #if USE(EGL)
 void PlatformDisplayX11::initializeEGLDisplay()
 {
-#if defined(EGL_KHR_platform_x11)
     const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
-    if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base")) {
-        if (auto* getPlatformDisplay = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(eglGetProcAddress("eglGetPlatformDisplay")))
-            m_eglDisplay = getPlatformDisplay(EGL_PLATFORM_X11_KHR, m_display, nullptr);
-    } else if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base")) {
-        if (auto* getPlatformDisplay = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(eglGetProcAddress("eglGetPlatformDisplayEXT")))
-            m_eglDisplay = getPlatformDisplay(EGL_PLATFORM_X11_KHR, m_display, nullptr);
-    } else
-#endif
+    if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
+        m_eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_X11_KHR, m_display, nullptr);
+    else if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
+        m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_X11_KHR, m_display, nullptr);
+    else
         m_eglDisplay = eglGetDisplay(m_display);
 
     PlatformDisplay::initializeEGLDisplay();

--- a/Source/WebCore/platform/graphics/x11/XUniquePtr.cpp
+++ b/Source/WebCore/platform/graphics/x11/XUniquePtr.cpp
@@ -29,11 +29,7 @@
 #if PLATFORM(X11)
 
 #if USE(GLX)
-#if USE(LIBEPOXY)
 #include <epoxy/glx.h>
-#else
-extern "C" void glXDestroyContext(::Display*, GLXContext);
-#endif
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/x11/XUniqueResource.cpp
+++ b/Source/WebCore/platform/graphics/x11/XUniqueResource.cpp
@@ -36,11 +36,7 @@
 #endif
 
 #if USE(GLX)
-#if USE(LIBEPOXY)
 #include <epoxy/glx.h>
-#else
-#include <GL/glx.h>
-#endif
 #endif
 
 namespace WebCore {

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -29,6 +29,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/PlatformDisplay.h>
 #include <WebCore/PlatformScreen.h>
+#include <epoxy/gl.h>
 #include <gio/gio.h>
 #include <wtf/URL.h>
 #include <wtf/glib/GRefPtr.h>
@@ -51,30 +52,14 @@
 #endif
 #endif
 
-#if USE(LIBEPOXY)
-#include <epoxy/gl.h>
-#elif USE(OPENGL_ES)
-#include <GLES2/gl2.h>
-#else
-#include <WebCore/OpenGLShims.h>
-#endif
-
 #if USE(EGL)
-#if USE(LIBEPOXY)
 #include <epoxy/egl.h>
-#else
-#include <EGL/egl.h>
-#endif
 #endif
 
 #if PLATFORM(X11)
 #include <WebCore/PlatformDisplayX11.h>
 #if USE(GLX)
-#if USE(LIBEPOXY)
 #include <epoxy/glx.h>
-#else
-#include <GL/glx.h>
-#endif
 #endif
 #endif
 
@@ -151,21 +136,9 @@ static bool webGLEnabled(WebKitURISchemeRequest* request)
 
 static const char* openGLAPI(bool isEGL)
 {
-#if USE(LIBEPOXY)
     if (epoxy_is_desktop_gl())
         return "OpenGL (libepoxy)";
     return "OpenGL ES 2 (libepoxy)";
-#else
-#if USE(EGL)
-    if (isEGL) {
-#if USE(OPENGL_ES)
-        return "OpenGL ES 2";
-#endif
-    }
-#endif
-    return "OpenGL";
-#endif
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)


### PR DESCRIPTION
#### 47a6f78c67302b62e26c9eeaa228868a6ee45cb2
<pre>
[GTK][WPE] Remove conditional includes of epoxy in files that are only used by GTK and WPE
<a href="https://bugs.webkit.org/show_bug.cgi?id=253429">https://bugs.webkit.org/show_bug.cgi?id=253429</a>

Reviewed by Žan Doberšek.

epoxy is now required by both GTK and WPE, so we can include it
unconditionally.

* Source/WebCore/PlatformGTK.cmake:
* Source/WebCore/platform/graphics/egl/GLContextEGLWayland.cpp:
* Source/WebCore/platform/graphics/egl/GLContextEGLX11.cpp:
* Source/WebCore/platform/graphics/glx/GLContextGLX.cpp:
(WebCore::checkExtentions):
(WebCore::GLContextGLX::createWindowContext):
(WebCore::GLContextGLX::createPbufferContext):
(WebCore::GLContextGLX::swapInterval):
(WebCore::hasSGISwapControlExtension): Deleted.
(WebCore::hasGLXARBCreateContextExtension): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/nicosia/texmap/NicosiaGCGLANGLELayer.cpp:
* Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.cpp:
(WebCore::PlatformDisplayWayland::initialize):
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp:
(WebCore::PlatformDisplayX11::initializeEGLDisplay):
* Source/WebCore/platform/graphics/x11/XUniquePtr.cpp:
* Source/WebCore/platform/graphics/x11/XUniqueResource.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::openGLAPI):

Canonical link: <a href="https://commits.webkit.org/261265@main">https://commits.webkit.org/261265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff0c3f25c73b001085635a410ac30763209e494d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119951 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2168 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103619 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44531 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12764 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86435 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9228 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18723 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15255 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4268 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->