### PR TITLE
Fix problems on changing 'multiple' state SELECT element to 'single' state

### DIFF
--- a/LayoutTests/fast/dom/HTMLSelectElement/change-multiple-preserve-selection-expected.txt
+++ b/LayoutTests/fast/dom/HTMLSelectElement/change-multiple-preserve-selection-expected.txt
@@ -1,9 +1,9 @@
 
 PASS selectElement.selectedIndex is -1
-PASS selectElement.selectedIndex is -1
+PASS selectElement.selectedIndex is 0
 PASS selectElement.selectedIndex is 0
 PASS selectElement.selectedIndex is -1
-PASS selectElement.selectedIndex is -1
+PASS selectElement.selectedIndex is 0
 PASS selectElement.selectedIndex is 0
 PASS selectElement.options[0].selected is true
 PASS selectElement.options[1].selected is true
@@ -14,4 +14,7 @@ PASS selectElement.options[2].selected is false
 PASS selectElement.options[0].selected is true
 PASS selectElement.options[1].selected is false
 PASS selectElement.options[2].selected is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/fast/dom/HTMLSelectElement/change-multiple-preserve-selection.html
+++ b/LayoutTests/fast/dom/HTMLSelectElement/change-multiple-preserve-selection.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script>
 var selectElement;
 function go() {
@@ -8,9 +9,9 @@ function go() {
     selectElement = document.getElementsByTagName('select')[0];
     shouldBe("selectElement.selectedIndex", "-1");
 
-    // Preserve selection on conversion.
+    // Do not preserve non-selected state on conversion to single.
     selectElement.multiple = false;
-    shouldBe("selectElement.selectedIndex", "-1");
+    shouldBe("selectElement.selectedIndex", "0");
 
     // <select multiple="false"> should have a selection by default and that
     // selection should be preserved.
@@ -24,7 +25,7 @@ function go() {
     selectElement.style.display = '';
     shouldBe("selectElement.selectedIndex", "-1");
     selectElement.multiple = false;
-    shouldBe("selectElement.selectedIndex", "-1");
+    shouldBe("selectElement.selectedIndex", "0");
 
     selectElement = document.getElementsByTagName('select')[3];
     selectElement.style.display = '';

--- a/LayoutTests/fast/forms/select-ask-for-reset-expected.txt
+++ b/LayoutTests/fast/forms/select-ask-for-reset-expected.txt
@@ -1,6 +1,9 @@
 
 PASS Adding a SELECT tree to another tree should not reset selection.
 PASS Removing a SELECT tree from another tree should not reset selection.
-PASS Reset should select the first option element in the list of options that is not disabled to true
+PASS Reset should select the first option element in the list of options that is not disabled to true.
+PASS Removing an OPTION from a SELECT element should reset selection.
+PASS Changing multiple SELECT to single should reset selection.
+
 
 

--- a/LayoutTests/fast/forms/select-ask-for-reset.html
+++ b/LayoutTests/fast/forms/select-ask-for-reset.html
@@ -16,6 +16,7 @@ test(function() {
     // option list.
     assert_equals(select.selectedIndex, -1);
 }, 'Adding a SELECT tree to another tree should not reset selection.');
+
 test(function() {
     var select = document.createElement('select');
     document.body.appendChild(select);
@@ -28,6 +29,7 @@ test(function() {
     // option list.
     assert_equals(select.selectedIndex, -1);
 }, 'Removing a SELECT tree from another tree should not reset selection.');
+
 test(function() {
     var form = document.createElement('form');
     document.body.appendChild(form);
@@ -37,6 +39,31 @@ test(function() {
     assert_equals(select.selectedIndex, 1);
     form.reset();
     assert_equals(select.selectedIndex, 1);
-}, 'Reset should select the first option element in the list of options that is not disabled to true');
+}, 'Reset should select the first option element in the list of options that is not disabled to true.');
+
+test(function() {
+    var select = document.createElement('select');
+    select.innerHTML = '<option>foo</option><option>bar</option>';
+    document.body.appendChild(select);
+    select.selectedIndex = -1;
+    select.removeChild(select.lastChild);
+    assert_equals(select.selectedIndex, 0);
+}, 'Removing an OPTION from a SELECT element should reset selection.');
+
+test(function() {
+    var select = document.createElement('select');
+    select.multiple = true;
+    select.innerHTML = '<option selected>foo</option><option selected>bar</option>';
+    document.body.appendChild(select);
+    select.removeAttribute('multiple');
+    assert_equals(select.selectedOptions.length, 1);
+    assert_equals(select.selectedIndex, 0, 'The first selected OPTION should be chosen.');
+
+    select.selectedIndex = -1;
+    select.multiple = true;
+    select.multiple = false;
+    assert_equals(select.selectedOptions.length, 1);
+    assert_equals(select.selectedIndex, 0);
+}, 'Changing multiple SELECT to single should reset selection.');
 </script>
 </body>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -432,18 +432,6 @@ void HTMLSelectElement::optionElementChildrenChanged()
         cache->childrenChanged(this);
 }
 
-void HTMLSelectElement::setMultiple(bool multiple)
-{
-    bool oldMultiple = this->multiple();
-    int oldSelectedIndex = selectedIndex();
-    setBooleanAttribute(multipleAttr, multiple);
-
-    // Restore selectedIndex after changing the multiple flag to preserve
-    // selection as single-line and multi-line has different defaults.
-    if (oldMultiple != this->multiple())
-        setSelectedIndex(oldSelectedIndex);
-}
-
 void HTMLSelectElement::setSize(unsigned size)
 {
     setUnsignedIntegralAttribute(sizeAttr, limitToOnlyHTMLNonNegative(size));
@@ -1059,10 +1047,18 @@ void HTMLSelectElement::restoreFormControlState(const FormControlState& state)
 void HTMLSelectElement::parseMultipleAttribute(const AtomString& value)
 {
     bool oldUsesMenuList = usesMenuList();
+    bool oldMultiple = m_multiple;
+    int oldSelectedIndex = selectedIndex();
     m_multiple = !value.isNull();
     updateValidity();
     if (oldUsesMenuList != usesMenuList())
         invalidateStyleAndRenderersForSubtree();
+    if (oldMultiple != m_multiple) {
+        if (oldSelectedIndex >= 0)
+            setSelectedIndex(oldSelectedIndex);
+        else
+            reset();
+    }
 }
 
 bool HTMLSelectElement::appendFormData(DOMFormData& formData)

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -78,8 +78,6 @@ public:
 
     void accessKeySetSelectedIndex(int);
 
-    WEBCORE_EXPORT void setMultiple(bool);
-
     WEBCORE_EXPORT void setSize(unsigned);
 
     // Called by the bindings for the unnamed index-setter.

--- a/Source/WebCore/html/HTMLSelectElement.idl
+++ b/Source/WebCore/html/HTMLSelectElement.idl
@@ -26,7 +26,7 @@
     [CEReactions] attribute [AtomString] DOMString autocomplete;
     [CEReactions, Reflect] attribute boolean disabled;
     readonly attribute HTMLFormElement? form;
-    [CEReactions] attribute boolean multiple;
+    [CEReactions, Reflect] attribute boolean multiple;
     [CEReactions, Reflect] attribute DOMString name;
     [CEReactions, Reflect] attribute boolean required;
     [CEReactions] attribute unsigned long size;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLSelectElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLSelectElement.cpp
@@ -443,7 +443,7 @@ void webkit_dom_html_select_element_set_multiple(WebKitDOMHTMLSelectElement* sel
     WebCore::JSMainThreadNullState state;
     g_return_if_fail(WEBKIT_DOM_IS_HTML_SELECT_ELEMENT(self));
     WebCore::HTMLSelectElement* item = WebKit::core(self);
-    item->setMultiple(value);
+    item->setBooleanAttribute(WebCore::HTMLNames::multipleAttr, value);
 }
 
 gchar* webkit_dom_html_select_element_get_name(WebKitDOMHTMLSelectElement* self)

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm
@@ -92,7 +92,7 @@
 - (void)setMultiple:(BOOL)newMultiple
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setMultiple(newMultiple);
+    IMPL->setBooleanAttribute(WebCore::HTMLNames::multipleAttr, newMultiple);
 }
 
 - (NSString *)name


### PR DESCRIPTION
#### febbe13cd11cd845645ec472954d2048e3289cda
<pre>
Fix problems on changing &apos;multiple&apos; state SELECT element to &apos;single&apos; state

<a href="https://bugs.webkit.org/show_bug.cgi?id=252969">https://bugs.webkit.org/show_bug.cgi?id=252969</a>
rdar://problem/106264081

Reviewed by Aditya Keerthi.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/ed6cd6b785c97d4a678c262bbf5e62bf46e5a2e8">https://chromium.googlesource.com/chromium/src.git/+/ed6cd6b785c97d4a678c262bbf5e62bf46e5a2e8</a>

This patch fixes two problems.

* Setting &apos;multiple&apos; IDL attribute to false and removing &apos;multiple&apos; content
  attribute had different behavior.
  They should be identical.  This patch removes HTMLSelectElement::setMultiple(), and
  add [Reflect] to &apos;multiple&apos; IDL attribute.

* If multiple SELECT without selected OPTIONs is changed to single, we should run
  reset().
  All other browsers agree with this behavior.

* Source/WebCore/html/HTMLSelectElement.cpp:
(HTMLSelectElement::setMultiple): Deleted
(HTMLSelectElement::parseMultipleAttribute): Update for &apos;reset&apos;
* Source/WebCore/html/HTMLSelectElement.h: Remove &apos;setMultiple&apos;
* Source/WebCore/html/HTMLSelectElement.idl: Update &apos;multiple&apos; to have [Reflect]
* Source/WebKitLegacy/mac/DOM/DOMHTMLSelectElement.mm: Update return instead of &apos;setMultiple&apos;
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLSelectElement.cpp:
(webkit_dom_html_select_element_set_multiple): Ditto
* LayoutTests/fast/forms/select-ask-for-reset.html: Sync up-to-date from Chromium Source
* LayoutTests/fast/forms/select-ask-for-reset-expected.txt: Rebaselined
* LayoutTests/fast/dom/HTMLSelectElement/change-multiple-preserve-selection.html: Rebaselined
* LayoutTests/fast/dom/HTMLSelectElement/change-multiple-preserve-selection-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/261380@main">https://commits.webkit.org/261380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e611e5df4c59adc0ddc274c2363516c3be87e001

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/10 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11719 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104108 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/6 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44928 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13032 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/6 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86826 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13540 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51987 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7922 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15502 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->