### PR TITLE
[popover] Implement popovertarget & popovertargetaction attributes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -1,10 +1,10 @@
 Button1  Button2  Invoker1  Button3  Button4
 Invoker  after
-Show popover
+Show popover Hide popover
 
 FAIL Popover focus navigation assert_equals: Hidden popover should be skipped expected Element node <button id="button2">Button2</button> but got Element node <body><div id="fixup">
   <button id="button1">Button1</bu...
 FAIL Circular reference tab navigation assert_equals: Step 2 expected Element node <button id="circular1" autofocus="" popovertarget="popove... but got Element node <body><div id="fixup">
   <button id="button1">Button1</bu...
-FAIL Popover focus returns when popover is hidden by invoker assert_true: popover should be invoked by invoker expected true got false
+FAIL Popover focus returns when popover is hidden by invoker assert_equals: Hide button should be focused due to autofocus attribute expected Element node <button popovertarget="deleted1" popovertargetaction="hid... but got Element node <button popovertarget="deleted1" popovertargetaction="sho...
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
@@ -2,8 +2,8 @@ This is a popover
 
 autofocus button  second autofocus button
 
-FAIL Popover focus test: default behavior - popover is not focused assert_true: expected true got false
-FAIL Popover button click focus test: default behavior - popover is not focused assert_equals: focus should return to the prior focus expected Element node <button id="priorFocus"></button> but got Element node <body>
+PASS Popover focus test: default behavior - popover is not focused
+FAIL Popover button click focus test: default behavior - popover is not focused assert_equals: Focus should go to unrelated button on light dismiss expected Element node <button></button> but got Element node <body>
 
 <div popover="" data-test="autofocus popover" aut...
 PASS Popover corner cases test: default behavior - popover is not focused

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute-expected.txt
@@ -1,1403 +1,1403 @@
 Toggle Popover 1
 
