### PR TITLE
Add support for pausing and resuming background fetches

### DIFF
--- a/LayoutTests/http/wpt/background-fetch/background-fetch-pause-resume.window-expected.txt
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-pause-resume.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS background fetch pause/resume should be able to recover if range requests are supported
+

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-pause-resume.window.html
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-pause-resume.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-pause-resume.window.js
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-pause-resume.window.js
@@ -1,0 +1,62 @@
+// META: script=/service-workers/service-worker/resources/test-helpers.sub.js
+// META: script=/background-fetch/resources/utils.js
+
+'use strict';
+
+function backgroundFetchDownloaded(id)
+{
+  const state = JSON.parse(testRunner.backgroundFetchState(id));
+  return state.downloaded;
+}
+
+function backgroundFetchIsPaused(id)
+{
+  const state = JSON.parse(testRunner.backgroundFetchState(id));
+  return state.isPaused;
+}
+
+promise_test(async t => {
+  let serviceWorkerRegistration = await service_worker_unregister_and_register(t, "sw.js", ".");
+  add_completion_callback(() => serviceWorkerRegistration.unregister());
+  await wait_for_state(t, serviceWorkerRegistration.installing, 'activated');
+
+  const id = uniqueId();
+  await serviceWorkerRegistration.backgroundFetch.fetch(id, ['resources/trickle-range.py?ms=2&count=5000']);
+
+  if (!window.testRunner)
+    return;
+
+  const internalId = testRunner.getBackgroundFetchIdentifier();
+  assert_greater_than(internalId.length, 0);
+
+  // Let's wait a bit to get some data.
+  let cptr = 0;
+  while(!backgroundFetchDownloaded(internalId) && ++cptr < 20)
+    await new Promise(resolve => setTimeout(resolve, 500));
+  assert_less_than(cptr, 20, "load is started");
+
+  assert_false(backgroundFetchIsPaused(internalId), "not paused1");
+  testRunner.pauseBackgroundFetch(internalId);
+  assert_true(backgroundFetchIsPaused(internalId), "paused");
+
+  let previousDownloaded;
+  let downloaded = backgroundFetchDownloaded(internalId);
+  cptr = 0;
+  do {
+    previousDownloaded = downloaded;
+    await new Promise(resolve => setTimeout(resolve, 100));
+    downloaded = backgroundFetchDownloaded(internalId);
+  } while (downloaded != previousDownloaded && ++cptr < 20);
+  assert_less_than(cptr, 20, "load is paused");
+
+  testRunner.resumeBackgroundFetch(internalId);
+  assert_false(backgroundFetchIsPaused(internalId), "not paused2");
+
+  cptr = 0;
+  do {
+    previousDownloaded = downloaded;
+    await new Promise(resolve => setTimeout(resolve, 100));
+    downloaded = backgroundFetchDownloaded(internalId);
+  } while (downloaded <= previousDownloaded && ++cptr < 20);
+  assert_less_than(cptr, 20, "load is resumed");
+}, "background fetch pause/resume should be able to recover if range requests are supported");

--- a/LayoutTests/http/wpt/background-fetch/resources/trickle-range.py
+++ b/LayoutTests/http/wpt/background-fetch/resources/trickle-range.py
@@ -1,0 +1,39 @@
+import re
+import time
+
+from wptserve.utils import isomorphic_decode
+
+
+def main(request, response):
+    delay = float(request.GET.first(b"ms", 500)) / 1E3
+    count = int(request.GET.first(b"count", 50))
+    range_header = request.headers.get(b'Range', b'')
+
+    start = 0
+    total_length = count
+    if not range_header:
+        start = 0
+        response.status = 200
+    else:
+        result = re.findall(r'\d+', isomorphic_decode(range_header))
+        start = int(result[0])
+        response.status = 206
+
+    length = total_length - start
+
+    response.headers.set(b"Accept-Ranges", b"bytes")
+
+    if length != total_length:
+        content_range = b"bytes %d-%d/%d" % (start, total_length - 1, total_length)
+        response.headers.set(b"Content-Range", content_range)
+
+    response.headers.set(b"Content-Length", length)
+    response.headers.set(b"Content-type", b"text/plain")
+
+    # Read request body
+    time.sleep(delay)
+    response.write_status_headers()
+
+    for i in range(length):
+        response.writer.write_content(b"T")
+        time.sleep(delay)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h
@@ -58,7 +58,7 @@ public:
     virtual void clearAllFetches(const ServiceWorkerRegistrationKey&, CompletionHandler<void()>&& = [] { }) = 0;
 
     enum class StoreResult : uint8_t { OK, QuotaError, InternalError };
