### PR TITLE
Fix SIMD global get and set in BBQ JIT

### DIFF
--- a/JSTests/wasm/stress/simd-global-get.js
+++ b/JSTests/wasm/stress/simd-global-get.js
@@ -1,0 +1,29 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (global $0 v128 v128.const i32x4 42 42 42 42)
+    (func $1 (result v128)
+        global.get $0
+    )
+    (func (export "test")
+        call $1
+        v128.const i32x4 42 42 42 42
+        i32x4.eq
+        i32x4.all_true
+        br_if 0
+        unreachable
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const { test } = instance.exports;
+    test();
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-global-set.js
+++ b/JSTests/wasm/stress/simd-global-set.js
@@ -1,0 +1,31 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (global $0 (mut v128) v128.const i32x4 0 0 0 0)
+    (func $1 (result v128)
+        v128.const i32x4 1 2 3 4
+        global.set $0
+        global.get $0
+    )
+    (func (export "test")
+        call $1
+        v128.const i32x4 1 2 3 4
+        i32x4.eq
+        i32x4.all_true
+        br_if 0
+        unreachable
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const { test } = instance.exports;
+    test();
+}
+
+assert.asyncTest(test())


### PR DESCRIPTION
#### c6d7e1b115e0f3ca2fa5509102eaf21b8369c108
<pre>
Fix SIMD global get and set in BBQ JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=253455">https://bugs.webkit.org/show_bug.cgi?id=253455</a>
rdar://106293111

Reviewed by Yusuke Suzuki and Justin Michaud.

The current implementation for global.get and global.set in BBQ JIT
uses the same helper to emit type-correct load and store instructions
as the rest of the WASM load and store ops. SIMD load ops aren&apos;t
included in these instructions though, so whenever we try to get or
set a v128 global with portable binding mode, we hit an
ASSERT_NOT_REACHED.

This patch adds a simple check for v128 globals to both of these
instruction implementations, and emits a loadVector/storeVector
instruction directly instead of calling out to the helper.

* JSTests/wasm/stress/simd-global-get.js: Added.
* JSTests/wasm/stress/simd-global-set.js: Added.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::getGlobal):
(JSC::Wasm::BBQJIT::setGlobal):
(JSC::Wasm::BBQJIT::emitLoad):

Canonical link: <a href="https://commits.webkit.org/261299@main">https://commits.webkit.org/261299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/768fcd6a96d1e3f2042e3a868b1f6090716d4f6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2597 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120007 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2221 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116929 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16108 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103730 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44623 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99739 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12827 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32288 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10927 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9278 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100893 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18785 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31459 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7831 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15314 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108928 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26861 "Passed tests") | 
<!--EWS-Status-Bubble-End-->