### PR TITLE
[popover] Avoid conflicting interactions in the top layer

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -710,7 +710,6 @@ webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popo
 webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-scroll-display.html [ ImageOnlyFailure ]
 webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-dialog-crash.html [ Skip ]
 webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-manual-crash.html [ Skip ]
-webkit.org/b/250171 imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-2.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-bom.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/referrer-policies.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations-expected.txt
@@ -1,8 +1,8 @@
 Visible button
 
-FAIL Popover combination: Popover Dialog assert_throws_dom: Calling showModal() on an already-showing Popover should throw InvalidStateError function "() => ex.showModal()" did not throw
-FAIL Popover combination: Open Non-modal Popover Dialog assert_throws_dom: Calling showModal() on an already-showing Popover should throw InvalidStateError function "() => ex.showModal()" did not throw
-FAIL Popover combination: Fullscreen Popover assert_false: requestFullscreen() should not succeed when the element is an already-showing Popover expected false got true
-FAIL Popover combination: Fullscreen Popover Dialog assert_throws_dom: Calling showModal() on an already-showing Popover should throw InvalidStateError function "() => ex.showModal()" did not throw
-FAIL Popover combination: Fullscreen Open Non-modal Popover Dialog assert_throws_dom: Calling showModal() on an already-showing Popover should throw InvalidStateError function "() => ex.showModal()" did not throw
+FAIL Popover combination: Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
+FAIL Popover combination: Open Non-modal Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
+FAIL Popover combination: Fullscreen Popover assert_true: Invoking element should be able to invoke all popovers: Popover doesn't match :open expected true got false
+FAIL Popover combination: Fullscreen Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
+FAIL Popover combination: Fullscreen Open Non-modal Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions-expected.txt
@@ -1,0 +1,11 @@
+
+PASS A Popover should close a Popover.
+PASS A Modal Dialog should close a Popover.
+PASS A Fullscreen Element should close a Popover.
+PASS A Popover should *not* close a Modal Dialog.
+PASS A Modal Dialog should *not* close a Modal Dialog.
+PASS A Fullscreen Element should *not* close a Modal Dialog.
+PASS A Popover should *not* close a Fullscreen Element.
+PASS A Modal Dialog should *not* close a Fullscreen Element.
+FAIL A Fullscreen Element should *not* close a Fullscreen Element. promise_test: Unhandled rejection with value: object "TypeError: Type error"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions.html
@@ -13,7 +13,7 @@
 <body>
 <script>
 const types = Object.freeze({
-  popover: Symbol("Popover API"),
+  popover: Symbol("Popover"),
   modalDialog: Symbol("Modal Dialog"),
   fullscreen: Symbol("Fullscreen Element"),
 });
@@ -30,17 +30,17 @@ const examples = [
     type: types.modalDialog,
     closes: [types.popover],
     createElement: () => document.createElement('dialog'),
-    trigger: function() {this.element.showModal();this.showing=true;},
-    close: function() {this.element.close();this.showing=false;},
-    isTopLayer: function() {return !!(this.element.isConnected && this.showing);},
+    trigger: function() {this.element.showModal()},
+    close: function() {this.element.close()},
+    isTopLayer: function() {return this.element.matches(':modal')},
   },
   {
     type: types.fullscreen,
     closes: [types.popover],
     createElement: () => document.createElement('div'),
     trigger: async function(visibleElement) {assert_false(this.isTopLayer());await blessTopLayer(visibleElement);await this.element.requestFullscreen();},
-    close: function() {document.exitFullscreen();},
-    isTopLayer: function() {return this.element.matches(':fullscreen');},
+    close: async function() {await document.exitFullscreen();},
+    isTopLayer: function() {return this.element.matches(':fullscreen')},
   },
 ];
 
@@ -53,10 +53,10 @@ function createElement(ex) {
   assert_false(ex.isTopLayer(),'Element should start out not in the top layer');
   return element;
 }
