### PR TITLE
[Unix] Again make UnixFileDescriptor non-copyable

### DIFF
--- a/Source/WTF/wtf/unix/UnixFileDescriptor.h
+++ b/Source/WTF/wtf/unix/UnixFileDescriptor.h
@@ -27,12 +27,14 @@
 
 #include <utility>
 #include <wtf/Compiler.h>
+#include <wtf/Noncopyable.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/UniStdExtras.h>
 
 namespace WTF {
 
 class UnixFileDescriptor {
+    WTF_MAKE_NONCOPYABLE(UnixFileDescriptor);
 public:
     UnixFileDescriptor() = default;
 
@@ -53,10 +55,6 @@ public:
         m_value = o.release();
     }
 
-    UnixFileDescriptor(const UnixFileDescriptor& o)
-        : UnixFileDescriptor(o.m_value, Duplicate)
-    { }
-
     UnixFileDescriptor& operator=(UnixFileDescriptor&& o)
     {
         if (&o == this)
@@ -64,16 +62,6 @@ public:
 
         this->~UnixFileDescriptor();
         new (this) UnixFileDescriptor(WTFMove(o));
-        return *this;
-    }
-
-    UnixFileDescriptor& operator=(const UnixFileDescriptor& o)
-    {
-        if (&o == this)
-            return *this;
-
-        this->~UnixFileDescriptor();
-        new (this) UnixFileDescriptor(o);
         return *this;
     }
 


### PR DESCRIPTION
#### 1ddd57d7f22f76dc02c2937821698aa81fdea00b
<pre>
[Unix] Again make UnixFileDescriptor non-copyable
<a href="https://bugs.webkit.org/show_bug.cgi?id=253433">https://bugs.webkit.org/show_bug.cgi?id=253433</a>

Reviewed by Carlos Garcia Campos.

UnixFileDescriptor is currently not required to be copyable, so the copy
constructor and the copy assignment operator can be deleted. Once or if again
necessary, a derived copyable class will be added to support copying this type
of resource.

* Source/WTF/wtf/unix/UnixFileDescriptor.h:

Canonical link: <a href="https://commits.webkit.org/261281@main">https://commits.webkit.org/261281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4894d21a7bc446dacf84ddc35fc13a054d99d3d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2539 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119956 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2176 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103632 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44544 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12769 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86445 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10871 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9232 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100834 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18728 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31440 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7822 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15260 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108870 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26842 "Passed tests") | 
<!--EWS-Status-Bubble-End-->