### PR TITLE
Use CAContext slots API to share IOSurfaces from the GPUP.

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -112,6 +112,8 @@
 		CD6122CD2559B6AC00FC657A /* OutputContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD6122CB2559B6AC00FC657A /* OutputContext.mm */; };
 		CD6122D12559B8F200FC657A /* OutputDevice.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD6122CF2559B8F200FC657A /* OutputDevice.mm */; };
 		CDACB3602387425B0018D7CE /* MediaToolboxSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDACB35E23873E480018D7CE /* MediaToolboxSoftLink.cpp */; };
+		D065131629B69F11008C65C4 /* QuartzCoreSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = D065131429B69F11008C65C4 /* QuartzCoreSoftLink.mm */; };
+		D065131729B69F12008C65C4 /* QuartzCoreSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = D065131529B69F11008C65C4 /* QuartzCoreSoftLink.h */; };
 		DD05A36027BF0ACE0096EFAB /* libWTF.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DD05A35F27BF0AC40096EFAB /* libWTF.a */; };
 		DD0B43C227F679A7009E31FC /* WebGPU.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DD0B43C127F67999009E31FC /* WebGPU.framework */; };
 		DD20DD1227BC90D60093D175 /* MediaTimeAVFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C00CFD21F68CE4600AAC26D /* MediaTimeAVFoundation.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -997,6 +999,8 @@
 		CDACB35F23873E480018D7CE /* MediaToolboxSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaToolboxSoftLink.h; sourceTree = "<group>"; };
 		CDF91112220E4EEC001EA39E /* CelestialSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CelestialSPI.h; sourceTree = "<group>"; };
 		CE5673862151A7B9002F92D7 /* IOKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IOKitSPI.h; sourceTree = "<group>"; };
+		D065131429B69F11008C65C4 /* QuartzCoreSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = QuartzCoreSoftLink.mm; sourceTree = "<group>"; };
+		D065131529B69F11008C65C4 /* QuartzCoreSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QuartzCoreSoftLink.h; sourceTree = "<group>"; };
 		DD05A35F27BF0AC40096EFAB /* libWTF.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libWTF.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD0B43C127F67999009E31FC /* WebGPU.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WebGPU.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDE99300278D07B800F60D26 /* libWebKitAdditions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libWebKitAdditions.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1438,6 +1442,8 @@
 				31647FAE251759DB0010F8FB /* OpenGLSoftLinkCocoa.mm */,
 				A1F63C9D21A4DBF7006FB43B /* PassKitSoftLink.h */,
 				A1F63C9E21A4DBF7006FB43B /* PassKitSoftLink.mm */,
+				D065131529B69F11008C65C4 /* QuartzCoreSoftLink.h */,
+				D065131429B69F11008C65C4 /* QuartzCoreSoftLink.mm */,
 				F4974EA1265EEA2200B49B8C /* RevealSoftLink.h */,
 				F4974EA2265EEA2200B49B8C /* RevealSoftLink.mm */,
 				93B38EBD25821CB600198E63 /* SpeechSoftLink.h */,
@@ -1912,6 +1918,7 @@
 				E34F26F62846D0D90076E549 /* PowerLogSPI.h in Headers */,
 				DD20DE0427BC90D80093D175 /* pthreadSPI.h in Headers */,
 				5CB898B2286274FA00CA3485 /* QuarantineSPI.h in Headers */,
+				D065131729B69F12008C65C4 /* QuartzCoreSoftLink.h in Headers */,
 				DD20DE0527BC90D80093D175 /* QuartzCoreSPI.h in Headers */,
 				DD20DE3F27BC90D80093D175 /* QuickLookMacSPI.h in Headers */,
 				DD20DDC127BC90D70093D175 /* QuickLookSoftLink.h in Headers */,
@@ -2271,6 +2278,7 @@
 				CD6122D12559B8F200FC657A /* OutputDevice.mm in Sources */,
 				A1F63CA021A4DBF7006FB43B /* PassKitSoftLink.mm in Sources */,
 				A1175B4F1F6B337300C4B9F0 /* PopupMenu.mm in Sources */,
