### PR TITLE
[JSC] Shrink sizeof(StreamingPlan)

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -84,14 +84,15 @@ protected:
     virtual bool isComplete() const = 0;
     virtual void complete() WTF_REQUIRES_LOCK(m_lock) = 0;
 
+    MemoryMode m_mode { MemoryMode::BoundsChecking };
+    Lock m_lock;
+    Condition m_completed;
+
     Ref<ModuleInformation> m_moduleInformation;
 
     Vector<std::pair<VM*, CompletionTask>, 1> m_completionTasks;
 
     String m_errorMessage;
-    MemoryMode m_mode { MemoryMode::BoundsChecking };
-    Lock m_lock;
-    Condition m_completed;
 };
 
 

--- a/Source/JavaScriptCore/wasm/WasmStreamingPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingPlan.h
@@ -61,8 +61,8 @@ private:
     }
 
     Ref<LLIntPlan> m_plan;
-    bool m_completed { false };
     uint32_t m_functionIndex;
+    bool m_completed { false };
 };
 
 } } // namespace JSC::Wasm


### PR DESCRIPTION
#### 362f05f03ed1f5569802f295a32dc204c8bec974
<pre>
[JSC] Shrink sizeof(StreamingPlan)
<a href="https://bugs.webkit.org/show_bug.cgi?id=253494">https://bugs.webkit.org/show_bug.cgi?id=253494</a>
rdar://106350760

Reviewed by Tadeu Zagallo.

Shrink a bit since this is super frequently allocated class when streaming compiling wasm code (so mainly for performance).
It gets 80 from 88.

* Source/JavaScriptCore/wasm/WasmPlan.h:
* Source/JavaScriptCore/wasm/WasmStreamingPlan.h:

Canonical link: <a href="https://commits.webkit.org/261344@main">https://commits.webkit.org/261344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd6ea2dd74cc08523717790e03cd669c2c016c84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20515 "Built successfully") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/21882 "Build was cancelled. Recent messages:worker ews154 ready; Configured build; Validated change; OS: Monterey (12.6), Xcode: 14.0; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261343@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; killing old processes; Validated change; Compiled WebKit (warnings); Archived built product; Failed to upload built product") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11608 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117141 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/21882 "Build was cancelled. Recent messages:worker ews154 ready; Configured build; Validated change; OS: Monterey (12.6), Xcode: 14.0; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261343@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; killing old processes; Validated change; Compiled WebKit (warnings); Archived built product; Failed to upload built product") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/21882 "Build was cancelled. Recent messages:worker ews154 ready; Configured build; Validated change; OS: Monterey (12.6), Xcode: 14.0; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261343@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; killing old processes; Validated change; Compiled WebKit (warnings); Archived built product; Failed to upload built product") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44875 "layout-tests (failure)") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13016 "Build was cancelled. Recent messages:worker ews168 ready; Configured build; Validated change; OS: Monterey (12.6.1), Xcode: 14.0; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261343@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Killed old processes; Validated change; Compiled WebKit (cancelled)") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/11129 "Build was cancelled. Recent messages:worker ews137 ready; Configured build; Pull request contains relevant changes; Validated change; OS: Monterey (12.6.3), Xcode: 13.3; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261343@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Killed old processes; Validated change; Compiled JSC (warnings); jscore-tests (cancelled)") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101098 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31489 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15485 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109136 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4306 "Built successfully and passed tests") | | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/26891 "Build was cancelled. Recent messages:worker igalia-jsc32-mipsel-ews-02 ready; Configured build; Pull request contains relevant changes; Validated change; Printed configuration; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision; Identifier: 261343@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Downloaded built product; Extracted built product; Killed old processes; jscore-tests (cancelled)") | 
<!--EWS-Status-Bubble-End-->