### PR TITLE
[GLib] Remove WebKitJavascriptResult

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -138,7 +138,6 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitHitTestResult.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitInputMethodContext.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitInstallMissingMediaPluginsPermissionRequest.h.in
-    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitJavascriptResult.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitMemoryPressureSettings.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitNavigationAction.h.in

--- a/Source/WebKit/PlatformGTKDeprecated.cmake
+++ b/Source/WebKit/PlatformGTKDeprecated.cmake
@@ -7,6 +7,7 @@ add_definitions(-DWEBKIT_DOM_USE_UNSTABLE_API)
 file(MAKE_DIRECTORY ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit2)
 
 list(APPEND WebKitGTK_HEADER_TEMPLATES
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitJavascriptResult.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitMimeInfo.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPlugin.h.in
     ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitPrintCustomWidget.h.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -153,7 +153,6 @@ set(WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitHitTestResult.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitInputMethodContext.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitInstallMissingMediaPluginsPermissionRequest.h.in
-    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitJavascriptResult.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitMemoryPressureSettings.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitNavigationAction.h.in

--- a/Source/WebKit/PlatformWPEDeprecated.cmake
+++ b/Source/WebKit/PlatformWPEDeprecated.cmake
@@ -6,6 +6,7 @@ list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
 
 list(APPEND WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFaviconDatabase.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitJavascriptResult.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitMimeInfo.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPlugin.h.in
 )

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -151,7 +151,6 @@ UIProcess/API/glib/WebKitInitialize.cpp @no-unify
 UIProcess/API/glib/WebKitInjectedBundleClient.cpp @no-unify
 UIProcess/API/glib/WebKitInputMethodContext.cpp @no-unify
 UIProcess/API/glib/WebKitInstallMissingMediaPluginsPermissionRequest.cpp @no-unify
-UIProcess/API/glib/WebKitJavascriptResult.cpp @no-unify
 UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitMemoryPressureSettings.cpp @no-unify
 UIProcess/API/glib/WebKitNavigationAction.cpp @no-unify

--- a/Source/WebKit/SourcesGTKDeprecated.txt
+++ b/Source/WebKit/SourcesGTKDeprecated.txt
@@ -21,6 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
+UIProcess/API/glib/WebKitJavascriptResult.cpp @no-unify
 UIProcess/API/glib/WebKitMimeInfo.cpp @no-unify
 UIProcess/API/glib/WebKitPlugin.cpp @no-unify
 

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -141,7 +141,6 @@ UIProcess/API/glib/WebKitInitialize.cpp @no-unify
 UIProcess/API/glib/WebKitInjectedBundleClient.cpp @no-unify
 UIProcess/API/glib/WebKitInputMethodContext.cpp @no-unify
 UIProcess/API/glib/WebKitInstallMissingMediaPluginsPermissionRequest.cpp @no-unify
-UIProcess/API/glib/WebKitJavascriptResult.cpp @no-unify
 UIProcess/API/glib/WebKitMediaKeySystemPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitMemoryPressureSettings.cpp @no-unify
 UIProcess/API/glib/WebKitNavigationAction.cpp @no-unify

--- a/Source/WebKit/SourcesWPEDeprecated.txt
+++ b/Source/WebKit/SourcesWPEDeprecated.txt
@@ -23,6 +23,7 @@
 
 UIProcess/API/glib/IconDatabase.cpp @no-unify
 UIProcess/API/glib/WebKitFaviconDatabase.cpp @no-unify
+UIProcess/API/glib/WebKitJavascriptResult.cpp @no-unify
 UIProcess/API/glib/WebKitMimeInfo.cpp @no-unify
 UIProcess/API/glib/WebKitPlugin.cpp @no-unify
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include "WebKitJavascriptResult.h"
 
+#if !ENABLE(2022_GLIB_API)
+
 #include "APISerializedScriptValue.h"
 #include "WebKitJavascriptResultPrivate.h"
 #include <jsc/JSCContextPrivate.h>
@@ -86,7 +88,7 @@ void webkit_javascript_result_unref(WebKitJavascriptResult* javascriptResult)
     }
 }
 
