### PR TITLE
Reduce PGM Metadata Storage from 64 to 40 bytes per allocation

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c
@@ -74,7 +74,10 @@ static bool pas_hash_map_entry_callback(pas_enumerator* enumerator, pas_ptr_hash
 {
     PAS_ASSERT_WITH_DETAIL(!arg);
 
-    pas_enumerator_record(enumerator, (void*)((char*)entry->key - pas_page_malloc_alignment()), ((pas_pgm_storage*) entry->value)->mem_to_alloc, pas_enumerator_object_record);
+    pas_pgm_storage* allocation = ((pas_pgm_storage*)entry->value);
+    size_t mem_to_alloc = (2 * allocation->page_size) + allocation->allocation_size_requested + allocation->mem_to_waste;
+    
+    pas_enumerator_record(enumerator, (void*)((char*)entry->key - pas_page_malloc_alignment()), mem_to_alloc, pas_enumerator_object_record);
     pas_enumerator_record(enumerator, (void*)entry->value, sizeof(pas_pgm_storage), pas_enumerator_meta_record);
 
     return true;

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -34,19 +34,20 @@
 
 PAS_BEGIN_EXTERN_C;
 
-/*
- * structure for holding metadata of pgm allocations
- * FIXME : Reduce size of structure
- */
+/* structure for holding pgm metadata allocations */
 typedef struct pas_pgm_storage pas_pgm_storage;
 struct pas_pgm_storage {
     size_t allocation_size_requested;
     size_t size_of_data_pages;
-    size_t mem_to_waste;
-    size_t mem_to_alloc;
     uintptr_t start_of_data_pages;
-    uintptr_t upper_guard_page;
-    uintptr_t lower_guard_page;
+
+    /*
+     * These parameter below rely on page sizes being less than 65536.
+     * I am not aware of any platforms using more than this at the moment.
+     */
+    uint16_t mem_to_waste;
+    uint16_t page_size;
+
     pas_large_heap* large_heap;
 };
 


### PR DESCRIPTION
#### 0014f22cde494c9382d376d0cf89c9d56cf03a04
<pre>
Reduce PGM Metadata Storage from 64 to 40 bytes per allocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=253458">https://bugs.webkit.org/show_bug.cgi?id=253458</a>

Reviewed by Yusuke Suzuki.

Decrease metadata storage significantly per allocation when performing a PGM allocation.
This is a solid first pass, but we can probably optimize the page_size entry a bit.

* Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c:
(pas_hash_map_entry_callback):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
(pas_probabilistic_guard_malloc_deallocate):
(pas_probabilistic_guard_malloc_debug_info):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:

Canonical link: <a href="https://commits.webkit.org/261305@main">https://commits.webkit.org/261305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce7d21e13b1b89541f10029b102d9992f1c201d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111245 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2671 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11482 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117007 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99332 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/103856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/30991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44711 "layout-tests (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99786 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12889 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/32327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11001 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13409 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100967 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18844 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31470 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7837 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15364 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109004 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26871 "Passed tests") | 
<!--EWS-Status-Bubble-End-->