+				D065131629B69F11008C65C4 /* QuartzCoreSoftLink.mm in Sources */,
 				4450FC9F21F5F602004DFA56 /* QuickLookSoftLink.mm in Sources */,
 				F4C85A4E2658551A005B89CC /* QuickLookUISoftLink.mm in Sources */,
 				071C00372707EDF000D027C7 /* ReplayKitSoftLink.mm in Sources */,

--- a/Source/WebCore/PAL/pal/PlatformMac.cmake
+++ b/Source/WebCore/PAL/pal/PlatformMac.cmake
@@ -21,6 +21,7 @@ list(APPEND PAL_PUBLIC_HEADERS
     cocoa/NetworkConnectionIntegritySoftLink.h
     cocoa/OpenGLSoftLinkCocoa.h
     cocoa/PassKitSoftLink.h
+    cocoa/QuartzCoreSoftLink.h
     cocoa/RevealSoftLink.h
     cocoa/SpeechSoftLink.h
     cocoa/TranslationUIServicesSoftLink.h
@@ -178,6 +179,7 @@ list(APPEND PAL_SOURCES
     cocoa/NetworkConnectionIntegritySoftLink.mm
     cocoa/OpenGLSoftLinkCocoa.mm
     cocoa/PassKitSoftLink.mm
+    cocoa/QuartzCoreSoftLink.mm
     cocoa/RevealSoftLink.mm
     cocoa/SpeechSoftLink.mm
     cocoa/TranslationUIServicesSoftLink.mm

--- a/Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <pal/spi/cocoa/QuartzCoreSPI.h>
+#include <wtf/SoftLinking.h>
+
+SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, QuartzCore)
+
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, QuartzCore, CAIOSurfaceCreate, CAIOSurfaceRef, (IOSurfaceRef surface), (surface))
+#define CAIOSurfaceCreate PAL::softLink_QuartzCore_CAIOSurfaceCreate
+

--- a/Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.mm
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <pal/spi/cocoa/QuartzCoreSPI.h>
+#include <wtf/SoftLinking.h>
+
+SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, QuartzCore, PAL_EXPORT)
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, QuartzCore, CAIOSurfaceCreate, CAIOSurfaceRef, (IOSurfaceRef surface), (surface), PAL_EXPORT)
+

--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -84,15 +84,19 @@ typedef struct _CARenderContext CARenderContext;
 
 @interface CAContext ()
 + (NSArray *)allContexts;
++ (CAContext *)contextWithId:(uint32_t)contextId;
 + (CAContext *)currentContext;
 + (CAContext *)localContext;
 + (CAContext *)remoteContextWithOptions:(NSDictionary *)dict;
 #if PLATFORM(MAC)
 + (CAContext *)contextWithCGSConnection:(CGSConnectionID)cid options:(NSDictionary *)dict;
 #endif
+- (uint32_t)createSlot;
+- (void)setObject:(id)obj forSlot:(uint32_t)name;
 + (id)objectForSlot:(uint32_t)name;
 - (uint32_t)createImageSlot:(CGSize)size hasAlpha:(BOOL)flag;
 - (void)deleteSlot:(uint32_t)name;
+- (void)transferSlot:(uint32_t)name toContextWithId:(uint32_t)contextId;
 - (void)invalidate;
 - (void)invalidateFences;
 - (mach_port_t)createFencePort;
@@ -226,6 +230,12 @@ typedef struct _CAMachPort *CAMachPortRef;
 CAMachPortRef CAMachPortCreate(mach_port_t);
 mach_port_t CAMachPortGetPort(CAMachPortRef);
 CFTypeID CAMachPortGetTypeID(void);