-#if PLATFORM(GTK) && !USE(GTK4)
+#if PLATFORM(GTK)
 /**
  * webkit_javascript_result_get_global_context: (skip)
  * @js_result: a #WebKitJavascriptResult
@@ -141,3 +143,5 @@ JSCValue* webkit_javascript_result_get_js_value(WebKitJavascriptResult* javascri
     g_return_val_if_fail(javascriptResult, nullptr);
     return javascriptResult->jsValue.get();
 }
+
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.h.in
@@ -22,11 +22,13 @@
 #ifndef WebKitJavascriptResult_h
 #define WebKitJavascriptResult_h
 
+#if !ENABLE(2022_GLIB_API)
+
 #include <jsc/jsc.h>
 #include <glib-object.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
 
-#if PLATFORM(GTK) && !ENABLE(2022_GLIB_API)
+#if PLATFORM(GTK)
 #include <JavaScriptCore/JSBase.h>
 #endif
 
@@ -46,7 +48,7 @@ webkit_javascript_result_ref                (WebKitJavascriptResult *js_result);
 WEBKIT_API void
 webkit_javascript_result_unref              (WebKitJavascriptResult *js_result);
 
-#if PLATFORM(GTK) && !ENABLE(2022_GLIB_API)
+#if PLATFORM(GTK)
 WEBKIT_DEPRECATED JSGlobalContextRef
 webkit_javascript_result_get_global_context (WebKitJavascriptResult *js_result);
 
@@ -56,6 +58,8 @@ webkit_javascript_result_get_value          (WebKitJavascriptResult *js_result);
 
 WEBKIT_API JSCValue *
 webkit_javascript_result_get_js_value       (WebKitJavascriptResult *js_result);
+
+#endif
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResultPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResultPrivate.h
@@ -22,4 +22,6 @@
 #include <WebCore/SerializedScriptValue.h>
 #include "WebKitJavascriptResult.h"
 
+#if !ENABLE(2022_GLIB_API)
 WebKitJavascriptResult* webkitJavascriptResultCreate(WebCore::SerializedScriptValue&);
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -645,7 +645,7 @@ webkit_web_view_evaluate_javascript                  (WebKitWebView             
                                                       GAsyncReadyCallback        callback,
                                                       gpointer                   user_data);
 
-WEBKIT_API WebKitJavascriptResult *
+WEBKIT_API JSCValue *
 webkit_web_view_evaluate_javascript_finish           (WebKitWebView             *web_view,
                                                       GAsyncResult              *result,
                                                       GError                   **error);
@@ -661,7 +661,7 @@ webkit_web_view_call_async_javascript_function       (WebKitWebView             
                                                       GAsyncReadyCallback        callback,
                                                       gpointer                   user_data);
 
-WEBKIT_API WebKitJavascriptResult *
+WEBKIT_API JSCValue *
 webkit_web_view_call_async_javascript_function_finish(WebKitWebView             *web_view,
                                                       GAsyncResult              *result,
                                                       GError                   **error);

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -69,7 +69,9 @@
 #include <@API_INCLUDE_PREFIX@/WebKitHitTestResult.h>
 #include <@API_INCLUDE_PREFIX@/WebKitInputMethodContext.h>
 #include <@API_INCLUDE_PREFIX@/WebKitInstallMissingMediaPluginsPermissionRequest.h>
+#if !ENABLE(2022_GLIB_API)
 #include <@API_INCLUDE_PREFIX@/WebKitJavascriptResult.h>
+#endif
 #include <@API_INCLUDE_PREFIX@/WebKitMediaKeySystemPermissionRequest.h>
 #include <@API_INCLUDE_PREFIX@/WebKitMemoryPressureSettings.h>
 #if !ENABLE(2022_GLIB_API)

--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -146,3 +146,8 @@ gained parameters to specify the script world to use.
 [method@WebKit.Download.set_destination], [method@WebKit.Download.get_destination],
 [property@WebKit.Download:destination], and [signal@WebKit.Download::created-destination]
 now all use a filesystem path rather than a URI. All uses must be updated accordingly.
+
+## JavaScript Results
+
+WebKitJavascriptResult has been removed. [signal@WebKit.UserContentManager::script-message-received]
+now directly returns a [class@JSC.Value] instead.

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -357,9 +357,13 @@ static void websiteDataClearedCallback(WebKitWebsiteDataManager *manager, GAsync
         webkit_web_view_reload(webkit_uri_scheme_request_get_web_view(dataRequest->request));
 }
 
-static void aboutDataScriptMessageReceivedCallback(WebKitUserContentManager *userContentManager, WebKitJavascriptResult *message, WebKitWebsiteDataManager *manager)
+static void aboutDataScriptMessageReceivedCallback(WebKitUserContentManager *userContentManager, gpointer message, WebKitWebsiteDataManager *manager)
 {
+#if GTK_CHECK_VERSION(3, 98, 0)
+    char *messageString = jsc_value_to_string(message);
+#else
     char *messageString = jsc_value_to_string(webkit_javascript_result_get_js_value(message));
+#endif
     char **tokens = g_strsplit(messageString, ":", 3);
     g_free(messageString);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp
@@ -45,7 +45,11 @@ public:
         CString sourceID;
     };
 
+#if ENABLE(2022_GLIB_API)
+    static void consoleMessageReceivedCallback(WebKitUserContentManager*, JSCValue* message, ConsoleMessageTest* test)
+#else
     static void consoleMessageReceivedCallback(WebKitUserContentManager*, WebKitJavascriptResult* message, ConsoleMessageTest* test)
+#endif
     {
         g_assert_nonnull(message);
         GUniquePtr<char> messageString(WebViewTest::javascriptResultToCString(message));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestGeolocationManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestGeolocationManager.cpp
@@ -113,11 +113,10 @@ public:
     Position lastPosition()
     {
         GUniqueOutPtr<GError> error;
-        auto* javascriptResult = runJavaScriptAndWaitUntilFinished("position", &error.outPtr());
-        g_assert_nonnull(javascriptResult);
+        auto* jsPosition = runJavaScriptAndWaitUntilFinished("position", &error.outPtr());
+        g_assert_nonnull(jsPosition);
         g_assert_no_error(error.get());
 
-        auto* jsPosition = webkit_javascript_result_get_js_value(javascriptResult);
         g_assert_true(jsc_value_is_object(jsPosition));
         Position result;
         GRefPtr<JSCValue> value = adoptGRef(jsc_value_object_get_property(jsPosition, "latitude"));
@@ -195,17 +194,16 @@ public:
             "  function(e) { error = e.message.toString(); }\n"
             ");";
         GUniqueOutPtr<GError> error;
-        auto* javascriptResult = runJavaScriptAndWaitUntilFinished(getCurrentPosition, &error.outPtr());
+        auto* value = runJavaScriptAndWaitUntilFinished(getCurrentPosition, &error.outPtr());
         g_assert_no_error(error.get());
         g_main_loop_run(m_mainLoop);
         m_errorMessage = nullptr;
 
-        javascriptResult = runJavaScriptAndWaitUntilFinished("error", &error.outPtr());
-        g_assert_nonnull(javascriptResult);
+        value = runJavaScriptAndWaitUntilFinished("error", &error.outPtr());
+        g_assert_nonnull(value);
         g_assert_no_error(error.get());
-        auto* jsErrorMessage = webkit_javascript_result_get_js_value(javascriptResult);
-        g_assert_true(jsc_value_is_string(jsErrorMessage));
-        return GUniquePtr<char>(jsc_value_to_string(jsErrorMessage));
+        g_assert_true(jsc_value_is_string(value));
+        return GUniquePtr<char>(jsc_value_to_string(value));
     }
 
     void startWatch()
@@ -228,8 +226,8 @@ public:
             "  position.timestamp = p.timestamp;\n"
             "});";
         GUniqueOutPtr<GError> error;
-        auto* javascriptResult = runJavaScriptAndWaitUntilFinished(watchPosition, &error.outPtr());
-        g_assert_nonnull(javascriptResult);
+        auto* value = runJavaScriptAndWaitUntilFinished(watchPosition, &error.outPtr());
+        g_assert_nonnull(value);
         g_assert_no_error(error.get());
         g_main_loop_run(m_mainLoop);
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp
@@ -486,9 +486,13 @@ public:
         static_cast<WebSocketTest*>(userData)->m_events |= WebSocketTest::EventFlags::DidServerCompleteHandshake;
     }
 
-    static void webSocketTestResultCallback(WebKitUserContentManager*, WebKitJavascriptResult* javascriptResult, WebSocketTest* test)
+#if ENABLE(2022_GLIB_API)
+    static void webSocketTestResultCallback(WebKitUserContentManager*, JSCValue* result, WebSocketTest* test)
+#else
+    static void webSocketTestResultCallback(WebKitUserContentManager*, WebKitJavascriptResult* result, WebSocketTest* test)
+#endif
     {
-        GUniquePtr<char> event(WebViewTest::javascriptResultToCString(javascriptResult));
+        GUniquePtr<char> event(WebViewTest::javascriptResultToCString(result));
         if (!g_strcmp0(event.get(), "open"))
             test->m_events |= WebSocketTest::EventFlags::DidOpen;
         else if (!g_strcmp0(event.get(), "close"))

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
@@ -247,9 +247,13 @@ public:
         return TRUE;
     }
 
-    static void permissionResultMessageReceivedCallback(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* javascriptResult, UIClientTest* test)
+#if ENABLE(2022_GLIB_API)
+    static void permissionResultMessageReceivedCallback(WebKitUserContentManager* userContentManager, JSCValue* result, UIClientTest* test)
+#else
+    static void permissionResultMessageReceivedCallback(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* result, UIClientTest* test)
+#endif
     {
-        test->m_permissionResult.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+        test->m_permissionResult.reset(WebViewTest::javascriptResultToCString(result));
         g_main_loop_quit(test->m_mainLoop);
     }
 
@@ -274,9 +278,13 @@ public:
         return TRUE;
     }
 
-    static void queryPermissionResultMessageReceivedCallback(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* javascriptResult, UIClientTest* test)
+#if ENABLE(2022_GLIB_API)
+    static void queryPermissionResultMessageReceivedCallback(WebKitUserContentManager* userContentManager, JSCValue* result, UIClientTest* test)
+#else
+    static void queryPermissionResultMessageReceivedCallback(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* result, UIClientTest* test)
+#endif
     {
-        test->m_queryPermissionResult.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+        test->m_queryPermissionResult.reset(WebViewTest::javascriptResultToCString(result));
         g_main_loop_quit(test->m_mainLoop);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebExtensions.cpp
@@ -195,9 +195,9 @@ static void testWebExtensionIsolatedWorld(WebViewTest* test, gconstpointer)
     test->runJavaScriptAndWaitUntilFinished(mainWorldScript, 0);
     g_assert_cmpstr(scriptDialogResult.get(), ==, "Main World");
 
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementById('console').innerHTML", 0);
-    g_assert_nonnull(javascriptResult);
-    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("document.getElementById('console').innerHTML", 0);
+    g_assert_nonnull(value);
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "Foo");
 
     static const char* isolatedWorldScript =
@@ -216,9 +216,9 @@ static void testWebExtensionIsolatedWorld(WebViewTest* test, gconstpointer)
     g_assert_cmpstr(scriptDialogResult.get(), ==, "Isolated World");
 
     // Check that 'top.foo' defined in main world is not visible in isolated world.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementById('console').innerHTML", 0);
-    g_assert_nonnull(javascriptResult);
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    value = test->runJavaScriptAndWaitUntilFinished("document.getElementById('console').innerHTML", 0);
+    g_assert_nonnull(value);
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "undefined");
 
     g_signal_handler_disconnect(test->m_webView, scriptDialogID);
@@ -765,16 +765,16 @@ static void testWebExtensionWindowObjectCleared(UserMessageTest* test, gconstpoi
     g_assert_cmpuint(messages.size(), ==, 2);
 
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.echo('Foo');", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("window.echo('Foo');", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "Foo");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("var f = new GFile('.'); f.path();", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("var f = new GFile('.'); f.path();", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     GUniquePtr<char> currentDirectory(g_get_current_dir());
     g_assert_cmpstr(valueString.get(), ==, currentDirectory.get());
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
@@ -41,9 +41,13 @@ public:
         None
     };
 
-    static void testHandlerMessageReceivedCallback(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* javascriptResult, PolicyClientTest* test)
+#if ENABLE(2022_GLIB_API)
+    static void testHandlerMessageReceivedCallback(WebKitUserContentManager* userContentManager, JSCValue* result, PolicyClientTest* test)
+#else
+    static void testHandlerMessageReceivedCallback(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* result, PolicyClientTest* test)
+#endif
     {
-        GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+        GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(result));
         if (g_str_equal(valueString.get(), "autoplayed"))
             test->m_autoplayed = true;
         else if (g_str_equal(valueString.get(), "did-not-play"))

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
@@ -81,12 +81,12 @@ static bool isStyleSheetInjectedForURLAtPath(WebViewTest* test, const char* path
     test->waitUntilLoadFinished();
 
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = world ? test->runJavaScriptInWorldAndWaitUntilFinished(kStyleSheetTestScript, world, nullptr, &error.outPtr())
+    JSCValue* value = world ? test->runJavaScriptInWorldAndWaitUntilFinished(kStyleSheetTestScript, world, nullptr, &error.outPtr())
         : test->runJavaScriptAndWaitUntilFinished(kStyleSheetTestScript, &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
 
-    GUniquePtr<char> resultString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> resultString(WebViewTest::javascriptResultToCString(value));
     return !g_strcmp0(resultString.get(), kStyleSheetTestScriptResult);
 }
 
@@ -96,12 +96,12 @@ static bool isScriptInjectedForURLAtPath(WebViewTest* test, const char* path, co
     test->waitUntilLoadFinished();
 
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = world ? test->runJavaScriptInWorldAndWaitUntilFinished(kScriptTestScript, world, nullptr, &error.outPtr())
+    JSCValue* value = world ? test->runJavaScriptInWorldAndWaitUntilFinished(kScriptTestScript, world, nullptr, &error.outPtr())
         : test->runJavaScriptAndWaitUntilFinished(kScriptTestScript, &error.outPtr());
-    if (javascriptResult) {
+    if (value) {
         g_assert_no_error(error.get());
 
-        GUniquePtr<char> resultString(WebViewTest::javascriptResultToCString(javascriptResult));
+        GUniquePtr<char> resultString(WebViewTest::javascriptResultToCString(value));
         return !g_strcmp0(resultString.get(), kScriptTestScriptResult);
     }
     return false;
@@ -266,17 +266,6 @@ class UserScriptMessageTest : public WebViewTest {
 public:
     MAKE_GLIB_TEST_FIXTURE(UserScriptMessageTest);
 
-    UserScriptMessageTest()
-        : m_scriptMessage(nullptr)
-    {
-    }
-
-    ~UserScriptMessageTest()
-    {
-        if (m_scriptMessage)
-            webkit_javascript_result_unref(m_scriptMessage);
-    }
-
     bool registerHandler(const char* handlerName, const char* worldName = nullptr, bool async = false)
     {
         if (async)
@@ -299,30 +288,33 @@ public:
 #endif
     }
 
-    static void scriptMessageReceived(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* jsResult, UserScriptMessageTest* test)
+#if ENABLE(2022_GLIB_API)
+    static void scriptMessageReceived(WebKitUserContentManager* userContentManager, JSCValue* result, UserScriptMessageTest* test)
+#else
+    static void scriptMessageReceived(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* result, UserScriptMessageTest* test)
+#endif
     {
         g_signal_handlers_disconnect_by_func(userContentManager, reinterpret_cast<gpointer>(scriptMessageReceived), test);
         if (!test->m_waitForScriptRun)
             g_main_loop_quit(test->m_mainLoop);
 
-        g_assert_null(test->m_scriptMessage);
-        test->m_scriptMessage = webkit_javascript_result_ref(jsResult);
+        g_assert_null(test->m_scriptMessage.get());
+#if ENABLE(2022_GLIB_API)
+        test->m_scriptMessage = result;
+#else
+        test->m_scriptMessage = webkit_javascript_result_get_js_value(result);
+#endif
     }
 
-    WebKitJavascriptResult* waitUntilMessageReceived(const char* handlerName)
+    JSCValue* waitUntilMessageReceived(const char* handlerName)
     {
-        if (m_scriptMessage) {
-            webkit_javascript_result_unref(m_scriptMessage);
-            m_scriptMessage = nullptr;
-        }
-
         GUniquePtr<char> signalName(g_strdup_printf("script-message-received::%s", handlerName));
         g_signal_connect(m_userContentManager.get(), signalName.get(), G_CALLBACK(scriptMessageReceived), this);
 
         g_main_loop_run(m_mainLoop);
         g_assert_false(m_waitForScriptRun);
-        g_assert_nonnull(m_scriptMessage);
-        return m_scriptMessage;
+        g_assert_nonnull(m_scriptMessage.get());
+        return m_scriptMessage.get();
     }
 
     static void runJavaScriptFinished(GObject*, GAsyncResult* result, UserScriptMessageTest* test)
@@ -332,7 +324,7 @@ public:
         g_main_loop_quit(test->m_mainLoop);
     }
 
-    WebKitJavascriptResult* postMessageAndWaitUntilReceived(const char* handlerName, const char* javascriptValueAsText, const char* worldName = nullptr)
+    JSCValue* postMessageAndWaitUntilReceived(const char* handlerName, const char* javascriptValueAsText, const char* worldName = nullptr)
     {
         GUniquePtr<char> javascriptSnippet(g_strdup_printf("window.webkit.messageHandlers.%s.postMessage(%s);", handlerName, javascriptValueAsText));
         m_waitForScriptRun = true;
@@ -340,13 +332,12 @@ public:
         return waitUntilMessageReceived(handlerName);
     }
 
-    static gboolean asyncScriptMessageReceived(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* jsResult, WebKitScriptMessageReply* scriptMessageReply, UserScriptMessageTest* test)
+    static gboolean asyncScriptMessageReceived(WebKitUserContentManager* userContentManager, JSCValue* jsValue, WebKitScriptMessageReply* scriptMessageReply, UserScriptMessageTest* test)
     {
         g_signal_handlers_disconnect_by_func(userContentManager, reinterpret_cast<gpointer>(asyncScriptMessageReceived), test);
         if (!test->m_waitForScriptRun)
             g_main_loop_quit(test->m_mainLoop);
 
-        auto* jsValue = webkit_javascript_result_get_js_value(jsResult);
         g_assert_true(JSC_IS_VALUE(jsValue));
         g_assert_true(jsc_value_is_string(jsValue));
         GUniquePtr<char> message(jsc_value_to_string(jsValue));
@@ -364,13 +355,8 @@ public:
         return TRUE;
     }
 
-    WebKitJavascriptResult* waitUntilPromiseResolved(const char* handlerName, GUniquePtr<GError>& error)
+    JSCValue* waitUntilPromiseResolved(const char* handlerName, GUniquePtr<GError>& error)
     {
-        if (m_scriptMessage) {
-            webkit_javascript_result_unref(m_scriptMessage);
-            m_scriptMessage = nullptr;
-        }
-
         GUniquePtr<char> signalName(g_strdup_printf("script-message-with-reply-received::%s", handlerName));
         g_signal_connect(m_userContentManager.get(), signalName.get(), G_CALLBACK(asyncScriptMessageReceived), this);
 
@@ -378,7 +364,7 @@ public:
         g_assert_false(m_waitForScriptRun);
 
         error.reset(m_scriptError.release());
-        return m_scriptMessage;
+        return m_scriptMessage.get();
     }
 
     static void runAsyncJavaScriptFinished(GObject* webView, GAsyncResult* result, UserScriptMessageTest* test)
@@ -389,7 +375,7 @@ public:
         g_main_loop_quit(test->m_mainLoop);
     }
 
-    WebKitJavascriptResult* postMessageAndWaitForPromiseResolved(const char* handlerName, const char* javascriptValueAsText, const char* worldName, GUniquePtr<GError>& error)
+    JSCValue* postMessageAndWaitForPromiseResolved(const char* handlerName, const char* javascriptValueAsText, const char* worldName, GUniquePtr<GError>& error)
     {
         GUniquePtr<char> javascriptSnippet(g_strdup_printf("var p = window.webkit.messageHandlers.%s.postMessage(%s); await p; return p;", handlerName, javascriptValueAsText));
         m_waitForScriptRun = true;
@@ -400,7 +386,7 @@ public:
     }
 
 private:
-    WebKitJavascriptResult* m_scriptMessage;
+    GRefPtr<JSCValue> m_scriptMessage;
     GUniqueOutPtr<GError> m_scriptError;
     bool m_waitForScriptRun { false };
 };
@@ -417,17 +403,17 @@ static void testUserContentManagerScriptMessageReceived(UserScriptMessageTest* t
 
     // Check that the "window.webkit.messageHandlers" namespace exists.
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "y");
 
     // Check that the "document.webkit.messageHandlers.msg" namespace exists.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg ? 'y' : 'n';", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg ? 'y' : 'n';", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "y");
 
     valueString.reset(WebViewTest::javascriptResultToCString(test->postMessageAndWaitUntilReceived("msg", "'user message'")));
@@ -437,17 +423,17 @@ static void testUserContentManagerScriptMessageReceived(UserScriptMessageTest* t
     g_assert_true(test->registerHandler("anotherHandler"));
 
     // Check that the "document.webkit.messageHandlers.msg" namespace still exists.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg ? 'y' : 'n';", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg ? 'y' : 'n';", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "y");
 
     // Check that the "document.webkit.messageHandlers.anotherHandler" namespace exists.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.anotherHandler ? 'y' : 'n';", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.anotherHandler ? 'y' : 'n';", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "y");
 
     valueString.reset(WebViewTest::javascriptResultToCString(test->postMessageAndWaitUntilReceived("msg", "'handler: msg'")));
@@ -459,8 +445,8 @@ static void testUserContentManagerScriptMessageReceived(UserScriptMessageTest* t
     // Unregistering a handler and re-registering again under the same name should work.
     test->unregisterHandler("msg");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg.postMessage('42');", &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg.postMessage('42');", &error.outPtr());
+    g_assert_null(value);
     g_assert_nonnull(error.get());
 
     // Re-registering a handler that has been unregistered must work
@@ -480,26 +466,26 @@ static void testUserContentManagerScriptMessageInWorldReceived(UserScriptMessage
 
     // Check that the "window.webkit.messageHandlers" namespace doesn't exist in isolated worlds.
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptInWorldAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
-    g_assert_null(javascriptResult);
+    JSCValue* value = test->runJavaScriptInWorldAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
     test->unregisterHandler("msg");
 
     g_assert_true(test->registerHandler("msg", "WebExtensionTestScriptWorld"));
 
     // Check that the "window.webkit.messageHandlers" namespace exists in the world.
-    javascriptResult = test->runJavaScriptInWorldAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptInWorldAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "y");
 
     valueString.reset(WebViewTest::javascriptResultToCString(test->postMessageAndWaitUntilReceived("msg", "'user message'", "WebExtensionTestScriptWorld")));
     g_assert_cmpstr(valueString.get(), ==, "user message");
 
     // Post message in main world should fail.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg.postMessage('42');", &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg.postMessage('42');", &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
 
     test->unregisterHandler("msg", "WebExtensionTestScriptWorld");
@@ -517,70 +503,70 @@ static void testUserContentManagerScriptMessageWithReplyReceived(UserScriptMessa
 
     // Check that the "window.webkit.messageHandlers" namespace exists.
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "y");
 
     // Check that the "document.webkit.messageHandlers.msg" namespace exists.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg ? 'y' : 'n';", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg ? 'y' : 'n';", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "y");
 
     GUniquePtr<GError> scriptError;
-    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'Ping'", nullptr, scriptError);
-    g_assert_nonnull(javascriptResult);
+    value = test->postMessageAndWaitForPromiseResolved("msg", "'Ping'", nullptr, scriptError);
+    g_assert_nonnull(value);
     g_assert_no_error(scriptError.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "Pong");
 
-    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'Fail'", nullptr, scriptError);
-    g_assert_null(javascriptResult);
+    value = test->postMessageAndWaitForPromiseResolved("msg", "'Fail'", nullptr, scriptError);
+    g_assert_null(value);
     g_assert_error(scriptError.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
     g_assert_cmpstr(scriptError->message, ==, "Error: Failed");
 
-    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'DoNothing'", nullptr, scriptError);
-    g_assert_nonnull(javascriptResult);
+    value = test->postMessageAndWaitForPromiseResolved("msg", "'DoNothing'", nullptr, scriptError);
+    g_assert_nonnull(value);
     g_assert_no_error(scriptError.get());
-    g_assert_true(WebViewTest::javascriptResultIsUndefined(javascriptResult));
+    g_assert_true(WebViewTest::javascriptResultIsUndefined(value));
 
     // Check that the "window.webkit.messageHandlers" namespace doesn't exist in isolated worlds.
-    javascriptResult = test->runJavaScriptInWorldAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runJavaScriptInWorldAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
     test->unregisterHandler("msg", nullptr);
 
     g_assert_true(test->registerHandler("msg", "WebExtensionTestScriptWorld", true));
 
     // Check that the "window.webkit.messageHandlers" namespace exists in the world.
-    javascriptResult = test->runJavaScriptInWorldAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptInWorldAndWaitUntilFinished("window.webkit.messageHandlers ? 'y' : 'n';", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "y");
 
-    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'Ping'", "WebExtensionTestScriptWorld", scriptError);
-    g_assert_nonnull(javascriptResult);
+    value = test->postMessageAndWaitForPromiseResolved("msg", "'Ping'", "WebExtensionTestScriptWorld", scriptError);
+    g_assert_nonnull(value);
     g_assert_no_error(scriptError.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "Pong");
 
-    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'Fail'", "WebExtensionTestScriptWorld", scriptError);
-    g_assert_null(javascriptResult);
+    value = test->postMessageAndWaitForPromiseResolved("msg", "'Fail'", "WebExtensionTestScriptWorld", scriptError);
+    g_assert_null(value);
     g_assert_error(scriptError.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
     g_assert_cmpstr(scriptError->message, ==, "Error: Failed");
 
-    javascriptResult = test->postMessageAndWaitForPromiseResolved("msg", "'DoNothing'", "WebExtensionTestScriptWorld", scriptError);
-    g_assert_nonnull(javascriptResult);
+    value = test->postMessageAndWaitForPromiseResolved("msg", "'DoNothing'", "WebExtensionTestScriptWorld", scriptError);
+    g_assert_nonnull(value);
     g_assert_no_error(scriptError.get());
-    g_assert_true(WebViewTest::javascriptResultIsUndefined(javascriptResult));
+    g_assert_true(WebViewTest::javascriptResultIsUndefined(value));
 
     // Post message in main world should fail.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg.postMessage('42');", &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("window.webkit.messageHandlers.msg.postMessage('42');", &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
 
     test->unregisterHandler("msg", "WebExtensionTestScriptWorld");
@@ -592,9 +578,9 @@ static void testUserContentManagerScriptMessageFromDOMBindings(UserScriptMessage
     g_assert_true(test->registerHandler("dom"));
 
     test->loadHtml("<html>1</html>", nullptr);
-    WebKitJavascriptResult* javascriptResult = test->waitUntilMessageReceived("dom");
-    g_assert_nonnull(javascriptResult);
-    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    JSCValue* value = test->waitUntilMessageReceived("dom");
+    g_assert_nonnull(value);
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "DocumentLoaded");
 
     test->unregisterHandler("dom");
@@ -607,11 +593,11 @@ static bool isCSSBlockedForURLAtPath(WebViewTest* test, const char* path)
     test->waitUntilLoadFinished();
 
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished(kScriptTestCSSBlocked, &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished(kScriptTestCSSBlocked, &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
 
-    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
     return !g_strcmp0(valueString.get(), kScriptTestCSSBlockedResult);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -342,88 +342,88 @@ static void testWebViewRunAsyncFunctions(WebViewTest* test, gconstpointer)
 {
     GUniqueOutPtr<GError> error;
 
-    WebKitJavascriptResult* javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(42); });", nullptr, nullptr, &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    JSCValue* value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(42); });", nullptr, nullptr, &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 42);
+    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), ==, 42);
 
     GVariantDict dict;
     g_variant_dict_init(&dict, nullptr);
     g_variant_dict_insert(&dict, "count", "u", 42);
     auto* args = g_variant_dict_end(&dict);
-    javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(count); });", args, nullptr, &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(count); });", args, nullptr, &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 42);
+    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), ==, 42);
 
     g_variant_dict_init(&dict, nullptr);
     g_variant_dict_insert(&dict, "motto", "s", "Never gonna give you up");
     args = g_variant_dict_end(&dict);
-    javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(motto); });", args, nullptr, &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(motto); });", args, nullptr, &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "Never gonna give you up");
 
-    javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise(function(resolve, reject) { setTimeout(function(){ reject('Rejected!') }, 0); })", nullptr, nullptr, &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise(function(resolve, reject) { setTimeout(function(){ reject('Rejected!') }, 0); })", nullptr, nullptr, &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
     g_assert_true(g_strstr_len(error->message, strlen(error->message), "Rejected!") != nullptr);
 
     g_variant_dict_init(&dict, nullptr);
     g_variant_dict_insert(&dict, "countt", "u", 42);
     args = g_variant_dict_end(&dict);
-    javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(count); });", args, nullptr, &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(count); });", args, nullptr, &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
 
     g_variant_dict_init(&dict, nullptr);
     g_variant_dict_insert(&dict, "count", "u", 42);
     args = g_variant_dict_end(&dict);
-    javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return count", args, nullptr, &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return count", args, nullptr, &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 42);
+    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), ==, 42);
 
     g_variant_dict_init(&dict, nullptr);
     g_variant_dict_insert(&dict, "count", "(u)", 42);
     args = g_variant_dict_end(&dict);
-    javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(count); });", args, nullptr, &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(count); });", args, nullptr, &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_INVALID_PARAMETER);
 
     {
         // Set a value in main world.
-        WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("a = 25;", &error.outPtr());
-        g_assert_nonnull(javascriptResult);
-        test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+        JSCValue* value = test->runJavaScriptAndWaitUntilFinished("a = 25;", &error.outPtr());
+        g_assert_nonnull(value);
+        test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
         g_assert_no_error(error.get());
-        g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 25);
+        g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), ==, 25);
 
         // Read back value from main world.
-        javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return a", nullptr, nullptr, &error.outPtr());
-        g_assert_nonnull(javascriptResult);
-        test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+        value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return a", nullptr, nullptr, &error.outPtr());
+        g_assert_nonnull(value);
+        test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
         g_assert_no_error(error.get());
-        g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 25);
+        g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), ==, 25);
 
         // Values of the main world are not available in the isolated one.
-        javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return a", nullptr, "WebExtensionTestScriptWorld", &error.outPtr());
-        g_assert_null(javascriptResult);
+        value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return a", nullptr, "WebExtensionTestScriptWorld", &error.outPtr());
+        g_assert_null(value);
         g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
 
         // An empty string for world name is a distinct isolated world.
-        javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return a", nullptr, "", &error.outPtr());
-        g_assert_null(javascriptResult);
+        value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return a", nullptr, "", &error.outPtr());
+        g_assert_null(value);
         g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
 
         // Running a script in a world that doesn't exist should fail.
-        javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return a", nullptr, "InvalidScriptWorld", &error.outPtr());
-        g_assert_null(javascriptResult);
+        value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return a", nullptr, "InvalidScriptWorld", &error.outPtr());
+        g_assert_null(value);
         g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
     }
 
@@ -439,8 +439,8 @@ static void testWebViewRunAsyncFunctions(WebViewTest* test, gconstpointer)
         g_object_set(G_OBJECT(newSettings.get()), "enable-javascript", FALSE, NULL);
         webkit_web_view_set_settings(test->m_webView, newSettings.get());
 
-        WebKitJavascriptResult* javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(42); });", nullptr, nullptr, &error.outPtr());
-        g_assert_null(javascriptResult);
+        JSCValue* value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(42); });", nullptr, nullptr, &error.outPtr());
+        g_assert_null(value);
         g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
 
         g_object_set(G_OBJECT(newSettings.get()), "enable-javascript", TRUE, NULL);
@@ -459,9 +459,9 @@ static void testWebViewRunAsyncFunctions(WebViewTest* test, gconstpointer)
         g_object_set(G_OBJECT(newSettings.get()), "enable-javascript-markup", FALSE, NULL);
         webkit_web_view_set_settings(test->m_webView, newSettings.get());
 
-        WebKitJavascriptResult* javascriptResult = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(42); });", nullptr, nullptr, &error.outPtr());
-        g_assert_nonnull(javascriptResult);
-        test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+        JSCValue* value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return new Promise((resolve) => { resolve(42); });", nullptr, nullptr, &error.outPtr());
+        g_assert_nonnull(value);
+        test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
         g_assert_no_error(error.get());
 
         g_object_set(G_OBJECT(newSettings.get()), "enable-javascript-markup", TRUE, NULL);
@@ -476,75 +476,74 @@ static void testWebViewRunJavaScript(WebViewTest* test, gconstpointer)
     test->waitUntilLoadFinished();
 
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.document.getElementById('WebKitLink').title;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("window.document.getElementById('WebKitLink').title;", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "WebKitGTK Title");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.document.getElementById('WebKitLink').href;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptAndWaitUntilFinished("window.document.getElementById('WebKitLink').href;", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "http://www.webkitgtk.org/");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.document.getElementById('WebKitLink').textContent", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptAndWaitUntilFinished("window.document.getElementById('WebKitLink').textContent", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "WebKitGTK Website");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("a = 25;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptAndWaitUntilFinished("a = 25;", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 25);
+    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), ==, 25);
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("a = 2.5;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptAndWaitUntilFinished("a = 2.5;", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 2.5);
+    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), ==, 2.5);
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("a = true", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptAndWaitUntilFinished("a = true", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_true(WebViewTest::javascriptResultToBoolean(javascriptResult));
+    g_assert_true(WebViewTest::javascriptResultToBoolean(value));
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("a = false", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptAndWaitUntilFinished("a = false", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_false(WebViewTest::javascriptResultToBoolean(javascriptResult));
+    g_assert_false(WebViewTest::javascriptResultToBoolean(value));
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("a = null", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptAndWaitUntilFinished("a = null", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_true(WebViewTest::javascriptResultIsNull(javascriptResult));
+    g_assert_true(WebViewTest::javascriptResultIsNull(value));
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("function Foo() { a = 25; } Foo();", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptAndWaitUntilFinished("function Foo() { a = 25; } Foo();", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_true(WebViewTest::javascriptResultIsUndefined(javascriptResult));
+    g_assert_true(WebViewTest::javascriptResultIsUndefined(value));
 
     GUniquePtr<char> scriptFile(g_build_filename(WEBKIT_SRC_DIR, "Tools", "TestWebKitAPI", "Tests", "JavaScriptCore", "glib", "script.js", nullptr));
     GUniqueOutPtr<char> contents;
     gsize contentsSize;
     g_assert_true(g_file_get_contents(scriptFile.get(), &contents.outPtr(), &contentsSize, nullptr));
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished(contents.get(), contentsSize, &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished(contents.get(), contentsSize, &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("testStringWithNull()", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    g_assert_no_error(error.get());
-    auto* value = webkit_javascript_result_get_js_value(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("testStringWithNull()", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_true(JSC_IS_VALUE(value));
+    g_assert_no_error(error.get());
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_true(jsc_value_is_string(value));
     valueString.reset(jsc_value_to_string(value));
@@ -558,48 +557,48 @@ static void testWebViewRunJavaScript(WebViewTest* test, gconstpointer)
     GRefPtr<GBytes> expectedBytes = adoptGRef(g_string_free_to_bytes(expected));
     g_assert_true(g_bytes_equal(valueBytes.get(), expectedBytes.get()));
 
-    javascriptResult = test->runJavaScriptFromGResourceAndWaitUntilFinished("/org/webkit/glib/tests/link-title.js", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptFromGResourceAndWaitUntilFinished("/org/webkit/glib/tests/link-title.js", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "WebKitGTK Title");
 
-    javascriptResult = test->runJavaScriptFromGResourceAndWaitUntilFinished("/wrong/path/to/resource.js", &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runJavaScriptFromGResourceAndWaitUntilFinished("/wrong/path/to/resource.js", &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), G_RESOURCE_ERROR, G_RESOURCE_ERROR_NOT_FOUND);
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("foo();", &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("foo();", &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
     g_assert_true(g_str_has_prefix(error->message, "file:///"));
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("window.document.body", &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("window.document.body", &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_INVALID_RESULT);
 
     // Values of the main world are not available in the isolated one.
-    javascriptResult = test->runJavaScriptInWorldAndWaitUntilFinished("a", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runJavaScriptInWorldAndWaitUntilFinished("a", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
     g_assert_true(g_str_has_prefix(error->message, "file:///"));
 
-    javascriptResult = test->runJavaScriptInWorldAndWaitUntilFinished("a = 50", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptInWorldAndWaitUntilFinished("a = 50", "WebExtensionTestScriptWorld", nullptr, &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 50);
+    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), ==, 50);
 
     // Values of the isolated world are not available in the normal one.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("a", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
-    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+    value = test->runJavaScriptAndWaitUntilFinished("a", &error.outPtr());
+    g_assert_nonnull(value);
+    test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
     g_assert_no_error(error.get());
-    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 25);
+    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), ==, 25);
 
     // Running a script in a world that doesn't exist should fail.
-    javascriptResult = test->runJavaScriptInWorldAndWaitUntilFinished("a", "InvalidScriptWorld", "foo:///bar", &error.outPtr());
-    g_assert_null(javascriptResult);
+    value = test->runJavaScriptInWorldAndWaitUntilFinished("a", "InvalidScriptWorld", "foo:///bar", &error.outPtr());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
     g_assert_true(g_str_has_prefix(error->message, "foo:///bar"));
 
@@ -615,8 +614,8 @@ static void testWebViewRunJavaScript(WebViewTest* test, gconstpointer)
         g_object_set(G_OBJECT(newSettings.get()), "enable-javascript", FALSE, NULL);
         webkit_web_view_set_settings(test->m_webView, newSettings.get());
 
-        WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("console.log(\"Hi\");", &error.outPtr());
-        g_assert_null(javascriptResult);
+        JSCValue* value = test->runJavaScriptAndWaitUntilFinished("console.log(\"Hi\");", &error.outPtr());
+        g_assert_null(value);
         g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
 
         g_object_set(G_OBJECT(newSettings.get()), "enable-javascript", TRUE, NULL);
@@ -635,9 +634,9 @@ static void testWebViewRunJavaScript(WebViewTest* test, gconstpointer)
         g_object_set(G_OBJECT(newSettings.get()), "enable-javascript-markup", FALSE, NULL);
         webkit_web_view_set_settings(test->m_webView, newSettings.get());
 
-        WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("console.log(\"Hi\");", &error.outPtr());
-        g_assert_nonnull(javascriptResult);
-        test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webkit_javascript_result_get_js_value(javascriptResult)));
+        JSCValue* value = test->runJavaScriptAndWaitUntilFinished("console.log(\"Hi\");", &error.outPtr());
+        g_assert_nonnull(value);
+        test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value));
         g_assert_no_error(error.get());
 
         g_object_set(G_OBJECT(newSettings.get()), "enable-javascript-markup", TRUE, NULL);
@@ -982,46 +981,46 @@ static void testWebViewPageVisibility(WebViewTest* test, gconstpointer)
     test->waitUntilLoadFinished();
 
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.visibilityState;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("document.visibilityState;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "hidden");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.hidden;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.hidden;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    g_assert_true(WebViewTest::javascriptResultToBoolean(javascriptResult));
+    g_assert_true(WebViewTest::javascriptResultToBoolean(value));
 
     // Show the page. The visibility should be updated to 'visible'.
     test->showInWindow();
     test->waitUntilTitleChangedTo("visible");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.visibilityState;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.visibilityState;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "visible");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.hidden;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.hidden;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    g_assert_false(WebViewTest::javascriptResultToBoolean(javascriptResult));
+    g_assert_false(WebViewTest::javascriptResultToBoolean(value));
 
     // Hide the page. The visibility should be updated to 'hidden'.
     test->hideView();
     test->waitUntilTitleChangedTo("hidden");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.visibilityState;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.visibilityState;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "hidden");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.hidden;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.hidden;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    g_assert_true(WebViewTest::javascriptResultToBoolean(javascriptResult));
+    g_assert_true(WebViewTest::javascriptResultToBoolean(value));
 }
 
 static void testWebViewDocumentFocus(WebViewTest* test, gconstpointer)
@@ -1046,18 +1045,18 @@ static void testWebViewDocumentFocus(WebViewTest* test, gconstpointer)
     test->waitUntilLoadFinished();
 
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.hasFocus();", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("document.hasFocus();", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    g_assert_true(WebViewTest::javascriptResultToBoolean(javascriptResult));
+    g_assert_true(WebViewTest::javascriptResultToBoolean(value));
 
     // Hide the view to make it lose the focus, the window is still the active one though.
     test->hideView();
     test->waitUntilTitleChangedTo("hidden");
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.hasFocus();", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.hasFocus();", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    g_assert_false(WebViewTest::javascriptResultToBoolean(javascriptResult));
+    g_assert_false(WebViewTest::javascriptResultToBoolean(value));
 }
 
 #if PLATFORM(GTK)
@@ -1311,9 +1310,13 @@ public:
         return TRUE;
     }
 
-    static void notificationsMessageReceivedCallback(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* javascriptResult, NotificationWebViewTest* test)
+#if ENABLE(2022_GLIB_API)
+    static void notificationsMessageReceivedCallback(WebKitUserContentManager* userContentManager, JSCValue* result, NotificationWebViewTest* test)
+#else
+    static void notificationsMessageReceivedCallback(WebKitUserContentManager* userContentManager, WebKitJavascriptResult* result, NotificationWebViewTest* test)
+#endif
     {
-        GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(javascriptResult));
+        GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(result));
 
         if (g_str_equal(valueString.get(), "clicked"))
             test->m_event = OnClicked;
@@ -1989,15 +1992,12 @@ static void testWebViewCORSAllowlist(WebViewTest* test, gconstpointer)
 
     auto waitForFooChanged = [&test]() {
         GUniqueOutPtr<GError> error;
-        WebKitJavascriptResult* result;
         JSCValue* jscvalue;
         int value;
         do {
-            result = test->runJavaScriptAndWaitUntilFinished("foo;", &error.outPtr());
+            jscvalue = test->runJavaScriptAndWaitUntilFinished("foo;", &error.outPtr());
             g_assert_no_error(error.get());
-            jscvalue = webkit_javascript_result_get_js_value(result);
             value = jsc_value_to_int32(jscvalue);
-            webkit_javascript_result_unref(result);
         } while (!value);
         return value;
     };
@@ -2031,15 +2031,14 @@ static void testWebViewCORSAllowlist(WebViewTest* test, gconstpointer)
 static void testWebViewDefaultContentSecurityPolicy(WebViewTest* test, gconstpointer)
 {
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult;
+    JSCValue* value;
 
     // Sanity check that eval works normally.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("eval('\"allowed\"')", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("eval('\"allowed\"')", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    GUniquePtr<char> evalValue(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> evalValue(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(evalValue.get(), ==, "allowed");
-    webkit_javascript_result_unref(javascriptResult);
 
     // Create a new web view with a policy that blocks eval().
     auto webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
@@ -2050,23 +2049,22 @@ static void testWebViewDefaultContentSecurityPolicy(WebViewTest* test, gconstpoi
         nullptr));
 
     // Ensure JavaScript still functions.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("'allowed'", &error.outPtr(), webView.get());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("'allowed'", &error.outPtr(), webView.get());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    GUniquePtr<char> value(WebViewTest::javascriptResultToCString(javascriptResult));
-    g_assert_cmpstr(value.get(), ==, "allowed");
-    webkit_javascript_result_unref(javascriptResult);
+    GUniquePtr<char> strValue(WebViewTest::javascriptResultToCString(value));
+    g_assert_cmpstr(strValue.get(), ==, "allowed");
 
     // Then ensure eval is blocked.
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("eval('\"allowed\"')", &error.outPtr(), webView.get());
-    g_assert_null(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("eval('\"allowed\"')", &error.outPtr(), webView.get());
+    g_assert_null(value);
     g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
 }
 
 static void testWebViewWebExtensionMode(WebViewTest* test, gconstpointer)
 {
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult;
+    JSCValue* value;
     static const char* html =
         "<html>"
         "  <head>"
@@ -2079,11 +2077,10 @@ static void testWebViewWebExtensionMode(WebViewTest* test, gconstpointer)
     // Sanity check that this HTML works as expected.
     test->loadHtml(html, nullptr);
     test->waitUntilLoadFinished();
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.title == 'set';", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.title == 'set';", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    g_assert_true(WebViewTest::javascriptResultToBoolean(javascriptResult));
-    webkit_javascript_result_unref(javascriptResult);
+    g_assert_true(WebViewTest::javascriptResultToBoolean(value));
 
     // Create a new web view with an extension mode that blocks the unsafe-inline keyword.
     auto webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
@@ -2094,10 +2091,10 @@ static void testWebViewWebExtensionMode(WebViewTest* test, gconstpointer)
         nullptr));
     test->loadHtml(html, nullptr, webView.get());
     test->waitUntilLoadFinished(webView.get());
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.title == 'unset';", &error.outPtr(), webView.get());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.title == 'unset';", &error.outPtr(), webView.get());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    g_assert_true(WebViewTest::javascriptResultToBoolean(javascriptResult));
+    g_assert_true(WebViewTest::javascriptResultToBoolean(value));
 }
 
 static void testWebViewDisableWebSecurity(WebViewTest* test, gconstpointer)
@@ -2116,10 +2113,8 @@ static void testWebViewDisableWebSecurity(WebViewTest* test, gconstpointer)
         int fooValue;
         do {
             GUniqueOutPtr<GError> error;
-            JSCValue* jscvalue;
-            WebKitJavascriptResult* result = test->runJavaScriptAndWaitUntilFinished("foo;", &error.outPtr());
+            JSCValue* jscvalue = test->runJavaScriptAndWaitUntilFinished("foo;", &error.outPtr());
             g_assert_no_error(error.get());
-            jscvalue = webkit_javascript_result_get_js_value(result);
             fooValue = jsc_value_to_int32(jscvalue);
         } while (!fooValue);
         return fooValue;

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
@@ -873,11 +873,9 @@ static void testWebViewHandleCorruptedLocalStorage(WebsiteDataTest* test, gconst
     const char html[] = "<html><script>let foo = (window.localStorage.length ? window.localStorage.getItem('item'):''); window.localStorage.setItem('item','value');</script></html>";
     auto waitForFooChanged = [&test](WebKitWebView* webView) {
         GUniqueOutPtr<GError> error;
-        JSCValue* jscvalue;
-        WebKitJavascriptResult* result = test->runJavaScriptAndWaitUntilFinished("foo;", &error.outPtr(), webView);
+        JSCValue* value = test->runJavaScriptAndWaitUntilFinished("foo;", &error.outPtr(), webView);
         g_assert_no_error(error.get());
-        jscvalue = webkit_javascript_result_get_js_value(result);
-        GUniquePtr<char> fooValue(jsc_value_to_string(jscvalue));
+        GUniquePtr<char> fooValue(jsc_value_to_string(value));
         return fooValue;
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestInspectorServer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestInspectorServer.cpp
@@ -175,22 +175,22 @@ static void testInspectorServerPageList(InspectorServerTest* test, gconstpointer
     g_assert_true(test->loadTargetListPageAndWaitUntilFinished());
 
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByClassName('targetname').length;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByClassName('targetname').length;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    g_assert_cmpint(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 1);
+    g_assert_cmpint(WebViewTest::javascriptResultToNumber(value), ==, 1);
 
     GUniquePtr<char> valueString;
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByClassName('targeturl')[0].innerText;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByClassName('targeturl')[0].innerText;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "http://127.0.0.1:2999/");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('input')[0].onclick.toString();", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('input')[0].onclick.toString();", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_nonnull(g_strrstr(valueString.get(), "window.webkit.messageHandlers.inspector.postMessage('1:1:WebPage');"));
 }
 
@@ -202,22 +202,22 @@ static void testInspectorHTTPServerPageList(InspectorHTTPServerTest* test, gcons
     g_assert_true(test->loadTargetListPageAndWaitUntilFinished());
 
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByClassName('targetname').length;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByClassName('targetname').length;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    g_assert_cmpint(WebViewTest::javascriptResultToNumber(javascriptResult), ==, 1);
+    g_assert_cmpint(WebViewTest::javascriptResultToNumber(value), ==, 1);
 
     GUniquePtr<char> valueString;
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByClassName('targeturl')[0].innerText;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByClassName('targeturl')[0].innerText;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(valueString.get(), ==, "http://127.0.0.1:2999/");
 
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('input')[0].onclick.toString();", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('input')[0].onclick.toString();", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    valueString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_nonnull(g_strrstr(valueString.get(), "window.open('Main.html?ws=' + window.location.host + '/socket/1/1/WebPage', '_blank', 'location=no,menubar=no,status=no,toolbar=no');"));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebViewEditor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebViewEditor.cpp
@@ -508,10 +508,10 @@ static void testWebViewEditorInsertImage(EditorTest* test, gconstpointer)
     GUniquePtr<char> imageURI(g_filename_to_uri(imagePath.get(), nullptr, nullptr));
     webkit_web_view_execute_editing_command_with_argument(test->m_webView, WEBKIT_EDITING_COMMAND_INSERT_IMAGE, imageURI.get());
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('IMG')[0].src", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('IMG')[0].src", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    GUniquePtr<char> resultString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> resultString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(resultString.get(), ==, imageURI.get());
 }
 
@@ -525,29 +525,29 @@ static void testWebViewEditorCreateLink(EditorTest* test, gconstpointer)
     static const char* webkitGTKURL = "http://www.webkitgtk.org/";
     webkit_web_view_execute_editing_command_with_argument(test->m_webView, WEBKIT_EDITING_COMMAND_CREATE_LINK, webkitGTKURL);
     GUniqueOutPtr<GError> error;
-    WebKitJavascriptResult* javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('A')[0].href;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('A')[0].href;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    GUniquePtr<char> resultString(WebViewTest::javascriptResultToCString(javascriptResult));
+    GUniquePtr<char> resultString(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(resultString.get(), ==, webkitGTKURL);
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('A')[0].innerText;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('A')[0].innerText;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    resultString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    resultString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(resultString.get(), ==, "webkitgtk.org");
 
     // When there isn't text selected, the URL is used as link text.
     webkit_web_view_execute_editing_command(test->m_webView, "MoveToEndOfLine");
     webkit_web_view_execute_editing_command_with_argument(test->m_webView, WEBKIT_EDITING_COMMAND_CREATE_LINK, webkitGTKURL);
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('A')[1].href;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('A')[1].href;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    resultString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    resultString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(resultString.get(), ==, webkitGTKURL);
-    javascriptResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('A')[1].innerText;", &error.outPtr());
-    g_assert_nonnull(javascriptResult);
+    value = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('A')[1].innerText;", &error.outPtr());
+    g_assert_nonnull(value);
     g_assert_no_error(error.get());
-    resultString.reset(WebViewTest::javascriptResultToCString(javascriptResult));
+    resultString.reset(WebViewTest::javascriptResultToCString(value));
     g_assert_cmpstr(resultString.get(), ==, webkitGTKURL);
 }
 

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
@@ -73,20 +73,27 @@ public:
     void emitPopupMenuSignal();
 #endif
 
-    WebKitJavascriptResult* runJavaScriptAndWaitUntilFinished(const char* javascript, GError**, WebKitWebView* = nullptr);
-    WebKitJavascriptResult* runJavaScriptAndWaitUntilFinished(const char* javascript, gsize, GError**);
-    WebKitJavascriptResult* runJavaScriptFromGResourceAndWaitUntilFinished(const char* resource, GError**);
-    WebKitJavascriptResult* runJavaScriptInWorldAndWaitUntilFinished(const char* javascript, const char* world, const char* sourceURI, GError**);
-    WebKitJavascriptResult* runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished(const char* body, GVariant* arguments, const char* world, GError**);
-    WebKitJavascriptResult* runJavaScriptWithoutForcedUserGesturesAndWaitUntilFinished(const char* javascript, GError**);
+    JSCValue* runJavaScriptAndWaitUntilFinished(const char* javascript, GError**, WebKitWebView* = nullptr);
+    JSCValue* runJavaScriptAndWaitUntilFinished(const char* javascript, gsize, GError**);
+    JSCValue* runJavaScriptFromGResourceAndWaitUntilFinished(const char* resource, GError**);
+    JSCValue* runJavaScriptInWorldAndWaitUntilFinished(const char* javascript, const char* world, const char* sourceURI, GError**);
+    JSCValue* runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished(const char* body, GVariant* arguments, const char* world, GError**);
+    JSCValue* runJavaScriptWithoutForcedUserGesturesAndWaitUntilFinished(const char* javascript, GError**);
     void runJavaScriptAndWait(const char* javascript);
 
     // Javascript result helpers.
+    static char* javascriptResultToCString(JSCValue*);
+    static double javascriptResultToNumber(JSCValue*);
+    static bool javascriptResultToBoolean(JSCValue*);
+    static bool javascriptResultIsNull(JSCValue*);
+    static bool javascriptResultIsUndefined(JSCValue*);
+#if !ENABLE(2022_GLIB_API)
     static char* javascriptResultToCString(WebKitJavascriptResult*);
     static double javascriptResultToNumber(WebKitJavascriptResult*);
     static bool javascriptResultToBoolean(WebKitJavascriptResult*);
     static bool javascriptResultIsNull(WebKitJavascriptResult*);
     static bool javascriptResultIsUndefined(WebKitJavascriptResult*);
+#endif
 
 #if PLATFORM(GTK)
     cairo_surface_t* getSnapshotAndWaitUntilReady(WebKitSnapshotRegion, WebKitSnapshotOptions);
@@ -107,7 +114,7 @@ public:
     GMainLoop* m_mainLoop;
     CString m_activeURI;
     CString m_expectedTitle;
-    WebKitJavascriptResult* m_javascriptResult { nullptr };
+    GRefPtr<JSCValue> m_javascriptResult;
     GError** m_javascriptError { nullptr };
     GUniquePtr<char> m_resourceData { nullptr };
     size_t m_resourceDataSize { 0 };


### PR DESCRIPTION
#### df21fc613d9758638def91a94598d5da6eb6d6a2
<pre>
[GLib] Remove WebKitJavascriptResult
<a href="https://bugs.webkit.org/show_bug.cgi?id=253476">https://bugs.webkit.org/show_bug.cgi?id=253476</a>

Reviewed by Carlos Garcia Campos.

WebKitJavascriptResult is not actually doing anything useful anymore, so
get rid of it in the new API version by replacing it with direct use of
JSCValue.

In the old API version, all APIs added in 2.40 are also changed to use
JSCValue.

This also fixes some suspicious use of webkit_javascript_result_unref()
in TestWebKitWebView.cpp where multiple functions, including
testWebViewDefaultContentSecurityPolicy, were unreffing the
WebKitJavascriptResult returned by
WebViewTest::runJavaScriptAndWaitUntilFinished, but that is owned by
WebViewTest itself.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformGTKDeprecated.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/PlatformWPEDeprecated.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesGTKDeprecated.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/SourcesWPEDeprecated.txt:
* Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitJavascriptResultPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
(webkit_user_content_manager_new): Deleted.
(webkit_user_content_manager_add_style_sheet): Deleted.
(webkit_user_content_manager_remove_style_sheet): Deleted.
(webkit_user_content_manager_remove_all_style_sheets): Deleted.
(webkit_user_content_manager_add_script): Deleted.
(webkit_user_content_manager_remove_script): Deleted.
(webkit_user_content_manager_remove_all_scripts): Deleted.
(_WebKitScriptMessageReply::_WebKitScriptMessageReply): Deleted.
(_WebKitScriptMessageReply::sendValue): Deleted.
(_WebKitScriptMessageReply::sendErrorMessage): Deleted.
(_WebKitScriptMessageReply::~_WebKitScriptMessageReply): Deleted.
(webkit_script_message_reply_ref): Deleted.
(webkit_script_message_reply_unref): Deleted.
(webKitScriptMessageReplyCreate): Deleted.
(webkit_script_message_reply_return_value): Deleted.
(webkit_script_message_reply_return_error_message): Deleted.
(webkit_user_content_manager_register_script_message_handler): Deleted.
(webkit_user_content_manager_unregister_script_message_handler): Deleted.
(webkit_user_content_manager_register_script_message_handler_with_reply): Deleted.
(webkit_user_content_manager_register_script_message_handler_in_world): Deleted.
(webkit_user_content_manager_unregister_script_message_handler_in_world): Deleted.
(webkit_user_content_manager_add_filter): Deleted.
(webkit_user_content_manager_remove_filter): Deleted.
(webkit_user_content_manager_remove_filter_by_id): Deleted.
(webkit_user_content_manager_remove_all_filters): Deleted.
(webkitUserContentManagerGetUserContentControllerProxy): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewRunJavaScriptWithParams):
(webkitWebViewRunJavascriptWithoutForcedUserGestures):
(webkitWebViewEvaluateJavascriptInternal):
(webkit_web_view_evaluate_javascript):
(webkit_web_view_evaluate_javascript_finish):
(webkitWebViewCallAsyncJavascriptFunctionInternal):
(webkit_web_view_call_async_javascript_function):
(webkit_web_view_call_async_javascript_function_finish):
(webkit_web_view_run_javascript):
(webkit_web_view_run_javascript_in_world):
(webkit_web_view_run_async_javascript_function_in_world):
(resourcesStreamReadCallback):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Source/WebKit/UIProcess/API/wpe/qt/WPEQtView.cpp:
(jsAsyncReadyCallback):
* Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md:
* Tools/MiniBrowser/gtk/main.c:
(aboutDataScriptMessageReceivedCallback):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp:
(ConsoleMessageTest::consoleMessageReceivedCallback):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestGeolocationManager.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestSSL.cpp:
(WebSocketTest::webSocketTestResultCallback):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebExtensions.cpp:
(testWebExtensionIsolatedWorld):
(testWebExtensionWindowObjectCleared):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp:
(isStyleSheetInjectedForURLAtPath):
(isScriptInjectedForURLAtPath):
(UserScriptMessageTest::scriptMessageReceived):
(UserScriptMessageTest::waitUntilMessageReceived):
(UserScriptMessageTest::postMessageAndWaitUntilReceived):
(UserScriptMessageTest::asyncScriptMessageReceived):
(UserScriptMessageTest::waitUntilPromiseResolved):
(UserScriptMessageTest::postMessageAndWaitForPromiseResolved):
(testUserContentManagerScriptMessageReceived):
(testUserContentManagerScriptMessageInWorldReceived):
(testUserContentManagerScriptMessageWithReplyReceived):
(testUserContentManagerScriptMessageFromDOMBindings):
(isCSSBlockedForURLAtPath):
(UserScriptMessageTest::UserScriptMessageTest): Deleted.
(UserScriptMessageTest::~UserScriptMessageTest): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp:
(testWebContextURIScheme):
(testWebContextLanguages):
(xhrMessageReceivedCallback):
(testWebContextSecurityFileXHR):
(testWebContextTimeZoneOverride):
(testWebContextTimeZoneOverrideInWorker):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp:
(testWebViewRunAsyncFunctions):
(testWebViewRunJavaScript):
(testWebViewPageVisibility):
(testWebViewDocumentFocus):
(testWebViewCORSAllowlist):
(testWebViewDefaultContentSecurityPolicy):
(testWebViewWebExtensionMode):
(testWebViewDisableWebSecurity):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp:
(testWebViewHandleCorruptedLocalStorage):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestInspectorServer.cpp:
(testInspectorServerPageList):
(testInspectorHTTPServerPageList):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebViewEditor.cpp:
(testWebViewEditorInsertImage):
(testWebViewEditorCreateLink):
* Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp:
(WebViewTest::~WebViewTest):
(WebViewTest::assertJavaScriptBecomesTrue):
(runJavaScriptReadyCallback):
(runAsyncJavaScriptFunctionInWorldReadyCallback):
(WebViewTest::runJavaScriptAndWaitUntilFinished):
(WebViewTest::runJavaScriptFromGResourceAndWaitUntilFinished):
(WebViewTest::runJavaScriptInWorldAndWaitUntilFinished):
(WebViewTest::runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished):
(WebViewTest::runJavaScriptWithoutForcedUserGesturesAndWaitUntilFinished):
(WebViewTest::javascriptResultToCString):
(WebViewTest::javascriptResultToNumber):
(WebViewTest::javascriptResultToBoolean):
(WebViewTest::javascriptResultIsNull):
(WebViewTest::javascriptResultIsUndefined):
(WebViewTest::runWebProcessTest):
* Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h:

Canonical link: <a href="https://commits.webkit.org/261320@main">https://commits.webkit.org/261320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4edeaea57090161d6c5d44c8e040dc410a56702

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120077 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2286 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117033 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103884 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/31006 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12912 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32344 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9336 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18867 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15387 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4298 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->