### PR TITLE
Use convenience initializers over smart pointers when autoreleasing

### DIFF
--- a/Source/JavaScriptCore/API/JSManagedValue.mm
+++ b/Source/JavaScriptCore/API/JSManagedValue.mm
@@ -61,14 +61,14 @@ static JSManagedValueHandleOwner& managedValueHandleOwner()
 
 + (JSManagedValue *)managedValueWithValue:(JSValue *)value
 {
-    return adoptNS([[self alloc] initWithValue:value]).autorelease();
+    return [[[self alloc] initWithValue:value] autorelease];
 }
 
 + (JSManagedValue *)managedValueWithValue:(JSValue *)value andOwner:(id)owner
 {
-    auto managedValue = adoptNS([[self alloc] initWithValue:value]);
-    [value.context.virtualMachine addManagedReference:managedValue.get() withOwner:owner];
-    return managedValue.autorelease();
+    JSManagedValue *managedValue = [[self alloc] initWithValue:value];
+    [value.context.virtualMachine addManagedReference:managedValue withOwner:owner];
+    return [managedValue autorelease];
 }
 
 - (instancetype)init

--- a/Source/JavaScriptCore/API/tests/Regress141275.mm
+++ b/Source/JavaScriptCore/API/tests/Regress141275.mm
@@ -36,7 +36,7 @@ extern "C" void JSSynchronousGarbageCollectForDebugging(JSContextRef);
 
 extern int failed;
 
-static const NSUInteger scriptToEvaluate = 50;
+static constexpr NSUInteger scriptToEvaluate = 50;
 
 @interface JSTEvaluator : NSObject
 - (instancetype)initWithScript:(NSString*)script;