-    virtual void storeFetch(const ServiceWorkerRegistrationKey&, const String&, uint64_t downloadTotal, uint64_t uploadTotal, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&) = 0;
+    virtual void storeFetch(const ServiceWorkerRegistrationKey&, const String&, uint64_t downloadTotal, uint64_t uploadTotal, std::optional<size_t> responseBodyIndexToClear, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&) = 0;
     virtual void storeFetchResponseBodyChunk(const ServiceWorkerRegistrationKey&, const String&, size_t, const SharedBuffer&, CompletionHandler<void(StoreResult)>&&) = 0;
 
     using RetrieveRecordResponseBodyCallback = Function<void(Expected<RefPtr<SharedBuffer>, ResourceError>&&)>;

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -283,7 +283,7 @@ public:
     WEBCORE_EXPORT void getAllOrigins(CompletionHandler<void(HashSet<ClientOrigin>&&)>&&);
 
     void requestBackgroundFetchPermission(const ClientOrigin& clientOrigin, CompletionHandler<void(bool)>&& callback) { m_delegate->requestBackgroundFetchPermission(clientOrigin, WTFMove(callback)); }
-    std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, const BackgroundFetchRequest& request, const WebCore::ClientOrigin& origin) { return m_delegate->createBackgroundFetchRecordLoader(client, request, origin); }
+    std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, const BackgroundFetchRequest& request, size_t responseDataSize, const WebCore::ClientOrigin& origin) { return m_delegate->createBackgroundFetchRecordLoader(client, request, responseDataSize, origin); }
     Ref<BackgroundFetchStore> createBackgroundFetchStore() { return m_delegate->createBackgroundFetchStore(); }
     WEBCORE_EXPORT BackgroundFetchEngine& backgroundFetchEngine();
 

--- a/Source/WebCore/workers/service/server/SWServerDelegate.h
+++ b/Source/WebCore/workers/service/server/SWServerDelegate.h
@@ -56,7 +56,7 @@ public:
     virtual void addAllowedFirstPartyForCookies(ProcessIdentifier, std::optional<ProcessIdentifier>, RegistrableDomain&&) = 0;
 
     virtual void requestBackgroundFetchPermission(const ClientOrigin&, CompletionHandler<void(bool)>&&) = 0;
-    virtual std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client&, const BackgroundFetchRequest&, const WebCore::ClientOrigin&) = 0;
+    virtual std::unique_ptr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client&, const BackgroundFetchRequest&, size_t responseDataSize, const WebCore::ClientOrigin&) = 0;
     virtual Ref<BackgroundFetchStore> createBackgroundFetchStore() = 0;
 };
 

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -44,7 +44,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-BackgroundFetchLoad::BackgroundFetchLoad(NetworkProcess& networkProcess, PAL::SessionID sessionID, Client& client, const BackgroundFetchRequest& request, const ClientOrigin& clientOrigin)
+BackgroundFetchLoad::BackgroundFetchLoad(NetworkProcess& networkProcess, PAL::SessionID sessionID, Client& client, const BackgroundFetchRequest& request, size_t responseDataSize, const ClientOrigin& clientOrigin)
     : m_sessionID(WTFMove(sessionID))
     , m_client(client)
     , m_request(request.internalRequest)
@@ -54,6 +54,9 @@ BackgroundFetchLoad::BackgroundFetchLoad(NetworkProcess& networkProcess, PAL::Se
         didFinish(ResourceError { String { }, 0, m_request.url(), "URL is not HTTP(S)"_s, ResourceError::Type::Cancellation });
         return;
     }
+
+    if (responseDataSize)
+        m_request.setHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes=", responseDataSize, '-'));
 
     m_networkLoadChecker->enableContentExtensionsCheck();
     if (request.cspResponseHeaders)

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
@@ -51,7 +51,7 @@ class NetworkProcess;
 class BackgroundFetchLoad final : public WebCore::BackgroundFetchRecordLoader, public CanMakeWeakPtr<BackgroundFetchLoad>, private NetworkDataTaskClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    BackgroundFetchLoad(NetworkProcess&, PAL::SessionID, Client&, const WebCore::BackgroundFetchRequest&, const WebCore::ClientOrigin&);