+
+typedef struct _CAIOSurface *CAIOSurfaceRef;
+
+@interface CAContext ()
+- (bool)createSlotArray:(uint32_t)count slots:(uint32_t*)array;
+@end
 
 void CABackingStoreCollectBlocking(void);
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -217,8 +217,11 @@ bool ImageBufferIOSurfaceBackend::setVolatile()
 
 SetNonVolatileResult ImageBufferIOSurfaceBackend::setNonVolatile()
 {
-    setVolatilityState(VolatilityState::NonVolatile);
-    return m_surface->setVolatile(false);
+    if (m_volatilityState == VolatilityState::Volatile) {
+        setVolatilityState(VolatilityState::NonVolatile);
+        return m_surface->setVolatile(false);
+    }
+    return SetNonVolatileResult::Valid;
 }
 
 VolatilityState ImageBufferIOSurfaceBackend::volatilityState() const

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -119,6 +119,7 @@ public:
     WEBCORE_EXPORT static void setBytesPerRowAlignment(size_t);
 
     WEBCORE_EXPORT WTF::MachSendRight createSendRight() const;
+    WEBCORE_EXPORT RetainPtr<id> createRenderingHandle() const;
 
     // Any images created from a surface need to be released before releasing
     // the surface, or an expensive GPU readback can result.
@@ -128,6 +129,8 @@ public:
 #ifdef __OBJC__
     id asLayerContents() const { return (__bridge id)m_surface.get(); }
 #endif
+    WEBCORE_EXPORT id asCachedLayerContents() const;
+    
     IOSurfaceRef surface() const { return m_surface.get(); }
     WEBCORE_EXPORT CGContextRef ensurePlatformContext(PlatformDisplayID = 0);
     // The graphics context cached on the surface counts as a "user", so to get
@@ -188,6 +191,8 @@ private:
     RetainPtr<CGContextRef> m_cgContext;
 
     RetainPtr<IOSurfaceRef> m_surface;
+
+    mutable RetainPtr<id> m_caSurface;
 
     static std::optional<IntSize> s_maximumSize;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -30,6 +30,9 @@
 #include "Connection.h"
 #include "DisplayListRecorderFlushIdentifier.h"
 #include "ImageBufferBackendHandle.h"
+#if PLATFORM(COCOA)
+#include "LayerHostingContext.h"
+#endif
 #include "MarkSurfacesAsVolatileRequestIdentifier.h"
 #include "MessageReceiver.h"
 #include "MessageSender.h"
@@ -128,7 +131,7 @@ private:
     void releaseAllResources();
     void finalizeRenderingUpdate(RenderingUpdateID);
     void markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier, const Vector<WebCore::RenderingResourceIdentifier>&);
-    void prepareBuffersForDisplay(Vector<PrepareBackingStoreBuffersInputData> swapBuffersInput, CompletionHandler<void(const Vector<PrepareBackingStoreBuffersOutputData>&)>&&);
+    void prepareBuffersForDisplay(LayerHostingContextID, Vector<PrepareBackingStoreBuffersInputData> swapBuffersInput, CompletionHandler<void(const Vector<PrepareBackingStoreBuffersOutputData>&)>&&);
 
     // Received messages translated to use QualifiedRenderingResourceIdentifier.
     void createImageBufferWithQualifiedIdentifier(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, QualifiedRenderingResourceIdentifier);