--- a/Source/JavaScriptCore/bytecode/Opcode.cpp
+++ b/Source/JavaScriptCore/bytecode/Opcode.cpp
@@ -86,12 +86,8 @@ static OpcodeStats logger;
 
 OpcodeStats::OpcodeStats()
 {
-    for (int i = 0; i < numOpcodeIDs; ++i)
-        opcodeCounts[i] = 0;
-    
-    for (int i = 0; i < numOpcodeIDs; ++i)
-        for (int j = 0; j < numOpcodeIDs; ++j)
-            opcodePairCounts[i][j] = 0;
+    memset(opcodeCounts, 0, sizeof(opcodeCounts));
+    memset(opcodePairCounts, 0, sizeof(opcodePairCounts));
 }
 
 static int compareOpcodeIndices(const void* left, const void* right)

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -237,7 +237,7 @@ void RemoteInspector::sendMessageToRemote(TargetID targetIdentifier, const Strin
 
     NSData *messageData = [static_cast<NSString *>(message) dataUsingEncoding:NSUTF8StringEncoding];
     NSUInteger messageLength = messageData.length;
-    const NSUInteger maxChunkSize = 2 * 1024 * 1024; // 2 Mebibytes
+    constexpr NSUInteger maxChunkSize = 2 * 1024 * 1024; // 2 Mebibytes
 
     if (!m_messageDataTypeChunkSupported || messageLength < maxChunkSize) {
         m_relayConnection->sendMessage(WIRRawDataMessage, @{

--- a/Source/WTF/wtf/cf/CFURLExtras.cpp
+++ b/Source/WTF/wtf/cf/CFURLExtras.cpp
@@ -30,18 +30,6 @@
 
 namespace WTF {
 
-RetainPtr<CFDataRef> bytesAsCFData(CFURLRef url)
-{
-    if (!url)
-        return nullptr;
-    auto bytesLength = CFURLGetBytes(url, nullptr, 0);
-    RELEASE_ASSERT(bytesLength != -1);
-    auto buffer = static_cast<uint8_t*>(malloc(bytesLength));
-    RELEASE_ASSERT(buffer);
-    CFURLGetBytes(url, buffer, bytesLength);
-    return adoptCF(CFDataCreateWithBytesNoCopy(nullptr, buffer, bytesLength, kCFAllocatorMalloc));
-}
-
 String bytesAsString(CFURLRef url)
 {
     if (!url)

--- a/Source/WTF/wtf/cf/CFURLExtras.h
+++ b/Source/WTF/wtf/cf/CFURLExtras.h
@@ -34,7 +34,6 @@ namespace WTF {
 
 constexpr size_t URLBytesVectorInlineCapacity = 2048;
 
-RetainPtr<CFDataRef> bytesAsCFData(CFURLRef);
 WTF_EXPORT_PRIVATE String bytesAsString(CFURLRef);
 WTF_EXPORT_PRIVATE Vector<uint8_t, URLBytesVectorInlineCapacity> bytesAsVector(CFURLRef);
 
@@ -42,6 +41,5 @@ bool isSameOrigin(CFURLRef, const URL&);
 
 }
 
-using WTF::bytesAsCFData;
 using WTF::bytesAsString;
 using WTF::bytesAsVector;

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -308,10 +308,10 @@ NSURL *URLByRemovingUserInfo(NSURL *URL)
 
 NSData *originalURLData(NSURL *URL)
 {
-    auto data = bridge_cast(bytesAsCFData(bridge_cast(URL)));
-    if (auto baseURL = bridge_cast(CFURLGetBaseURL(bridge_cast(URL))))
-        return originalURLData(URLWithData(data.get(), baseURL));
-    return data.autorelease();
+    NSData *data = URL.dataRepresentation;
+    if (NSURL *baseURL = URL.baseURL)
+        return originalURLData(URLWithData(data, baseURL));
+    return data;
 }
 
 NSString *userVisibleString(NSURL *URL)
@@ -325,9 +325,7 @@ BOOL isUserVisibleURL(NSString *string)
     // Return true if the userVisibleString function is guaranteed to not change the passed-in URL.
     // This function is used to optimize all the most common cases where we don't need the userVisibleString algorithm.
 
-    char buffer[1024];
-    auto success = CFStringGetCString(bridge_cast(string), reinterpret_cast<char*>(buffer), sizeof(buffer) - 1, kCFStringEncodingUTF8);
-    auto characters = success ? buffer : [string UTF8String];
+    auto characters = string.UTF8String;
 
     // Check for control characters, %-escape sequences that are non-ASCII, and xn--: these
     // are the things that might lead the userVisibleString function to actually change the string.

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
@@ -161,9 +161,9 @@ NSArray *platformSummaryItems(const ApplePayLineItem& total, const Vector<AppleP
     if (PKPaymentSummaryItem *totalItem = platformSummaryItem(total))
         [paymentSummaryItems addObject:totalItem];
 
-    return adoptNS([paymentSummaryItems copy]).autorelease();
+    return paymentSummaryItems;
 }
 
-} // namespace WebbCore
+} // namespace WebCore
 
 #endif // ENABLE(APPLE_PAY)

--- a/Source/WebCore/PAL/pal/system/mac/PopupMenu.mm
+++ b/Source/WebCore/PAL/pal/system/mac/PopupMenu.mm
@@ -53,20 +53,30 @@ void popUpMenu(NSMenu *menu, NSPoint location, float width, NSView *view, int se
     }
 
     // These numbers were extracted from visual inspection as the menu animates shut.
-    NSSize labelOffset = NSMakeSize(11, 1);
+    NSSize labelOffset;
     if (menu.userInterfaceLayoutDirection == NSUserInterfaceLayoutDirectionRightToLeft)
         labelOffset = NSMakeSize(24, 1);
+    else
+        labelOffset = NSMakeSize(11, 1);
 
-    auto options = adoptNS([@{
-        NSPopUpMenuPopupButtonBounds : [NSValue valueWithRect:adjustedPopupBounds],
-        NSPopUpMenuPopupButtonLabelOffset : [NSValue valueWithSize:labelOffset],
-        NSPopUpMenuPopupButtonSize : @(controlSize)
-    } mutableCopy]);
+    if (usesCustomAppearance) {
+        NSDictionary *options = @{
+            NSPopUpMenuPopupButtonBounds : [NSValue valueWithRect:adjustedPopupBounds],
+            NSPopUpMenuPopupButtonLabelOffset : [NSValue valueWithSize:labelOffset],
+            NSPopUpMenuPopupButtonSize : @(controlSize),
+            NSPopUpMenuPopupButtonWidget : @""
+        };
 
-    if (usesCustomAppearance)
-        [options setObject:@"" forKey:NSPopUpMenuPopupButtonWidget];
+        [[menu _menuImpl] popUpMenu:menu atLocation:location width:width forView:view withSelectedItem:selectedItem withFont:font withFlags:0 withOptions:options];
+    } else {
+        NSDictionary *options = @{
+            NSPopUpMenuPopupButtonBounds : [NSValue valueWithRect:adjustedPopupBounds],
+            NSPopUpMenuPopupButtonLabelOffset : [NSValue valueWithSize:labelOffset],
+            NSPopUpMenuPopupButtonSize : @(controlSize)
+        };
 
-    [[menu _menuImpl] popUpMenu:menu atLocation:location width:width forView:view withSelectedItem:selectedItem withFont:font withFlags:(usesCustomAppearance ? 0 : NSPopUpMenuIsPopupButton) withOptions:options.get()];
+        [[menu _menuImpl] popUpMenu:menu atLocation:location width:width forView:view withSelectedItem:selectedItem withFont:font withFlags:NSPopUpMenuIsPopupButton withOptions:options];
+    }
 }
 
 } // namespace PAL

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -408,7 +408,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
             return [attachmentView accessibilityElements];
     }
 
-    auto array = adoptNS([[NSMutableArray alloc] init]);
+    NSMutableArray *array = [NSMutableArray array];
     for (const auto& child : self.axBackingObject->children()) {
         auto* wrapper = child->wrapper();
         if (child->isAttachment()) {
@@ -425,7 +425,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     }
 #endif
 
-    return array.autorelease();
+    return array;
 }
 
 - (NSInteger)accessibilityElementCount

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -128,7 +128,7 @@
 #endif
 
 // Very large strings can negatively impact the performance of notifications, so this length is chosen to try to fit an average paragraph or line of text, but not allow strings to be large enough to hurt performance.
-static const NSUInteger AXValueChangeTruncationLength = 1000;
+static constexpr NSUInteger AXValueChangeTruncationLength = 1000;
 
 // Check if platform provides enums for text change notifications
 #ifndef AXTextStateChangeDefined
@@ -544,15 +544,15 @@ static NSDictionary *textReplacementChangeDictionary(AXCoreObject& object, AXTex
     NSUInteger length = [text length];
     if (!length)
         return nil;
-    auto change = adoptNS([[NSMutableDictionary alloc] initWithCapacity:4]);
+    NSMutableDictionary *change = [NSMutableDictionary dictionaryWithCapacity:4];
     [change setObject:@(platformEditTypeForWebCoreEditType(type)) forKey:NSAccessibilityTextEditType];
     if (length > AXValueChangeTruncationLength) {
         [change setObject:@(length) forKey:NSAccessibilityTextChangeValueLength];
         text = [text substringToIndex:AXValueChangeTruncationLength];
     }
     [change setObject:text forKey:NSAccessibilityTextChangeValue];
-    addTextMarkerFor(change.get(), object, markerTarget);
-    return change.autorelease();
+    addTextMarkerFor(change, object, markerTarget);
+    return change;
 }
 
 void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject* object, AXTextEditType type, const String& text, const VisiblePosition& position)
@@ -774,7 +774,9 @@ AXTextMarkerRef textMarkerForVisiblePosition(AXObjectCache* cache, const Visible
     if (!textMarkerData)
         return nil;
 
-    return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&textMarkerData.value(), sizeof(textMarkerData.value()))).autorelease();
+    AXTextMarkerRef result = AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8 *)&textMarkerData.value(), sizeof(textMarkerData.value()));
+    CFAutorelease(result);
+    return result;
 }
 
 VisiblePosition visiblePositionForTextMarker(AXObjectCache* cache, AXTextMarkerRef textMarker)
