### PR TITLE
Debug webgl/2.0.y/conformance2/state/gl-object-get-calls.html is slow because synthetic error management is slow

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -790,9 +790,9 @@ WebGLAny WebGL2RenderingContext::getInternalformatParameter(GCGLenum target, GCG
     if (!validateForbiddenInternalFormats("getInternalformatParameter", internalformat))
         return nullptr;
 
-    m_context->moveErrorsToSyntheticErrorList();
+    updateErrors();
     GCGLint numValues = m_context->getInternalformati(target, internalformat, GraphicsContextGL::NUM_SAMPLE_COUNTS);
-    if (m_context->moveErrorsToSyntheticErrorList() || numValues < 0)
+    if (updateErrors() || numValues < 0)
         return nullptr;
 
     // Integer formats do not support multisampling, so numValues == 0 may occur.
@@ -800,7 +800,7 @@ WebGLAny WebGL2RenderingContext::getInternalformatParameter(GCGLenum target, GCG
     Vector<GCGLint> params(numValues);
     if (numValues > 0) {
         m_context->getInternalformativ(target, internalformat, pname, params);
-        if (m_context->moveErrorsToSyntheticErrorList())
+        if (updateErrors())
             return nullptr;
     }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -600,7 +600,7 @@ protected:
             : mode(mode)
         {
         }
-        ListHashSet<GCGLint> errors; // Losing context and WEBGL_lose_context generates errors here.
+        GCGLErrorCodeSet errors; // Losing context and WEBGL_lose_context generates errors here.
         LostContextMode mode { LostContextMode::RealLostContext };
         bool restoreRequested { false };
     };
@@ -610,7 +610,7 @@ protected:
     Lock m_objectGraphLock;
 
     SuspendableTimer m_restoreTimer;
-
+    GCGLErrorCodeSet m_errors;
     bool m_needsUpdate;
     bool m_markedCanvasDirty;
     HashSet<WebGLContextObject*> m_contextObjects;
@@ -1131,6 +1131,11 @@ protected:
 #endif
 
     bool validateTypeAndArrayBufferType(const char* functionName, ArrayBufferViewFunctionType, GCGLenum type, ArrayBufferView* pixels);
+
+    // Fetches all errors from the underlying context and updates local list of errors
+    // based on that.
+    // Returns true if underlying context had errors.
+    bool updateErrors();
 
 private:
     void scheduleTaskToDispatchContextLostEvent();

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1133,6 +1133,26 @@ public:
 #endif
     }
 