@@ -138,7 +141,9 @@ private:
     void releaseResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
     void cacheFontWithQualifiedIdentifier(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
 
-    void prepareLayerBuffersForDisplay(const PrepareBackingStoreBuffersInputData&, PrepareBackingStoreBuffersOutputData&);
+    void prepareLayerBuffersForDisplay(LayerHostingContextID, const PrepareBackingStoreBuffersInputData&, PrepareBackingStoreBuffersOutputData&);
+
+    std::optional<ImageBufferBackendHandle> handleFromBuffer(LayerHostingContextID, WebCore::ImageBuffer&);
 
     Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     Ref<IPC::StreamServerConnection> m_streamConnection;
@@ -149,6 +154,10 @@ private:
     RefPtr<SharedMemory> m_getPixelBufferSharedMemory;
 #if HAVE(IOSURFACE)
     Ref<WebCore::IOSurfacePool> m_ioSurfacePool;
+#endif
+
+#if PLATFORM(COCOA)
+    std::unique_ptr<LayerHostingContext> m_context;
 #endif
 
     Lock m_remoteDisplayListsLock;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -36,7 +36,7 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     ReleaseAllResources()
     ReleaseResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
 
-    PrepareBuffersForDisplay(Vector<WebKit::PrepareBackingStoreBuffersInputData> swapBuffersInput) -> (Vector<WebKit::PrepareBackingStoreBuffersOutputData> swapBuffersOutput) Synchronous NotStreamEncodable NotStreamEncodableReply
+    PrepareBuffersForDisplay(WebKit::LayerHostingContextID context, Vector<WebKit::PrepareBackingStoreBuffersInputData> swapBuffersInput) -> (Vector<WebKit::PrepareBackingStoreBuffersOutputData> swapBuffersOutput) Synchronous NotStreamEncodable NotStreamEncodableReply
 
     MarkSurfacesVolatile(WebKit::MarkSurfacesAsVolatileRequestIdentifier requestIdentifier, Vector<WebCore::RenderingResourceIdentifier> renderingResourceIdentifiers)
     FinalizeRenderingUpdate(WebKit::RenderingUpdateID renderingUpdateID)

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -28,6 +28,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/Vector.h>
 
 OBJC_CLASS CALayer;
 OBJC_CLASS CAContext;
@@ -65,6 +66,9 @@ public:
 
 #endif // HAVE(OUT_OF_PROCESS_LAYER_HOSTING)
 
+    static void beginTransaction();
+    static void commitTransaction();
+
     LayerHostingContext();
     ~LayerHostingContext();
 
@@ -96,6 +100,10 @@ public:
     void updateCachedContextID(LayerHostingContextID);
     LayerHostingContextID cachedContextID();
 
+    // Assigns obj to a new slot on the current hosting context, and
+    // transfers ownership of the slot to destContext.
+    uint32_t assignToSlotAndTransfer(RetainPtr<id>&&, LayerHostingContextID destContext);
+
 private:
     LayerHostingMode m_layerHostingMode;
     // Denotes the contextID obtained from GPU process, should be returned
@@ -103,6 +111,8 @@ private:
     // is enabled. This is done to avoid making calls to CARenderServer from webprocess
     LayerHostingContextID m_cachedContextID;
     RetainPtr<CAContext> m_context;
+
+    WTF::Vector<uint32_t> m_slots;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ImageBufferBackendHandle.h"
+#include "LayerHostingContext.h"
 #include <WebCore/FloatRect.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/Region.h>
@@ -126,7 +127,7 @@ public:
     PlatformCALayerRemote* layer() const { return m_layer; }
 
     enum class LayerContentsType { IOSurface, CAMachPort };
-    void applyBackingStoreToLayer(CALayer *, LayerContentsType, bool replayCGDisplayListsIntoBackingStore);
+    void applyBackingStoreToLayer(CALayer *, LayerContentsType, bool replayCGDisplayListsIntoBackingStore, LayerHostingContextID);
 
     void encode(IPC::Encoder&) const;
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, RemoteLayerBackingStore&);
@@ -163,7 +164,7 @@ public:
 
     void clearBackingStore();
 
-    static RetainPtr<id> layerContentsBufferFromBackendHandle(ImageBufferBackendHandle&&, LayerContentsType);
+    static RetainPtr<id> layerContentsBufferFromBackendHandle(ImageBufferBackendHandle&&, LayerContentsType, LayerHostingContextID = 0);
 
 private:
     RemoteLayerBackingStoreCollection* backingStoreCollection() const;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -257,7 +257,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
     {
         auto* backingStore = properties.backingStore.get();
         if (backingStore && properties.backingStoreAttached)
-            backingStore->applyBackingStoreToLayer(layer, layerContentsType, layerTreeHost->replayCGDisplayListsIntoBackingStore());
+            backingStore->applyBackingStoreToLayer(layer, layerContentsType, layerTreeHost->replayCGDisplayListsIntoBackingStore(), layerTreeHost->layerHostingContextID());
         else
             [layer _web_clearContents];
     }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm
@@ -99,7 +99,7 @@ void RemoteLayerWithRemoteRenderingBackingStoreCollection::prepareBackingStoresF
     }
 
     auto& remoteRenderingBackend = layerTreeContext().ensureRemoteRenderingBackendProxy();
-    auto swapResult = remoteRenderingBackend.prepareBuffersForDisplay(WTFMove(prepareBuffersData));
+    auto swapResult = remoteRenderingBackend.prepareBuffersForDisplay(layerTreeContext().hostingContextID(), WTFMove(prepareBuffersData));
 
     RELEASE_ASSERT(swapResult.size() == backingStoreList.size());
     for (unsigned i = 0; i < swapResult.size(); ++i) {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -55,6 +55,8 @@ public:
     void acceleratedAnimationDidStart(WebCore::GraphicsLayer::PlatformLayerID, const String& key, MonotonicTime startTime);
     void acceleratedAnimationDidEnd(WebCore::GraphicsLayer::PlatformLayerID, const String& key);
 
+    void setLayerHostingContextID(LayerHostingContextID);
+
     TransactionID nextLayerTreeTransactionID() const { return m_pendingLayerTreeTransactionID.next(); }
     TransactionID lastCommittedLayerTreeTransactionID() const { return m_transactionIDForPendingCACommit; }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -28,6 +28,7 @@
 
 #import "DrawingAreaMessages.h"
 #import "Logging.h"
+#import "PageClient.h"
 #import "RemoteLayerTreeDrawingAreaProxyMessages.h"
 #import "RemoteScrollingCoordinatorProxy.h"
 #import "RemoteScrollingCoordinatorTransaction.h"
@@ -342,6 +343,11 @@ void RemoteLayerTreeDrawingAreaProxy::initializeDebugIndicator()
         RetainPtr<CGColorRef> color = adoptCF(CGColorCreate(colorSpace, components));
         [m_exposedRectIndicatorLayer setBorderColor:color.get()];
     }
+}
+
+void RemoteLayerTreeDrawingAreaProxy::setLayerHostingContextID(LayerHostingContextID id)
+{
+    m_webPageProxy.send(Messages::DrawingArea::SetHostingContextID(id), m_identifier);
 }
 
 void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LayerHostingContext.h"
 #include "PlaybackSessionContextIdentifier.h"
 #include "RemoteLayerTreeNode.h"
 #include "RemoteLayerTreeTransaction.h"
@@ -84,13 +85,18 @@ public:
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     const HashSet<WebCore::GraphicsLayer::PlatformLayerID>& overlayRegionIDs() const { return m_overlayRegionIDs; }
     void updateOverlayRegionIDs(const HashSet<WebCore::GraphicsLayer::PlatformLayerID> &overlayRegionNodes) { m_overlayRegionIDs = overlayRegionNodes; }
+
 #endif
+
+    LayerHostingContextID layerHostingContextID() { return m_contextID.value_or(0); }
 
 private:
     void createLayer(const RemoteLayerTreeTransaction::LayerCreationProperties&);
     std::unique_ptr<RemoteLayerTreeNode> makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties&);
 
     void layerWillBeRemoved(WebCore::GraphicsLayer::PlatformLayerID);
+
+    void ensureHostingContext(RemoteLayerTreeNode*);
 
     RemoteLayerBackingStore::LayerContentsType layerContentsType() const;
 
@@ -106,6 +112,8 @@ private:
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     HashSet<WebCore::GraphicsLayer::PlatformLayerID> m_overlayRegionIDs;
 #endif
+    std::optional<LayerHostingContextID> m_contextID;
+
     bool m_isDebugLayerTreeHost { false };
 };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandle.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandle.h