@@ -822,7 +824,9 @@ AXTextMarkerRef textMarkerForCharacterOffset(AXObjectCache* cache, const Charact
     auto textMarkerData = cache->textMarkerDataForCharacterOffset(characterOffset);
     if (!textMarkerData.objectID || textMarkerData.ignored)
         return nil;
-    return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&textMarkerData, sizeof(textMarkerData))).autorelease();
+    AXTextMarkerRef result = AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8 *)&textMarkerData, sizeof(textMarkerData));
+    CFAutorelease(result);
+    return result;
 }
 
 CharacterOffset characterOffsetForTextMarker(AXObjectCache* cache, AXTextMarkerRef textMarker)
@@ -846,7 +850,9 @@ AXTextMarkerRef startOrEndTextMarkerForRange(AXObjectCache* cache, const std::op
     auto textMarkerData = cache->startOrEndTextMarkerDataForRange(*range, isStart);
     if (!textMarkerData.objectID)
         return nil;
-    return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&textMarkerData, sizeof(textMarkerData))).autorelease();
+    AXTextMarkerRef result = AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8 *)&textMarkerData, sizeof(textMarkerData));
+    CFAutorelease(result);
+    return result;
 }
 
 AXTextMarkerRangeRef textMarkerRangeFromRange(AXObjectCache* cache, const std::optional<SimpleRange>& range)

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -409,15 +409,15 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
     RefPtr<AXCoreObject> backingObject = [self baseUpdateBackingStore];
     if (!backingObject)
         return nil;
-    
-    RetainPtr<NSMutableArray<AXCustomContent *>> accessibilityCustomContent = nil;
+
+    NSMutableArray<AXCustomContent *> *accessibilityCustomContent = nil;
     auto extendedDescription = backingObject->extendedDescription();
     if (extendedDescription.length()) {
-        accessibilityCustomContent = adoptNS([[NSMutableArray alloc] init]);
+        accessibilityCustomContent = [NSMutableArray array];
         [accessibilityCustomContent addObject:[PAL::getAXCustomContentClass() customContentWithLabel:WEB_UI_STRING("description", "description detail") value:extendedDescription]];
     }
-    
-    return accessibilityCustomContent.autorelease();
+
+    return accessibilityCustomContent;
 }
 #endif
 

--- a/Source/WebCore/crypto/mac/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/mac/SerializedCryptoKeyWrapMac.mm
@@ -55,7 +55,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 namespace WebCore {
 
-const NSUInteger currentSerializationVersion = 1;
+constexpr NSUInteger currentSerializationVersion = 1;
 
 const NSString* versionKey = @"version";
 const NSString* wrappedKEKKey = @"wrappedKEK";

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -431,7 +431,7 @@ namespace WebCore {
 #define WEB_UI_CFSTRING(string, description) WebCore::localizedString(CFSTR(string))
 #define WEB_UI_CFSTRING_KEY(string, key, description) WebCore::localizedString(CFSTR(key))
 
-    WEBCORE_EXPORT RetainPtr<CFStringRef> copyLocalizedString(CFStringRef key);
+    WEBCORE_EXPORT CFStringRef copyLocalizedString(CFStringRef key);
 #endif
 
 #if PLATFORM(COCOA)
@@ -468,7 +468,8 @@ namespace WebCore {
 
     inline NS_FORMAT_ARGUMENT(1) NSString *localizedNSString(NSString *key)
     {
-        return bridge_cast(copyLocalizedString(bridge_cast(key)).autorelease());
+        // FIXME: Find a way to do this without round-tripping between NSString and CFString
+        return adoptCF(copyLocalizedString(bridge_cast(key))).bridgingAutorelease();
     }
 #endif
 

--- a/Source/WebCore/platform/cocoa/SystemVersion.mm
+++ b/Source/WebCore/platform/cocoa/SystemVersion.mm
@@ -33,7 +33,7 @@ static RetainPtr<NSString> createSystemMarketingVersion()
     // Can't use -[NSProcessInfo operatingSystemVersionString] because it has too much stuff we don't want.
     auto systemVersionDictionary = adoptCF(_CFCopySystemVersionDictionary());
     CFStringRef productVersion = static_cast<CFStringRef>(CFDictionaryGetValue(systemVersionDictionary.get(), _kCFSystemVersionProductVersionKey));
-    return adoptNS([(__bridge NSString *)productVersion copy]);
+    return adoptNS((__bridge NSString *)productVersion);
 }
 
 NSString *systemMarketingVersion()

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -257,9 +257,9 @@ ImageDecoderCG::ImageDecoderCG(FragmentedSharedBuffer& data, AlphaOption, GammaA
         utiHint = adoptCF(CGImageSourceGetTypeWithData(data.makeContiguous()->createCFData().get(), nullptr, nullptr));
     
     if (utiHint) {
-        const void* key = kCGImageSourceTypeIdentifierHint;
-        const void* value = utiHint.get();
-        auto options = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, &key, &value, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+        CFTypeRef key[] = { kCGImageSourceTypeIdentifierHint };
+        CFTypeRef value[] = { utiHint.get() };
+        auto options = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, key, value, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
         m_nativeDecoder = adoptCF(CGImageSourceCreateIncremental(options.get()));
     } else
         m_nativeDecoder = adoptCF(CGImageSourceCreateIncremental(nullptr));

--- a/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/WebControlView.mm
@@ -159,9 +159,10 @@ static NSRect _clipBounds;
 
     // FIXME: This is a workaround for <rdar://problem/11385461>. When that bug is resolved, we should remove this code,
     // as well as the internal method overrides below.
-    auto coreUIDrawOptions = adoptCF(CFDictionaryCreateMutableCopy(NULL, 0, defaultOptions));
-    CFDictionarySetValue(coreUIDrawOptions.get(), CFSTR("borders only"), kCFBooleanTrue);
-    return coreUIDrawOptions.autorelease();
+    CFMutableDictionaryRef coreUIDrawOptions = CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, defaultOptions);
+    CFDictionarySetValue(coreUIDrawOptions, CFSTR("borders only"), kCFBooleanTrue);
+    CFAutorelease(coreUIDrawOptions);
+    return coreUIDrawOptions;
 }
 
 - (CFDictionaryRef)_coreUIDrawOptionsWithFrame:(NSRect)cellFrame inView:(NSView *)controlView includeFocus:(BOOL)includeFocus

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -674,7 +674,7 @@ Class webAVPlayerControllerClass()
 
 - (BOOL)hasLegibleMediaSelectionOptions
 {
-    const NSUInteger numDefaultLegibleOptions = 2;
+    constexpr NSUInteger numDefaultLegibleOptions = 2;
     return [[self legibleMediaSelectionOptions] count] > numDefaultLegibleOptions;
 }
 

--- a/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
+++ b/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
@@ -75,7 +75,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSArray<NSString *> *)web_fileUploadContentTypes
 {
-    auto types = adoptNS([NSMutableArray new]);
+    NSMutableArray *types = [NSMutableArray array];
     for (NSString *identifier in self.registeredTypeIdentifiers) {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (UTTypeConformsTo((__bridge CFStringRef)identifier, kUTTypeURL))
@@ -92,7 +92,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             [types addObject:identifier];
     }
 
-    return types.autorelease();
+    return types;
 }
 
 @end
