### PR TITLE
Remove macOS Mojave Specific Flags in testapi.mm

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.mm
+++ b/Source/JavaScriptCore/API/tests/testapi.mm
@@ -649,10 +649,6 @@ static void testObjectiveCAPIMain()
         checkResult(@"Should be a created from Obj-C", symbol.isSymbol);
     }
 
-// Older platforms ifdef the type of some selectors so these tests don't work.
-// FIXME: Remove this when we stop building for macOS 10.14/iOS 12.
-#if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500) || (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 130000)
-
     @autoreleasepool {
         JSContext *context = [[JSContext alloc] init];
         JSValue *arrayIterator = [context evaluateScript:@"Array.prototype[Symbol.iterator]"];
@@ -737,8 +733,6 @@ static void testObjectiveCAPIMain()
         checkResult(@"iterator should not throw", ![context exception]);
         checkResult(@"iteration count should be 1", [count toUInt32] == 1);
     }
-
-#endif
 
     @autoreleasepool {
         JSCollection* myPrivateProperties = [[JSCollection alloc] init];


### PR DESCRIPTION
#### fce1443f5c80de586d523eee710d453994c63a53
<pre>
Remove macOS Mojave Specific Flags in testapi.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=253511">https://bugs.webkit.org/show_bug.cgi?id=253511</a>

Reviewed by NOBODY (OOPS!).

We dropped support for macOS 10.14 a while ago. Remove flags that were specific to it.

* Source/JavaScriptCore/API/tests/testapi.mm:
(testObjectiveCAPIMain):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fce1443f5c80de586d523eee710d453994c63a53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20456 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/43855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/2742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/21820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/11552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/2742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117078 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/21820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/43855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/103949 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/21820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/43855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/99854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/12955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/43855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11069 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/11552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101035 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/43855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31479 "Passed tests") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109071 "Built successfully") | 
| | | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/26883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->