### PR TITLE
[JSC] Use JumpTable in WasmBBQJIT

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -827,12 +827,12 @@ public:
         }
 
         template<typename Stack, size_t N>
-        void addExit(BBQJIT& generator, const Vector<Location, N>& targetLocations, Stack& expressionStack)
+        bool addExit(BBQJIT& generator, const Vector<Location, N>& targetLocations, Stack& expressionStack)
         {
             unsigned targetArity = targetLocations.size();
 
             if (!targetArity)
-                return;
+                return false;
 
             // We move all passed temporaries to the successor, in its argument slots.
             unsigned offset = expressionStack.size() - targetArity;
@@ -844,6 +844,7 @@ public:
                 resultLocations.append(targetLocations[i]);
             }
             generator.emitShuffle(resultValues, resultLocations);
+            return true;
         }
 
         template<typename Stack>
@@ -920,19 +921,27 @@ public:
             m_branchList.append(jump);
         }
 
-        void addBranch(const JumpList& jumpList)
+        void addLabel(Box<CCallHelpers::Label>&& label)
         {
-            m_branchList.append(jumpList);
+            m_labels.append(WTFMove(label));
+        }
+
+        void delegateJumpsTo(ControlData& delegateTarget)
+        {
+            delegateTarget.m_branchList.append(std::exchange(m_branchList, { }));
+            delegateTarget.m_labels.appendVector(std::exchange(m_labels, { }));
         }
 
         void linkJumps(MacroAssembler::AbstractMacroAssemblerType* masm)
         {
             m_branchList.link(masm);
+            fillLabels(masm->label());
         }
 
         void linkJumpsTo(MacroAssembler::Label label, MacroAssembler::AbstractMacroAssemblerType* masm)
         {
             m_branchList.linkTo(label, masm);
+            fillLabels(label);
         }
 
         void linkIfBranch(MacroAssembler::AbstractMacroAssemblerType* masm)
@@ -940,12 +949,6 @@ public:
             ASSERT(m_blockType == BlockType::If);
             if (m_ifBranch.isSet())
                 m_ifBranch.link(masm);
-        }
-
-        JumpList releaseJumps()
-        {
-            auto branchList = std::exchange(m_branchList, { });
-            return branchList;
         }
 
         void dump(PrintStream& out) const
@@ -1060,12 +1063,19 @@ public:
     private:
         friend class BBQJIT;
 
+        void fillLabels(CCallHelpers::Label label)
+        {
+            for (auto& box : m_labels)
+                *box = label;
+        }
+
         BlockSignature m_signature;
         BlockType m_blockType;
         CatchKind m_catchKind { CatchKind::Catch };
         Vector<Location, 2> m_argumentLocations; // List of input locations to write values into when entering this block.
         Vector<Location, 2> m_resultLocations; // List of result locations to write values into when exiting this block.
         JumpList m_branchList; // List of branch control info for branches targeting the end of this block.
+        Vector<Box<CCallHelpers::Label>> m_labels; // List of labels filled.
         MacroAssembler::Label m_loopLabel;
         MacroAssembler::Jump m_ifBranch;
         LocalOrTempIndex m_enclosedHeight; // Height of enclosed expression stack, used as the base for all temporary locations.
@@ -1230,7 +1240,7 @@ private:
 public:
     static constexpr bool tierSupportsSIMD = true;
 
-    BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, Callee& callee, const FunctionData& function, uint32_t functionIndex, const ModuleInformation& info, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, MemoryMode mode, InternalFunction* compilation, std::optional<bool> hasExceptionHandlers, unsigned loopIndexForOSREntry, TierUpCount* tierUp)
+    BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, BBQCallee& callee, const FunctionData& function, uint32_t functionIndex, const ModuleInformation& info, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, MemoryMode mode, InternalFunction* compilation, std::optional<bool> hasExceptionHandlers, unsigned loopIndexForOSREntry, TierUpCount* tierUp)
         : m_jit(jit)
         , m_callee(callee)
         , m_function(function)
