### PR TITLE
[WGSL] Store reference struct node in the struct type

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -158,7 +158,7 @@ std::optional<FailedCheck> TypeChecker::check()
 // Declarations
 void TypeChecker::visit(AST::Structure& structure)
 {
-    Type* structType = m_types.structType(structure.name());
+    Type* structType = m_types.structType(structure);
     introduceVariable(structure.name(), structType);
 }
 

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -112,9 +112,9 @@ TypeStore::TypeStore()
     allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat4x4, 4, 4);
 }
 
-Type* TypeStore::structType(const AST::Identifier& name)
+Type* TypeStore::structType(AST::Structure& structure)
 {
-    return allocateType<Struct>(name);
+    return allocateType<Struct>(structure);
 }
 
 Type* TypeStore::constructType(AST::ParameterizedTypeName::Base base, Type* elementType)

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -54,7 +54,7 @@ public:
     Type* abstractFloatType() const { return m_abstractFloat; }
     Type* f32Type() const { return m_f32; }
 
-    Type* structType(const AST::Identifier& name);
+    Type* structType(AST::Structure&);
     Type* arrayType(Type*, std::optional<unsigned>);
     Type* vectorType(Type*, uint8_t);
     Type* matrixType(Type*, uint8_t columns, uint8_t rows);

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "Types.h"
 
+#include "ASTStructure.h"
 #include <wtf/StringPrintStream.h>
 
 namespace WGSL {
@@ -58,7 +59,7 @@ void Type::dump(PrintStream& out) const
             out.print(">");
         },
         [&](const Struct& structure) {
-            out.print(structure.name);
+            out.print(structure.structure.name());
         },
         [&](const Function&) {
             // FIXME: implement this

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ASTForward.h"
 #include <wtf/HashMap.h>
 #include <wtf/PrintStream.h>
 #include <wtf/text/WTFString.h>
@@ -67,11 +68,12 @@ struct Matrix {
 
 struct Array {
     Type* element;
+
     std::optional<unsigned> size;
 };
 
 struct Struct {
-    String name;
+    AST::Structure& structure;
     HashMap<String, Type*> fields { };
 };
 


### PR DESCRIPTION
#### dee031899a36fef4d80847330a06fc17a76a8b54
<pre>
[WGSL] Store reference struct node in the struct type
<a href="https://bugs.webkit.org/show_bug.cgi?id=253519">https://bugs.webkit.org/show_bug.cgi?id=253519</a>
rdar://106364421

Reviewed by Myles C. Maxfield.

Simplify the usage of struct types in the entry point rewriter by storing a
pointer to the AST node in the type instead of just the name.

* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::rewrite):
(WGSL::EntryPointRewriter::checkReturnType):
(WGSL::EntryPointRewriter::visit):
(WGSL::EntryPointRewriter::collectStructs): Deleted.
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::structType):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/261620@main">https://commits.webkit.org/261620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0b16db908b77306f599d4f70559e018c5e72766

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120277 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2722 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104266 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/69 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45071 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/67 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86865 "12 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9510 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52050 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8102 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15601 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->