+    static constexpr GCGLErrorCode enumToErrorCode(GCGLenum error)
+    {
+        switch (error) {
+        case INVALID_ENUM:
+            return GCGLErrorCode::InvalidEnum;
+        case INVALID_VALUE:
+            return GCGLErrorCode::InvalidValue;
+        case INVALID_OPERATION:
+            return GCGLErrorCode::InvalidOperation;
+        case OUT_OF_MEMORY:
+            return GCGLErrorCode::OutOfMemory;
+        case INVALID_FRAMEBUFFER_OPERATION:
+            return GCGLErrorCode::InvalidFramebufferOperation;
+        case CONTEXT_LOST_WEBGL:
+            return GCGLErrorCode::ContextLost;
+        }
+        ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
+        return GCGLErrorCode::InvalidOperation;
+    }
+
     class Client {
     public:
         WEBCORE_EXPORT Client();
@@ -1224,7 +1244,7 @@ public:
     virtual GCGLint getProgrami(PlatformGLObject program, GCGLenum pname) = 0;
     virtual void getBooleanv(GCGLenum pname, GCGLSpan<GCGLboolean> value) = 0;
 
-    virtual GCGLenum getError() = 0;
+    virtual GCGLErrorCodeSet getErrors() = 0;
 
     // getFramebufferAttachmentParameter
     virtual GCGLint getFramebufferAttachmentParameteri(GCGLenum target, GCGLenum attachment, GCGLenum pname) = 0;
@@ -1531,20 +1551,6 @@ public:
     WEBCORE_EXPORT virtual void setDrawingBufferColorSpace(const DestinationColorSpace&);
 
     virtual bool isGLES2Compliant() const = 0;
-
-    // Synthesizes an OpenGL error which will be returned from a
-    // later call to getError. This is used to emulate OpenGL ES
-    // 2.0 behavior on the desktop and to enforce additional error
-    // checking mandated by WebGL.
-    //
-    // Per the behavior of glGetError, this stores at most one
-    // instance of any given error, and returns them from calls to
-    // getError in the order they were added.
-    virtual void synthesizeGLError(GCGLenum error) = 0;
-
-    // Read real OpenGL errors, and move them to the synthetic
-    // error list. Return true if at least one error is moved.
-    virtual bool moveErrorsToSyntheticErrorList() = 0;
 
     virtual void prepareForDisplay() = 0;
 

--- a/Source/WebCore/platform/graphics/GraphicsTypesGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypesGL.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <cstdint>
+#include <wtf/EnumTraits.h>
+#include <wtf/OptionSet.h>
 
 // GCGL types match the corresponding GL types as defined in OpenGL ES 2.0
 // header file gl2.h from khronos.org.
@@ -62,3 +64,30 @@ using GCGLContext = void*;
 #if !PLATFORM(COCOA)
 typedef unsigned GLuint;
 #endif
+
+// Order in inverse of in GL specification, so that iteration is in GL specification order.
+enum class GCGLErrorCode : uint8_t {
+    ContextLost = 1,
+    InvalidFramebufferOperation = 1 << 2,
+    OutOfMemory = 1 << 3,
+    InvalidOperation = 1 << 4,
+    InvalidValue = 1 << 5,
+    InvalidEnum = 1 << 6
+};
+using GCGLErrorCodeSet = OptionSet<GCGLErrorCode>;
+
+namespace WTF {
+
+template <> struct EnumTraits<GCGLErrorCode> {
+    using values = EnumValues <
+    GCGLErrorCode,
+    GCGLErrorCode::ContextLost,
+    GCGLErrorCode::InvalidFramebufferOperation,
+    GCGLErrorCode::OutOfMemory,
+    GCGLErrorCode::InvalidOperation,
+    GCGLErrorCode::InvalidValue,
+    GCGLErrorCode::InvalidEnum
+    >;
+};
+
+}

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -123,7 +123,7 @@ public:
     GCGLint getAttribLocation(PlatformGLObject, const String& name) final;
     void getBooleanv(GCGLenum pname, GCGLSpan<GCGLboolean> value) final;
     GCGLint getBufferParameteri(GCGLenum target, GCGLenum pname) final;
-    GCGLenum getError() final;
+    GCGLErrorCodeSet getErrors() final;
     void getFloatv(GCGLenum pname, GCGLSpan<GCGLfloat> value) final;
     GCGLint getFramebufferAttachmentParameteri(GCGLenum target, GCGLenum attachment, GCGLenum pname) final;
     void getIntegerv(GCGLenum pname, GCGLSpan<GCGLint> value) final;
@@ -349,8 +349,6 @@ public:
     void deleteRenderbuffer(PlatformGLObject) final;
     void deleteShader(PlatformGLObject) final;
     void deleteTexture(PlatformGLObject) final;
-    void synthesizeGLError(GCGLenum error) final;
-    bool moveErrorsToSyntheticErrorList() final;
     void simulateEventForTesting(SimulatedEventForTesting) override;
     void paintRenderingResultsToCanvas(ImageBuffer&) final;
     RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer() final;
@@ -360,8 +358,12 @@ public:
     RefPtr<PixelBuffer> readCompositedResultsForPainting();
     // Returns true on success.
     bool readnPixelsWithStatus(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLSpan<GCGLvoid> data);
+
+    void addError(GCGLErrorCode);
 protected:
     GraphicsContextGLANGLE(GraphicsContextGLAttributes);
+
+    bool updateErrors();
 
     // Called once by all the public entry points that eventually call OpenGL.
     bool makeContextCurrent() WARN_UNUSED_RETURN;
@@ -430,8 +432,7 @@ protected:
     GCGLuint m_preserveDrawingBufferFBO { 0 };
     // Queried at display startup.
     GCGLint m_drawingBufferTextureTarget { -1 };
-    // Errors raised by synthesizeGLError().
-    ListHashSet<GCGLenum> m_syntheticErrors;
+    GCGLErrorCodeSet m_errors;
     bool m_isForWebGL2 { false };
     unsigned m_statusCheckCount { 0 };
     bool m_failNextStatusCheck { false };

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -191,16 +191,10 @@ void RemoteGraphicsContextGL::prepareForDisplay(CompletionHandler<void()>&& comp
 }
 #endif
 
-void RemoteGraphicsContextGL::synthesizeGLError(uint32_t error)
+void RemoteGraphicsContextGL::getErrors(CompletionHandler<void(GCGLErrorCodeSet)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    m_context->synthesizeGLError(static_cast<GCGLenum>(error));
-}
-
-void RemoteGraphicsContextGL::getError(CompletionHandler<void(uint32_t)>&& completionHandler)
-{
-    assertIsCurrent(workQueue());
-    completionHandler(static_cast<uint32_t>(m_context->getError()));
+    completionHandler(m_context->getErrors());
 }
 
 void RemoteGraphicsContextGL::ensureExtensionEnabled(String&& extension)
@@ -335,9 +329,9 @@ void RemoteGraphicsContextGL::readnPixels2(int32_t x, int32_t y, int32_t width, 
         if (auto buffer = SharedMemory::map(WTFMove(handle), SharedMemory::Protection::ReadWrite))
             success = m_context->readnPixelsWithStatus(x, y, width, height, format, type, GCGLSpan<void> { buffer->data(), buffer->size() });
         else
-            m_context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION);
+            m_context->addError(GCGLErrorCode::InvalidOperation);
     } else
