### PR TITLE
Complete the list of ARIA roles used for Interaction Regions

### DIFF
--- a/LayoutTests/interaction-region/aria-roles-expected.txt
+++ b/LayoutTests/interaction-region/aria-roles-expected.txt
@@ -1,6 +1,8 @@
 This works like a button
+This works like a link
 Menu option 1
 Menu option 2
+Menu option 3
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -15,11 +17,23 @@ Menu option 2
 
       (interaction regions [
         (interaction
-            (rect (40,36) width=760 height=20)
+            (rect (0,0) width=800 height=20)
+)
+        (borderRadius 0.00),
+        (interaction
+            (rect (0,20) width=800 height=20)
 )
         (borderRadius 0.00),
         (interaction
             (rect (40,56) width=760 height=20)
+)
+        (borderRadius 0.00),
+        (interaction
+            (rect (40,76) width=760 height=20)
+)
+        (borderRadius 0.00),
+        (interaction
+            (rect (40,96) width=760 height=20)
 )
         (borderRadius 0.00)])
       )

--- a/LayoutTests/interaction-region/aria-roles.html
+++ b/LayoutTests/interaction-region/aria-roles.html
@@ -4,10 +4,12 @@
     body { margin: 0; }
 </style>
 <body>
-<div aria-role="button">This works like a button</div>
+<div role="button">This works like a button</div>
+<div role="link">This works like a link</div>
 <ul role="menu">
     <li role="menuitem">Menu option 1</li>
     <li role="menuitem">Menu option 2</li>
+    <li role="option">Menu option 3</li>
 </ul>
 <pre id="results"></pre>
 <script>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -84,6 +84,29 @@ static bool shouldAllowElement(const Element& element)
     return true;
 }
 
+static bool shouldAllowAccessibilityRoleAsPointerCursorReplacement(const Element& element)
+{
+    switch (AccessibilityObject::ariaRoleToWebCoreRole(element.attributeWithoutSynchronization(HTMLNames::roleAttr))) {
+    case AccessibilityRole::Button:
+    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::DisclosureTriangle:
+    case AccessibilityRole::ImageMapLink:
+    case AccessibilityRole::Link:
+    case AccessibilityRole::WebCoreLink:
+    case AccessibilityRole::ListBoxOption:
+    case AccessibilityRole::MenuButton:
+    case AccessibilityRole::MenuItem:
+    case AccessibilityRole::MenuItemCheckbox:
+    case AccessibilityRole::MenuItemRadio:
+    case AccessibilityRole::PopUpButton:
+    case AccessibilityRole::RadioButton:
+    case AccessibilityRole::ToggleButton:
+        return true;
+    default:
+        return false;
+    }
+}
+
 static bool shouldAllowNonPointerCursorForElement(const Element& element)
 {
 #if ENABLE(ATTACHMENT_ELEMENT)
@@ -97,12 +120,7 @@ static bool shouldAllowNonPointerCursorForElement(const Element& element)
     if (is<SliderThumbElement>(element))
         return true;
 
-    auto role = [](const Element& element) -> AccessibilityRole {
-        return AccessibilityObject::ariaRoleToWebCoreRole(element.attributeWithoutSynchronization(HTMLNames::roleAttr));
-    };
-
-    auto elementRole = role(element);
-    if (elementRole == AccessibilityRole::Button || elementRole == AccessibilityRole::MenuItem)
+    if (shouldAllowAccessibilityRoleAsPointerCursorReplacement(element))
         return true;
 
     return false;


### PR DESCRIPTION
#### e4492ac14176ce45aab4280d85c1bf9628f49b00
<pre>
Complete the list of ARIA roles used for Interaction Regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=253460">https://bugs.webkit.org/show_bug.cgi?id=253460</a>
&lt;rdar://105700895&gt;

Reviewed by Tim Horton.

Expand the list of ARIA roles that enable the creation of an
Interaction Region.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowAccessibilityRoleAsPointerCursorReplacement):
Extract the ARIA check in a function.
(WebCore::shouldAllowNonPointerCursorForElement):
Use the new function when evaluating an element missing
`cursor:pointer`.

* LayoutTests/interaction-region/aria-roles-expected.txt:
* LayoutTests/interaction-region/aria-roles.html:
Fix an issue with the existing `role=&quot;button&quot;` test case.
Add new cases covering this change.

Canonical link: <a href="https://commits.webkit.org/261337@main">https://commits.webkit.org/261337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2949ee508ddb8618f0dde1c8109a33b899a7a8cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120020 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2232 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103794 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44672 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12843 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86546 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9288 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18801 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7858 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15329 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->