@@ -571,7 +571,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (_loadResults.isEmpty())
         return @[ ];
 
-    auto values = adoptNS([[NSMutableArray alloc] init]);
+    NSMutableArray *values = [NSMutableArray array];
     RetainPtr<WebItemProviderPasteboard> retainedSelf = self;
     [itemSet enumerateIndexesUsingBlock:[retainedSelf, pasteboardType, values] (NSUInteger index, BOOL *) {
         NSItemProvider *provider = [retainedSelf itemProviderAtIndex:index];
@@ -581,7 +581,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (NSData *loadedData = [retainedSelf _preLoadedDataConformingToType:pasteboardType forItemProviderAtIndex:index])
             [values addObject:loadedData];
     }];
-    return values.autorelease();
+    return values;
 }
 
 static NSArray<Class<NSItemProviderReading>> *allLoadableClasses()
@@ -617,7 +617,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (_loadResults.isEmpty())
         return @[ ];
 
-    auto values = adoptNS([[NSMutableArray alloc] init]);
+    NSMutableArray *values = [NSMutableArray array];
     RetainPtr<WebItemProviderPasteboard> retainedSelf = self;
     [itemSet enumerateIndexesUsingBlock:[retainedSelf, pasteboardType, values] (NSUInteger index, BOOL *) {
         NSItemProvider *provider = [retainedSelf itemProviderAtIndex:index];
@@ -637,7 +637,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             [values addObject:readObject];
     }];
 
-    return values.autorelease();
+    return values;
 }
 
 - (NSInteger)changeCount
@@ -647,9 +647,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSArray<NSURL *> *)fileUploadURLsAtIndex:(NSUInteger)index fileTypes:(NSArray<NSString *> **)outFileTypes
 {
-    auto fileTypes = adoptNS([NSMutableArray new]);
-    auto fileURLs = adoptNS([NSMutableArray new]);
-
     if (index >= _loadResults.size())
         return @[ ];
 
@@ -657,6 +654,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (![result canBeRepresentedAsFileUpload])
         return @[ ];
 
+    NSMutableArray *fileTypes = [NSMutableArray array];
+    NSMutableArray *fileURLs = [NSMutableArray array];
     for (NSString *contentType in [result itemProvider].web_fileUploadContentTypes) {
         if (NSURL *url = [result fileURLForType:contentType]) {
             [fileTypes addObject:contentType];
@@ -664,8 +663,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
     }
 
-    *outFileTypes = fileTypes.autorelease();
-    return fileURLs.autorelease();
+    *outFileTypes = fileTypes;
+    return fileURLs;
 }
 
 - (NSArray<NSURL *> *)allDroppedFileURLs

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -230,7 +230,7 @@ static RetainPtr<CTFontRef> attachmentActionFont()
 {
     auto style = kCTUIFontTextStyleFootnote;
     auto size = contentSizeCategory();
-    auto attributes = static_cast<CFDictionaryRef>(@{ (id)kCTFontTraitsAttribute: @{ (id)kCTFontSymbolicTrait: @(kCTFontTraitTightLeading | kCTFontTraitEmphasized) } });
+    auto attributes = (__bridge CFDictionaryRef)(@{ (id)kCTFontTraitsAttribute : @{ (id)kCTFontSymbolicTrait : @(kCTFontTraitTightLeading | kCTFontTraitEmphasized) } });
     auto emphasizedFontDescriptor = adoptCF(CTFontDescriptorCreateWithTextStyleAndAttributes(style, size, attributes));
 
     return adoptCF(CTFontCreateWithFontDescriptor(emphasizedFontDescriptor.get(), 0, nullptr));

--- a/Source/WebGPU/WebGPU/Adapter.mm
+++ b/Source/WebGPU/WebGPU/Adapter.mm
@@ -79,7 +79,7 @@ void Adapter::getProperties(WGPUAdapterProperties& properties)
 
 bool Adapter::hasFeature(WGPUFeatureName feature)
 {
-    return std::find(m_capabilities.features.begin(), m_capabilities.features.end(), feature);
+    return m_capabilities.features.find(feature);
 }
 
 void Adapter::requestDevice(const WGPUDeviceDescriptor& descriptor, CompletionHandler<void(WGPURequestDeviceStatus, Ref<Device>&&, String&&)>&& callback)

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -221,7 +221,7 @@ Queue& Device::getQueue()
 
 bool Device::hasFeature(WGPUFeatureName feature)
 {
-    return std::find(m_capabilities.features.begin(), m_capabilities.features.end(), feature);
+    return m_capabilities.features.find(feature);
 }
 
 auto Device::currentErrorScope(WGPUErrorFilter type) -> ErrorScope*

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -62,7 +62,7 @@ NSDictionary *filterObjects<NSDictionary>(NSDictionary *dictionary, bool NS_NOES
             filterResult[key] = value;
     }];
 
-    return [filterResult copy];
+    return filterResult;
 }
 
 template<>