-        m_context->synthesizeGLError(GraphicsContextGL::INVALID_OPERATION);
+        m_context->addError(GCGLErrorCode::InvalidOperation);
     completionHandler(success);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -121,8 +121,7 @@ protected:
 #else
     void prepareForDisplay(CompletionHandler<void()>&&);
 #endif
-    void getError(CompletionHandler<void(uint32_t)>&&);
-    void synthesizeGLError(uint32_t error);
+    void getErrors(CompletionHandler<void(GCGLErrorCodeSet)>&&);
     void paintRenderingResultsToCanvas(WebCore::RenderingResourceIdentifier, CompletionHandler<void()>&&);
     void paintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier, CompletionHandler<void()>&&);
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -40,8 +40,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
 #endif
     void EnsureExtensionEnabled(String extension)
     void MarkContextChanged()
-    void SynthesizeGLError(uint32_t error)
-    void GetError() -> (uint32_t returnValue) Synchronous
+    void GetErrors() -> (GCGLErrorCodeSet returnValue) Synchronous
     void PaintRenderingResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
     void PaintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
@@ -63,7 +62,6 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void MultiDrawArraysInstancedBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t> firstsCountsInstanceCountsAndBaseInstances)
     void MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, uint32_t type)
 
-    void MoveErrorsToSyntheticErrorList() -> (bool returnValue) Synchronous
     void ActiveTexture(uint32_t texture)
     void AttachShader(uint32_t program, uint32_t shader)
     void BindAttribLocation(uint32_t arg0, uint32_t index, String name)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -25,13 +25,6 @@
 // This file should be included in the private section of the
 // RemoteGraphicsContextGL implementations.
 #pragma once
