### PR TITLE
REGRESSION(261097@main) test-webkitpy is failing to install pytest-asyncio-0.20.3

### DIFF
--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -36,9 +36,9 @@ AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}
 
 if sys.version_info >= (3, 7):
     AutoInstall.register(Package('pylint', Version(2, 6, 0)))
-    AutoInstall.register(Package('pytest_asyncio', Version(0, 20, 3), pypi_name='pytest-asyncio'))
+    AutoInstall.register(Package('pytest', Version(7, 2, 0), implicit_deps=['attr', 'pluggy', 'iniconfig']))
+    AutoInstall.register(Package('pytest_asyncio', Version(0, 20, 3), pypi_name='pytest-asyncio', implicit_deps=['pytest']))
     AutoInstall.register(Package('pytest_timeout', Version(2, 1, 0), pypi_name='pytest-timeout'))
-    AutoInstall.register(Package('pytest', Version(7, 2, 0), implicit_deps=['pytest_asyncio', 'pytest_timeout']))
     AutoInstall.register(Package('websockets', Version(8, 1)))
     if sys.version_info < (3, 11):
         AutoInstall.register(Package('exceptiongroup', Version(1, 1, 0), wheel=True))


### PR DESCRIPTION
#### 8fd5bfebd3eb80b05d25f54db1b64e854aaff557
<pre>
REGRESSION(261097@main) test-webkitpy is failing to install pytest-asyncio-0.20.3
<a href="https://bugs.webkit.org/show_bug.cgi?id=253421">https://bugs.webkit.org/show_bug.cgi?id=253421</a>

Reviewed by Jonathan Bedard.

After 261097@main changed webkitpy to install pytest-asyncio by
creating setup.py, Windows Python had been failing to install from the
clean working copy. Loading pytest failed during the installation
because pytest wasn&apos;t installed yet. The pytest module should be
installed before pytest-asyncio.

* Tools/Scripts/webkitpy/__init__.py:
Fixed implicit_deps of the pytest and pytest_asyncio modules to ensure
pytest is loaded before pytest_asyncio.

Canonical link: <a href="https://commits.webkit.org/261341@main">https://commits.webkit.org/261341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/876e6c13727a3ddcdf872561ce033445232d5791

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2677 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2270 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103854 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/114678 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/30992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44715 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12894 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86575 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9322 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18849 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7859 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15368 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->