### PR TITLE
[UI-side compositing] fast/canvas/webgl/lose-context-on-timeout.html fails

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3911,10 +3911,6 @@ webkit.org/b/241027 webgl/2.0.0/conformance2/textures/image_bitmap_from_image_bi
 # Failing on certain hardware configurations: macOS with Intel GPUs. Also slow.
 webkit.org/b/220753 webgl/conformance/extensions/webgl-multi-draw.html [ Pass Failure Slow ]
 
-# Timeout testing is not applicable to in-process webgl, only webgl in gpu process.
-fast/canvas/webgl/lose-context-on-timeout-async.html [ Skip ]
-fast/canvas/webgl/lose-context-on-timeout.html [ Skip ]
-
 # WebGL conformance test suite 1.0.x is skipped until 1.0.3 is retired.
 webgl/1.0.x [ Skip ]
 

--- a/LayoutTests/fast/canvas/webgl/lose-context-on-timeout-async-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/lose-context-on-timeout-async-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: WebGL: CONTEXT_LOST_WEBGL: loseContext: context lost
+CONSOLE MESSAGE: WebGL: context lost.
 Checks that a GPU process timeout on a non-result producing WebGL call will lose the context.
 NOTE: This only passes in the test harness because it requires Internals.
 

--- a/LayoutTests/fast/canvas/webgl/lose-context-on-timeout-async.html
+++ b/LayoutTests/fast/canvas/webgl/lose-context-on-timeout-async.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ UseGPUProcessForWebGLEnabled=true ] -->
 <head>
 <style>
 canvas {
@@ -37,6 +37,7 @@ async function runTest() {
     gl.clear(gl.COLOR_BUFFER_BIT);
     shouldBeFalse("gl.isContextLost()");
     shouldBe("gl.getError()", "gl.NO_ERROR");
+    let webglcontextlost = webGLContextLost(canvas);
     if (window.internals)
         window.internals.simulateEventForWebGLContext("Timeout", gl);
     // We're trying to fill the command buffer with calls after the timeout,
@@ -46,7 +47,7 @@ async function runTest() {
     for (let i = 0; i < callCount; ++i)
         gl.clearColor(1.0, 1.0, 0.0 + i/callCount, 1.0);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    await webGLContextLost(canvas);
+    await webglcontextlost;
     shouldBeTrue("gl.isContextLost()");
     shouldBe("gl.getError()", "gl.CONTEXT_LOST_WEBGL");
     finishTest();

--- a/LayoutTests/fast/canvas/webgl/lose-context-on-timeout-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/lose-context-on-timeout-expected.txt
@@ -1,12 +1,13 @@
-CONSOLE MESSAGE: WebGL: CONTEXT_LOST_WEBGL: loseContext: context lost
+CONSOLE MESSAGE: WebGL: context lost.
 Checks that a GPU process timeout on a result producing WebGL call will lose the context.
 NOTE: This only passes in the test harness because it requires Internals.
 
 PASS gl.isContextLost() is false
 PASS gl.getError() is gl.NO_ERROR
+PASS color[0] is 77
+PASS val is <= 998
 PASS gl.isContextLost() is true
 PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
-PASS val is [0, 0, 0, 0]
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/webgl/lose-context-on-timeout.html
+++ b/LayoutTests/fast/canvas/webgl/lose-context-on-timeout.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ UseGPUProcessForWebGLEnabled=true ] -->
 <head>
 <style>
 canvas {
@@ -25,27 +25,36 @@ debug("");
 async function webGLContextLost(canvas) {
     return new Promise(resolve => canvas.addEventListener("webglcontextlost", resolve));
 }
-var val;
+var val = 0;
+var color = new Uint8Array(4);
 async function runTest() {
     let canvas = document.createElement("canvas");
     canvas.width = 200;
     canvas.height = 200;
     gl = wtu.create3DContext(canvas);
-    wtu.setupColorQuad(gl);
     gl.viewport(0, 0, canvas.width, canvas.height);
     gl.clearColor(0.0, 1.0, 0.0, 1.0);
     gl.clear(gl.COLOR_BUFFER_BIT);
     shouldBeFalse("gl.isContextLost()");
     shouldBe("gl.getError()", "gl.NO_ERROR");
+    let webglcontextlost = webGLContextLost(canvas);
     if (window.internals)
         window.internals.simulateEventForWebGLContext("Timeout", gl);
-    gl.clearColor(1.0, 1.0, 0.0, 1.0);
-    gl.clear(gl.COLOR_BUFFER_BIT);
-    val = gl.getParameter(gl.COLOR_CLEAR_VALUE);
-    await webGLContextLost(canvas);
+    // Call a function that is guaranteed to be run on the remote process.
+    // The timeout simulation does not neccessarily invoke the timeout for the
+    // next gl command, so wait until we know that the command was not
+    // executed. Limit to 1000 iterations in case this is run without internals.
+    do {
+        color[0] = 77;
+        gl.clearColor(1.0, ((++val % 10) / 10.) , 0.0, 1.0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, color);
+    } while (color[0] != 77 && val < 1000);
+    await webglcontextlost;
+    shouldBe("color[0]", "77");
+    shouldBeLessThanOrEqual("val", "998");
     shouldBeTrue("gl.isContextLost()");
     shouldBe("gl.getError()", "gl.CONTEXT_LOST_WEBGL");
-    shouldBe("val", "[0, 0, 0, 0]");
     finishTest();
 }
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2461,3 +2461,7 @@ http/tests/websocket/tests/hybi/multiple-connections-limit.html [ Skip ]
 
 # Displays blank on WK1
 fullscreen/fullscreen-iframe-navigation.html [ Skip ]
+
+# Timeout testing is not applicable to in-process webgl, only webgl in gpu process.
+fast/canvas/webgl/lose-context-on-timeout-async.html [ Skip ]
+fast/canvas/webgl/lose-context-on-timeout.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1761,7 +1761,6 @@ webkit.org/b/252866 [ Debug ] fast/text/glyph-display-lists/glyph-display-list-c
 [ BigSur+ x86_64 ] fast/mediastream/getUserMedia-to-canvas-2.html [ Pass Timeout ]
 [ Monterey+ ] fast/borders/border-painting-correctness-dashed.html [ ImageOnlyFailure ]
 [ Monterey+ ] fast/borders/border-painting-correctness-dotted.html [ ImageOnlyFailure ]
-[ BigSur+ ] fast/canvas/webgl/lose-context-on-timeout.html [ Timeout ]
 [ BigSur+ x86_64 ] css3/blending/background-blend-mode-body-image.html [ ImageOnlyFailure ]
 [ BigSur Monterey ] fast/images/animated-heics-draw.html [ Skip ]
 [ Ventura+ ] fast/images/animated-heics-draw.html [ Pass Timeout ]


### PR DESCRIPTION
#### 28a6eb594193c9b4fe94118ba2e3c0c0efa2bf64
<pre>
[UI-side compositing] fast/canvas/webgl/lose-context-on-timeout.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=253496">https://bugs.webkit.org/show_bug.cgi?id=253496</a>
rdar://106115219

Reviewed by Simon Fraser.

The simulated timeout mechanism does not at the moment apply immediately
because it posts work from GPUP RemoteGraphicsContextGL work queue to
main thread. Take this into account in lose-context-on-timeout.html
by ensuring that the call to be timed out is called potentially
multiple times.

Also fix other test problems related to lose-context-on-timeout.html
and the async variant:
- Use a method that is more likely not cached caller side
- Register the WebGL context lost handler before the context loss has
  chance of being invoked
- Use test metadata to always select GPUP WebGL as the testing variant.
  This way the testing skips can be removed from the TestExpectations
  and the test is run by default.

* LayoutTests/TestExpectations:
* LayoutTests/fast/canvas/webgl/lose-context-on-timeout-async-expected.txt:
* LayoutTests/fast/canvas/webgl/lose-context-on-timeout-async.html:
* LayoutTests/fast/canvas/webgl/lose-context-on-timeout-expected.txt:
* LayoutTests/fast/canvas/webgl/lose-context-on-timeout.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/261360@main">https://commits.webkit.org/261360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b2013cc4db4fe85102ce9108aa11ab03661a919

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2741 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120120 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11551 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/31041 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44795 "Found 1 new test failure: fast/canvas/webgl/lose-context-on-timeout-async.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12954 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86634 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13470 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9373 "Found 1 new test failure: http/tests/misc/heic-accept-header.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18911 "Built successfully") | [💥 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51964 "An unexpected error occured. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7880 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15427 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->