@@ -6418,7 +6428,7 @@ public:
         }
         dataCatch.setTryInfo(data.tryStart(), data.tryEnd(), data.tryCatchDepth());
 
-        dataCatch.addBranch(data.releaseJumps());
+        data.delegateJumpsTo(dataCatch);
         dataCatch.addBranch(m_jit.jump());
         LOG_DEDENT();
         LOG_INSTRUCTION("Catch");
@@ -6440,7 +6450,7 @@ public:
         }
         dataCatch.setTryInfo(data.tryStart(), data.tryEnd(), data.tryCatchDepth());
 
-        dataCatch.addBranch(data.releaseJumps());
+        data.delegateJumpsTo(dataCatch);
         LOG_DEDENT();
         LOG_INSTRUCTION("Catch");
         LOG_INDENT();
@@ -6462,7 +6472,7 @@ public:
         }
         dataCatch.setTryInfo(data.tryStart(), data.tryEnd(), data.tryCatchDepth());
 
-        dataCatch.addBranch(data.releaseJumps());
+        data.delegateJumpsTo(dataCatch);
         dataCatch.addBranch(m_jit.jump());
         LOG_DEDENT();
         LOG_INSTRUCTION("CatchAll");
@@ -6484,7 +6494,7 @@ public:
         }
         dataCatch.setTryInfo(data.tryStart(), data.tryEnd(), data.tryCatchDepth());
 
-        dataCatch.addBranch(data.releaseJumps());
+        data.delegateJumpsTo(dataCatch);
         LOG_DEDENT();
         LOG_INSTRUCTION("CatchAll");
         LOG_INDENT();
@@ -6660,22 +6670,55 @@ public:
         // Flush everything below the top N values.
         currentControlData().flushAtBlockBoundary(*this, defaultTarget.targetLocations().size(), results, true);
 