+    BackgroundFetchLoad(NetworkProcess&, PAL::SessionID, Client&, const WebCore::BackgroundFetchRequest&, size_t responseDataSize, const WebCore::ClientOrigin&);
     ~BackgroundFetchLoad();
 
 private:

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -751,9 +751,9 @@ void NetworkSession::addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier w
     m_networkProcess->addAllowedFirstPartyForCookies(webProcessIdentifier, WTFMove(firstPartyForCookies), LoadedWebArchive::No, [] { });
 }
 
-std::unique_ptr<BackgroundFetchRecordLoader> NetworkSession::createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, const WebCore::BackgroundFetchRequest& request, const ClientOrigin& clientOrigin)
+std::unique_ptr<BackgroundFetchRecordLoader> NetworkSession::createBackgroundFetchRecordLoader(BackgroundFetchRecordLoader::Client& client, const WebCore::BackgroundFetchRequest& request, size_t responseDataSize, const ClientOrigin& clientOrigin)
 {
-    return makeUnique<BackgroundFetchLoad>(m_networkProcess.get(), m_sessionID, client, request, clientOrigin);
+    return makeUnique<BackgroundFetchLoad>(m_networkProcess.get(), m_sessionID, client, request, responseDataSize, clientOrigin);
 }
 
 Ref<BackgroundFetchStore> NetworkSession::createBackgroundFetchStore()

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -287,7 +287,7 @@ protected:
     void appBoundDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&) final;
     void addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier, std::optional<WebCore::ProcessIdentifier>, WebCore::RegistrableDomain&&) final;
     void requestBackgroundFetchPermission(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&) final;
-    std::unique_ptr<WebCore::BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(WebCore::BackgroundFetchRecordLoader::Client&, const WebCore::BackgroundFetchRequest&, const WebCore::ClientOrigin&) final;
+    std::unique_ptr<WebCore::BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(WebCore::BackgroundFetchRecordLoader::Client&, const WebCore::BackgroundFetchRequest&, size_t responseDataSize, const WebCore::ClientOrigin&) final;
     Ref<WebCore::BackgroundFetchStore> createBackgroundFetchStore() final;
 
     BackgroundFetchStoreImpl& ensureBackgroundFetchStore();

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
@@ -219,7 +219,7 @@ void BackgroundFetchStoreImpl::clearAllFetches(const ServiceWorkerRegistrationKe
     });
 }
 
