### PR TITLE
Rename 'm_bParsing' and get rid of FIXME

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3404,12 +3404,12 @@ void Document::implicitClose()
 
 void Document::setParsing(bool b)
 {
-    m_bParsing = b;
+    m_isParsing = b;
 
-    if (m_bParsing && !m_sharedObjectPool)
+    if (m_isParsing && !m_sharedObjectPool)
         m_sharedObjectPool = makeUnique<DocumentSharedObjectPool>();
 
-    if (!m_bParsing && view() && !view()->needsLayout())
+    if (!m_isParsing && view() && !view()->needsLayout())
         view()->fireLayoutRelatedMilestonesIfNeeded();
 }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -811,7 +811,7 @@ public:
 
     void setReadyState(ReadyState);
     void setParsing(bool);
-    bool parsing() const { return m_bParsing; }
+    bool parsing() const { return m_isParsing; }
 
     bool shouldScheduleLayout() const;
     bool isLayoutPending() const;
@@ -2316,7 +2316,7 @@ private:
     bool m_loadEventFinished { false };
 
     bool m_visuallyOrdered { false };
-    bool m_bParsing { false }; // FIXME: rename
+    bool m_isParsing { false };
 
     bool m_needsFullStyleRebuild { false };
     bool m_inStyleRecalc { false };


### PR DESCRIPTION
<pre>
Rename 'm_bParsing' and get rid of FIXME
<a href="https://bugs.webkit.org/show_bug.cgi?id=253417">https://bugs.webkit.org/show_bug.cgi?id=253417</a>

Reviewed by NOBODY (OOPS!).

Inspired - <a href="https://chromium.googlesource.com/chromium/blink/+/56ef94099e79af642ee0ef5a3c8a3523c1ecc7dc">https://chromium.googlesource.com/chromium/blink/+/56ef94099e79af642ee0ef5a3c8a3523c1ecc7dc</a>

This patch is pure renaming of variable 'm_bParsing' to 'm_isParsing' and get rid of FIXME as well.

* Source/WebCore/dom/Document.cpp:
(Document::implicitClose):
* Source/WebCore/dom/Document.h:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0cfabda99343bf672194889633657fc696d8fa9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2551 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/119968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2190 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44562 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12781 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32256 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86460 "Found 2 new API test failures: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable, /WebKitGTK/TestDownloads:/webkit/Downloads/local-file-error (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9242 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51847 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15272 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->