### PR TITLE
[WebGPU] Implement deferred compilation for RenderPipeline

### DIFF
--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -118,6 +118,8 @@
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
 		97296766299C09BC001C8BD4 /* TypeDeclarations.rb in Sources */ = {isa = PBXBuildFile; fileRef = 97296765299C09B0001C8BD4 /* TypeDeclarations.rb */; };
+		973F784729C8A78200166C66 /* Pipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 973F784529C8A78200166C66 /* Pipeline.h */; };
+		973F784829C8A78200166C66 /* Pipeline.mm in Sources */ = {isa = PBXBuildFile; fileRef = 973F784629C8A78200166C66 /* Pipeline.mm */; };
 		9776BE732992A236002D6D93 /* Overload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9776BE712992A236002D6D93 /* Overload.cpp */; };
 		9776BE742992A236002D6D93 /* Overload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE722992A236002D6D93 /* Overload.h */; };
 		9776BE7629957E12002D6D93 /* WGSLShaderModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE7529957E12002D6D93 /* WGSLShaderModule.h */; };
@@ -343,6 +345,8 @@
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
 		97296764299BFB72001C8BD4 /* main.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = main.rb; sourceTree = "<group>"; };
 		97296765299C09B0001C8BD4 /* TypeDeclarations.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = TypeDeclarations.rb; sourceTree = "<group>"; };
+		973F784529C8A78200166C66 /* Pipeline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Pipeline.h; sourceTree = "<group>"; };
+		973F784629C8A78200166C66 /* Pipeline.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Pipeline.mm; sourceTree = "<group>"; };
 		9776BE712992A236002D6D93 /* Overload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Overload.cpp; sourceTree = "<group>"; };
 		9776BE722992A236002D6D93 /* Overload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Overload.h; sourceTree = "<group>"; };
 		9776BE7529957E12002D6D93 /* WGSLShaderModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WGSLShaderModule.h; sourceTree = "<group>"; };
@@ -444,6 +448,8 @@
 				1C5ACAA0273A426D0095F8D5 /* Instance.h */,
 				1C5ACA92273A41C20095F8D5 /* Instance.mm */,
 				1C33755D27FA23B8002F1644 /* IsValidToUseWith.h */,
+				973F784529C8A78200166C66 /* Pipeline.h */,
+				973F784629C8A78200166C66 /* Pipeline.mm */,
 				1C5ACADA273A4E710095F8D5 /* PipelineLayout.h */,
 				1C5ACAE4273A55DD0095F8D5 /* PipelineLayout.mm */,
 				1C9F7CDE29762F51006B5BE9 /* PresentationContext.h */,
@@ -649,6 +655,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1CEBD7E72716AFBA00A5254D /* WebGPU.h in Headers */,
+				973F784729C8A78200166C66 /* Pipeline.h in Headers */,
 				1C5ACAD3273A4C860095F8D5 /* WebGPUExt.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -868,6 +875,7 @@
 				1C5ACAC1273A426D0095F8D5 /* Device.mm in Sources */,
 				1C0F41EE280940650005886D /* HardwareCapabilities.mm in Sources */,
 				1C5ACA94273A41C20095F8D5 /* Instance.mm in Sources */,
+				973F784829C8A78200166C66 /* Pipeline.mm in Sources */,
 				1C5ACAE5273A55DD0095F8D5 /* PipelineLayout.mm in Sources */,
 				1C9F7CDF29762F51006B5BE9 /* PresentationContext.mm in Sources */,
 				1CBD2E972977DAC900BBF52C /* PresentationContextCoreAnimation.mm in Sources */,