-void BackgroundFetchStoreImpl::storeFetch(const ServiceWorkerRegistrationKey& key, const String& identifier, uint64_t downloadTotal, uint64_t uploadTotal, Vector<uint8_t>&& fetch, CompletionHandler<void(StoreResult)>&& callback)
+void BackgroundFetchStoreImpl::storeFetch(const ServiceWorkerRegistrationKey& key, const String& identifier, uint64_t downloadTotal, uint64_t uploadTotal, std::optional<size_t> responseBodyIndexToClear, Vector<uint8_t>&& fetch, CompletionHandler<void(StoreResult)>&& callback)
 {
     if (!m_manager) {
         callback(StoreResult::InternalError);
@@ -247,14 +247,14 @@ void BackgroundFetchStoreImpl::storeFetch(const ServiceWorkerRegistrationKey& ke
         callback(result);
     };
 
-    m_manager->dispatchTaskToBackgroundFetchManager(origin, [fetchStorageIdentifier = crossThreadCopy(fetchStorageIdentifier), downloadTotal, uploadTotal, fetch = WTFMove(fetch), internalCallback = WTFMove(internalCallback)](auto* backgroundFetchManager) mutable {
+    m_manager->dispatchTaskToBackgroundFetchManager(origin, [fetchStorageIdentifier = crossThreadCopy(fetchStorageIdentifier), downloadTotal, uploadTotal, responseBodyIndexToClear, fetch = WTFMove(fetch), internalCallback = WTFMove(internalCallback)](auto* backgroundFetchManager) mutable {
         if (!backgroundFetchManager) {
             callOnMainRunLoop([internalCallback = WTFMove(internalCallback)]() mutable {
                 internalCallback(StoreResult::InternalError);
             });
             return;
         }
-        backgroundFetchManager->storeFetch(fetchStorageIdentifier, downloadTotal, uploadTotal, WTFMove(fetch), [internalCallback = WTFMove(internalCallback)](auto result) mutable {
+        backgroundFetchManager->storeFetch(fetchStorageIdentifier, downloadTotal, uploadTotal, responseBodyIndexToClear, WTFMove(fetch), [internalCallback = WTFMove(internalCallback)](auto result) mutable {
             callOnMainRunLoop([result, internalCallback = WTFMove(internalCallback)]() mutable {
                 internalCallback(result);
             });
@@ -382,7 +382,7 @@ void BackgroundFetchStoreImpl::getBackgroundFetchState(const String& backgroundF
             return;
         }
         auto information = fetch->information();
-        callback(BackgroundFetchState { key.topOrigin(), key.scope(), fetch->identifier(), fetch->options(), information.uploadTotal, information.uploaded, information.downloadTotal, information.downloaded, information.result, information.failureReason, fetch->isActive() });
+        callback({ { key.topOrigin(), key.scope(), fetch->identifier(), fetch->options(), information.downloadTotal, information.downloaded, information.uploadTotal, information.uploaded, information.result, information.failureReason, fetch->pausedFlagIsSet() } });
     });
 }
 

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
@@ -62,7 +62,7 @@ private:
     void initializeFetches(const WebCore::ServiceWorkerRegistrationKey&, CompletionHandler<void()>&&) final;
     void clearFetch(const WebCore::ServiceWorkerRegistrationKey&, const String&, CompletionHandler<void()>&&) final;
     void clearAllFetches(const WebCore::ServiceWorkerRegistrationKey&, CompletionHandler<void()>&&) final;
-    void storeFetch(const WebCore::ServiceWorkerRegistrationKey&, const String&, uint64_t downloadTotal, uint64_t uploadTotal, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&) final;
+    void storeFetch(const WebCore::ServiceWorkerRegistrationKey&, const String&, uint64_t downloadTotal, uint64_t uploadTotal, std::optional<size_t> responseBodyIndexToClear, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&) final;
     void storeFetchResponseBodyChunk(const WebCore::ServiceWorkerRegistrationKey&, const String&, size_t, const WebCore::SharedBuffer&, CompletionHandler<void(StoreResult)>&&) final;
     void retrieveResponseBody(const WebCore::ServiceWorkerRegistrationKey&, const String&, size_t, RetrieveRecordResponseBodyCallback&&) final;
 

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h
@@ -56,13 +56,13 @@ public:
     void clearAllFetches(const Vector<String>&, CompletionHandler<void()>&&);
 
     using StoreResult = WebCore::BackgroundFetchStore::StoreResult;
-    void storeFetch(const String&, uint64_t downloadTotal, uint64_t uploadTotal, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&);
+    void storeFetch(const String&, uint64_t downloadTotal, uint64_t uploadTotal, std::optional<size_t> responseBodyIndexToClear, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&);
     void storeFetchResponseBodyChunk(const String&, size_t, const WebCore::SharedBuffer&, CompletionHandler<void(StoreResult)>&&);
 
     void retrieveResponseBody(const String&, size_t, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
 
 private:
-    void storeFetchAfterQuotaCheck(const String&, uint64_t downloadTotal, uint64_t uploadTotal, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&);
+    void storeFetchAfterQuotaCheck(const String&, uint64_t downloadTotal, uint64_t uploadTotal, std::optional<size_t> responseBodyIndexToClear, Vector<uint8_t>&&, CompletionHandler<void(StoreResult)>&&);
 
     String m_path;
     Ref<WTF::WorkQueue> m_taskQueue;

--- a/Source/WebKit/Shared/BackgroundFetchState.h
+++ b/Source/WebKit/Shared/BackgroundFetchState.h
@@ -54,7 +54,7 @@ struct BackgroundFetchState {
     WebCore::BackgroundFetchResult result { WebCore::BackgroundFetchResult::EmptyString };
     WebCore::BackgroundFetchFailureReason failureReason { WebCore::BackgroundFetchFailureReason::EmptyString };
     
-    bool isActive { false };
+    bool isPaused { false };
     
 #if PLATFORM(COCOA)
     NSDictionary *toDictionary() const;

--- a/Source/WebKit/Shared/BackgroundFetchState.serialization.in
+++ b/Source/WebKit/Shared/BackgroundFetchState.serialization.in
@@ -34,6 +34,6 @@ struct WebKit::BackgroundFetchState {
     uint64_t uploaded;
     WebCore::BackgroundFetchResult result;
     WebCore::BackgroundFetchFailureReason failureReason;
-    bool isActive;
+    bool isPaused;
 };
 #endif

--- a/Source/WebKit/Shared/Cocoa/BackgroundFetchStateCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/BackgroundFetchStateCocoa.mm
@@ -47,7 +47,7 @@ NSDictionary *BackgroundFetchState::toDictionary() const
         @"Uploaded" : @(uploaded),
         @"Result" : (NSString *)(convertEnumerationToString(result)),
         @"FailureReason" : (NSString *)(convertEnumerationToString(failureReason)),
-        @"IsActive" : @(isActive),
+        @"IsPaused" : @(isPaused),
     };
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -220,6 +220,11 @@ interface TestRunner {
     undefined pauseBackgroundFetch(DOMString identifier);
     undefined resumeBackgroundFetch(DOMString identifier);
     undefined simulateClickBackgroundFetch(DOMString identifier);
+    undefined setBackgroundFetchPermission(boolean value);
+    DOMString lastAddedBackgroundFetchIdentifier();
+    DOMString lastRemovedBackgroundFetchIdentifier();
+    DOMString lastUpdatedBackgroundFetchIdentifier();
+    DOMString backgroundFetchState(DOMString identifier);
 
     // Geolocation
     undefined setGeolocationPermission(boolean value);
@@ -260,10 +265,6 @@ interface TestRunner {
     undefined setAuthenticationPassword(DOMString password);
 
     undefined setAllowsAnySSLCertificate(boolean value);
-    undefined setBackgroundFetchPermission(boolean value);
-    DOMString lastAddedBackgroundFetchIdentifier();
-    DOMString lastRemovedBackgroundFetchIdentifier();
-    DOMString lastUpdatedBackgroundFetchIdentifier();
 
     undefined setShouldSwapToEphemeralSessionOnNextNavigation(boolean value);
     undefined setShouldSwapToDefaultSessionOnNextNavigation(boolean value);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -931,6 +931,13 @@ WKRetainPtr<WKStringRef> InjectedBundle::lastUpdatedBackgroundFetchIdentifier() 
     return static_cast<WKStringRef>(result);
 }
 
+WKRetainPtr<WKStringRef> InjectedBundle::backgroundFetchState(WKStringRef identifier)
+{
+    WKTypeRef result = nullptr;
+    WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("BackgroundFetchState").get(), identifier, &result);
+    return static_cast<WKStringRef>(result);
+}
+
 void InjectedBundle::textDidChangeInTextField()
 {
     m_testRunner->textDidChangeInTextFieldCallback();

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -160,6 +160,7 @@ public:
     WKRetainPtr<WKStringRef> lastAddedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> lastRemovedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;
+    WKRetainPtr<WKStringRef> backgroundFetchState(WKStringRef);
 
 private:
     InjectedBundle() = default;

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -475,6 +475,12 @@ JSRetainPtr<JSStringRef> TestRunner::lastUpdatedBackgroundFetchIdentifier() cons
     return WKStringCopyJSString(identifier.get());
 }
 
+JSRetainPtr<JSStringRef> TestRunner::backgroundFetchState(JSStringRef identifier)
+{
+    auto state = InjectedBundle::singleton().backgroundFetchState(toWK(identifier).get());
+    return WKStringCopyJSString(state.get());
+}
+
 void TestRunner::setShouldSwapToEphemeralSessionOnNextNavigation(bool shouldSwap)
 {
     postSynchronousPageMessage("SetShouldSwapToEphemeralSessionOnNextNavigation", shouldSwap);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -113,10 +113,6 @@ public:
     void setCacheModel(int);
     void setAsynchronousSpellCheckingEnabled(bool);
     void setAllowsAnySSLCertificate(bool);
-    void setBackgroundFetchPermission(bool);
-    JSRetainPtr<JSStringRef> lastAddedBackgroundFetchIdentifier() const;
-    JSRetainPtr<JSStringRef> lastRemovedBackgroundFetchIdentifier() const;
-    JSRetainPtr<JSStringRef> lastUpdatedBackgroundFetchIdentifier() const;
 
     void setShouldSwapToEphemeralSessionOnNextNavigation(bool);
     void setShouldSwapToDefaultSessionOnNextNavigation(bool);
@@ -307,6 +303,11 @@ public:
     void pauseBackgroundFetch(JSStringRef);
     void resumeBackgroundFetch(JSStringRef);
     void simulateClickBackgroundFetch(JSStringRef);
+    void setBackgroundFetchPermission(bool);
+    JSRetainPtr<JSStringRef> lastAddedBackgroundFetchIdentifier() const;
+    JSRetainPtr<JSStringRef> lastRemovedBackgroundFetchIdentifier() const;
+    JSRetainPtr<JSStringRef> lastUpdatedBackgroundFetchIdentifier() const;
+    JSRetainPtr<JSStringRef> backgroundFetchState(JSStringRef);
 
     // Geolocation.
     void setGeolocationPermission(bool);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1454,6 +1454,10 @@ WKRetainPtr<WKStringRef> TestController::lastUpdatedBackgroundFetchIdentifier() 
     return adoptWK(WKStringCreateWithUTF8CString("not implemented"));
 }
 
+WKRetainPtr<WKStringRef> TestController::backgroundFetchState(WKStringRef)
+{
+    return { };
+}
 #endif
 
 WKURLRef TestController::createTestURL(const char* pathOrURL)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -188,10 +188,6 @@ public:
     void setAuthenticationUsername(String username) { m_authenticationUsername = username; }
     void setAuthenticationPassword(String password) { m_authenticationPassword = password; }
     void setAllowsAnySSLCertificate(bool);
-    void setBackgroundFetchPermission(bool);
-    WKRetainPtr<WKStringRef> lastAddedBackgroundFetchIdentifier() const;
-    WKRetainPtr<WKStringRef> lastRemovedBackgroundFetchIdentifier() const;
-    WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;
 
     void setShouldSwapToEphemeralSessionOnNextNavigation(bool value) { m_shouldSwapToEphemeralSessionOnNextNavigation = value; }
     void setShouldSwapToDefaultSessionOnNextNavigation(bool value) { m_shouldSwapToDefaultSessionOnNextNavigation = value; }
@@ -415,6 +411,11 @@ public:
     void pauseBackgroundFetch(WKStringRef);
     void resumeBackgroundFetch(WKStringRef);
     void simulateClickBackgroundFetch(WKStringRef);
+    void setBackgroundFetchPermission(bool);
+    WKRetainPtr<WKStringRef> lastAddedBackgroundFetchIdentifier() const;
+    WKRetainPtr<WKStringRef> lastRemovedBackgroundFetchIdentifier() const;
+    WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;
+    WKRetainPtr<WKStringRef> backgroundFetchState(WKStringRef);
 
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -952,13 +952,36 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         TestController::singleton().setBackgroundFetchPermission(booleanValue(messageBody));
         return nullptr;
     }
+    if (WKStringIsEqualToUTF8CString(messageName, "GetBackgroundFetchIdentifier"))
+        return TestController::singleton().getBackgroundFetchIdentifier();
 
+    if (WKStringIsEqualToUTF8CString(messageName, "AbortBackgroundFetch")) {
+        TestController::singleton().abortBackgroundFetch(stringValue(messageBody));
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "PauseBackgroundFetch")) {
+        TestController::singleton().pauseBackgroundFetch(stringValue(messageBody));
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "ResumeBackgroundFetch")) {
+        TestController::singleton().resumeBackgroundFetch(stringValue(messageBody));
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "SimulateClickBackgroundFetch")) {
+        TestController::singleton().simulateClickBackgroundFetch(stringValue(messageBody));
+        return nullptr;
+    }
     if (WKStringIsEqualToUTF8CString(messageName, "LastAddedBackgroundFetchIdentifier"))
         return TestController::singleton().lastAddedBackgroundFetchIdentifier();
     if (WKStringIsEqualToUTF8CString(messageName, "LastRemovedBackgroundFetchIdentifier"))
         return TestController::singleton().lastRemovedBackgroundFetchIdentifier();
     if (WKStringIsEqualToUTF8CString(messageName, "LastUpdatedBackgroundFetchIdentifier"))
         return TestController::singleton().lastUpdatedBackgroundFetchIdentifier();
+    if (WKStringIsEqualToUTF8CString(messageName, "BackgroundFetchState"))
+        return TestController::singleton().backgroundFetchState(stringValue(messageBody));
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetShouldSwapToEphemeralSessionOnNextNavigation")) {
         TestController::singleton().setShouldSwapToEphemeralSessionOnNextNavigation(booleanValue(messageBody));
@@ -1092,29 +1115,6 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
 
     if (WKStringIsEqualToUTF8CString(messageName, "DenyNotificationPermissionOnPrompt"))
         return adoptWK(WKBooleanCreate(TestController::singleton().denyNotificationPermissionOnPrompt(stringValue(messageBody))));
-
-    if (WKStringIsEqualToUTF8CString(messageName, "GetBackgroundFetchIdentifier"))
-        return TestController::singleton().getBackgroundFetchIdentifier();
-
-    if (WKStringIsEqualToUTF8CString(messageName, "AbortBackgroundFetch")) {
-        TestController::singleton().abortBackgroundFetch(stringValue(messageBody));
-        return nullptr;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "PauseBackgroundFetch")) {
-        TestController::singleton().pauseBackgroundFetch(stringValue(messageBody));
-        return nullptr;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "ResumeBackgroundFetch")) {
-        TestController::singleton().resumeBackgroundFetch(stringValue(messageBody));
-        return nullptr;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SimulateClickBackgroundFetch")) {
-        TestController::singleton().simulateClickBackgroundFetch(stringValue(messageBody));
-        return nullptr;
-    }
 
     if (WKStringIsEqualToUTF8CString(messageName, "IsDoingMediaCapture"))
         return adoptWK(WKBooleanCreate(TestController::singleton().isDoingMediaCapture()));

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -534,26 +534,6 @@ void TestController::setAllowsAnySSLCertificate(bool allows)
     [globalWebsiteDataStoreDelegateClient() setAllowAnySSLCertificate: allows];
 }
 
-void TestController::setBackgroundFetchPermission(bool value)
-{
-    [globalWebsiteDataStoreDelegateClient() setBackgroundFetchPermission: value];
-}
-
-WKRetainPtr<WKStringRef> TestController::lastAddedBackgroundFetchIdentifier() const
-{
-    return adoptWK(WKStringCreateWithCFString((__bridge CFStringRef)[globalWebsiteDataStoreDelegateClient() lastAddedBackgroundFetchIdentifier]));
-}
-
-WKRetainPtr<WKStringRef> TestController::lastRemovedBackgroundFetchIdentifier() const
-{
-    return adoptWK(WKStringCreateWithCFString((__bridge CFStringRef)[globalWebsiteDataStoreDelegateClient() lastRemovedBackgroundFetchIdentifier]));
-}
-
-WKRetainPtr<WKStringRef> TestController::lastUpdatedBackgroundFetchIdentifier() const
-{
-    return adoptWK(WKStringCreateWithCFString((__bridge CFStringRef)[globalWebsiteDataStoreDelegateClient() lastUpdatedBackgroundFetchIdentifier]));
-}
-
 void TestController::setAllowedMenuActions(const Vector<String>& actions)
 {
 #if PLATFORM(IOS_FAMILY)
@@ -645,6 +625,41 @@ void TestController::simulateClickBackgroundFetch(WKStringRef identifier)
         isDone = true;
     }];
     platformRunUntil(isDone, noTimeout);