-    void moveErrorsToSyntheticErrorList(CompletionHandler<void(bool)>&& completionHandler)
-    {
-        bool returnValue = { };
-        assertIsCurrent(workQueue());
-        returnValue = m_context->moveErrorsToSyntheticErrorList();
-        completionHandler(returnValue);
-    }
     void activeTexture(uint32_t texture)
     {
         assertIsCurrent(workQueue());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -296,26 +296,16 @@ RefPtr<Image> RemoteGraphicsContextGLProxy::videoFrameToImage(WebCore::VideoFram
 }
 #endif
 
-void RemoteGraphicsContextGLProxy::synthesizeGLError(GCGLenum error)
+GCGLErrorCodeSet RemoteGraphicsContextGLProxy::getErrors()
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::SynthesizeGLError(error));
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetErrors());
         if (!sendResult)
             markContextLost();
-        return;
+        auto [returnValue] = sendResult.takeReplyOr(GCGLErrorCodeSet { });
+        return returnValue;
     }
-}
-
-GCGLenum RemoteGraphicsContextGLProxy::getError()
-{
-    if (!isContextLost()) {
-        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetError());
-        if (!sendResult)
-            markContextLost();
-        auto [returnValue] = sendResult.takeReplyOr(0);
-        return static_cast<GCGLenum>(returnValue);
-    }
-    return NO_ERROR;
+    return { };
 }
 
 void RemoteGraphicsContextGLProxy::simulateEventForTesting(SimulatedEventForTesting event)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -82,8 +82,7 @@ public:
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
     RefPtr<WebCore::VideoFrame> paintCompositedResultsToVideoFrame() final;
 #endif
-    void synthesizeGLError(GCGLenum error) final;
-    GCGLenum getError() final;
+    GCGLErrorCodeSet getErrors() final;
 #if ENABLE(VIDEO)
     bool copyTextureFromMedia(WebCore::MediaPlayer&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type, bool premultiplyAlpha, bool flipY) final;
     bool copyTextureFromVideoFrame(WebCore::VideoFrame&, PlatformGLObject /* texture */, GCGLenum /* target */, GCGLint /* level */, GCGLenum /* internalFormat */, GCGLenum /* format */, GCGLenum /* type */, bool /* premultiplyAlpha */, bool /* flipY */) final;
@@ -102,7 +101,6 @@ public:
     void multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLsizei, const GCGLsizei, const GCGLsizei, const GCGLint, const GCGLuint> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, GCGLenum type) final;
 
     // Functions with a generated implementation. This list is used by generate-gpup-webgl script.
