### PR TITLE
TestWebKitAPI.WebKit.FirstResponderScrollingPosition fails when GPU Process & UI side compositing is enabled

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/FirstResponderScrollingPosition.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FirstResponderScrollingPosition.mm
@@ -30,6 +30,7 @@
 #import <WebKit/WKRetainPtr.h>
 #import <WebKit/WKPage.h>
 #import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
 namespace TestWebKitAPI {
@@ -79,6 +80,12 @@ TEST(WebKit, FirstResponderScrollingPosition)
 
     ASSERT_TRUE([webView.platformView() respondsToSelector:@selector(scrollLineDown:)]);
     [webView.platformView() scrollLineDown:nil];
+
+    __block bool done = false;
+    [webView.platformView() _doAfterNextPresentationUpdate:^{
+        done = true;
+    }];
+    Util::run(&done);
 
     EXPECT_JS_EQ(webView.page(), "window.scrollY", "40");
 


### PR DESCRIPTION
#### 68217ead01958d7976f61518d325ce66d56d2818
<pre>
TestWebKitAPI.WebKit.FirstResponderScrollingPosition fails when GPU Process &amp; UI side compositing is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=253475">https://bugs.webkit.org/show_bug.cgi?id=253475</a>
&lt;rdar://106324196&gt;

Reviewed by Simon Fraser.

Wait for the presentation update after calling scrollLineDown before checking the scroll position.

* Tools/TestWebKitAPI/Tests/mac/FirstResponderScrollingPosition.mm:
(WebKit.FirstResponderScrollingPosition):

Canonical link: <a href="https://commits.webkit.org/261307@main">https://commits.webkit.org/261307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d9ca8b9d4470d129fd2b6343801a52206cbe466

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120040 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2251 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/116981 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103803 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98099 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30981 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/onerror-event.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44678 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12870 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32316 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9310 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18827 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15349 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4289 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->