### PR TITLE
TestWebKitAPI.WebKit.ScrollByLineCommands fails when GPU Process and UI side compositing are enabled

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/EditorCommands.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/EditorCommands.mm
@@ -31,6 +31,7 @@
 #import <WebKit/WKPage.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKRetainPtr.h>
+#import <WebKit/WKWebViewPrivate.h>
 
 namespace TestWebKitAPI {
 
@@ -70,10 +71,22 @@ TEST(WebKit, ScrollByLineCommands)
     ASSERT_TRUE([webView.platformView() respondsToSelector:@selector(scrollLineDown:)]);
     [webView.platformView() scrollLineDown:nil];
 
+    __block bool didUpdatePresentation = false;
+    [webView.platformView() _doAfterNextPresentationUpdate:^{
+        didUpdatePresentation = true;
+    }];
+    Util::run(&didUpdatePresentation);
+
     EXPECT_JS_EQ(webView.page(), "window.scrollY", "40");
 
     ASSERT_TRUE([webView.platformView() respondsToSelector:@selector(scrollLineUp:)]);
     [webView.platformView() scrollLineUp:nil];
+
+    didUpdatePresentation = false;
+    [webView.platformView() _doAfterNextPresentationUpdate:^{
+        didUpdatePresentation = true;
+    }];
+    Util::run(&didUpdatePresentation);
 
     EXPECT_JS_EQ(webView.page(), "window.scrollY", "0");
 }


### PR DESCRIPTION
#### db48c673a4106883821feda69300283afc761987
<pre>
TestWebKitAPI.WebKit.ScrollByLineCommands fails when GPU Process and UI side compositing are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=253488">https://bugs.webkit.org/show_bug.cgi?id=253488</a>
&lt;rdar://106324669&gt;

Reviewed by Simon Fraser.

Wait for the presentation update after scrolling.

* Tools/TestWebKitAPI/Tests/WebKit/mac/EditorCommands.mm:
(WebKit.ScrollByLineCommands):

Canonical link: <a href="https://commits.webkit.org/261316@main">https://commits.webkit.org/261316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4f4cda6ebab94a9c11b08ec67166a24a6e285f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2697 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2285 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117032 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103891 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/31004 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12911 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32342 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13430 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18866 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15386 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4294 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->