### PR TITLE
[UI-side compositng] Flashing scrollbars via two finger gesture causes the scrollbar to never hide

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -67,7 +67,8 @@ public:
 
     virtual bool canHandleWheelEvent(const PlatformWheelEvent&, EventTargeting) const;
     virtual WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting = EventTargeting::Propagate);
-
+    virtual void handleWheelEventPhase(const PlatformWheelEventPhase) { }
+    
     FloatPoint currentScrollPosition() const { return m_currentScrollPosition; }
     FloatPoint currentScrollOffset() const { return ScrollableArea::scrollOffsetFromPosition(m_currentScrollPosition, toFloatSize(m_scrollOrigin)); }
     FloatPoint lastCommittedScrollPosition() const { return m_lastCommittedScrollPosition; }

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -47,7 +47,7 @@ public:
 
     virtual void updateFromStateNode(const ScrollingStateScrollingNode&) { }
     
-    virtual bool handleWheelEventForScrollbars(const PlatformWheelEvent&) { return false; }
+    virtual void handleWheelEventPhase(const PlatformWheelEventPhase) { }
     virtual bool handleMouseEventForScrollbars(const PlatformMouseEvent&) { return false; }
     
     virtual void updateScrollbarLayers() { }

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -30,6 +30,7 @@
 #include "ScrollerMac.h"
 #include <WebCore/FloatRect.h>
 #include <WebCore/FloatSize.h>
+#include <WebCore/PlatformWheelEvent.h>
 
 OBJC_CLASS NSScrollerImpPair;
 OBJC_CLASS WebScrollerImpPairDelegateMac;
@@ -53,7 +54,7 @@ public:
     ScrollerMac& verticalScroller() { return m_verticalScroller; }
     ScrollerMac& horizontalScroller() { return m_horizontalScroller; }
 
-    bool handleWheelEvent(const WebCore::PlatformWheelEvent&);
+    void handleWheelEventPhase(PlatformWheelEventPhase);
     bool handleMouseEvent(const WebCore::PlatformMouseEvent&);
 
     void updateValues();

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -144,9 +144,9 @@ ScrollerPairMac::~ScrollerPairMac()
     [m_scrollerImpPair setDelegate:nil];
 }
 
-bool ScrollerPairMac::handleWheelEvent(const WebCore::PlatformWheelEvent& event)
+void ScrollerPairMac::handleWheelEventPhase(PlatformWheelEventPhase phase)
 {
-    switch (event.phase()) {
+    switch (phase) {
     case WebCore::PlatformWheelEventPhase::Began:
         [m_scrollerImpPair beginScrollGesture];
         break;
@@ -161,8 +161,6 @@ bool ScrollerPairMac::handleWheelEvent(const WebCore::PlatformWheelEvent& event)
     default:
         break;
     }
-    // FIXME: this needs to return whether the event was handled.
-    return true;
 }
 
 bool ScrollerPairMac::handleMouseEvent(const WebCore::PlatformMouseEvent& event)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -60,7 +60,7 @@ public:
     void updateScrollbarPainters();
     void updateScrollbarLayers() final;
     
-    bool handleWheelEventForScrollbars(const PlatformWheelEvent&) final;
+    void handleWheelEventPhase(const PlatformWheelEventPhase) final;
     bool handleMouseEventForScrollbars(const PlatformMouseEvent&) final;
     
     void initScrollbars() final;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -322,9 +322,9 @@ void ScrollingTreeScrollingNodeDelegateMac::updateScrollbarLayers()
     m_scrollerPair.updateValues();
 }
 
