### PR TITLE
Revert 256469@main as it violates the specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/compat/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compat/idlharness.window-expected.txt
@@ -22,10 +22,10 @@ PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique
 PASS Element includes ChildNode: member names are unique
 PASS Element includes Slottable: member names are unique
-PASS HTMLBodyElement interface: attribute onorientationchange
-PASS HTMLBodyElement interface: document.body must inherit property "onorientationchange" with the proper type
-PASS Window interface: attribute orientation
-PASS Window interface: attribute onorientationchange
-PASS Window interface: window must inherit property "orientation" with the proper type
-PASS Window interface: window must inherit property "onorientationchange" with the proper type
+FAIL HTMLBodyElement interface: attribute onorientationchange assert_true: The prototype object must have a property "onorientationchange" expected true got false
+FAIL HTMLBodyElement interface: document.body must inherit property "onorientationchange" with the proper type assert_inherits: property "onorientationchange" not found in prototype chain
+FAIL Window interface: attribute orientation assert_own_property: The global object must have a property "orientation" expected property "orientation" missing
+FAIL Window interface: attribute onorientationchange assert_own_property: The global object must have a property "onorientationchange" expected property "onorientationchange" missing
+FAIL Window interface: window must inherit property "orientation" with the proper type assert_own_property: expected property "orientation" missing
+FAIL Window interface: window must inherit property "onorientationchange" with the proper type assert_own_property: expected property "onorientationchange" missing
 

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -410,6 +410,7 @@
 #define ENABLE_THUNDER 0
 #endif
 
+// ORIENTATION_EVENTS should never get enabled on Desktop, only Mobile.
 #if !defined(ENABLE_ORIENTATION_EVENTS)
 #define ENABLE_ORIENTATION_EVENTS 0
 #endif

--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -497,6 +497,7 @@
 #define ENABLE_OFFSCREEN_CANVAS 1
 #endif
 
+// ORIENTATION_EVENTS should never get enabled on Desktop, only Mobile.
 #if !defined(ENABLE_ORIENTATION_EVENTS) && PLATFORM(IOS_FAMILY)
 #define ENABLE_ORIENTATION_EVENTS 1
 #endif

--- a/Source/WebCore/html/HTMLBodyElement+Compat.idl
+++ b/Source/WebCore/html/HTMLBodyElement+Compat.idl
@@ -25,5 +25,5 @@
 
 // https://compat.spec.whatwg.org/#windoworientation-interface
 partial interface HTMLBodyElement {
-    [WindowEventHandler] attribute EventHandler onorientationchange;
+    [Conditional=ORIENTATION_EVENTS, WindowEventHandler] attribute EventHandler onorientationchange;
 };

--- a/Source/WebCore/page/DOMWindow+Compat.idl
+++ b/Source/WebCore/page/DOMWindow+Compat.idl
@@ -24,7 +24,9 @@
  */
 
 // https://compat.spec.whatwg.org/#windoworientation-interface
-partial interface DOMWindow {
+[
+    Conditional=ORIENTATION_EVENTS
+] partial interface DOMWindow {
     readonly attribute short orientation;
     [WindowEventHandler] attribute EventHandler onorientationchange;
 };

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -648,17 +648,15 @@ ExceptionOr<RefPtr<Element>> DOMWindow::matchingElementInFlatTree(Node& scope, c
     return RefPtr<Element> { nullptr };
 }
 
+#if ENABLE(ORIENTATION_EVENTS)
 int DOMWindow::orientation() const
 {
-#if !ENABLE(ORIENTATION_EVENTS)
-    return 0;
-#else
     auto* frame = this->frame();
     if (!frame)
         return 0;
     return frame->orientation();
-#endif
 }
+#endif
 
 Screen& DOMWindow::screen()
 {

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -348,10 +348,12 @@ public:
     ExceptionOr<Ref<NodeList>> collectMatchingElementsInFlatTree(Node&, const String& selectors);
     ExceptionOr<RefPtr<Element>> matchingElementInFlatTree(Node&, const String& selectors);
 
+#if ENABLE(ORIENTATION_EVENTS)
     // This is the interface orientation in degrees. Some examples are:
     //  0 is straight up; -90 is when the device is rotated 90 clockwise;
     //  90 is when rotated counter clockwise.
     int orientation() const;
+#endif
 
     Performance& performance() const;
     WEBCORE_EXPORT ReducedResolutionSeconds nowTimestamp() const;


### PR DESCRIPTION
#### b35ab41a5c7a3d289232d483f299c1cb92b6ef21
<pre>
Revert 256469@main as it violates the specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=253435">https://bugs.webkit.org/show_bug.cgi?id=253435</a>
rdar://106273441

Reviewed by Alex Christensen.

Revert 256469@main. The specification [1] says that we should not expose this
API on non-mobile devices. This broke the Final Cut Pro download page as it
relies on this API being missing to detect we&apos;re on desktop.

Note that neither Firefox not Chrome expose the window orientation API on
Desktop.

[1] <a href="https://compat.spec.whatwg.org/#windoworientation-interface">https://compat.spec.whatwg.org/#windoworientation-interface</a>

* LayoutTests/imported/w3c/web-platform-tests/compat/idlharness.window-expected.txt:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WebCore/html/HTMLBodyElement+Compat.idl:
* Source/WebCore/page/DOMWindow+Compat.idl:
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::orientation const):
* Source/WebCore/page/DOMWindow.h:

Canonical link: <a href="https://commits.webkit.org/261282@main">https://commits.webkit.org/261282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c66f3480d1c63bfa59004a48dc2abd3e158432e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2186 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116878 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103644 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44556 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99700 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12780 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32258 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86453 "Found 2 new API test failures: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/document-loaded-signal, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10882 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9245 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100845 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18739 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31446 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7820 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15271 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108881 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26848 "Passed tests") | 
<!--EWS-Status-Bubble-End-->