### PR TITLE
[popover] Implement popover focusing steps

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -1,10 +1,10 @@
 Button1  Button2  Invoker1  Button3  Button4
 Invoker  after
-Show popover Hide popover
+Show popover
 
 FAIL Popover focus navigation assert_equals: Hidden popover should be skipped expected Element node <button id="button2">Button2</button> but got Element node <body><div id="fixup">
   <button id="button1">Button1</bu...
 FAIL Circular reference tab navigation assert_equals: Step 2 expected Element node <button id="circular1" autofocus="" popovertarget="popove... but got Element node <body><div id="fixup">
   <button id="button1">Button1</bu...
-FAIL Popover focus returns when popover is hidden by invoker assert_equals: Hide button should be focused due to autofocus attribute expected Element node <button popovertarget="deleted1" popovertargetaction="hid... but got Element node <button popovertarget="deleted1" popovertargetaction="sho...
+PASS Popover focus returns when popover is hidden by invoker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-child-dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-child-dialog-expected.txt
@@ -1,4 +1,6 @@
 
-PASS Popovers should not initially focus child dialog elements.
-PASS Popovers should not initially focus child popover elements.
+FAIL Popovers should not initially focus child dialog elements. assert_equals: Nothing should have gotten focused. expected Element node <body><div id="popover1" popover="">
+  <dialog id="childd... but got Element node <button autofocus="">hello world</button>
+FAIL Popovers should not initially focus child popover elements. assert_equals: Nothing should have gotten focused. expected Element node <body><div id="popover1" popover="">
+  <dialog id="childd... but got Element node <button autofocus="">hello world</button>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
@@ -1,31 +1,88 @@
-This is a popover
-
-autofocus button  second autofocus button
 
 PASS Popover focus test: default behavior - popover is not focused
 FAIL Popover button click focus test: default behavior - popover is not focused assert_equals: Focus should go to unrelated button on light dismiss expected Element node <button></button> but got Element node <body>
 
 <div popover="" data-test="autofocus popover" aut...
 PASS Popover corner cases test: default behavior - popover is not focused
-FAIL Popover focus test: autofocus popover assert_equals: autofocus popover activated by popover.showPopover() expected Element node <div popover="" data-test="autofocus popover" autofocus="... but got Element node <button id="priorFocus"></button>
-FAIL Popover button click focus test: autofocus popover assert_false: popover should start out hidden expected false got true
-FAIL Popover corner cases test: autofocus popover assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus empty popover assert_equals: autofocus empty popover activated by popover.showPopover() expected Element node <div popover="" data-test="autofocus empty popover" autof... but got Element node <button id="priorFocus"></button>
-FAIL Popover button click focus test: autofocus empty popover assert_false: popover should start out hidden expected false got true
-FAIL Popover corner cases test: autofocus empty popover assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus popover with button assert_equals: autofocus popover with button activated by popover.showPopover() expected Element node <div popover="" data-test="autofocus popover with button"... but got Element node <button id="priorFocus"></button>
-FAIL Popover button click focus test: autofocus popover with button assert_false: popover should start out hidden expected false got true
-FAIL Popover corner cases test: autofocus popover with button assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus child assert_equals: autofocus child activated by popover.showPopover() expected Element node <button autofocus="" class="should-be-focused">autofocus ... but got Element node <button id="priorFocus"></button>
-FAIL Popover button click focus test: autofocus child assert_false: popover should start out hidden expected false got true
-FAIL Popover corner cases test: autofocus child assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus on tabindex=0 element assert_equals: autofocus on tabindex=0 element activated by popover.showPopover() expected Element node <p autofocus="" tabindex="0" class="should-be-focused">Th... but got Element node <button id="priorFocus"></button>
-FAIL Popover button click focus test: autofocus on tabindex=0 element assert_false: popover should start out hidden expected false got true
+PASS Popover focus test: autofocus popover
+FAIL Popover button click focus test: autofocus popover assert_equals: Focus should go to unrelated button on light dismiss expected Element node <button></button> but got Element node <body>
+
+
+
+<div popover="" data-test="autofocus empty popo...
+PASS Popover corner cases test: autofocus popover
+PASS Popover focus test: autofocus empty popover
+FAIL Popover button click focus test: autofocus empty popover assert_equals: Focus should go to unrelated button on light dismiss expected Element node <button></button> but got Element node <body>
+
+
+
+
+
+<div popover="" data-test="autofocus popover ...
+PASS Popover corner cases test: autofocus empty popover
+PASS Popover focus test: autofocus popover with button
+FAIL Popover button click focus test: autofocus popover with button assert_equals: Focus should go to unrelated button on light dismiss expected Element node <button></button> but got Element node <body>
+
+
+
+
+
+
+
+<div popover="" data-test="autofocus child"...
+PASS Popover corner cases test: autofocus popover with button
+PASS Popover focus test: autofocus child
+FAIL Popover button click focus test: autofocus child assert_equals: Focus should go to unrelated button on light dismiss expected Element node <button></button> but got Element node <body>
+
+
+
+
+
+
+
+
+
+<div popover="" data-test="autofocus on t...
+PASS Popover corner cases test: autofocus child
+PASS Popover focus test: autofocus on tabindex=0 element
+FAIL Popover button click focus test: autofocus on tabindex=0 element assert_false: clicking button should hide the popover expected false got true
 FAIL Popover corner cases test: autofocus on tabindex=0 element assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus multiple children assert_equals: autofocus multiple children activated by popover.showPopover() expected Element node <button autofocus="" class="should-be-focused">autofocus ... but got Element node <button id="priorFocus"></button>