@@ -96,7 +96,7 @@ NSArray *mapObjects<NSArray>(NSArray *array, __kindof id NS_NOESCAPE (^block)(__
                 [mapResult addObject:result];
         }];
 
-        return [mapResult copy];
+        return mapResult;
     }
     }
 }
@@ -114,7 +114,7 @@ NSDictionary *mapObjects<NSDictionary>(NSDictionary *dictionary, __kindof id NS_
             mapResult[key] = result;
     }];
 
-    return [mapResult copy];
+    return mapResult;
 }
 
 template<>
@@ -137,7 +137,7 @@ NSSet *mapObjects<NSSet>(NSSet *set, __kindof id NS_NOESCAPE (^block)(__kindof i
                 [mapResult addObject:result];
         }];
 
-        return [mapResult copy];
+        return mapResult;
     }
     }
 }
@@ -237,20 +237,20 @@ WallTime toImpl(NSDate *date)
 
 NSSet *toAPI(HashSet<String>& set)
 {
-    NSMutableSet *result = [[NSMutableSet alloc] initWithCapacity:set.size()];
+    NSMutableSet *result = [NSMutableSet setWithCapacity:set.size()];
     for (auto& element : set)
         [result addObject:static_cast<NSString *>(element)];
 
-    return [result copy];
+    return result;
 }
 
 NSArray *toAPIArray(HashSet<String>& set)
 {
-    NSMutableArray *result = [[NSMutableArray alloc] initWithCapacity:set.size()];
+    NSMutableArray *result = [NSMutableArray arrayWithCapacity:set.size()];
     for (auto& element : set)
         [result addObject:static_cast<NSString *>(element)];
 
-    return [result copy];
+    return result;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -118,7 +118,7 @@ static PKPaymentErrorCode toPKPaymentErrorCode(WebCore::ApplePayErrorCode code)
 
 static NSError *toNSError(const WebCore::ApplePayError& error)
 {
-    auto userInfo = adoptNS([[NSMutableDictionary alloc] init]);
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
     [userInfo setObject:error.message() forKey:NSLocalizedDescriptionKey];
 
     if (auto contactField = error.contactField()) {
@@ -192,7 +192,7 @@ static NSError *toNSError(const WebCore::ApplePayError& error)
             [userInfo setObject:postalAddressKey forKey:PKPaymentErrorPostalAddressUserInfoKey];
     }
 
-    return [NSError errorWithDomain:PKPaymentErrorDomain code:toPKPaymentErrorCode(error.code()) userInfo:userInfo.get()];
+    return [NSError errorWithDomain:PKPaymentErrorDomain code:toPKPaymentErrorCode(error.code()) userInfo:userInfo];
 }
 
 static RetainPtr<NSArray> toNSErrors(const Vector<RefPtr<WebCore::ApplePayError>>& errors)

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -1122,11 +1122,11 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
     if (!_allowedClasses)
         return [NSSet set];
 
-    auto result = adoptNS([[NSMutableSet alloc] init]);
+    NSMutableSet *result = [NSMutableSet set];
     for (auto allowedClass : *_allowedClasses)
         [result addObject:(__bridge Class)allowedClass];
 
-    return result.autorelease();
+    return result;
 }
 
 @end

--- a/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfiguration.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfiguration.mm
@@ -64,10 +64,10 @@ std::optional<PaymentSetupConfiguration> PaymentSetupConfiguration::decode(IPC::
     static NeverDestroyed<RetainPtr<NSArray>> allowedClasses;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        auto allowed = adoptNS([[NSMutableArray alloc] initWithCapacity:1]);
         if (auto pkPaymentSetupConfigurationClass = PAL::getPKPaymentSetupConfigurationClass())
-            [allowed addObject:pkPaymentSetupConfigurationClass];
-        allowedClasses.get() = adoptNS([allowed copy]);
+            allowedClasses.get() = @[ pkPaymentSetupConfigurationClass ];
+        else
+            allowedClasses.get() = @[];
     });
 
     auto configuration = IPC::decode<PKPaymentSetupConfiguration>(decoder, allowedClasses.get().get());

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -128,19 +128,19 @@ static constexpr NSString *baseURLKey = @"WK.baseURL";
     BOOL hasBaseURL;
     [coder decodeValueOfObjCType:"c" at:&hasBaseURL size:sizeof(hasBaseURL)];
 
-    RetainPtr<NSURL> baseURL;
+    NSURL *baseURL = nil;
     if (hasBaseURL)
         baseURL = (NSURL *)[coder decodeObjectOfClass:NSURL.class forKey:baseURLKey];
 
     NSUInteger length;
     if (auto bytes = (UInt8 *)[coder decodeBytesWithReturnedLength:&length]) {
-        m_wrappedURL = bridge_cast(adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, length, kCFStringEncodingUTF8, bridge_cast(baseURL.get()), true)));
+        m_wrappedURL = bridge_cast(adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, length, kCFStringEncodingUTF8, bridge_cast(baseURL), true)));
         if (!m_wrappedURL)
             LOG_ERROR("Failed to decode NSURL due to invalid encoding of length %d. Substituting a blank URL", length);
     }
 
     if (!m_wrappedURL)