-    bool moveErrorsToSyntheticErrorList() final;
     void activeTexture(GCGLenum texture) final;
     void attachShader(PlatformGLObject program, PlatformGLObject shader) final;
     void bindAttribLocation(PlatformGLObject arg0, GCGLuint index, const String& name) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -30,19 +30,6 @@
 
 namespace WebKit {
 
-bool RemoteGraphicsContextGLProxy::moveErrorsToSyntheticErrorList()
-{
-    if (isContextLost())
-        return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::MoveErrorsToSyntheticErrorList());
-    if (!sendResult) {
-        markContextLost();
-        return { };
-    }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
-}
-
 void RemoteGraphicsContextGLProxy::activeTexture(GCGLenum texture)
 {
     if (isContextLost())

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -104,8 +104,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
 #endif
     void EnsureExtensionEnabled(String extension)
     void MarkContextChanged()
-    void SynthesizeGLError(uint32_t error)
-    void GetError() -> (uint32_t returnValue) Synchronous
+    void GetErrors() -> (GCGLErrorCodeSet returnValue) Synchronous
     void PaintRenderingResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
     void PaintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
 #if ENABLE(VIDEO) && PLATFORM(COCOA)


### PR DESCRIPTION
#### a45c00cc8d709a8fd83ec2f1b31d8ded5410e5fe
<pre>
Debug webgl/2.0.y/conformance2/state/gl-object-get-calls.html is slow because synthetic error management is slow
<a href="https://bugs.webkit.org/show_bug.cgi?id=253509">https://bugs.webkit.org/show_bug.cgi?id=253509</a>
rdar://106358460

Reviewed by Matt Woodrow.

WebGL validation would cause synthetic errors, where as
OpenGL validation and execution would cause &quot;real&quot; errors.
The error management had following issues:
- Errors were stored redundantly in ListHashSet&lt;GCGLint&gt;, which is
  very slow data structure. Mutating this would show up in traces.
- Synthetized errors were sent from WP to GPUP just to be merged
  with the real error list
- getError() would always fetch one error from GPUP

For WebGL 1, OpenGL ES 2.0 spec does not specify the error behavior in detail.
For WebGL 2, OpenGL ES 3.0 spec specifies that &quot;there may be several flag-code
pairs&quot; which are cleared in non-deterministic order when calling getError().

So to fix, instead:
- Errors are stored in OptionSet, since there are only few possible error
  codes.
- When returning an error, return one locally known error. If the known
  error set is empty, fetch all the errors from the underlying context,
  store that as the locally known set and return a possible error from
  that set.

Decreases the runtime of Debug webgl/2.0.y/conformance2/state/gl-object-get-calls.html
from 14s to 10s on MacBook Pro Max.

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getInternalformatParameter):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::errorCodeToString):
(WebCore::errorCodeToGLenum):
(WebCore::WebGLRenderingContextBase::initializeNewContext):
(WebCore::WebGLRenderingContextBase::updateErrors):
(WebCore::WebGLRenderingContextBase::getError):
(WebCore::WebGLRenderingContextBase::loseContextImpl):
(WebCore::WebGLRenderingContextBase::synthesizeGLError):
(WebCore::WebGLRenderingContextBase::synthesizeLostContextGLError):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
(WebCore::GraphicsContextGL::enumToErrorCode):
* Source/WebCore/platform/graphics/GraphicsTypesGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::readnPixelsImpl):
(WebCore::GraphicsContextGLANGLE::reshape):
(WebCore::GraphicsContextGLANGLE::getBufferSubData):
(WebCore::GraphicsContextGLANGLE::getActiveAttribImpl):
(WebCore::GraphicsContextGLANGLE::getActiveUniformImpl):
(WebCore::GraphicsContextGLANGLE::getAttachedShaders):
(WebCore::GraphicsContextGLANGLE::updateErrors):
(WebCore::GraphicsContextGLANGLE::getErrors):
(WebCore::GraphicsContextGLANGLE::getActiveUniformBlockName):
(WebCore::GraphicsContextGLANGLE::addError):
(WebCore::GraphicsContextGLANGLE::moveErrorsToSyntheticErrorList): Deleted.
(WebCore::GraphicsContextGLANGLE::getError): Deleted.
(WebCore::GraphicsContextGLANGLE::synthesizeGLError): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::getErrors):
(WebKit::RemoteGraphicsContextGL::readnPixels2):
(WebKit::RemoteGraphicsContextGL::synthesizeGLError): Deleted.
(WebKit::RemoteGraphicsContextGL::getError): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(moveErrorsToSyntheticErrorList): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::getErrors):
(WebKit::RemoteGraphicsContextGLProxy::synthesizeGLError): Deleted.
(WebKit::RemoteGraphicsContextGLProxy::getError): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::moveErrorsToSyntheticErrorList): Deleted.
* Tools/Scripts/generate-gpup-webgl:

Canonical link: <a href="https://commits.webkit.org/261494@main">https://commits.webkit.org/261494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82d2f45231a1b53c50b7bd95d3e487770a9a65df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/52 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120229 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2650 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104176 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/36 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44993 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13079 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/34 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86793 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9476 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52017 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7999 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15550 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->