-FAIL Popover button click focus test: autofocus multiple children assert_false: popover should start out hidden expected false got true
-FAIL Popover corner cases test: autofocus multiple children assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus popover and multiple autofocus children assert_equals: autofocus popover and multiple autofocus children activated by popover.showPopover() expected Element node <div popover="" autofocus="" tabindex="-1" data-test="aut... but got Element node <button id="priorFocus"></button>
-FAIL Popover button click focus test: autofocus popover and multiple autofocus children assert_false: popover should start out hidden expected false got true
-FAIL Popover corner cases test: autofocus popover and multiple autofocus children assert_false: popover should start out hidden expected false got true
+PASS Popover focus test: autofocus multiple children
+FAIL Popover button click focus test: autofocus multiple children assert_equals: Focus should go to unrelated button on light dismiss expected Element node <button></button> but got Element node <body>
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div popover="" autofocus="" tabindex...
+PASS Popover corner cases test: autofocus multiple children
+PASS Popover focus test: autofocus popover and multiple autofocus children
+FAIL Popover button click focus test: autofocus popover and multiple autofocus children assert_equals: Focus should go to unrelated button on light dismiss expected Element node <button></button> but got Element node <body>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+  [popover] {
+    border: 2...
+PASS Popover corner cases test: autofocus popover and multiple autofocus children
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus.html
@@ -129,7 +129,7 @@
       popover.showPopover();
       assert_equals(document.activeElement, expectedFocusedElement, `${testName} activated by popover.showPopover()`);
       assert_equals(popover.popover, 'auto', 'All popovers in this test should start as popover=auto');
-      popover.popover = 'hint';
+      popover.popover = 'manual';
       assert_false(popover.matches(':open'), 'Changing the popover type should hide the popover');
       assert_equals(document.activeElement, priorFocus, 'prior element should get focus when the type is changed');
       assert_false(isElementVisible(popover));

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
@@ -2,7 +2,7 @@ This is a popover
 
 autofocus button  second autofocus button
 
-FAIL Popover focus test: default behavior - popover is not focused assert_false: expected false got true
+FAIL Popover focus test: default behavior - popover is not focused assert_equals: default behavior - popover is not focused activated by popover.showPopover() expected Element node <button id="priorFocus"></button> but got Element node <button>first button</button>
 FAIL Popover button click focus test: default behavior - popover is not focused assert_false: popover should start out hidden expected false got true
 PASS Popover corner cases test: default behavior - popover is not focused
 FAIL Popover focus test: autofocus popover assert_equals: autofocus popover activated by popover.showPopover() expected Element node <div popover="" data-test="autofocus popover" autofocus="... but got Element node <button id="priorFocus"></button>
@@ -11,19 +11,19 @@ FAIL Popover corner cases test: autofocus popover assert_false: popover should s
 FAIL Popover focus test: autofocus empty popover assert_equals: autofocus empty popover activated by popover.showPopover() expected Element node <div popover="" data-test="autofocus empty popover" autof... but got Element node <button id="priorFocus"></button>
 FAIL Popover button click focus test: autofocus empty popover assert_false: popover should start out hidden expected false got true
 FAIL Popover corner cases test: autofocus empty popover assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus popover with button assert_equals: autofocus popover with button activated by popover.showPopover() expected Element node <div popover="" data-test="autofocus popover with button"... but got Element node <button id="priorFocus"></button>
+FAIL Popover focus test: autofocus popover with button assert_equals: autofocus popover with button activated by popover.showPopover() expected Element node <div popover="" data-test="autofocus popover with button"... but got Element node <button>button</button>
 FAIL Popover button click focus test: autofocus popover with button assert_false: popover should start out hidden expected false got true
 FAIL Popover corner cases test: autofocus popover with button assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus child assert_equals: autofocus child activated by popover.showPopover() expected Element node <button autofocus="" class="should-be-focused">autofocus ... but got Element node <button id="priorFocus"></button>
+FAIL Popover focus test: autofocus child assert_equals: prior element should get focus after Escape expected Element node <button id="priorFocus"></button> but got Element node <button autofocus="" class="should-be-focused">autofocus ...
 FAIL Popover button click focus test: autofocus child assert_false: popover should start out hidden expected false got true
 FAIL Popover corner cases test: autofocus child assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus on tabindex=0 element assert_equals: autofocus on tabindex=0 element activated by popover.showPopover() expected Element node <p autofocus="" tabindex="0" class="should-be-focused">Th... but got Element node <button id="priorFocus"></button>
+FAIL Popover focus test: autofocus on tabindex=0 element assert_equals: prior element should get focus after Escape expected Element node <button id="priorFocus"></button> but got Element node <p autofocus="" tabindex="0" class="should-be-focused">Th...
 FAIL Popover button click focus test: autofocus on tabindex=0 element assert_false: popover should start out hidden expected false got true
 FAIL Popover corner cases test: autofocus on tabindex=0 element assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus multiple children assert_equals: autofocus multiple children activated by popover.showPopover() expected Element node <button autofocus="" class="should-be-focused">autofocus ... but got Element node <button id="priorFocus"></button>
+FAIL Popover focus test: autofocus multiple children assert_equals: prior element should get focus after Escape expected Element node <button id="priorFocus"></button> but got Element node <button autofocus="" class="should-be-focused">autofocus ...
 FAIL Popover button click focus test: autofocus multiple children assert_false: popover should start out hidden expected false got true
 FAIL Popover corner cases test: autofocus multiple children assert_false: popover should start out hidden expected false got true
-FAIL Popover focus test: autofocus popover and multiple autofocus children assert_equals: autofocus popover and multiple autofocus children activated by popover.showPopover() expected Element node <div popover="" autofocus="" tabindex="-1" data-test="aut... but got Element node <button id="priorFocus"></button>
+FAIL Popover focus test: autofocus popover and multiple autofocus children assert_equals: autofocus popover and multiple autofocus children activated by popover.showPopover() expected Element node <div popover="" autofocus="" tabindex="-1" data-test="aut... but got Element node <button autofocus="">autofocus button</button>
 FAIL Popover button click focus test: autofocus popover and multiple autofocus children assert_false: popover should start out hidden expected false got true
 FAIL Popover corner cases test: autofocus popover and multiple autofocus children assert_false: popover should start out hidden expected false got true
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3423,6 +3423,9 @@ static bool isProgramaticallyFocusable(Element& element)
 // https://html.spec.whatwg.org/multipage/interaction.html#autofocus-delegate
 static RefPtr<Element> autoFocusDelegate(ContainerNode& target, FocusTrigger trigger)
 {
+    if (auto* root = target.shadowRoot(); root && !root->delegatesFocus())
+        return nullptr;
+
     for (auto& element : descendantsOfType<Element>(target)) {
         if (!element.hasAttributeWithoutSynchronization(HTMLNames::autofocusAttr))
             continue;
@@ -3448,6 +3451,8 @@ static RefPtr<Element> autoFocusDelegate(ContainerNode& target, FocusTrigger tri
 // https://html.spec.whatwg.org/multipage/interaction.html#focus-delegate
 RefPtr<Element> Element::findFocusDelegateForTarget(ContainerNode& target, FocusTrigger trigger)
 {
+    if (auto* root = target.shadowRoot(); root && !root->delegatesFocus())
+        return nullptr;
     if (auto element = autoFocusDelegate(target, trigger))
         return element;
     for (auto& element : descendantsOfType<Element>(target)) {
@@ -3468,6 +3473,12 @@ RefPtr<Element> Element::findFocusDelegateForTarget(ContainerNode& target, Focus
         }
     }
     return nullptr;
+}
+
+// https://html.spec.whatwg.org/multipage/interaction.html#autofocus-delegate
+RefPtr<Element> Element::findAutofocusDelegate(FocusTrigger trigger)
+{
+    return autoFocusDelegate(*this, trigger);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#focus-delegate

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -462,6 +462,7 @@ public:
 
     static RefPtr<Element> findFocusDelegateForTarget(ContainerNode&, FocusTrigger);
     RefPtr<Element> findFocusDelegate(FocusTrigger = FocusTrigger::Other);
+    RefPtr<Element> findAutofocusDelegate(FocusTrigger = FocusTrigger::Other);
 
     static AXTextStateChangeIntent defaultFocusTextStateChangeIntent() { return AXTextStateChangeIntent(AXTextStateChangeTypeSelectionMove, AXTextSelection { AXTextSelectionDirectionDiscontiguous, AXTextSelectionGranularityUnknown, true }); }
     virtual void focus(const FocusOptions& = { });


### PR DESCRIPTION
#### 3558eb52e9aca998f3b1319d3f53dfe1ce40c931
<pre>
[popover] Implement popover focusing steps
<a href="https://bugs.webkit.org/show_bug.cgi?id=253231">https://bugs.webkit.org/show_bug.cgi?id=253231</a>
rdar://106132025

Reviewed by Ryosuke Niwa.

<a href="https://html.spec.whatwg.org/#popover-focusing-steps">https://html.spec.whatwg.org/#popover-focusing-steps</a>

PR open here to update the popover focusing steps: <a href="https://github.com/whatwg/html/pull/8998">https://github.com/whatwg/html/pull/8998</a>

The remaining failures are due to new dialog focusing steps being not implemented yet (TBD in <a href="https://bugs.webkit.org/show_bug.cgi?id=250795)">https://bugs.webkit.org/show_bug.cgi?id=250795)</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-child-dialog-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::autoFocusDelegate):
(WebCore::Element::findFocusDelegateForTarget):
(WebCore::Element::findAutofocusDelegate):
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::runPopoverFocusingSteps):
(WebCore::HTMLElement::showPopover):

Canonical link: <a href="https://commits.webkit.org/261400@main">https://commits.webkit.org/261400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f47dda03f4c1337a717247f4cb9accf4bc425357

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11830 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117381 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104476 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/140 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13726 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52132 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7938 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15712 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->