-        m_wrappedURL = [NSURL URLWithString:@""];
+        m_wrappedURL = [[NSURL alloc] initWithString:@""];
 
     return selfPtr.leakRef();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -116,13 +116,13 @@ static NSString *dataTypesToString(NSSet *dataTypes)
 
 - (NSString *)description
 {
-    auto result = adoptNS([[NSMutableString alloc] initWithFormat:@"<%@: %p; displayName = %@; dataTypes = { %@ }", NSStringFromClass(self.class), self, self.displayName, dataTypesToString(self.dataTypes)]);
+    NSMutableString *result = [NSMutableString stringWithFormat:@"<%@: %p; displayName = %@; dataTypes = { %@ }", NSStringFromClass(self.class), self, self.displayName, dataTypesToString(self.dataTypes)];
 
     if (auto* dataSize = self._dataSize)
         [result appendFormat:@"; _dataSize = { %llu bytes }", dataSize.totalSize];
 
     [result appendString:@">"];
-    return result.autorelease();
+    return result;
 }
 
 - (NSString *)displayName

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationToken.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationToken.mm
@@ -112,7 +112,7 @@ static BOOL isEqualOrBothNil(id a, id b)
 
     [description appendString:@">"];
 
-    return adoptNS([description copy]).autorelease();
+    return description;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -704,6 +704,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
         
     [query removeObjectForKey:(id)kSecReturnRef];
     [query setObject: @YES forKey:(id)kSecReturnAttributes];
+
     CFTypeRef attributesArrayRef = nullptr;
     status = SecItemCopyMatching(bridge_cast(query.get()), &attributesArrayRef);
     if (status && status != errSecItemNotFound) {
@@ -711,7 +712,6 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
         return nullptr;
     }
     auto attributes = adoptNS((__bridge NSDictionary *)attributesArrayRef);
-
     int64_t keyType, keySize;
     if (!CFNumberGetValue((__bridge CFNumberRef)attributes.get()[bridge_id_cast(kSecAttrKeyType)], kCFNumberSInt64Type, &keyType)) {
         createNSErrorFromWKErrorIfNecessary(error, WKErrorMalformedCredential);

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -57,7 +57,7 @@
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/Base64.h>
 
-static const NSUInteger windowStyleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable | NSWindowStyleMaskFullSizeContentView;
+static constexpr NSUInteger windowStyleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable | NSWindowStyleMaskFullSizeContentView;
 
 // The time we keep our WebView alive before closing it and its process.
 // Reusing the WebView improves start up time for people that jump in and out of the Inspector.
@@ -923,8 +923,8 @@ DebuggableInfoData WebInspectorUIProxy::infoForLocalDebuggable()
     DebuggableInfoData result;
     result.debuggableType = Inspector::DebuggableType::WebPage;
     result.targetPlatformName = "macOS"_s;
-    result.targetBuildVersion = plist[static_cast<NSString *>(_kCFSystemVersionBuildVersionKey)];
-    result.targetProductVersion = plist[static_cast<NSString *>(_kCFSystemVersionProductUserVisibleVersionKey)];
+    result.targetBuildVersion = plist[bridge_cast(_kCFSystemVersionBuildVersionKey)];
+    result.targetProductVersion = plist[bridge_cast(_kCFSystemVersionProductUserVisibleVersionKey)];
     result.targetIsSimulator = false;
 
     return result;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12713,13 +12713,14 @@ static UIMenu *menuFromLegacyPreviewOrDefaultActions(UIViewController *previewVi
             if (ddResult)
                 dataForPreview.get()[UIPreviewDataDDResult] = (__bridge id)ddResult;
             if (!_positionInformation.textBefore.isEmpty() || !_positionInformation.textAfter.isEmpty()) {
-                extendedContext = adoptNS([@{
-                    getkDataDetectorsLeadingText() : _positionInformation.textBefore,
-                    getkDataDetectorsTrailingText() : _positionInformation.textAfter,
-                } mutableCopy]);
-                
                 if (newContext)
-                    [extendedContext addEntriesFromDictionary:newContext];
+                    extendedContext = adoptNS([newContext mutableCopy]);
+                else
+                    extendedContext = adoptNS([[NSMutableDictionary alloc] init]);
+
+                extendedContext.get()[getkDataDetectorsLeadingText()] = _positionInformation.textBefore;
+                extendedContext.get()[getkDataDetectorsTrailingText()] = _positionInformation.textAfter;
+
                 newContext = extendedContext.get();
             }
             if (newContext)

--- a/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
@@ -43,7 +43,7 @@
 // FIXME: Implement scrollFindMatchToVisible.
 // FIXME: The NSTextFinder overlay doesn't move with scrolling; we should have a mode where we manage the overlay.
 
-static const NSUInteger maximumFindMatches = 1000;
+static constexpr NSUInteger maximumFindMatches = 1000;
 
 @interface WKTextFinderClient ()
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -670,14 +670,14 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 
 @synthesize currentListType = _currentListType;
 
-static const CGFloat listControlSegmentWidth = 67;
+static constexpr CGFloat listControlSegmentWidth = 67;
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER) && ENABLE(FULLSCREEN_API)
-static const CGFloat exitFullScreenButtonWidth = 64;
+static constexpr CGFloat exitFullScreenButtonWidth = 64;
 #endif
 
-static const NSUInteger noListSegment = 0;
-static const NSUInteger unorderedListSegment = 1;
-static const NSUInteger orderedListSegment = 2;
+static constexpr NSUInteger noListSegment = 0;
+static constexpr NSUInteger unorderedListSegment = 1;
+static constexpr NSUInteger orderedListSegment = 2;
 
 - (instancetype)initWithWebViewImpl:(WebKit::WebViewImpl*)webViewImpl
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
@@ -79,9 +79,10 @@
         return nil;
 
 #if USE(APPKIT)
+    // imageWithCGImage only exists for UIImage, not NSImage
     return adoptNS([[NSImage alloc] initWithCGImage:nativeImage->platformImage().get() size:NSZeroSize]).autorelease();
 #else
-    return adoptNS([[UIImage alloc] initWithCGImage:nativeImage->platformImage().get()]).autorelease();
+    return [UIImage imageWithCGImage:nativeImage->platformImage().get()];
 #endif
 }
 

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
@@ -229,7 +229,7 @@ void SocketStreamHandleImpl::chooseProxyFromArray(CFArrayRef proxyArray)
         if (auto proxyInfo = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(proxyArray, 0))) {
             if (auto proxyType = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(proxyInfo, kCFProxyTypeKey)); proxyType && CFEqual(proxyType, kCFProxyTypeAutoConfigurationURL)) {
                 if (auto pacFileURL = dynamic_cf_cast<CFURLRef>(CFDictionaryGetValue(proxyInfo, kCFProxyAutoConfigurationURLKey))) {
-                    executePACFileURL(static_cast<CFURLRef>(pacFileURL));
+                    executePACFileURL(pacFileURL);
                     return;
                 }
             }