-        Vector<int64_t> cases;
-        cases.reserveInitialCapacity(targets.size());
-        for (size_t i = 0; i < targets.size(); ++i)
-            cases.uncheckedAppend(i);
+        constexpr unsigned minCasesForTable = 7;
+        if (minCasesForTable <= targets.size()) {
+            Vector<Box<CCallHelpers::Label>> labels;
+            labels.reserveInitialCapacity(targets.size());
+            auto* jumpTable = m_callee.addJumpTable(targets.size());
+            auto fallThrough = m_jit.branch32(RelationalCondition::AboveOrEqual, m_scratchGPR, TrustedImm32(targets.size()));
+            m_jit.zeroExtend32ToWord(m_scratchGPR, m_scratchGPR);
+            m_jit.lshiftPtr(TrustedImm32(3), m_scratchGPR);
+            m_jit.addPtr(TrustedImmPtr(jumpTable->data()), m_scratchGPR);
+            m_jit.farJump(Address(m_scratchGPR), JSSwitchPtrTag);
 
-        BinarySwitch binarySwitch(m_scratchGPR, cases, BinarySwitch::Int32);
-        while (binarySwitch.advance(m_jit)) {
-            unsigned value = binarySwitch.caseValue();
-            unsigned index = binarySwitch.caseIndex();
-            ASSERT_UNUSED(value, value == index);
-            ASSERT(index < targets.size());
-            currentControlData().addExit(*this, targets[index]->targetLocations(), results);
-            targets[index]->addBranch(m_jit.jump());
+            for (unsigned index = 0; index < targets.size(); ++index) {
+                Box<CCallHelpers::Label> label = Box<CCallHelpers::Label>::create(m_jit.label());
+                labels.uncheckedAppend(label);
+                bool isCodeEmitted = currentControlData().addExit(*this, targets[index]->targetLocations(), results);
+                if (isCodeEmitted)
+                    targets[index]->addBranch(m_jit.jump());
+                else {
+                    // It is common that we do not need to emit anything before jumping to the target block.
+                    // In that case, we put Box<Label> which will be filled later when the end of the block is linked.
+                    // We put direct jump to that block in the link task.
+                    targets[index]->addLabel(WTFMove(label));
+                }
+            }
+
+            m_jit.addLinkTask([labels = WTFMove(labels), jumpTable](LinkBuffer& linkBuffer) {
+                for (unsigned index = 0; index < labels.size(); ++index)
+                    jumpTable->at(index) = linkBuffer.locationOf<JSSwitchPtrTag>(*labels[index]);
+            });
+
+            fallThrough.link(&m_jit);
+        } else {
+            Vector<int64_t> cases;
+            cases.reserveInitialCapacity(targets.size());
+            for (size_t i = 0; i < targets.size(); ++i)
+                cases.uncheckedAppend(i);
+
+            BinarySwitch binarySwitch(m_scratchGPR, cases, BinarySwitch::Int32);
+            while (binarySwitch.advance(m_jit)) {
+                unsigned value = binarySwitch.caseValue();
+                unsigned index = binarySwitch.caseIndex();
+                ASSERT_UNUSED(value, value == index);
+                ASSERT(index < targets.size());
+                currentControlData().addExit(*this, targets[index]->targetLocations(), results);
+                targets[index]->addBranch(m_jit.jump());
+            }
+
+            binarySwitch.fallThrough().link(&m_jit);
         }
-
-        binarySwitch.fallThrough().link(&m_jit);
         currentControlData().addExit(*this, defaultTarget.targetLocations(), results);
         defaultTarget.addBranch(m_jit.jump());
 
@@ -9088,7 +9131,7 @@ private:
 #undef RESULT
 
     CCallHelpers& m_jit;
-    Callee& m_callee;
+    BBQCallee& m_callee;
     const FunctionData& m_function;
     const FunctionSignature* m_functionSignature;
     uint32_t m_functionIndex;
@@ -9146,7 +9189,7 @@ private:
     Vector<CCallHelpers::Label> m_catchEntrypoints;
 };
 
-Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(CompilationContext& compilationContext, Callee& callee, const FunctionData& function, const TypeDefinition& signature, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, const ModuleInformation& info, MemoryMode mode, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, unsigned loopIndexForOSREntry, TierUpCount* tierUp)
+Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(CompilationContext& compilationContext, BBQCallee& callee, const FunctionData& function, const TypeDefinition& signature, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, const ModuleInformation& info, MemoryMode mode, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, unsigned loopIndexForOSREntry, TierUpCount* tierUp)
 {
     CompilerTimingScope totalTime("BBQ", "Total BBQ");
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -31,7 +31,9 @@
 
 namespace JSC { namespace Wasm {
 
-Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(CompilationContext&, Callee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, const ModuleInformation&, MemoryMode, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, unsigned, TierUpCount* = nullptr);
+class BBQCallee;
+
+Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileBBQ(CompilationContext&, BBQCallee&, const FunctionData&, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>&, const ModuleInformation&, MemoryMode, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, unsigned, TierUpCount* = nullptr);
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -272,7 +272,7 @@ void BBQPlan::compileFunction(uint32_t functionIndex)
     }
 }
 
-std::unique_ptr<InternalFunction> BBQPlan::compileFunction(uint32_t functionIndex, Callee& callee, CompilationContext& context, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, TierUpCount* tierUp)
+std::unique_ptr<InternalFunction> BBQPlan::compileFunction(uint32_t functionIndex, BBQCallee& callee, CompilationContext& context, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, TierUpCount* tierUp)
 {
     const auto& function = m_moduleInformation->functions[functionIndex];
     TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -83,7 +83,7 @@ private:
     void compileFunction(uint32_t functionIndex) final;
     void didCompleteCompilation() WTF_REQUIRES_LOCK(m_lock) final;
 
-    std::unique_ptr<InternalFunction> compileFunction(uint32_t functionIndex, Callee&, CompilationContext&, Vector<UnlinkedWasmToWasmCall>&, TierUpCount*);
+    std::unique_ptr<InternalFunction> compileFunction(uint32_t functionIndex, BBQCallee&, CompilationContext&, Vector<UnlinkedWasmToWasmCall>&, TierUpCount*);
 
     Vector<std::unique_ptr<InternalFunction>> m_wasmInternalFunctions;
     Vector<std::unique_ptr<LinkBuffer>> m_wasmInternalFunctionLinkBuffers;

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -36,6 +36,7 @@
 #include "WasmIndexOrName.h"
 #include "WasmLLIntTierUpCounter.h"
 #include "WasmTierUpCount.h"
+#include <wtf/EmbeddedFixedVector.h>
 #include <wtf/FixedVector.h>
 #include <wtf/RefCountedFixedVector.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -272,6 +273,13 @@ public:
         m_loopEntrypoints = WTFMove(loopEntrypoints);
         m_osrEntryScratchBufferSize = osrEntryScratchBufferSize;
         OptimizingJITCallee::setEntrypoint(WTFMove(entrypoint), WTFMove(unlinkedCalls), WTFMove(stackmaps), WTFMove(exceptionHandlers), WTFMove(exceptionHandlerLocations));
+        m_switchJumpTables.shrinkToFit();
+    }
+
+    EmbeddedFixedVector<CodeLocationLabel<JSSwitchPtrTag>>* addJumpTable(unsigned size)
+    {
+        m_switchJumpTables.append(EmbeddedFixedVector<CodeLocationLabel<JSSwitchPtrTag>>::create(size));
+        return m_switchJumpTables.last().ptr();
     }
 
 private:
@@ -290,6 +298,7 @@ private:
     unsigned m_osrEntryScratchBufferSize { 0 };
     bool m_didStartCompilingOSREntryCallee { false };
     SavedFPWidth m_savedFPWidth { SavedFPWidth::DontSaveVectors };
+    Vector<UniqueRef<EmbeddedFixedVector<CodeLocationLabel<JSSwitchPtrTag>>>> m_switchJumpTables;
 };
 #endif
 


### PR DESCRIPTION
#### 7202c59d1d29bec2ad6994e6c59aa4e27bf60f85
<pre>
[JSC] Use JumpTable in WasmBBQJIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=253472">https://bugs.webkit.org/show_bug.cgi?id=253472</a>
rdar://106330476

Reviewed by Justin Michaud.

This patch implements JumpTable in WasmBBQJIT to implement wasm BrTable efficiently.
Currently, we are always doing binary-switch, which significantly bloats the code size.
Fortunately, wasm BrTable is super simple: targets are 0-N, and taking default if it exceeds N.
This is pretty easy to generate JumpTable for that.

We generate JumpTable in the link task, and put it in BBQCallee. It improves JetStream2/tsf-wasm&apos;s Runtime by 7~10%.

Before:
    Running tsf-wasm:
        Startup: 833.333
        Run time: 3.415
        Score: 53.349

After:
    Running tsf-wasm:
        Startup: 833.333
        Run time: 3.652
        Score: 55.169

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJIT::addSwitch):
(JSC::Wasm::parseAndCompileBBQ):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmCallee.h:

Canonical link: <a href="https://commits.webkit.org/261345@main">https://commits.webkit.org/261345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12e9b32481ae43dc7f2d70350d4b392bc1b56101

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2665 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120049 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2259 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117001 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16147 "Found 1 new test failure: fast/scrolling/keyboard-scrolling-home.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44696 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99780 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12883 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86565 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/10995 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9313 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/100961 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51909 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31468 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15358 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/108998 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4308 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26869 "Passed tests") | 
<!--EWS-Status-Bubble-End-->