### PR TITLE
/build-archives/ shouldn't rely on JS to rewrite dates

### DIFF
--- a/Websites/webkit.org/wp-content/themes/webkit/build-archives.php
+++ b/Websites/webkit.org/wp-content/themes/webkit/build-archives.php
@@ -62,9 +62,9 @@ add_action('wp_head', function() { ?>
     (function(document) {
         document.addEventListener("DOMContentLoaded", function () {
 
-            var creationTimeNodes = Array.prototype.slice.call(document.getElementsByClassName("date"));
-            for (var timestamp of creationTimeNodes) {
-                var date = new Date(parseInt(timestamp.textContent));
+            var creationTimeNodes = Array.prototype.slice.call(document.querySelectorAll("time.date"));
+            for (var time of creationTimeNodes) {
+                var date = new Date(Date.parse(time.getAttribute("datetime")));
                 timestamp.textContent = date.toLocaleDateString("en", {
                     "timeZoneName": "short",
                     "minute":       "2-digit",
@@ -143,7 +143,7 @@ add_filter('the_content', function ($content) {
         <?php foreach ($changes as $change => $entry): ?>
         <li>
             <h6><a href="<?php echo esc_url($entry->url); ?>"><?php echo $change; ?></a></h6>
-            <span class="date"><?php echo intval($entry->creationTime) * 1000; ?></span>
+            <time datetime="<?php echo gmdate("Y-m-d\\TH:i:s\\Z", intval($entry->creationTime)); ?>" class="date"><?php echo wp_date("F j, Y \\a\\t h:i A T", intval($entry->creationTime)); ?></time>
         </li>
         <?php endforeach?>
     </ul>


### PR DESCRIPTION
#### 48f65ed5868565a3d7fee2c8b8a1c915c4a64039
<pre>
/build-archives/ shouldn&apos;t rely on JS to rewrite dates
<a href="https://bugs.webkit.org/show_bug.cgi?id=253449">https://bugs.webkit.org/show_bug.cgi?id=253449</a>

Reviewed by Alexey Proskuryakov.

* Websites/webkit.org/wp-content/themes/webkit/build-archives.php:

Canonical link: <a href="https://commits.webkit.org/261761@main">https://commits.webkit.org/261761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b80d24e361e673cd81e28078f4f109659bded07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3640 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120569 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3386 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104892 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45575 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13455 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/337 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/92647 "re-run-api-tests (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13971 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9749 "15 flakes 2 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52338 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15938 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4497 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->