### PR TITLE
Fix synchronisation issue with setMediaOverridesForTesting state when a new WebContent process is used for testing

### DIFF
--- a/LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort.html
+++ b/LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort.html
@@ -18,6 +18,9 @@
 
     window.addEventListener('load', async event => {
         try {
+            // VP9 is explicitly required for this test to run
+            internals.setVP9DecoderDisabledForTesting(false);
+
             findMediaElement();
             loader = new MediaSourceLoader('content/test-vp9-manifest.json');
             await loaderPromise(loader);

--- a/LayoutTests/media/media-source/media-source-webm-init-inside-segment.html
+++ b/LayoutTests/media/media-source/media-source-webm-init-inside-segment.html
@@ -18,6 +18,9 @@
 
     window.addEventListener('load', async event => {
         try {
+            // VP9 is explicitly required for this test to run
+            internals.setVP9DecoderDisabledForTesting(false);
+
             findMediaElement();
             loader = new MediaSourceLoader('content/test-vp9-long-manifest.json');
             await loaderPromise(loader);

--- a/LayoutTests/media/media-source/media-source-webm.html
+++ b/LayoutTests/media/media-source/media-source-webm.html
@@ -33,6 +33,9 @@
 
     window.addEventListener('load', async event => {
         try {
+            // VP9 is explicitly required for this test to run
+            internals.setVP9DecoderDisabledForTesting(false);
+
             findMediaElement();
             loader = new MediaSourceLoader('content/test-vp9-manifest.json');
             await loaderPromise(loader);

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2012,9 +2012,6 @@ webkit.org/b/215778 fast/overflow/horizontal-scroll-after-back.html [ Pass Timeo
 
 webkit.org/b/215926 svg/custom/object-sizing.xhtml [ Pass Failure ]
 
-# rdar://problem/66487888 [ BigSur+ ] media/media-source/media-source-webm.html is a constant failure
-[ BigSur+ ] media/media-source/media-source-webm.html [ Failure ]
-
 # rdar://65188503
 [ BigSur+ ] platform/mac/media/media-source/is-type-supported-vp9-codec-check.html [ Skip ]
 
@@ -2053,9 +2050,6 @@ webkit.org/b/221009 fast/harness/render-tree-as-text-options.html [ Pass Failure
 webkit.org/b/221095 [ BigSur+ ] media/mediacapabilities/vp9.html [ Skip ]
 
 webkit.org/b/221146 [ BigSur ] imported/w3c/web-platform-tests/media-source/mediasource-invalid-codec.html [ Failure ]
-
-webkit.org/b/221369 [ BigSur+ ] media/media-source/media-source-webm-append-buffer-after-abort.html [ Skip ]
-webkit.org/b/220552 [ BigSur+ ] media/media-source/media-source-webm-init-inside-segment.html [ Skip ]
 
 webkit.org/b/221347 imported/w3c/web-platform-tests/css/css-flexbox/overflow-auto-006.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 86455e13a77df8c3f50f8915e52ed60746f66813
<pre>
Resolve broken VP9 tests which were being run after VP9 was disabled in previous tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=253468">https://bugs.webkit.org/show_bug.cgi?id=253468</a>
rdar://106328795

Reviewed by NOBODY (OOPS!).

Explicitly enable VP9 for tests which rely on the functionality.

* LayoutTests/media/media-source/media-source-webm-append-buffer-after-abort.html:
* LayoutTests/media/media-source/media-source-webm-init-inside-segment.html:
* LayoutTests/media/media-source/media-source-webm.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86455e13a77df8c3f50f8915e52ed60746f66813

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2625 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120030 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2239 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103781 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98087 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30974 "Found 2 new test failures: media/media-source/media-source-webm-append-buffer-after-abort.html, media/media-source/media-source-webm-init-inside-segment.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44665 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86540 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9300 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18814 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15339 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->