--- a/Source/WebKitLegacy/mac/Misc/WebLocalizableStringsInternal.h
+++ b/Source/WebKitLegacy/mac/Misc/WebLocalizableStringsInternal.h
@@ -32,13 +32,13 @@
 extern "C" {
 #endif
 
-NSString *WebLocalizedStringInternal(const char* key) NS_FORMAT_ARGUMENT(1);
+NSString *WebLocalizedStringInternal(CFStringRef key) NS_FORMAT_ARGUMENT(1);
 
 #ifdef __cplusplus
 }
 #endif
 
-#define UI_STRING_INTERNAL(string, comment) WebLocalizedStringInternal(string)
-#define UI_STRING_KEY_INTERNAL(string, key, comment) WebLocalizedStringInternal(key)
+#define UI_STRING_INTERNAL(string, comment) WebLocalizedStringInternal(CFSTR(string))
+#define UI_STRING_KEY_INTERNAL(string, key, comment) WebLocalizedStringInternal(CFSTR(key))
 
 #endif // WebLocalizableStringsInternal_h

--- a/Source/WebKitLegacy/mac/Misc/WebLocalizableStringsInternal.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebLocalizableStringsInternal.mm
@@ -29,8 +29,7 @@
 
 using namespace WebCore;
 
-NSString *WebLocalizedStringInternal(const char* key)
+NSString *WebLocalizedStringInternal(CFStringRef key)
 {
-    auto keyString = adoptCF(CFStringCreateWithCStringNoCopy(0, key, kCFStringEncodingUTF8, kCFAllocatorNull));
-    return localizedNSString(bridge_cast(keyString.get()));
+    return adoptCF(copyLocalizedString(key)).bridgingAutorelease();
 }

--- a/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
@@ -82,8 +82,8 @@
 
 - (BOOL)_web_isEmpty
 {
-    if (!CFURLGetBaseURL(bridge_cast(self)))
-        return !CFURLGetBytes(bridge_cast(self), nullptr, 0);
+    if (!self.baseURL)
+        return !self.dataRepresentation.length;
     return ![WTF::originalURLData(self) length];
 }
 
@@ -224,13 +224,7 @@
     if (colon.location != NSNotFound && colon.location > 0) {
         NSRange scheme = {0, colon.location};
         static NeverDestroyed inverseSchemeCharacterSet = [] {
-            /*
-             This stuff is very expensive.  10-15 msec on a 2x1.2GHz.  If not cached it swamps
-             everything else when adding items to the autocomplete DB.  Makes me wonder if we
-             even need to enforce the character set here.
-            */
-            NSString *acceptableCharacters = @"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+.-";
-            return RetainPtr { [[NSCharacterSet characterSetWithCharactersInString:acceptableCharacters] invertedSet] };
+            return RetainPtr { [[NSCharacterSet URLHostAllowedCharacterSet] invertedSet] };
         }();
         NSRange illegals = [self rangeOfCharacterFromSet:inverseSchemeCharacterSet.get().get() options:0 range:scheme];
         if (illegals.location == NSNotFound)

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -1138,28 +1138,29 @@ static NSControlStateValue kit(TriState state)
 
 + (NSArray *)_excludedElementsForAttributedStringConversion
 {
-    auto elements = adoptNS([[NSMutableArray alloc] initWithObjects:
+#if !ENABLE(ATTACHMENT_ELEMENT)
+    return @[
+#else
+    NSMutableArray *elements = [NSMutableArray arrayWithObjects:
+#endif
         // Omit style since we want style to be inline so the fragment can be easily inserted.
         @"style",
         // Omit xml so the result is not XHTML.
-        @"xml",
-        // Omit tags that will get stripped when converted to a fragment anyway.
         @"doctype", @"html", @"head", @"body",
         // Omit deprecated tags.
         @"applet", @"basefont", @"center", @"dir", @"font", @"menu", @"s", @"strike", @"u",
-        // Omit object so no file attachments are part of the fragment.
 #if !ENABLE(ATTACHMENT_ELEMENT)
         // Omit object so no file attachments are part of the fragment.
-        @"object",
-#endif
-        nil]);
+        @"object"
+    ];
+#else
+    nil];
 
-#if ENABLE(ATTACHMENT_ELEMENT)
     if (!WebCore::DeprecatedGlobalSettings::attachmentElementEnabled())
         [elements addObject:@"object"];
-#endif
 
-    return elements.autorelease();
+    return elements;
+#endif
 }
 
 - (DOMDocumentFragment *)_documentFragmentFromPasteboard:(NSPasteboard *)pasteboard inContext:(DOMRange *)context allowPlainText:(BOOL)allowPlainText

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1000,7 +1000,7 @@ enum class WebListType {
 
 @synthesize currentListType = _currentListType;
 
-static const CGFloat listControlSegmentWidth = 67.0;
+static constexpr CGFloat listControlSegmentWidth = 67.0;
 
 static const NSUInteger noListSegment = 0;
 static const NSUInteger unorderedListSegment = 1;

--- a/Tools/TestWebKitAPI/Tests/WebKit/FontRegistrySandboxCheck.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/FontRegistrySandboxCheck.mm
@@ -58,7 +58,7 @@ TEST(WebKit, UserInstalledFontsWork)
 {
     NSURL *fontURL = [[NSBundle mainBundle] URLForResource:@"Ahem" withExtension:@"ttf" subdirectory:@"TestWebKitAPI.resources"];
     CFErrorRef error = nil;
-    auto registrationSucceeded = CTFontManagerRegisterFontsForURL(static_cast<CFURLRef>(fontURL), kCTFontManagerScopeUser, &error);
+    auto registrationSucceeded = CTFontManagerRegisterFontsForURL((__bridge CFURLRef)fontURL, kCTFontManagerScopeUser, &error);
 
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     WKContextSetUsesSingleWebProcess(context.get(), true);
@@ -74,7 +74,7 @@ TEST(WebKit, UserInstalledFontsWork)
 
     if (registrationSucceeded) {
         error = nil;
-        CTFontManagerUnregisterFontsForURL(static_cast<CFURLRef>(fontURL), kCTFontManagerScopeUser, &error);
+        CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)fontURL, kCTFontManagerScopeUser, &error);
         ASSERT_FALSE(error);
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm
@@ -60,7 +60,7 @@ static RetainPtr<SecIdentityRef> createTestIdentity(const Vector<uint8_t>& priva
         (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrKeySizeInBits: @4096,
     };
-    const NSUInteger pemEncodedPrivateKeyHeaderLength = 26;
+    constexpr NSUInteger pemEncodedPrivateKeyHeaderLength = 26;
     CFErrorRef error = nullptr;
     auto privateKey = adoptCF(SecKeyCreateWithData((__bridge CFDataRef)[derEncodedPrivateKey subdataWithRange:NSMakeRange(pemEncodedPrivateKeyHeaderLength, derEncodedPrivateKey.length - pemEncodedPrivateKeyHeaderLength)], (__bridge CFDictionaryRef)options, &error));
     EXPECT_NULL(error);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextWidth.mm
@@ -47,13 +47,13 @@ TEST(WebKit, TextWidth)
     }];
     TestWebKitAPI::Util::run(&didEvaluateJavaScript);
 
-    auto font = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 24, static_cast<CFStringRef>(@"en-US")));
+    auto font = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 24, CFSTR("en-US")));
     // Use CFAttributedString so we don't have to deal with NSFont / UIFont and have this code be platform-dependent.
     CFTypeRef keys[] = { kCTFontAttributeName };
     CFTypeRef values[] = { font.get() };
     auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, CFSTR("This is a test string"), attributes.get()));
