### PR TITLE
[svg] text transformation not starting on initial render

### DIFF
--- a/LayoutTests/svg/text/text-transform-style-changed-by-script-expected.html
+++ b/LayoutTests/svg/text/text-transform-style-changed-by-script-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg width="100" height="100">
+  <text y="50">Hello World</text>
+</svg>

--- a/LayoutTests/svg/text/text-transform-style-changed-by-script.html
+++ b/LayoutTests/svg/text/text-transform-style-changed-by-script.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<svg width="100" height="100">
+  <text y="50" style="transform: scale(0)">Hello World</text>
+</svg>
+<script>
+
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+
+requestAnimationFrame(() => {
+    document.querySelector("text").style.transform = "scale(1)";
+
+    if (window.testRunner)
+        window.testRunner.notifyDone();    
+});
+
+</script>

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.h
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.h
@@ -41,6 +41,7 @@ protected:
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     bool needsHasSVGTransformFlags() const override;
 #endif
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 
 private:
     void element() const = delete;
@@ -48,7 +49,6 @@ private:
 
     void absoluteRects(Vector<IntRect>&, const LayoutPoint& accumulatedOffset) const override;
     void absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const override;
-    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     LayoutPoint currentSVGLayoutLocation() const final { return location(); }

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -96,6 +96,8 @@ private:
 
     void willBeDestroyed() override;
 
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
+
     // FIXME: [LBSE] Begin code only needed for legacy SVG engine.
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) override;
     const AffineTransform& localToParentTransform() const override { return m_localTransform; }


### PR DESCRIPTION
#### 1fe8f8ec39961f73275ec569545709774886e2e5
<pre>
[svg] text transformation not starting on initial render
<a href="https://bugs.webkit.org/show_bug.cgi?id=253259">https://bugs.webkit.org/show_bug.cgi?id=253259</a>

Reviewed by Nikolas Zimmermann.

RenderSVGText has a custom implementation for localTransform() and localToParentTransform() which
require setNeedsTransformUpdate() to be called when the transform needs an update. This would not
be called correctly when the transform was changed via script.

We now have an override for styleDidChange() which looks over transform-related RenderStyle methods
to determine whether style has changed.

* LayoutTests/svg/text/text-transform-style-changed-by-script-expected.html: Added.
* LayoutTests/svg/text/text-transform-style-changed-by-script.html: Added.
* Source/WebCore/rendering/svg/RenderSVGBlock.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGText.h:

Canonical link: <a href="https://commits.webkit.org/261408@main">https://commits.webkit.org/261408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76cbbba3af4b1a34dde40be8a858a2474c5e2b93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/76 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120257 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115532 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2686 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104205 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/56 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45018 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13107 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/54 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86818 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9498 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52037 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15578 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4329 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->