### PR TITLE
Fix synchronisation issue with setMediaOverridesForTesting state when a new WebContent process is used for testing

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1824,10 +1824,6 @@ webkit.org/b/251187 [ Debug ] imported/w3c/web-platform-tests/fetch/api/redirect
 
 webkit.org/b/250046 [ Monterey+ ] svg/clip-path/clip-opacity-translate.svg [ ImageOnlyFailure ]
 
-webkit.org/b/253153 [ BigSur+ ] media/media-source/media-source-webm-append-buffer-after-abort.html [ Pass Failure ]
-webkit.org/b/253153 [ BigSur+ ] media/media-source/media-source-webm-init-inside-segment.html [ Pass Failure ]
-webkit.org/b/253153 [ BigSur+ ] media/media-source/media-source-webm.html [ Pass Failure ]
-
 # Early hints require network callbacks that are only present in macOS 12 / iOS 15 or greater.
 [ Monterey+ ] http/wpt/loading/early-hints [ Pass ]
 

--- a/Source/WebCore/platform/cocoa/SystemBattery.h
+++ b/Source/WebCore/platform/cocoa/SystemBattery.h
@@ -48,12 +48,13 @@ public:
     void setHasBattery(std::optional<bool>&&);
     std::optional<bool> hasBattery() { return  m_hasBattery; }
 
-    void setConfigurationChangedCallback(std::function<void()>&&);
+    void setConfigurationChangedCallback(std::function<void(bool)>&&);
+    void resetOverridesToDefaultValues();
 
 private:
     std::optional<bool> m_hasBattery;
     std::optional<bool> m_hasAC;
-    Function<void()> m_configurationChangedCallback;
+    Function<void(bool)> m_configurationChangedCallback;
 };
 
 }

