### PR TITLE
Bake offsets into shape-outside Shapes

### DIFF
--- a/Source/WebCore/rendering/shapes/Shape.h
+++ b/Source/WebCore/rendering/shapes/Shape.h
@@ -72,7 +72,7 @@ public:
         Path marginShape;
     };
 
-    static std::unique_ptr<Shape> createShape(const BasicShape&, const LayoutSize& logicalBoxSize, WritingMode, float margin);
+    static std::unique_ptr<Shape> createShape(const BasicShape&, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode, float margin);
     static std::unique_ptr<Shape> createRasterShape(Image*, float threshold, const LayoutRect& imageRect, const LayoutRect& marginRect, WritingMode, float margin);
     static std::unique_ptr<Shape> createBoxShape(const RoundedRect&, WritingMode, float margin);
 

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
@@ -94,19 +94,13 @@ public:
 
     void invalidateForSizeChangeIfNeeded();
 
-    LayoutUnit shapeLogicalTop() const { return computedShape().shapeMarginLogicalBoundingBox().y() + logicalTopOffset(); }
-    LayoutUnit shapeLogicalBottom() const { return computedShape().shapeMarginLogicalBoundingBox().maxY() + logicalTopOffset(); }
-    LayoutUnit shapeLogicalLeft() const { return computedShape().shapeMarginLogicalBoundingBox().x() + logicalLeftOffset(); }
-    LayoutUnit shapeLogicalRight() const { return computedShape().shapeMarginLogicalBoundingBox().maxX() + logicalLeftOffset(); }
-    LayoutUnit shapeLogicalWidth() const { return computedShape().shapeMarginLogicalBoundingBox().width(); }
-    LayoutUnit shapeLogicalHeight() const { return computedShape().shapeMarginLogicalBoundingBox().height(); }
+    LayoutUnit shapeLogicalBottom() const { return computedShape().shapeMarginLogicalBoundingBox().maxY(); }
 
     void markShapeAsDirty() { m_shape = nullptr; }
     bool isShapeDirty() { return !m_shape; }
 
     LayoutRect computedShapePhysicalBoundingBox() const;
     FloatPoint shapeToRendererPoint(const FloatPoint&) const;
-    FloatSize shapeToRendererSize(const FloatSize&) const;
 
     const Shape& computedShape() const;
 

--- a/Source/WebCore/rendering/style/ShapeValue.cpp
+++ b/Source/WebCore/rendering/style/ShapeValue.cpp
@@ -71,4 +71,11 @@ Ref<ShapeValue> ShapeValue::blend(const ShapeValue& to, const BlendingContext& c
     return ShapeValue::create(to.shape()->blend(*m_shape, context), m_cssBox);
 }
 
+CSSBoxType ShapeValue::effectiveCSSBox() const
+{
+    if (m_cssBox == CSSBoxType::BoxMissing)
+        return m_type == ShapeValue::Type::Image ? CSSBoxType::ContentBox : CSSBoxType::MarginBox;
+    return m_cssBox;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/ShapeValue.h
+++ b/Source/WebCore/rendering/style/ShapeValue.h
@@ -59,6 +59,7 @@ public:
     Type type() const { return m_type; }
     BasicShape* shape() const { return m_shape.get(); }
     CSSBoxType cssBox() const { return m_cssBox; }
+    CSSBoxType effectiveCSSBox() const;
     StyleImage* image() const { return m_image.get(); }
     bool isImageValid() const;
 


### PR DESCRIPTION
#### 5817fa68b77f91160a62299c9c54fc7a01e4b761
<pre>
Bake offsets into shape-outside Shapes
<a href="https://bugs.webkit.org/show_bug.cgi?id=253499">https://bugs.webkit.org/show_bug.cgi?id=253499</a>
rdar://106353011

Reviewed by Alan Baradlay.

Currently Shapes are varyingly relative to the margin/border/padding/content box.
The code that uses the shapes needs to recover this box and compute the real offset.

We can simplify the code by always making shapes relative to the same reference box (border box for now).

* Source/WebCore/rendering/shapes/Shape.cpp:
(WebCore::Shape::createShape):
(WebCore::Shape::createBoxShape):
* Source/WebCore/rendering/shapes/Shape.h:
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::ShapeOutsideInfo::computedShapePhysicalBoundingBox const):
(WebCore::ShapeOutsideInfo::shapeToRendererPoint const):
(WebCore::computeLogicalBoxSize):
(WebCore::makeShapeForShapeOutside):
(WebCore::logicalTopOffset):
(WebCore::logicalLeftOffset):
(WebCore::ShapeOutsideInfo::computeDeltasForContainingBlockLine):
(WebCore::ShapeOutsideInfo::shapeToRendererSize const): Deleted.
(WebCore::referenceBox): Deleted.
(WebCore::ShapeOutsideInfo::logicalTopOffset const): Deleted.
(WebCore::ShapeOutsideInfo::logicalLeftOffset const): Deleted.
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.h:
* Source/WebCore/rendering/style/ShapeValue.cpp:
(WebCore::ShapeValue::effectiveCSSBox const):
* Source/WebCore/rendering/style/ShapeValue.h:

Canonical link: <a href="https://commits.webkit.org/261331@main">https://commits.webkit.org/261331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a6834311a124abba9d42290d2d41fabc1bb7f0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2721 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120099 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11533 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117056 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/31020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44774 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12933 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86616 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13451 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9353 "Found 1 new test failure: imported/w3c/web-platform-tests/background-fetch/mixed-content-and-allowed-schemes.https.window.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18890 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/51944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7853 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15406 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->