-FAIL Test <button type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <button type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <button type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <button type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <button type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <button type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <button type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <button type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <button type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <button type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <button type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <button type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <button type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <button type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <button type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <button type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <button type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <button type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <button type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <button type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <button type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <button type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <button type="">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <button type="">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <button type="">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <button type="">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <button type="">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <button type="">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <button type="">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="image">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="image">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="image">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="image">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="image">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="image">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="image">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="text">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="text">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="text">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="text">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="text">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="text">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="text">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="email">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="email">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="email">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="email">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="email">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="email">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="email">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="password">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="password">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="password">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="password">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="password">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="password">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="password">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="search">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="search">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="search">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="search">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="search">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="search">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="search">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="tel">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="tel">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="tel">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="tel">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="tel">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="tel">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="tel">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="url">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="url">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="url">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="url">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="url">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="url">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="url">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="checkbox">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="checkbox">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="checkbox">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="checkbox">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="checkbox">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="checkbox">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="radio">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="radio">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="radio">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="radio">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="radio">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="radio">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="radio">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="range">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="range">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="range">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="range">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="range">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="range">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="range">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="file">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="file">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="file">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="file">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="file">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="file">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="file">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="color">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="color">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="color">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="color">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="color">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="color">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="color">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="date">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="date">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="date">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="date">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="date">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="date">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="date">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="datetime-local">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="datetime-local">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="datetime-local">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="month">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="month">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="month">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="month">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="month">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="month">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="month">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="time">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="time">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="time">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="time">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="time">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="time">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="time">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="week">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="week">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="week">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="week">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="week">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="week">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="week">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="number">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="number">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="number">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="number">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="number">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="number">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="number">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <button type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <button type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <button type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <button type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <button type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <button type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <button type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <button type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <button type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <button type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <button type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <button type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <button type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <button type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <button type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <button type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <button type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <button type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <button type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <button type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <button type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <button type="">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <button type="">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <button type="">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <button type="">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <button type="">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <button type="">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <button type="">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <button type="">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <button type="">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="image">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="image">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="image">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="image">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="image">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="image">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="image">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="image">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="image">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="text">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="text">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="text">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="text">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="text">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="text">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="text">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="text">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="text">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="email">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="email">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="email">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="email">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="email">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="email">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="email">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="email">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="email">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="password">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="password">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="password">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="password">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="password">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="password">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="password">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="password">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="password">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="search">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="search">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="search">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="search">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="search">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="search">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="search">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="search">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="search">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="tel">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="tel">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="tel">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="tel">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="tel">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="tel">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="tel">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="tel">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="tel">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="url">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="url">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="url">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="url">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="url">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="url">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="url">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="url">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="url">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="checkbox">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="checkbox">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="checkbox">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="checkbox">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="checkbox">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="checkbox">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="checkbox">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="checkbox">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="radio">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="radio">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="radio">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="radio">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="radio">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="radio">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="radio">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="radio">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="radio">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="range">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="range">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="range">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="range">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="range">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="range">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="range">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="range">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="range">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="file">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="file">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="file">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="file">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="file">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="file">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="file">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="file">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="file">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="color">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="color">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="color">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="color">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="color">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="color">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="color">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="color">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="color">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="date">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="date">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="date">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="date">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="date">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="date">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="date">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="date">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="date">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="datetime-local">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="datetime-local">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="datetime-local">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="datetime-local">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="month">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="month">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="month">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="month">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="month">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="month">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="month">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="month">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="month">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="time">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="time">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="time">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="time">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="time">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="time">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="time">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="time">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="time">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="week">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="week">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="week">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="week">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="week">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="week">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="week">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="week">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="week">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "toggle" but got (object) null
-FAIL Test <input type="number">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "hide" but got (object) null
-FAIL Test <input type="number">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "show" but got (object) null
-FAIL Test <input type="number">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "ShOw" but got (object) null
-FAIL Test <input type="number">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "garbage" but got (object) null
-FAIL Test <input type="number">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "null" but got (object) null
-FAIL Test <input type="number">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual assert_equals: targetElement should be null before the popover is in the document expected (object) null but got (undefined) undefined
-FAIL Test <input type="number">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual assert_equals: action reflection expected (string) "undefined" but got (object) null
-FAIL Test <input type="number">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
-FAIL Test <input type="number">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual assert_equals: attribute value expected (string) "" but got (object) null
+PASS Test <button type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <button type="">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="image">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="image">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="text">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="text">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="email">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="email">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="password">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="password">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="search">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="search">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="tel">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="tel">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="url">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="url">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="checkbox">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="checkbox">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="radio">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="radio">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="range">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="range">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="file">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="file">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="color">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="color">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="date">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="date">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="month">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="month">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="time">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="time">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="week">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="week">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=hide, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=show, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=null, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=auto
+PASS Test <input type="number">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=auto
+PASS Test <input type="number">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=auto
+PASS Test <button type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <button type="">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <button type="">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="image">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="image">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="text">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="text">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="email">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="email">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="password">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="password">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="search">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="search">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="tel">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="tel">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="url">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="url">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="checkbox">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="checkbox">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="radio">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="radio">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="range">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="range">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="file">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="file">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="color">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="color">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="date">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="date">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="month">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="month">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="time">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="time">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="week">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="week">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=hide, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=show, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=null, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=manual
+PASS Test <input type="number">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=manual
+PASS Test <input type="number">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=manual
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -8,20 +8,20 @@ FAIL Synthetic events can't close popovers assert_false: expected false got true
 FAIL Moving focus outside the popover should not dismiss the popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking inside a child popover shouldn't close either popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking inside a parent popover should close child popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover assert_true: expected true got false
-FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case) assert_true: button2 should activate popover2 expected true got false
-FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation) promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on invoking element, even if it wasn't used for activation, shouldn't close its popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on popovertarget element, even if it wasn't used for activation, should hide it exactly once promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on anchor element (that isn't an invoking element) shouldn't prevent its popover from being closed promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Dragging from an open popover outside an open popover should leave the popover open promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL A popover inside an invoking element doesn't participate in that invoker's ancestor chain assert_true: invoking element should open popover expected true got false
-FAIL An invoking element that was not used to invoke the popover can still be part of the ancestor chain assert_true: expected true got false
+PASS Clicking on invoking element, after using it for activation, shouldn't close its popover
+PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case)
+PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation)
+PASS Clicking on invoking element, even if it wasn't used for activation, shouldn't close its popover
+PASS Clicking on popovertarget element, even if it wasn't used for activation, should hide it exactly once
+PASS Clicking on anchor element (that isn't an invoking element) shouldn't prevent its popover from being closed
+PASS Dragging from an open popover outside an open popover should leave the popover open
+PASS A popover inside an invoking element doesn't participate in that invoker's ancestor chain
+PASS An invoking element that was not used to invoke the popover can still be part of the ancestor chain
 FAIL Scrolling within a popover should not close the popover promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
 PASS Clicking inside a shadow DOM popover does not close that popover
 PASS Clicking outside a shadow DOM popover should close that popover
 FAIL Moving focus back to the anchor element should not dismiss the popover assert_equals: Focus should move to the anchor element expected Element node <button id="p8anchor">Popover8 anchor (no action)</button> but got Element node <body><button id="b1t" popovertarget="p1">Popover 1</butt...
-FAIL Ensure circular/convoluted ancestral relationships are functional assert_true: expected true got false
-FAIL Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover() promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
+PASS Ensure circular/convoluted ancestral relationships are functional
+PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-stacking-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-stacking-expected.txt
@@ -14,8 +14,8 @@ Popover 1  Dialog
 
 PASS Direct DOM children
 PASS Grandchildren
-FAIL popovertarget attribute relationship assert_true: expected true got false
-FAIL nested popovertarget attribute relationship assert_true: expected true got false
+PASS popovertarget attribute relationship
+PASS nested popovertarget attribute relationship
 FAIL anchor attribute relationship assert_true: expected true got false
 FAIL indirect anchor attribute relationship assert_true: expected true got false
 FAIL more complex nesting, all using anchor ancestry assert_equals: Popover #1 incorrect state expected true but got false

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled-expected.txt
@@ -2,9 +2,9 @@ form
 popover
 
 PASS Disabled popover*target buttons should not affect the popover heirarchy.
-FAIL Disabling popover*target buttons when popovers are open should still cause all popovers to be closed when the formerly outer popover is closed. assert_true: The outer popover should stay open when opening the inner one. expected true got false
-FAIL Disabling popover*target buttons when popovers are open should still cause all popovers to be closed when the formerly inner popover is closed. assert_true: The outer popover should stay open when opening the inner one. expected true got false
-FAIL Setting the form attribute on popover*target buttons when popovers are open should close all popovers. assert_true: The outer popover should stay open when opening the inner one. expected true got false
-FAIL Changing the input type on a popover*target button when popovers are open should close all popovers. assert_true: The outer popover should stay open when opening the inner one. expected true got false
-FAIL Disconnecting popover*target buttons when popovers are open should close all popovers. assert_true: The outer popover should stay open when opening the inner one. expected true got false
+FAIL Disabling popover*target buttons when popovers are open should still cause all popovers to be closed when the formerly outer popover is closed. assert_false: The inner popover should be closed when the hierarchy is broken. expected false got true
+FAIL Disabling popover*target buttons when popovers are open should still cause all popovers to be closed when the formerly inner popover is closed. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
+FAIL Setting the form attribute on popover*target buttons when popovers are open should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
+FAIL Changing the input type on a popover*target button when popovers are open should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
+FAIL Disconnecting popover*target buttons when popovers are open should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations-expected.txt
@@ -2,7 +2,7 @@ Visible button
 
 FAIL Popover combination: Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
 FAIL Popover combination: Open Non-modal Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
-FAIL Popover combination: Fullscreen Popover assert_true: Invoking element should be able to invoke all popovers: Popover doesn't match :open expected true got false
+PASS Popover combination: Fullscreen Popover
 FAIL Popover combination: Fullscreen Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
 FAIL Popover combination: Fullscreen Open Non-modal Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -1,8 +1,8 @@
 Button1  Button2  Invoker1  Button3  Button4
 Invoker  after
-Show popover
+Show popover Hide popover
 
-FAIL Popover focus navigation assert_true: popover1 should be invoked by invoker1 expected true got false
-FAIL Circular reference tab navigation assert_equals: Step 2 expected Element node <button id="circular1" autofocus="" popovertarget="popove... but got Element node <button id="circular4">after</button>
-FAIL Popover focus returns when popover is hidden by invoker assert_true: popover should be invoked by invoker expected true got false
+FAIL Popover focus navigation assert_equals: Focus should move from invoker into the open popover expected Element node <button id="inside_popover1">Inside1</button> but got Element node <button id="button3">Button3</button>
+PASS Circular reference tab navigation
+FAIL Popover focus returns when popover is hidden by invoker assert_equals: Hide button should be focused due to autofocus attribute expected Element node <button popovertarget="deleted1" popovertargetaction="hid... but got Element node <button popovertarget="deleted1" popovertargetaction="sho...
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
@@ -2,8 +2,8 @@ This is a popover
 
 autofocus button  second autofocus button
 
-FAIL Popover focus test: default behavior - popover is not focused assert_true: expected true got false
-FAIL Popover button click focus test: default behavior - popover is not focused assert_equals: focus should return to the prior focus expected Element node <button id="priorFocus"></button> but got Element node <button popovertarget="popover-id">Click me</button>
+PASS Popover focus test: default behavior - popover is not focused
+PASS Popover button click focus test: default behavior - popover is not focused
 PASS Popover corner cases test: default behavior - popover is not focused
 FAIL Popover focus test: autofocus popover assert_equals: autofocus popover activated by popover.showPopover() expected Element node <div popover="" data-test="autofocus popover" autofocus="... but got Element node <button id="priorFocus"></button>
 FAIL Popover button click focus test: autofocus popover assert_false: popover should start out hidden expected false got true

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -8,20 +8,20 @@ FAIL Synthetic events can't close popovers assert_false: expected false got true
 FAIL Moving focus outside the popover should not dismiss the popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking inside a child popover shouldn't close either popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking inside a parent popover should close child popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover assert_true: expected true got false
-FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case) assert_true: button2 should activate popover2 expected true got false
-FAIL Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation) promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on invoking element, even if it wasn't used for activation, shouldn't close its popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on popovertarget element, even if it wasn't used for activation, should hide it exactly once promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking on anchor element (that isn't an invoking element) shouldn't prevent its popover from being closed promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Dragging from an open popover outside an open popover should leave the popover open promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL A popover inside an invoking element doesn't participate in that invoker's ancestor chain assert_true: invoking element should open popover expected true got false
-FAIL An invoking element that was not used to invoke the popover can still be part of the ancestor chain assert_true: expected true got false
+PASS Clicking on invoking element, after using it for activation, shouldn't close its popover
+PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case)
+PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation)
+PASS Clicking on invoking element, even if it wasn't used for activation, shouldn't close its popover
+PASS Clicking on popovertarget element, even if it wasn't used for activation, should hide it exactly once
+PASS Clicking on anchor element (that isn't an invoking element) shouldn't prevent its popover from being closed
+PASS Dragging from an open popover outside an open popover should leave the popover open
+PASS A popover inside an invoking element doesn't participate in that invoker's ancestor chain
+PASS An invoking element that was not used to invoke the popover can still be part of the ancestor chain
 FAIL Scrolling within a popover should not close the popover promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
 PASS Clicking inside a shadow DOM popover does not close that popover
 PASS Clicking outside a shadow DOM popover should close that popover
 PASS Moving focus back to the anchor element should not dismiss the popover
-FAIL Ensure circular/convoluted ancestral relationships are functional assert_true: expected true got false
-FAIL Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover() promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
+PASS Ensure circular/convoluted ancestral relationships are functional
+PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
 

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -16,12 +16,12 @@ FAIL Clicking on popovertarget element, even if it wasn't used for activation, s
 FAIL Clicking on anchor element (that isn't an invoking element) shouldn't prevent its popover from being closed promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Dragging from an open popover outside an open popover should leave the popover open promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL A popover inside an invoking element doesn't participate in that invoker's ancestor chain assert_true: invoking element should open popover expected true got false
-FAIL An invoking element that was not used to invoke the popover can still be part of the ancestor chain assert_true: expected true got false
+PASS An invoking element that was not used to invoke the popover can still be part of the ancestor chain
 FAIL Scrolling within a popover should not close the popover promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
 PASS Clicking inside a shadow DOM popover does not close that popover
 FAIL Clicking outside a shadow DOM popover should close that popover assert_false: expected false got true
 FAIL Moving focus back to the anchor element should not dismiss the popover assert_equals: Focus should move to the anchor element expected Element node <button id="p8anchor">Popover8 anchor (no action)</button> but got Element node <body><button id="b1t" popovertarget="p1">Popover 1</butt...
-FAIL Ensure circular/convoluted ancestral relationships are functional assert_true: expected true got false
-FAIL Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover() promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
+PASS Ensure circular/convoluted ancestral relationships are functional
+PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -90,6 +90,7 @@ imported/w3c/web-platform-tests/fullscreen
 compositing/no-compositing-when-full-screen-is-present.html
 webkit.org/b/200308 fast/events/touch/ios/content-observation/non-visible-content-change-in-fullscreen-mode.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations.html [ Skip ]
 media/video-supports-fullscreen.html [ Skip ]
 
 # Encrypted Media Extensions are not enabled

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1168,6 +1168,7 @@ set(WebCore_NON_SVG_IDL_FILES
     html/MediaEncryptedEvent.idl
     html/MediaError.idl
     html/OffscreenCanvas.idl
+    html/PopoverInvokerElement.idl
     html/RadioNodeList.idl
     html/SubmitEvent.idl
     html/TextMetrics.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1323,6 +1323,7 @@ $(PROJECT_DIR)/html/MediaController.idl
 $(PROJECT_DIR)/html/MediaEncryptedEvent.idl
 $(PROJECT_DIR)/html/MediaError.idl
 $(PROJECT_DIR)/html/OffscreenCanvas.idl
+$(PROJECT_DIR)/html/PopoverInvokerElement.idl
 $(PROJECT_DIR)/html/RadioNodeList.idl
 $(PROJECT_DIR)/html/SubmitEvent.idl
 $(PROJECT_DIR)/html/TextMetrics.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2053,6 +2053,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPointerEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPointerEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPopStateEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPopStateEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPopoverInvokerElement.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPopoverInvokerElement.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionErrorCallback.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1162,6 +1162,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/MediaEncryptedEvent.idl \
     $(WebCore)/html/MediaError.idl \
     $(WebCore)/html/OffscreenCanvas.idl \
+    $(WebCore)/html/PopoverInvokerElement.idl \
     $(WebCore)/html/RadioNodeList.idl \
     $(WebCore)/html/SubmitEvent.idl \
     $(WebCore)/html/TextMetrics.idl \

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -4113,12 +4113,12 @@ void AXObjectCache::updateRelationsForTree(ContainerNode& rootNode)
 void AXObjectCache::addRelations(Element& origin, const QualifiedName& attribute)
 {
     if (m_document.settings().ariaReflectionForElementReferencesEnabled()) {
-        if (Element::isElementReflectionAttribute(attribute)) {
+        if (Element::isElementReflectionAttribute(m_document.settings(), attribute)) {
             if (auto reflectedElement = origin.getElementAttribute(attribute)) {
                 addRelation(&origin, reflectedElement, attributeToRelationType(attribute));
                 return;
             }
-        } else if (Element::isElementsArrayReflectionAttribute(attribute)) {
+        } else if (Element::isElementsArrayReflectionAttribute(m_document.settings(), attribute)) {
             if (auto reflectedElements = origin.getElementsArrayAttribute(attribute)) {
                 for (auto reflectedElement : reflectedElements.value())
                     addRelation(&origin, reflectedElement.get(), attributeToRelationType(attribute));

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3746,13 +3746,13 @@ Vector<Element*> AccessibilityObject::elementsFromAttribute(const QualifiedName&
 
     auto& element = downcast<Element>(*node);
     if (document()->settings().ariaReflectionForElementReferencesEnabled()) {
-        if (Element::isElementReflectionAttribute(attribute)) {
+        if (Element::isElementReflectionAttribute(document()->settings(), attribute)) {
             if (auto reflectedElement = element.getElementAttribute(attribute)) {
                 Vector<Element*> elements;
                 elements.append(reflectedElement);
                 return elements;
             }
-        } else if (Element::isElementsArrayReflectionAttribute(attribute)) {
+        } else if (Element::isElementsArrayReflectionAttribute(document()->settings(), attribute)) {
             if (auto reflectedElements = element.getElementsArrayAttribute(attribute)) {
                 return WTF::map(reflectedElements.value(), [](RefPtr<Element> element) -> Element* {
                     return element.get();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8981,6 +8981,7 @@ void Document::hideAllPopoversUntil(Element* endpoint, FocusPreviousElement focu
         popover->hidePopoverInternal(focusPreviousElement, fireEvents);
 }
 
+// https://html.spec.whatwg.org/#popover-light-dismiss
 void Document::handlePopoverLightDismiss(PointerEvent& event)
 {
     ASSERT(event.isTrusted());
@@ -8992,15 +8993,41 @@ void Document::handlePopoverLightDismiss(PointerEvent& event)
     RefPtr popoverToAvoidHiding = [&]() -> HTMLElement* {
         auto& target = downcast<Node>(*event.target());
         auto* startElement = is<Element>(target) ? &downcast<Element>(target) : target.parentElement();
-        for (auto& element : lineageOfType<HTMLElement>(*startElement)) {
-            if (element.popoverState() != PopoverState::Auto)
-                continue;
-            if (element.popoverData()->visibilityState() != PopoverVisibilityState::Showing)
-                continue;
-            return &element;
-        }
-        // FIXME: Handle popovertarget attributes.
-        return nullptr;
+        auto [clickedPopover, invokerPopover] = [&]() {
+            RefPtr<HTMLElement> clickedPopover;
+            RefPtr<HTMLElement> invokerPopover;
+            auto isShowingAutoPopover = [](HTMLElement& element) -> bool {
+                return element.popoverState() == PopoverState::Auto && element.popoverData()->visibilityState() == PopoverVisibilityState::Showing;
+            };
+            for (auto& element : lineageOfType<HTMLElement>(*startElement)) {
+                if (!clickedPopover && isShowingAutoPopover(element))
+                    clickedPopover = &element;
+
+                if (!invokerPopover) {
+                    if (auto* button = dynamicDowncast<HTMLFormControlElement>(element)) {
+                        if (auto* popover = button->popoverTargetElement(); popover && isShowingAutoPopover(*popover))
+                            invokerPopover = popover;
+                    }
+                }
+                if (clickedPopover && invokerPopover)
+                    break;
+            }
+            return std::tuple { WTFMove(clickedPopover), WTFMove(invokerPopover) };
+        }();
+
+        auto highestInTopLayer = [&](HTMLElement* first, HTMLElement* second) -> HTMLElement* {
+            if (!first || first == second)
+                return second;
+            if (!second)
+                return first;
+            for (auto& element : makeReversedRange(m_topLayerElements)) {
+                if (element.ptr() == first || element.ptr() == second)
+                    return downcast<HTMLElement>(element.ptr());
+            }
+            ASSERT_NOT_REACHED();
+            return nullptr;
+        };
+        return highestInTopLayer(clickedPopover.get(), invokerPopover.get());
     }();
 
     if (event.type() == eventNames().pointerdownEvent) {

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -138,8 +138,8 @@ public:
     WEBCORE_EXPORT void setElementAttribute(const QualifiedName& attributeName, Element* value);
     WEBCORE_EXPORT std::optional<Vector<RefPtr<Element>>> getElementsArrayAttribute(const QualifiedName& attributeName) const;
     WEBCORE_EXPORT void setElementsArrayAttribute(const QualifiedName& attributeName, std::optional<Vector<RefPtr<Element>>>&& value);
-    static bool isElementReflectionAttribute(const QualifiedName&);
-    static bool isElementsArrayReflectionAttribute(const QualifiedName&);
+    static bool isElementReflectionAttribute(const Settings&, const QualifiedName&);
+    static bool isElementsArrayReflectionAttribute(const Settings&, const QualifiedName&);
 
     // Call this to get the value of an attribute that is known not to be the style
     // attribute or one of the SVG animatable attributes.

--- a/Source/WebCore/dom/PopoverData.h
+++ b/Source/WebCore/dom/PopoverData.h
@@ -27,6 +27,7 @@
 
 #include "Element.h"
 #include "HTMLElement.h"
+#include "HTMLFormControlElement.h"
 
 namespace WebCore {
 
@@ -58,11 +59,15 @@ public:
     void setQueuedToggleEventData(PopoverToggleEventData data) { m_queuedToggleEventData = data; }
     void clearQueuedToggleEventData() { m_queuedToggleEventData = std::nullopt; }
 
+    HTMLFormControlElement* invoker() const { return m_invoker.get(); }
+    void setInvoker(const HTMLFormControlElement* element) { m_invoker = element; }
+
 private:
     PopoverState m_popoverState;
     PopoverVisibilityState m_visibilityState;
     std::optional<PopoverToggleEventData> m_queuedToggleEventData;
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_previouslyFocusedElement;
+    WeakPtr<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_invoker;
 };
 
 }

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -365,6 +365,8 @@ playsinline
 pluginspage
 pluginurl
 popover
+popovertarget
+popovertargetaction
 poster
 preload
 primary

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -155,7 +155,8 @@ void HTMLButtonElement::defaultEventHandler(Event& event)
 
             if (m_type == SUBMIT || m_type == RESET)
                 event.setDefaultHandled();
-        }
+        } else
+            handlePopoverTargetAction();
     }
 
     if (is<KeyboardEvent>(event)) {

--- a/Source/WebCore/html/HTMLButtonElement.idl
+++ b/Source/WebCore/html/HTMLButtonElement.idl
@@ -43,3 +43,5 @@
 
     readonly attribute NodeList labels;
 };
+
+HTMLButtonElement includes PopoverInvokerElement;

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -37,6 +37,7 @@
 #include "HTMLFormElement.h"
 #include "HTMLInputElement.h"
 #include "HTMLParserIdioms.h"
+#include "PopoverData.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "Quirks.h"
 #include "RenderBox.h"
@@ -319,6 +320,85 @@ AutofillData HTMLFormControlElement::autofillData() const
 String HTMLFormControlElement::resultForDialogSubmit() const
 {
     return attributeWithoutSynchronization(HTMLNames::valueAttr);
+}
+
+static const AtomString& toggleAtom()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("toggle"_s);
+    return identifier;
+}
+
+static const AtomString& showAtom()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("show"_s);
+    return identifier;
+}
+
+static const AtomString& hideAtom()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("hide"_s);
+    return identifier;
+}
+
+// https://html.spec.whatwg.org/#popover-target-element
+HTMLElement* HTMLFormControlElement::popoverTargetElement() const
+{
+    auto canInvokePopovers = [](const HTMLFormControlElement& element) -> bool {
+        if (auto* inputElement = dynamicDowncast<HTMLInputElement>(element))
+            return inputElement->isTextButton() || inputElement->isImageButton();
+        return is<HTMLButtonElement>(element);
+    };
+
+    if (!canInvokePopovers(*this))
+        return nullptr;
+
+    if (isDisabledFormControl())
+        return nullptr;
+
+    if (form() && isSubmitButton())
+        return nullptr;
+
+    auto* element = dynamicDowncast<HTMLElement>(getElementAttribute(popovertargetAttr));
+    if (element && element->popoverState() != PopoverState::None)
+        return element;
+    return nullptr;
+}
+
+const AtomString& HTMLFormControlElement::popoverTargetAction() const
+{
+    auto value = attributeWithoutSynchronization(HTMLNames::popovertargetactionAttr);
+
+    if (equalIgnoringASCIICase(value, showAtom()))
+        return showAtom();
+    if (equalIgnoringASCIICase(value, hideAtom()))
+        return hideAtom();
+
+    return toggleAtom();
+}
+
+void HTMLFormControlElement::setPopoverTargetAction(const AtomString& value)
+{
+    setAttributeWithoutSynchronization(HTMLNames::popovertargetactionAttr, value);
+}
+
+// https://html.spec.whatwg.org/#popover-target-attribute-activation-behavior
+void HTMLFormControlElement::handlePopoverTargetAction() const
+{
+    RefPtr target = popoverTargetElement();
+    if (!target)
+        return;
+
+    ASSERT(target->popoverData());
+
+    auto action = popoverTargetAction();
+    bool canHide = action == hideAtom() || action == toggleAtom();
+    bool canShow = action == showAtom() || action == toggleAtom();
+    if (canHide && target->popoverData()->visibilityState() == PopoverVisibilityState::Showing)
+        target->hidePopover();
+    else if (canShow && target->popoverData()->visibilityState() == PopoverVisibilityState::Hidden) {
+        target->popoverData()->setInvoker(this);
+        target->showPopover();
+    }
 }
 
 // FIXME: We should remove the quirk once <rdar://problem/47334655> is fixed.

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -95,6 +95,10 @@ public:
 
     virtual String resultForDialogSubmit() const;
 
+    HTMLElement* popoverTargetElement() const;
+    const AtomString& popoverTargetAction() const;
+    void setPopoverTargetAction(const AtomString& value);
+
     using Node::ref;
     using Node::deref;
 
@@ -119,6 +123,8 @@ protected:
     void didRecalcStyle(Style::Change) override;
 
     void dispatchBlurEvent(RefPtr<Element>&& newFocusedElement) override;
+
+    void handlePopoverTargetAction() const;
 
 private:
     void refFormAssociatedElement() const final { ref(); }

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1195,6 +1195,7 @@ void HTMLInputElement::defaultEventHandler(Event& event)
     // must dispatch a DOMActivate event - a click event will not do the job.
     if (event.type() == eventNames().DOMActivateEvent) {
         m_inputType->handleDOMActivateEvent(event);
+        handlePopoverTargetAction();
         if (event.defaultHandled())
             return;
     }

--- a/Source/WebCore/html/HTMLInputElement.idl
+++ b/Source/WebCore/html/HTMLInputElement.idl
@@ -95,3 +95,5 @@
     // See http://www.w3.org/TR/html-media-capture/
     [CEReactions=NotNeeded, Conditional=MEDIA_CAPTURE, Reflect] attribute DOMString capture;
 };
+
+HTMLInputElement includes PopoverInvokerElement;

--- a/Source/WebCore/html/PopoverInvokerElement.idl
+++ b/Source/WebCore/html/PopoverInvokerElement.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[EnabledBySetting=PopoverAttributeEnabled]
+interface mixin PopoverInvokerElement {
+    [CEReactions, Reflect=popovertarget] attribute Element? popoverTargetElement;
+    [CEReactions] attribute [AtomString] DOMString popoverTargetAction;
+};


### PR DESCRIPTION
#### 25998fb94754e1acb8d93fa0f51d0c1e1e694ba4
<pre>
[popover] Implement popovertarget &amp; popovertargetaction attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=252078">https://bugs.webkit.org/show_bug.cgi?id=252078</a>
rdar://105612966

Reviewed by Chris Dumez.

This adds support for the popoverTargetElement &amp; popoverTargetAction IDL attributes, which map to popovertarget &amp; popovertargetaction HTML attributes.

Spec change is at <a href="https://github.com/whatwg/html/pull/8962">https://github.com/whatwg/html/pull/8962</a> , WPT have already been updated by a Chromium commit to match.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-stacking-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
Rebaseline tests with progressions. Remaining failures are either due to these unimplemented parts:
- invoker relationship removal handling (not standardized?)
- popover focusing steps (<a href="https://bugs.webkit.org/show_bug.cgi?id=253231)">https://bugs.webkit.org/show_bug.cgi?id=253231)</a>
- anchor attribute (not standardized)

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
Update list of built files.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::handlePopoverLightDismiss):
Check for invokers as described in algorithm in: <a href="https://html.spec.whatwg.org/#topmost-clicked-popover">https://html.spec.whatwg.org/#topmost-clicked-popover</a>

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::addRelations):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isElementReflectionAttribute):
(WebCore::Element::isElementsArrayReflectionAttribute):
(WebCore::Element::attributeChanged):
(WebCore::Element::getElementAttribute const):
(WebCore::Element::setElementAttribute):
(WebCore::Element::getElementsArrayAttribute const):
(WebCore::Element::setElementsArrayAttribute):
* Source/WebCore/dom/Element.h:
Add IDL element reflection support for popovertarget attribute. Simplified settings checks.

* Source/WebCore/dom/PopoverData.h:
(WebCore::PopoverData::invoker const):
(WebCore::PopoverData::setInvoker):
Store invoker in popover data.

* Source/WebCore/html/HTMLAttributeNames.in: Define popovertargetAttr &amp; popovertargetActionAttr.
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::defaultEventHandler): Invoke popover activation behavior.
* Source/WebCore/html/HTMLButtonElement.idl: Use PopoverInvokerElement mixin.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::topmostPopoverAncestor): Check for invokers as defined in the spec: <a href="https://html.spec.whatwg.org/#topmost-popover-ancestor">https://html.spec.whatwg.org/#topmost-popover-ancestor</a>
(WebCore::HTMLElement::hidePopoverInternal): Clear invoker as defined in the spec.
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::toggleAtom):
(WebCore::showAtom):
(WebCore::hideAtom):
(WebCore::HTMLFormControlElement::popoverTargetElement const): Implement <a href="https://html.spec.whatwg.org/#popover-target-element">https://html.spec.whatwg.org/#popover-target-element</a>
(WebCore::HTMLFormControlElement::popoverTargetAction const): Implement attribute reflection.
(WebCore::HTMLFormControlElement::handlePopoverTargetAction const): Implement activation behavior: <a href="https://html.spec.whatwg.org/#popover-target-attribute-activation-behavior">https://html.spec.whatwg.org/#popover-target-attribute-activation-behavior</a>
* Source/WebCore/html/HTMLFormControlElement.h:
(WebCore::HTMLFormControlElement::setPopoverTargetAction): Implement attribute reflection.
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::defaultEventHandler): Invoke popover activation behavior.
* Source/WebCore/html/HTMLInputElement.idl: Use PopoverInvokerElement mixin.
* Source/WebCore/html/PopoverInvokerElement.idl: Added.

Canonical link: <a href="https://commits.webkit.org/261346@main">https://commits.webkit.org/261346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af4f69208c3617dd61d8691c24fd9a4f39e9ab1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20526 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/5 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11620 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117153 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/5 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/5 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13027 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/5 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/5 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15497 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4309 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->