@@ -36,6 +36,7 @@ using ImageBufferBackendHandle = std::variant<
     ShareableBitmapHandle
 #if PLATFORM(COCOA) // FIXME: This is really about IOSurface.
     , MachSendRight
+    , uint32_t
 #endif
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
     , CGDisplayList

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandleSharing.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandleSharing.h
@@ -26,13 +26,22 @@
 #pragma once
 
 #include "ImageBufferBackendHandle.h"
+#include "LayerHostingContext.h"
 #include <WebCore/ImageBufferBackend.h>
+
+#if PLATFORM(COCOA)
+#import <wtf/RetainPtr.h>
+typedef struct objc_object* id;
+#endif
 
 namespace WebKit {
 
 class ImageBufferBackendHandleSharing : public WebCore::ImageBufferBackendSharing {
 public:
     virtual ImageBufferBackendHandle createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const = 0;
+#if PLATFORM(COCOA)
+    virtual RetainPtr<id> createLayerContentsHandle() const { return nullptr; }
+#endif
     virtual RefPtr<ShareableBitmap> bitmap() const { return nullptr; }
 
     virtual void setBackendHandle(ImageBufferBackendHandle&&) { }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -272,7 +272,7 @@ void RemoteRenderingBackendProxy::releaseRemoteResource(RenderingResourceIdentif
     send(Messages::RemoteRenderingBackend::ReleaseResource(renderingResourceIdentifier));
 }
 
-auto RemoteRenderingBackendProxy::prepareBuffersForDisplay(const Vector<LayerPrepareBuffersData>& prepareBuffersInput) -> Vector<SwapBuffersResult>
+auto RemoteRenderingBackendProxy::prepareBuffersForDisplay(LayerHostingContextID context, const Vector<LayerPrepareBuffersData>& prepareBuffersInput) -> Vector<SwapBuffersResult>
 {
     if (prepareBuffersInput.isEmpty())
         return { };
@@ -316,7 +316,7 @@ auto RemoteRenderingBackendProxy::prepareBuffersForDisplay(const Vector<LayerPre
     }
 
     Vector<PrepareBackingStoreBuffersOutputData> outputData;
-    auto sendResult = sendSync(Messages::RemoteRenderingBackend::PrepareBuffersForDisplay(inputData));
+    auto sendResult = sendSync(Messages::RemoteRenderingBackend::PrepareBuffersForDisplay(context, inputData));
     if (!sendResult) {
         // GPU Process crashed. Set the output data to all null buffers, requiring a full display.
         outputData.resize(inputData.size());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -119,7 +119,7 @@ public:
         SwapBuffersDisplayRequirement displayRequirement;
     };
 
-    Vector<SwapBuffersResult> prepareBuffersForDisplay(const Vector<LayerPrepareBuffersData>&);
+    Vector<SwapBuffersResult> prepareBuffersForDisplay(LayerHostingContextID, const Vector<LayerPrepareBuffersData>&);
 
     void finalizeRenderingUpdate();
     void didPaintLayers();

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -56,7 +56,7 @@ size_t ImageBufferRemoteIOSurfaceBackend::calculateExternalMemoryCost(const Para
 
 std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> ImageBufferRemoteIOSurfaceBackend::create(const Parameters& parameters, ImageBufferBackendHandle handle)
 {
-    if (!std::holds_alternative<MachSendRight>(handle)) {
+    if (!std::holds_alternative<MachSendRight>(handle) && !std::holds_alternative<uint32_t>(handle)) {
         RELEASE_ASSERT_NOT_REACHED();
         return nullptr;
     }
@@ -66,6 +66,9 @@ std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> ImageBufferRemoteIOSurfaceBac
 
 ImageBufferBackendHandle ImageBufferRemoteIOSurfaceBackend::createBackendHandle(SharedMemory::Protection) const
 {
+    if (std::holds_alternative<uint32_t>(m_handle))
+        return std::get<uint32_t>(m_handle);
+
     if (!std::holds_alternative<MachSendRight>(m_handle)) {
         RELEASE_ASSERT_NOT_REACHED();
         return { };

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
@@ -79,6 +79,11 @@ ImageBufferBackendHandle ImageBufferShareableMappedIOSurfaceBackend::createBacke
     return ImageBufferBackendHandle(m_surface->createSendRight());
 }
 
+RetainPtr<id> ImageBufferShareableMappedIOSurfaceBackend::createLayerContentsHandle() const
+{
+    return m_surface->asCachedLayerContents();
+}
+
 void ImageBufferShareableMappedIOSurfaceBackend::setOwnershipIdentity(const WebCore::ProcessIdentity& resourceOwner)
 {
     m_surface->setOwnershipIdentity(resourceOwner);

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
@@ -49,6 +49,7 @@ public:
     void setOwnershipIdentity(const WebCore::ProcessIdentity&);
 
     ImageBufferBackendHandle createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const final;
+    RetainPtr<id> createLayerContentsHandle() const final;
 
 private:
     // ImageBufferBackendSharing

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -105,6 +105,8 @@ public:
     virtual void acceleratedAnimationDidEnd(WebCore::GraphicsLayer::PlatformLayerID, const String& /*key*/) { }
     virtual void addFence(const WTF::MachSendRight&) { }
 
+    virtual void setHostingContextID(WebCore::LayerHostingContextID) { }
+
     virtual WebCore::FloatRect exposedContentRect() const = 0;
     virtual void setExposedContentRect(const WebCore::FloatRect&) = 0;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -38,6 +38,8 @@ messages -> DrawingArea NotRefCounted {
     AcceleratedAnimationDidEnd(WebCore::GraphicsLayer::PlatformLayerID layerID, String key)
     
     DispatchAfterEnsuringDrawing() -> () CallWithReplyID
+
+    SetHostingContextID(uint32_t id)
 #endif
 
 #if USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LayerHostingContext.h"
 #include "LayerTreeContext.h"
 #include "RemoteLayerBackingStoreCollection.h"
 #include "RemoteLayerTreeTransaction.h"
@@ -98,6 +99,9 @@ public:
 
     WebPage& webPage() { return m_webPage; }
 
+    void setHostingContextID(WebCore::LayerHostingContextID id) { m_layerHostingContextID = id; }
+    WebCore::LayerHostingContextID hostingContextID() { return m_layerHostingContextID; }
+
 private:
     // WebCore::GraphicsLayerFactory
     Ref<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayer::Type, WebCore::GraphicsLayerClient&) override;
@@ -118,6 +122,8 @@ private:
     std::unique_ptr<RemoteLayerBackingStoreCollection> m_backingStoreCollection;
 
     WebCore::LayerPool m_layerPool;
+
+    LayerHostingContextID m_layerHostingContextID;
 
     RemoteLayerTreeTransaction* m_currentTransaction { nullptr };
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -100,6 +100,8 @@ private:
     void acceleratedAnimationDidStart(WebCore::GraphicsLayer::PlatformLayerID, const String& key, MonotonicTime startTime) override;
     void acceleratedAnimationDidEnd(WebCore::GraphicsLayer::PlatformLayerID, const String& key) override;
 
+    void setHostingContextID(WebCore::LayerHostingContextID) override;
+
     WebCore::FloatRect exposedContentRect() const override;
     void setExposedContentRect(const WebCore::FloatRect&) override;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -382,6 +382,11 @@ void RemoteLayerTreeDrawingArea::didCompleteRenderingUpdateDisplay()
     DrawingArea::didCompleteRenderingUpdateDisplay();
 }
 
+void RemoteLayerTreeDrawingArea::setHostingContextID(WebCore::LayerHostingContextID id)
+{
+    m_remoteLayerTreeContext->setHostingContextID(id);
+}
+
 void RemoteLayerTreeDrawingArea::displayDidRefresh()
 {
     // FIXME: This should use a counted replacement for setLayerTreeStateIsFrozen, but


### PR DESCRIPTION
#### 2ca874985cf701b520a1795a721d646667522e4d
<pre>
Use CAContext slots API to share IOSurfaces from the GPUP.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253477">https://bugs.webkit.org/show_bug.cgi?id=253477</a>
&lt;rdar://106335020&gt;

Reviewed by NOBODY (OOPS!).

Uses the CAContext slots API to create a slot, and assign the front buffer IOSurface to it.
Tranfers ownership of the slot to the UI-process CAContext so that it can be deleted there.

The slot ID gets serialized to the UI-process (instead of a mach port), and is then set as
the layer contents.

The context ID of the CAContext used for rendering in the UI process is lazily detected, and then
serialized to the web process, which enables the slot code path.

At this point, initial buffer allocations are still serialized using a mach port, only swaps via
preareBuffersForDisplay potentially hit the slot path.

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/PlatformMac.cmake:
* Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.h: Added.
* Source/WebCore/PAL/pal/cocoa/QuartzCoreSoftLink.mm: Added.
* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::setNonVolatile):
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::asCachedLayerContents const):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::handleFromBuffer):
(WebKit::RemoteRenderingBackend::prepareBuffersForDisplay):
(WebKit::RemoteRenderingBackend::prepareLayerBuffersForDisplay):
(WebKit::handleFromBuffer): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::LayerHostingContext::beginTransaction):
(WebKit::LayerHostingContext::commitTransaction):
(WebKit::LayerHostingContext::assignToSlotAndTransfer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::layerContentsBufferFromBackendHandle):
(WebKit::RemoteLayerBackingStore::applyBackingStoreToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStoreCollection.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStoreCollection::prepareBackingStoresForDisplay):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::setLayerHostingContextID):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
(WebKit::RemoteLayerTreeHost::layerHostingContextID):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::ensureHostingContext):
(WebKit::RemoteLayerTreeHost::createLayer):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandle.h:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandleSharing.h:
(WebKit::ImageBufferBackendHandleSharing::createLayerContentsHandle const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::prepareBuffersForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::create):
(WebKit::ImageBufferRemoteIOSurfaceBackend::createBackendHandle const):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBackend::createLayerContentsHandle const):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::setHostingContextID):
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
(WebKit::RemoteLayerTreeContext::setHostingContextID):
(WebKit::RemoteLayerTreeContext::hostingContextID):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::setHostingContextID):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ca874985cf701b520a1795a721d646667522e4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20494 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43893 "Build is being retried. Recent messages:worker ews118 ready; Configured build; Validated change; OS: Big Sur (11.7.2), Xcode: 12.5.1; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261341@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Killed old processes; Validated change; Compiled WebKit (retry)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3192 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120155 "Hash 2ca87498 for PR 11143 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2559 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117120 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16235 "2 new passes 14 flakes 8 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/43893 "Build is being retried. Recent messages:worker ews118 ready; Configured build; Validated change; OS: Big Sur (11.7.2), Xcode: 12.5.1; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261341@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Killed old processes; Validated change; Compiled WebKit (retry)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104020 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98191 "1 api test failed or timed out") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/43893 "Build is being retried. Recent messages:worker ews118 ready; Configured build; Validated change; OS: Big Sur (11.7.2), Xcode: 12.5.1; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261341@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Killed old processes; Validated change; Compiled WebKit (retry)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44881 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12995 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/43893 "Build is being retried. Recent messages:worker ews118 ready; Configured build; Validated change; OS: Big Sur (11.7.2), Xcode: 12.5.1; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261341@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Killed old processes; Validated change; Compiled WebKit (retry)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86676 "16 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9459 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18949 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/43893 "Build is being retried. Recent messages:worker ews118 ready; Configured build; Validated change; OS: Big Sur (11.7.2), Xcode: 12.5.1; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261341@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Killed old processes; Validated change; Compiled WebKit (retry)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15464 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->