-function doneWithExample(ex) {
+async function doneWithExample(ex) {
   assert_true(!!ex.element);
   if (ex.isTopLayer())
-    ex.close();
+    await ex.close();
   ex.element.remove();
   ex.element = null;
 }
@@ -66,11 +66,16 @@ for(let i=0;i<examples.length;++i) {
     const example1 = Object.assign([],examples[i]);
     const example2 = Object.assign([],examples[j]);
     const shouldClose = example2.closes.includes(example1.type);
-    const desc = `A ${example2.type.description} should ${shouldClose ? "" : "*not*"} close a ${example1.type.description}`;
+    const desc = `A ${example2.type.description} should${shouldClose ? "" : " *not*"} close a ${example1.type.description}.`;
     promise_test(async t => {
       const element1 = createElement(example1);
       const element2 = createElement(example2);
-      t.add_cleanup(() => {doneWithExample(example1);doneWithExample(example2);});
+      t.add_cleanup(() => {
+        return Promise.all([
+          doneWithExample(example1),
+          doneWithExample(example2),
+        ]);
+      });
       await example1.trigger(document.body); // Open the 1st top layer element
       assert_true(example1.isTopLayer()); // Make sure it is top layer
       await example2.trigger(element1); // Open the 2nd top layer element

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
@@ -3,9 +3,7 @@ This is a popover
 autofocus button  second autofocus button
 
 FAIL Popover focus test: default behavior - popover is not focused assert_true: expected true got false
-FAIL Popover button click focus test: default behavior - popover is not focused assert_equals: focus should return to the prior focus expected Element node <button id="priorFocus"></button> but got Element node <body>
-
-<div popover="" data-test="autofocus popover" aut...
+FAIL Popover button click focus test: default behavior - popover is not focused assert_equals: focus should return to the prior focus expected Element node <button id="priorFocus"></button> but got Element node <button popovertarget="popover-id">Click me</button>
 PASS Popover corner cases test: default behavior - popover is not focused
 FAIL Popover focus test: autofocus popover assert_equals: autofocus popover activated by popover.showPopover() expected Element node <div popover="" data-test="autofocus popover" autofocus="... but got Element node <button id="priorFocus"></button>
 FAIL Popover button click focus test: autofocus popover assert_false: popover should start out hidden expected false got true

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -89,7 +89,7 @@ http/tests/fullscreen
 imported/w3c/web-platform-tests/fullscreen
 compositing/no-compositing-when-full-screen-is-present.html
 webkit.org/b/200308 fast/events/touch/ios/content-observation/non-visible-content-change-in-fullscreen-mode.html [ Skip ]
-
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions.html [ Skip ]
 media/video-supports-fullscreen.html [ Skip ]
 
 # Encrypted Media Extensions are not enabled

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -32,6 +32,7 @@
 #include "EventNames.h"
 #include "FocusOptions.h"
 #include "HTMLNames.h"
+#include "PopoverData.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "RenderElement.h"
 #include "ScopedEventQueue.h"
@@ -70,6 +71,9 @@ ExceptionOr<void> HTMLDialogElement::showModal()
 
     // If subject is not connected, then throw an "InvalidStateError" DOMException.
     if (!isConnected())
+        return Exception { InvalidStateError };
+
+    if (popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Showing)
         return Exception { InvalidStateError };
 
     // setBooleanAttribute will dispatch a DOMSubtreeModified event.
@@ -126,6 +130,8 @@ void HTMLDialogElement::queueCancelTask()
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-focusing-steps
 void HTMLDialogElement::runFocusingSteps()
 {
+    document().hideAllPopoversUntil(nullptr, FocusPreviousElement::No, FireEvents::No);
+
     RefPtr control = findFocusDelegate();
 
     if (!control)


### PR DESCRIPTION
#### ffc70a735c9be6f27a14c3e87a169d4b56e97a51
<pre>
[popover] Avoid conflicting interactions in the top layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=252297">https://bugs.webkit.org/show_bug.cgi?id=252297</a>
rdar://105763866

Reviewed by Simon Fraser.

- Run &quot;hide all popovers&quot; algorithm every time something is appended to the top layer (since the auto popovers will be covered by the new element)
- Don&apos;t allow something in the popover showing visibility state to be appended in the top layer, since it is already there (this is similar to how dialogs can&apos;t go fullscreen).
- Fix test to avoid race conditions by properly waiting for async operations

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt: Added.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::willEnterFullscreen):
(WebCore::isInPopoverShowingState):
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::showModal):
(WebCore::HTMLDialogElement::runFocusingSteps):

Canonical link: <a href="https://commits.webkit.org/261317@main">https://commits.webkit.org/261317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44904651f05410f66ae8a2dd6f048cb28a773a11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20424 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2711 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11523 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117046 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103900 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12923 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13442 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18880 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/7844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15397 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4295 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->