--- a/Source/WebCore/platform/cocoa/SystemBattery.mm
+++ b/Source/WebCore/platform/cocoa/SystemBattery.mm
@@ -129,19 +129,27 @@ void SystemBatteryStatusTestingOverrides::setHasBattery(std::optional<bool>&& ha
 {
     m_hasBattery = WTFMove(hasBattery);
     if (m_configurationChangedCallback)
-        m_configurationChangedCallback();
+        m_configurationChangedCallback(false);
 }
 
 void SystemBatteryStatusTestingOverrides::setHasAC(std::optional<bool>&& hasAC)
 {
     m_hasAC = WTFMove(hasAC);
     if (m_configurationChangedCallback)
-        m_configurationChangedCallback();
+        m_configurationChangedCallback(false);
 }
 
-void SystemBatteryStatusTestingOverrides::setConfigurationChangedCallback(std::function<void()>&& callback)
+void SystemBatteryStatusTestingOverrides::setConfigurationChangedCallback(std::function<void(bool)>&& callback)
 {
     m_configurationChangedCallback = WTFMove(callback);
+}
+
+void SystemBatteryStatusTestingOverrides::resetOverridesToDefaultValues()
+{
+    setHasBattery(std::nullopt);
+    setHasAC(std::nullopt);
+    if (m_configurationChangedCallback)
+        m_configurationChangedCallback(true);
 }
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
@@ -83,13 +83,14 @@ public:
     void setVP9ScreenSizeAndScale(std::optional<ScreenDataOverrides>&&);
     std::optional<ScreenDataOverrides> vp9ScreenSizeAndScale()  { return m_screenSizeAndScale; }
 
-    void setConfigurationChangedCallback(std::function<void()>&&);
+    void setConfigurationChangedCallback(std::function<void(bool)>&&);
+    void resetOverridesToDefaultValues();
 
 private:
     std::optional<bool> m_hardwareDecoderDisabled;
     std::optional<bool> m_vp9DecoderDisabled;
     std::optional<ScreenDataOverrides> m_screenSizeAndScale;
-    Function<void()> m_configurationChangedCallback;
+    Function<void(bool)> m_configurationChangedCallback;
 };
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -60,26 +60,35 @@ void VP9TestingOverrides::setHardwareDecoderDisabled(std::optional<bool>&& disab
 {
     m_hardwareDecoderDisabled = WTFMove(disabled);
     if (m_configurationChangedCallback)
-        m_configurationChangedCallback();
+        m_configurationChangedCallback(false);
 }
 
 void VP9TestingOverrides::setVP9DecoderDisabled(std::optional<bool>&& disabled)
 {
     m_vp9DecoderDisabled = WTFMove(disabled);
     if (m_configurationChangedCallback)
-        m_configurationChangedCallback();
+        m_configurationChangedCallback(false);
 }
 
 void VP9TestingOverrides::setVP9ScreenSizeAndScale(std::optional<ScreenDataOverrides>&& overrides)
 {
     m_screenSizeAndScale = WTFMove(overrides);
     if (m_configurationChangedCallback)
-        m_configurationChangedCallback();
+        m_configurationChangedCallback(false);
 }
 
-void VP9TestingOverrides::setConfigurationChangedCallback(std::function<void()>&& callback)
+void VP9TestingOverrides::setConfigurationChangedCallback(std::function<void(bool)>&& callback)
 {
     m_configurationChangedCallback = WTFMove(callback);
+}
+
+void VP9TestingOverrides::resetOverridesToDefaultValues()
+{
+    setHardwareDecoderDisabled(std::nullopt);
+    setVP9DecoderDisabled(std::nullopt);
+    setVP9ScreenSizeAndScale(std::nullopt);
+    if (m_configurationChangedCallback)
+        m_configurationChangedCallback(true);
 }
 
 enum class ResolutionCategory : uint8_t {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -716,14 +716,11 @@ Internals::Internals(Document& document)
 #endif
 
 #if PLATFORM(COCOA)
-    SystemBatteryStatusTestingOverrides::singleton().setHasAC(std::nullopt);
-    SystemBatteryStatusTestingOverrides::singleton().setHasBattery(std::nullopt);
+    SystemBatteryStatusTestingOverrides::singleton().resetOverridesToDefaultValues();
 #endif
 
 #if ENABLE(VP9) && PLATFORM(COCOA)
-    VP9TestingOverrides::singleton().setHardwareDecoderDisabled(std::nullopt);
-    VP9TestingOverrides::singleton().setVP9DecoderDisabled(std::nullopt);
-    VP9TestingOverrides::singleton().setVP9ScreenSizeAndScale(std::nullopt);
+    VP9TestingOverrides::singleton().resetOverridesToDefaultValues();
 #endif
 }
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -384,10 +384,10 @@ void GPUProcessConnection::enableVP9Decoders(bool enableVP8Decoder, bool enableV
 }
 #endif
 
-void GPUProcessConnection::updateMediaConfiguration()
+void GPUProcessConnection::updateMediaConfiguration(bool forceUpdate)
 {
 #if PLATFORM(COCOA)
-    bool settingsChanged = false;
+    bool settingsChanged = forceUpdate;
 
     if (m_mediaOverridesForTesting.systemHasAC != SystemBatteryStatusTestingOverrides::singleton().hasAC() || m_mediaOverridesForTesting.systemHasBattery != SystemBatteryStatusTestingOverrides::singleton().hasBattery())
         settingsChanged = true;

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -85,7 +85,7 @@ public:
     RemoteAudioSourceProviderManager& audioSourceProviderManager();
 #endif
 
-    void updateMediaConfiguration();
+    void updateMediaConfiguration(bool forceUpdate);
 
 #if ENABLE(VP9)
     void enableVP9Decoders(bool enableVP8Decoder, bool enableVP9Decoder, bool enableVP9SWDecoder);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2170,12 +2170,12 @@ void WebProcess::setUseGPUProcessForMedia(bool useGPUProcessForMedia)
 
 #if PLATFORM(COCOA)
     if (useGPUProcessForMedia) {
-        SystemBatteryStatusTestingOverrides::singleton().setConfigurationChangedCallback([this] () {
-            ensureGPUProcessConnection().updateMediaConfiguration();
+        SystemBatteryStatusTestingOverrides::singleton().setConfigurationChangedCallback([this] (bool forceUpdate) {
+            ensureGPUProcessConnection().updateMediaConfiguration(forceUpdate);
         });
 #if ENABLE(VP9)
-        VP9TestingOverrides::singleton().setConfigurationChangedCallback([this] () {
-            ensureGPUProcessConnection().updateMediaConfiguration();
+        VP9TestingOverrides::singleton().setConfigurationChangedCallback([this] (bool forceUpdate) {
+            ensureGPUProcessConnection().updateMediaConfiguration(forceUpdate);
         });
 #endif
     } else {


### PR DESCRIPTION
#### 419ca9b090186afea80666a5f59f586e89ef29e2
<pre>
Fix synchronisation issue with setMediaOverridesForTesting state when a new WebContent process is used for testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=253468">https://bugs.webkit.org/show_bug.cgi?id=253468</a>
rdar://106328795

Reviewed by Brady Eidson.

This changes resolves a synchronisation issue which arose when a new WebContent
process was spawned for a media-source test after a previous test changed
the setMediaOverridesForTesting from the default values.

The way setMediaOverridesForTesting works is that a singleton state is
maintained in both the WebProcess and the GPUP. When you request an
update to setMediaOverridesForTesting, the new state is checked against
the current local state stored within the process. If the two states are
different, a CoreIPC message is dispatched to the GPUProcess to tell
it to update the GPU side configuration.

WKTR will spawn new WebProcesses if the prior WebProcess is not suitable
for the next test, the prior WebProcess crashed, etc. When a new WebProcess
is spawned, the override&apos;s state is set back to it&apos;s default values.
However, we never reset the GPUP side state in this case. This would lead
to flaky failures.

During Internals construction, we now force reset WebProcess &amp; GPU side
state back to default values.

* Source/WebCore/platform/cocoa/SystemBattery.h:
* Source/WebCore/platform/cocoa/SystemBattery.mm:
(WebCore::SystemBatteryStatusTestingOverrides::setHasBattery):
(WebCore::SystemBatteryStatusTestingOverrides::setHasAC):
(WebCore::SystemBatteryStatusTestingOverrides::setConfigurationChangedCallback):
(WebCore::SystemBatteryStatusTestingOverrides::forceConfigurationUpdate):
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::VP9TestingOverrides::setHardwareDecoderDisabled):
(WebCore::VP9TestingOverrides::setVP9DecoderDisabled):
(WebCore::VP9TestingOverrides::setVP9ScreenSizeAndScale):
(WebCore::VP9TestingOverrides::setConfigurationChangedCallback):
(WebCore::VP9TestingOverrides::forceConfigurationUpdate):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::Internals):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::updateMediaConfiguration):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setUseGPUProcessForMedia):

Canonical link: <a href="https://commits.webkit.org/261520@main">https://commits.webkit.org/261520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdc9a86b642e9ee128401eeaebbc6508d219beed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3655 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3403 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117656 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104910 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98564 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45590 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13468 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/350 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9761 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52351 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8024 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15951 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->