### PR TITLE
Move data members specific to ElementRareData out of NodeRareData

### DIFF
--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -34,6 +34,8 @@
 namespace WebCore {
 
 struct SameSizeAsElementRareData : NodeRareData {
+    unsigned short m_childIndex;
+    int m_tabIndex;
     IntPoint savedLayerScrollPosition;
     Vector<std::unique_ptr<ElementAnimationRareData>> animationRareData;
     void* pointers[16];

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -193,11 +193,16 @@ public:
             result.add(UseType::ExplicitlySetAttrElementsMap);
         if (m_popoverData)
             result.add(UseType::Popover);
+        if (m_childIndex)
+            result.add(UseType::ChildIndex);
         return result;
     }
 #endif
 
 private:
+    unsigned short m_childIndex { 0 }; // Keep on top for better bit packing with NodeRareData.
+    int m_unusualTabIndex { 0 }; // Keep on top for better bit packing with NodeRareData.
+
     IntPoint m_savedLayerScrollPosition;
     std::unique_ptr<RenderStyle> m_computedStyle;
     std::unique_ptr<RenderStyle> m_displayContentsStyle;
@@ -234,8 +239,6 @@ private:
     ExplicitlySetAttrElementsMap m_explicitlySetAttrElementsMap;
 
     std::unique_ptr<PopoverData> m_popoverData;
-
-    void releasePseudoElement(PseudoElement*);
 };
 
 inline ElementRareData::ElementRareData()

--- a/Source/WebCore/dom/NodeRareData.cpp
+++ b/Source/WebCore/dom/NodeRareData.cpp
@@ -36,10 +36,9 @@
 namespace WebCore {
 
 struct SameSizeAsNodeRareData {
-    uint32_t m_tabIndex;
-    uint32_t m_childIndexAndIsElementRareDataFlag;
     void* m_pointer[2];
     WeakPtr<Node, WeakPtrImplWithEventTargetData> m_weakPointer;
+    bool m_isElementRareData;
 };
 
 static_assert(sizeof(NodeRareData) == sizeof(SameSizeAsNodeRareData), "NodeRareData should stay small");

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -263,7 +263,7 @@ public:
     {
     }
 
-    bool isElementRareData() { return m_isElementRareData; }
+    bool isElementRareData() const { return m_isElementRareData; }
 
     void clearNodeLists() { m_nodeLists = nullptr; }
     NodeListsNodeData* nodeLists() const { return m_nodeLists.get(); }
@@ -292,8 +292,6 @@ public:
         OptionSet<UseType> result;
         if (m_unusualTabIndex)
             result.add(UseType::TabIndex);
-        if (m_childIndex)
-            result.add(UseType::ChildIndex);
         if (m_nodeLists)
             result.add(UseType::NodeList);
         if (m_mutationObserverData)
@@ -306,17 +304,11 @@ public:
 
     void operator delete(NodeRareData*, std::destroying_delete_t);
 
-protected:
-    // Used by ElementRareData. Defined here for better packing in 64-bit.
-    int m_unusualTabIndex { 0 };
-    unsigned short m_childIndex { 0 };
-
 private:
-    bool m_isElementRareData;
-
     std::unique_ptr<NodeListsNodeData> m_nodeLists;
     std::unique_ptr<NodeMutationObserverData> m_mutationObserverData;
     WeakPtr<HTMLSlotElement, WeakPtrImplWithEventTargetData> m_manuallyAssignedSlot;
+    bool m_isElementRareData; // Keep last for better bit packing with ElementRareData.
 };
 
 template<> struct NodeListTypeIdentifier<NameNodeList> {


### PR DESCRIPTION
#### 11ece517da22714cb7c175c07c15cef8e875a7c5
<pre>
Move data members specific to ElementRareData out of NodeRareData
<a href="https://bugs.webkit.org/show_bug.cgi?id=253461">https://bugs.webkit.org/show_bug.cgi?id=253461</a>

Reviewed by Darin Adler.

Move data members specific to ElementRareData out of NodeRareData. Those were
put in NodeRareData for better packing but we can achieve the same packing by
reordering data members.

I have verified that sizeof(NodeRareData)=32 and sizeof(ElementRareDate)=232
before and after my change.

* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::useTypes const):
* Source/WebCore/dom/NodeRareData.cpp:
* Source/WebCore/dom/NodeRareData.h:
(WebCore::NodeRareData::isElementRareData const):
(WebCore::NodeRareData::useTypes const):
(WebCore::NodeRareData::isElementRareData): Deleted.

Canonical link: <a href="https://commits.webkit.org/261308@main">https://commits.webkit.org/261308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a40448eac310d16e28deb0d72433bc0e68238c57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2610 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120018 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2230 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98079 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44633 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12841 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86515 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9284 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18799 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7838 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15327 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->