+}
+
+void TestController::setBackgroundFetchPermission(bool value)
+{
+    [globalWebsiteDataStoreDelegateClient() setBackgroundFetchPermission:value];
+}
+
+WKRetainPtr<WKStringRef> TestController::lastAddedBackgroundFetchIdentifier() const
+{
+    return adoptWK(WKStringCreateWithCFString((__bridge CFStringRef)[globalWebsiteDataStoreDelegateClient() lastAddedBackgroundFetchIdentifier]));
+}
+
+WKRetainPtr<WKStringRef> TestController::lastRemovedBackgroundFetchIdentifier() const
+{
+    return adoptWK(WKStringCreateWithCFString((__bridge CFStringRef)[globalWebsiteDataStoreDelegateClient() lastRemovedBackgroundFetchIdentifier]));
+}
+
+WKRetainPtr<WKStringRef> TestController::lastUpdatedBackgroundFetchIdentifier() const
+{
+    return adoptWK(WKStringCreateWithCFString((__bridge CFStringRef)[globalWebsiteDataStoreDelegateClient() lastUpdatedBackgroundFetchIdentifier]));
+}
+
+WKRetainPtr<WKStringRef> TestController::backgroundFetchState(WKStringRef identifier)
+{
+    __block bool isDone = false;
+    __block String backgroundFetchState;
+    [globalWebViewConfiguration().get().websiteDataStore _getBackgroundFetchState:toWTFString(identifier) completionHandler:^(NSDictionary *state) {
+        backgroundFetchState = makeString("{ ",
+            "\"downloaded\":", [[state valueForKey:@"Downloaded"] unsignedIntegerValue], ",",
+            "\"isPaused\":", [[state valueForKey:@"IsPaused"] boolValue] ? "true" : "false",
+        "}");
+        isDone = true;
+    }];
+    platformRunUntil(isDone, noTimeout);
+    return toWK(backgroundFetchState);
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### 6420384c096fc03eba04e7002a7e92e2ec88f6c4
<pre>
Add support for pausing and resuming background fetches
<a href="https://bugs.webkit.org/show_bug.cgi?id=253308">https://bugs.webkit.org/show_bug.cgi?id=253308</a>
rdar://problem/106192062

Reviewed by Sihui Liu.

Add support for the pausedFlag as defined in <a href="https://wicg.github.io/background-fetch/#background-fetch-paused-flag.">https://wicg.github.io/background-fetch/#background-fetch-paused-flag.</a>
When pause is called, we stop the loader if active.
When resuming, we restart the loader. If there is already some downloaded data, we use a range request.
If the response is not a range response, we clear response body and start writing the data from start.
If the response is a range response, we validate it as per spec and we store the data.

We store the paused flag in the store and do not restart background fetches if it is paused.
We expose the paused flag in BackgroundFetchState as well.

Drive-by fix to correctly expose downloaded (it was exposed as uploaded previously).
Add test runner API to get the currewnt downloaded size.

Covered by newly added test.

* LayoutTests/http/wpt/background-fetch/background-fetch-pause-resume.window-expected.txt: Added.
* LayoutTests/http/wpt/background-fetch/background-fetch-pause-resume.window.html: Added.
* LayoutTests/http/wpt/background-fetch/background-fetch-pause-resume.window.js: Added.
(backgroundFetchDownloaded):
(backgroundFetchIsPaused):
(promise_test.async t):
* LayoutTests/http/wpt/background-fetch/resources/trickle-range.py: Added.
(main):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::BackgroundFetch):
(WebCore::BackgroundFetch::pause):
(WebCore::BackgroundFetch::resume):
(WebCore::BackgroundFetch::storeResponse):
(WebCore::BackgroundFetch::setRecords):
(WebCore::BackgroundFetch::Record::complete):
(WebCore::BackgroundFetch::Record::pause):
(WebCore::extractContentRangeValues):
(WebCore::validatePartialResponse):
(WebCore::BackgroundFetch::Record::didReceiveResponse):
(WebCore::BackgroundFetch::doStore):
(WebCore::BackgroundFetch::createFromStore):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.h:
(WebCore::BackgroundFetch::pausedFlagIsSet const):
(WebCore::BackgroundFetch::doStore):
(WebCore::BackgroundFetch::setRecords): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp:
(WebCore::BackgroundFetchEngine::startBackgroundFetch):
(WebCore::BackgroundFetchEngine::notifyBackgroundFetchUpdate):
(WebCore::BackgroundFetchEngine::pauseBackgroundFetch):
(WebCore::BackgroundFetchEngine::resumeBackgroundFetch):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchStore.h:
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::createBackgroundFetchRecordLoader):
* Source/WebCore/workers/service/server/SWServerDelegate.h:
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp:
(WebKit::BackgroundFetchLoad::BackgroundFetchLoad):
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::createBackgroundFetchRecordLoader):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp:
(WebKit::BackgroundFetchStoreImpl::storeFetch):
(WebKit::BackgroundFetchStoreImpl::getBackgroundFetchState):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
(WebKit::BackgroundFetchStoreManager::storeFetch):
(WebKit::BackgroundFetchStoreManager::storeFetchAfterQuotaCheck):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.h:
* Source/WebKit/Shared/BackgroundFetchState.h:
* Source/WebKit/Shared/BackgroundFetchState.serialization.in:
* Source/WebKit/Shared/Cocoa/BackgroundFetchStateCocoa.mm:
(WebKit::BackgroundFetchState::toDictionary const):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::backgroundFetchState):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::backgroundFetchState):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::backgroundFetchState):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::setBackgroundFetchPermission):
(WTR::TestController::lastAddedBackgroundFetchIdentifier const):
(WTR::TestController::lastRemovedBackgroundFetchIdentifier const):
(WTR::TestController::lastUpdatedBackgroundFetchIdentifier const):
(WTR::TestController::backgroundFetchState):

Canonical link: <a href="https://commits.webkit.org/261625@main">https://commits.webkit.org/261625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53e05373f0488611dc17950cbf8132f4b0bc5f00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4132 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120962 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4906 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105403 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45969 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13864 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/736 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14558 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52741 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8107 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16362 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->