--- a/Source/WebGPU/WebGPU/Pipeline.h
+++ b/Source/WebGPU/WebGPU/Pipeline.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "ShaderModule.h"
+
+namespace WebGPU {
+
+struct LibraryCreationResult {
+    id<MTLLibrary> library;
+    WGSL::Reflection::EntryPointInformation entryPointInformation; // FIXME(PERFORMANCE): This is big. Don't copy this around.
+};
+
+std::optional<LibraryCreationResult> createLibrary(id<MTLDevice>, const ShaderModule&, const PipelineLayout*, const String& entryPointName, NSString *label);
+
+MTLFunctionConstantValues *createConstantValues(uint32_t constantCount, const WGPUConstantEntry* constants, const WGSL::Reflection::EntryPointInformation&);
+
+id<MTLFunction> createFunction(id<MTLLibrary>, const WGSL::Reflection::EntryPointInformation&, const WGPUProgrammableStageDescriptor*, NSString *label);
+
+} // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "Pipeline.h"
+
+#import "APIConversions.h"
+#import "ShaderModule.h"
+
+namespace WebGPU {
+
+std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const ShaderModule& shaderModule, const PipelineLayout* pipelineLayout, const String& entryPoint, NSString *label)
+{
+    if (shaderModule.library() && pipelineLayout) {
+        if (const auto* pipelineLayoutHint = shaderModule.pipelineLayoutHint(entryPoint)) {
+            if (*pipelineLayoutHint == *pipelineLayout) {
+                if (const auto* entryPointInformation = shaderModule.entryPointInformation(entryPoint))
+                    return { { shaderModule.library(), *entryPointInformation } };
+            }
+        }
+    }
+
+    auto* ast = shaderModule.ast();
+    if (!ast)
+        return std::nullopt;
+
+    std::optional<WGSL::PipelineLayout> wgslPipelineLayout { std::nullopt };
+    if (pipelineLayout)
+        wgslPipelineLayout = ShaderModule::convertPipelineLayout(*pipelineLayout);
+
+    auto prepareResult = WGSL::prepare(*ast, entryPoint, wgslPipelineLayout);
+
+    auto library = ShaderModule::createLibrary(device, prepareResult.msl, label);
+
+    auto iterator = prepareResult.entryPoints.find(entryPoint);
+    if (iterator == prepareResult.entryPoints.end())
+        return std::nullopt;
+    const auto& entryPointInformation = iterator->value;
+
+    return { { library, entryPointInformation } };
+}
+
+MTLFunctionConstantValues *createConstantValues(uint32_t constantCount, const WGPUConstantEntry* constants, const WGSL::Reflection::EntryPointInformation& entryPointInformation)
+{
+    auto constantValues = [MTLFunctionConstantValues new];
+    for (uint32_t i = 0; i < constantCount; ++i) {
+        const auto& entry = constants[i];
+        auto nameIterator = entryPointInformation.specializationConstantIndices.find(fromAPI(entry.key));
+        if (nameIterator == entryPointInformation.specializationConstantIndices.end())
+            return nullptr;
+        auto specializationConstantIndex = nameIterator->value;
+        auto indexIterator = entryPointInformation.specializationConstants.find(specializationConstantIndex);
+        if (indexIterator == entryPointInformation.specializationConstants.end())
+            return nullptr;
+        const auto& specializationConstant = indexIterator->value;
+        switch (specializationConstant.type) {
+        case WGSL::Reflection::SpecializationConstantType::Boolean: {
+            bool value = entry.value;
+            [constantValues setConstantValue:&value type:MTLDataTypeBool withName:specializationConstant.mangledName];
+            break;
+        }
+        case WGSL::Reflection::SpecializationConstantType::Float: {
+            float value = entry.value;
+            [constantValues setConstantValue:&value type:MTLDataTypeFloat withName:specializationConstant.mangledName];
+            break;
+        }
+        case WGSL::Reflection::SpecializationConstantType::Int: {
+            int value = entry.value;
+            [constantValues setConstantValue:&value type:MTLDataTypeInt withName:specializationConstant.mangledName];
+            break;
+        }
+        case WGSL::Reflection::SpecializationConstantType::Unsigned: {
+            unsigned value = entry.value;
+            [constantValues setConstantValue:&value type:MTLDataTypeUInt withName:specializationConstant.mangledName];
+            break;
+        }
+        }
+    }
+    return constantValues;
+}
+
+id<MTLFunction> createFunction(id<MTLLibrary> library, const WGSL::Reflection::EntryPointInformation& entryPointInformation, const WGPUProgrammableStageDescriptor* compute, NSString *label)
+{
+    auto functionDescriptor = [MTLFunctionDescriptor new];
+    functionDescriptor.name = entryPointInformation.mangledName;
+    if (compute && compute->constantCount) {
+        auto constantValues = createConstantValues(compute->constantCount, compute->constants, entryPointInformation);
+        if (!constantValues)
+            return nullptr;
+        functionDescriptor.constantValues = constantValues;
+    }
+    NSError *error = nil;
+    id<MTLFunction> function = [library newFunctionWithDescriptor:functionDescriptor error:&error];
+    if (error)
+        WTFLogAlways("Function creation error: %@", error);
+    function.label = label;
+    return function;
+}
+
+} // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -29,6 +29,7 @@
 #import "APIConversions.h"
 #import "BindGroupLayout.h"
 #import "Device.h"