-bool ScrollingTreeScrollingNodeDelegateMac::handleWheelEventForScrollbars(const PlatformWheelEvent& wheelEvent)
+void ScrollingTreeScrollingNodeDelegateMac::handleWheelEventPhase(const PlatformWheelEventPhase wheelEventPhase)
 {
-    return m_scrollerPair.handleWheelEvent(wheelEvent);
+    m_scrollerPair.handleWheelEventPhase(wheelEventPhase);
 }
 bool ScrollingTreeScrollingNodeDelegateMac::handleMouseEventForScrollbars(const PlatformMouseEvent& mouseEvent)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -55,9 +55,10 @@ RemoteScrollingTreeMac::RemoteScrollingTreeMac(RemoteScrollingCoordinatorProxy& 
 
 RemoteScrollingTreeMac::~RemoteScrollingTreeMac() = default;
 
-void RemoteScrollingTreeMac::handleWheelEventPhase(ScrollingNodeID, PlatformWheelEventPhase)
+void RemoteScrollingTreeMac::handleWheelEventPhase(ScrollingNodeID nodeID, PlatformWheelEventPhase phase)
 {
-    // FIXME: Is this needed?
+    RefPtr targetNode = nodeForID(nodeID);
+    dynamicDowncast<ScrollingTreeScrollingNode>(*targetNode)->handleWheelEventPhase(phase);
 }
 
 void RemoteScrollingTreeMac::displayDidRefresh(PlatformDisplayID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -61,11 +61,9 @@ void ScrollingTreeFrameScrollingNodeRemoteMac::repositionRelatedLayers()
     m_delegate->updateScrollbarLayers();
 }
 
-WheelEventHandlingResult ScrollingTreeFrameScrollingNodeRemoteMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)
+void ScrollingTreeFrameScrollingNodeRemoteMac::handleWheelEventPhase(const PlatformWheelEventPhase phase)
 {
-    auto result = ScrollingTreeFrameScrollingNodeMac::handleWheelEvent(wheelEvent, eventTargeting);
-    m_delegate->handleWheelEventForScrollbars(wheelEvent);
-    return result;
+    m_delegate->handleWheelEventPhase(phase);
 }
 
 bool ScrollingTreeFrameScrollingNodeRemoteMac::handleMouseEvent(const PlatformMouseEvent& mouseEvent)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
@@ -44,7 +44,8 @@ private:
     ScrollingTreeFrameScrollingNodeRemoteMac(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);
 
     void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
-    WebCore::WheelEventHandlingResult handleWheelEvent(const WebCore::PlatformWheelEvent&, WebCore::EventTargeting) override;
+    void handleWheelEventPhase(const PlatformWheelEventPhase) override;
+
     void repositionRelatedLayers() override;
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
@@ -63,11 +63,9 @@ void ScrollingTreeOverflowScrollingNodeRemoteMac::repositionRelatedLayers()
     m_delegate->updateScrollbarLayers();
 }
 
-WheelEventHandlingResult ScrollingTreeOverflowScrollingNodeRemoteMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)
+void ScrollingTreeOverflowScrollingNodeRemoteMac::handleWheelEventPhase(const PlatformWheelEventPhase phase)
 {
-    auto result = ScrollingTreeOverflowScrollingNodeMac::handleWheelEvent(wheelEvent, eventTargeting);
-    m_delegate->handleWheelEventForScrollbars(wheelEvent);
-    return result;
+    m_delegate->handleWheelEventPhase(phase);
 }
 
 bool ScrollingTreeOverflowScrollingNodeRemoteMac::handleMouseEvent(const PlatformMouseEvent& mouseEvent)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h
@@ -44,7 +44,7 @@ private:
     ScrollingTreeOverflowScrollingNodeRemoteMac(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
 
     void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
-    WebCore::WheelEventHandlingResult handleWheelEvent(const WebCore::PlatformWheelEvent&, WebCore::EventTargeting) override;
+    void handleWheelEventPhase(const WebCore::PlatformWheelEventPhase) override;
     void repositionRelatedLayers() override;
 };
 


### PR DESCRIPTION
#### d9636c006aee4698e2722a5f6b414c18fc51c71b
<pre>
[UI-side compositng] Flashing scrollbars via two finger gesture causes the scrollbar to never hide
<a href="https://bugs.webkit.org/show_bug.cgi?id=253471">https://bugs.webkit.org/show_bug.cgi?id=253471</a>
rdar://106329824

Reviewed by Simon Fraser.

Doing the two finger gesture generates two wheel events, one that is a may begin event
and the second which is an ended event. With ui-side compositng on, we never hide the
scrollbars when the ended event comes in because we never reach handleWheelEvent for the
scrolling node. To solve this, factor the scrollbar updates out of the scrolling node&apos;s
handleWheelEvent function into a handleWheelEventPhase function. Hook this up to
RemoteScrollingTreeMac::handleWheelEventPhase.

* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::handleWheelEventPhase):
(WebCore::ScrollingTreeScrollingNodeDelegate::handleWheelEventForScrollbars): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::handleWheelEventPhase):
(WebCore::ScrollerPairMac::handleWheelEvent): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleWheelEventPhase):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleWheelEventForScrollbars): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::handleWheelEventPhase):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::handleWheelEventPhase):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::handleWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeOverflowScrollingNodeRemoteMac::handleWheelEventPhase):
(WebKit::ScrollingTreeOverflowScrollingNodeRemoteMac::handleWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h:

Canonical link: <a href="https://commits.webkit.org/261333@main">https://commits.webkit.org/261333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5a3142967f1fe0cf3369508513fa45cf9072491

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111217 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2250 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103815 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98098 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44684 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86562 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13395 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9307 "Found 1 new test failure: imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18826 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15348 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4300 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->