-    auto line = adoptCF(CTLineCreateWithAttributedString(static_cast<CFAttributedStringRef>(attributedString)));
+    auto line = adoptCF(CTLineCreateWithAttributedString(attributedString.get()));
     double coreTextWidth = CTLineGetTypographicBounds(line.get(), nullptr, nullptr, nullptr);
 
     EXPECT_NEAR(webKitWidth, coreTextWidth, 3);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -1129,7 +1129,7 @@ TEST_F(WKContentRuleListStoreTest, NullPatternSet)
             preferences._activeContentRuleListActionPatterns = [NSDictionary dictionaryWithObject:[NSSet setWithObject:@"testscheme://*/*"] forKey:@"testidentifier"];
             break;
         case DelegateAction::AllowNone:
-            preferences._activeContentRuleListActionPatterns = [NSDictionary dictionary];
+            preferences._activeContentRuleListActionPatterns = @{ };
             break;
         case DelegateAction::AllowTestHost:
             preferences._activeContentRuleListActionPatterns = [NSDictionary dictionaryWithObject:[NSSet setWithObject:@"testscheme://testhost/*"] forKey:@"testidentifier"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm
@@ -38,7 +38,7 @@
 #endif
 
 static bool focusDidStartInputSession;
-static const NSUInteger maxCount = 100;
+static constexpr NSUInteger maxCount = 100;
 
 @interface WKWebViewFindStringInputDelegate : NSObject <_WKInputDelegate>
 @end


### PR DESCRIPTION
#### 993dd98fc6dbf5ae452b1e7b87517867ebf5a70a
<pre>
Use convenience initializers over smart pointers when autoreleasing
<a href="https://bugs.webkit.org/show_bug.cgi?id=253518">https://bugs.webkit.org/show_bug.cgi?id=253518</a>

Reviewed by NOBODY (OOPS!).

Since we are autoreleasing anyway, having a smart pointer do the
redundant work is silly.

* Source/JavaScriptCore/API/JSManagedValue.mm:
* Source/JavaScriptCore/bytecode/Opcode.cpp:
* Source/WTF/wtf/cf/CFURLExtras.cpp:
* Source/WTF/wtf/cf/CFURLExtras.h:
* Source/WTF/wtf/cocoa/NSURLExtras.mm:
* Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm:
* Source/WebCore/PAL/pal/system/mac/PopupMenu.mm:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
* Source/WebCore/platform/LocalizedStrings.cpp:
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/platform/cocoa/SystemVersion.mm:
* Source/WebCore/platform/graphics/mac/controls/WebControlView.mm:
* Source/WebCore/platform/ios/WebItemProviderPasteboard.mm:
* Source/WebGPU/WebGPU/Adapter.mm:
* Source/WebGPU/WebGPU/Device.mm:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm:
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
* Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfiguration.mm:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
* Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextManipulationToken.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm:
* Source/WebKitLegacy/mac/Misc/WebLocalizableStringsInternal.h:
* Source/WebKitLegacy/mac/Misc/WebLocalizableStringsInternal.mm:
* Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm:
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/993dd98fc6dbf5ae452b1e7b87517867ebf5a70a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1336 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/1375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1419 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/2239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1427 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/1435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/2239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1348 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/2085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/1169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/1221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/1304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/1435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1370 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/1220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/283 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1305 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1374 "Built successfully") | 
| | | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->