+#import "Pipeline.h"
 
 namespace WebGPU {
 
@@ -362,6 +363,7 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
         return RenderPipeline::createInvalid(*this);
 
     MTLRenderPipelineDescriptor* mtlRenderPipelineDescriptor = [MTLRenderPipelineDescriptor new];
+    auto label = fromAPI(descriptor.label);
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=249345 don't unconditionally set this to YES
     mtlRenderPipelineDescriptor.supportIndirectCommandBuffers = YES;
 
@@ -372,10 +374,15 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
         const auto& vertexModule = WebGPU::fromAPI(descriptor.vertex.module);
         const auto& vertexFunctionName = String::fromLatin1(descriptor.vertex.entryPoint);
 
-        const auto vertexFunction = vertexModule.getNamedFunction(vertexFunctionName, buildKeyValueReplacements(descriptor.vertex));
-        if (!vertexFunction)
-            return RenderPipeline::createInvalid(*this);
+        auto vertexFunction = vertexModule.getNamedFunction(vertexFunctionName, buildKeyValueReplacements(descriptor.vertex));
+        if (!vertexFunction) {
+            auto libraryCreationResult = createLibrary(m_device, vertexModule, nullptr, vertexFunctionName, label);
+            if (!libraryCreationResult)
+                return RenderPipeline::createInvalid(*this);
 
+            const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
+            vertexFunction = createFunction(libraryCreationResult->library, entryPointInformation, nullptr, label);
+        }
         mtlRenderPipelineDescriptor.vertexFunction = vertexFunction;
     }
 
@@ -388,11 +395,16 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
         const auto& fragmentModule = WebGPU::fromAPI(fragmentDescriptor.module);
         const auto& fragmentFunctionName = String::fromLatin1(fragmentDescriptor.entryPoint);
 
-        const auto fragmentFunction = fragmentModule.getNamedFunction(fragmentFunctionName, buildKeyValueReplacements(fragmentDescriptor));
+        auto fragmentFunction = fragmentModule.getNamedFunction(fragmentFunctionName, buildKeyValueReplacements(fragmentDescriptor));
 
-        if (!fragmentFunction)
-            return RenderPipeline::createInvalid(*this);
+        if (!fragmentFunction) {
+            auto libraryCreationResult = createLibrary(m_device, fragmentModule, nullptr, fragmentFunctionName, label);
+            if (!libraryCreationResult)
+                return RenderPipeline::createInvalid(*this);
 
+            const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
+            fragmentFunction = createFunction(libraryCreationResult->library, entryPointInformation, nullptr, label);
+        }
         mtlRenderPipelineDescriptor.fragmentFunction = fragmentFunction;
 
         for (uint32_t i = 0; i < fragmentDescriptor.targetCount; ++i) {


### PR DESCRIPTION
#### aefb962a382399124429bcfaf40325debec4848c
<pre>
[WebGPU] Implement deferred compilation for RenderPipeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=253520">https://bugs.webkit.org/show_bug.cgi?id=253520</a>
rdar://106365226

Reviewed by Mike Wyrzykowski and Myles C. Maxfield.

So far, for render pipelines, we only support compiling if layout hints are
provided at ShaderModule-creation time. This implements deferred compilation
when creating the pipeline if no hints were provided.

* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::Device::createComputePipeline):
(WebGPU::createLibrary): Deleted.
(WebGPU::createConstantValues): Deleted.
(WebGPU::createFunction): Deleted.
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):

Canonical link: <a href="https://commits.webkit.org/261874@main">https://commits.webkit.org/261874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d160ae20a361aabf18b2be3953ff1d59b42fa53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22254 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4893 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121585 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/23625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/13437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/6138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118909 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/23625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106204 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/23625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14557 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/98833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15272 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/13437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20565 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8291 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17118 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->