### PR TITLE
Use more efficient treeOrder<>() in compareDeclarativeAnimationOwningElementPositionsInDocumentTreeOrder()

### DIFF
--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -86,16 +86,16 @@ static bool compareDeclarativeAnimationOwningElementPositionsInDocumentTreeOrder
     };
 
     auto& aReferenceElement = a.element;
-    int aSortingIndex = sortingIndex(a.pseudoId);
-
     auto& bReferenceElement = b.element;
-    int bSortingIndex = sortingIndex(b.pseudoId);
 
     if (&aReferenceElement == &bReferenceElement) {
+        auto aSortingIndex = sortingIndex(a.pseudoId);
+        auto bSortingIndex = sortingIndex(b.pseudoId);
         ASSERT(aSortingIndex != bSortingIndex);
         return aSortingIndex < bSortingIndex;
     }
-    return aReferenceElement.compareDocumentPosition(bReferenceElement) & Node::DOCUMENT_POSITION_FOLLOWING;
+
+    return is_lt(treeOrder<Tree>(aReferenceElement, bReferenceElement));
 }
 
 static bool compareCSSTransitions(const CSSTransition& a, const CSSTransition& b)


### PR DESCRIPTION
#### 9556da2412e5eb453a6a99acf7a0ef55c633f28f
<pre>
Use more efficient treeOrder&lt;&gt;() in compareDeclarativeAnimationOwningElementPositionsInDocumentTreeOrder()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253521">https://bugs.webkit.org/show_bug.cgi?id=253521</a>

Reviewed by Darin Adler.

Use more efficient treeOrder&lt;&gt;() in compareDeclarativeAnimationOwningElementPositionsInDocumentTreeOrder()
instead of Node::compareDocumentPosition(), which is meant to be used by JavaScript and has additional
cruft.

Also only call sortingIndex() when its result is actually used.

* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareDeclarativeAnimationOwningElementPositionsInDocumentTreeOrder):

Canonical link: <a href="https://commits.webkit.org/261359@main">https://commits.webkit.org/261359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b05b6f5e445eea59f82ad087f1c6842756037b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/43882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/2811 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120144 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11576 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16224 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99408 "Build was cancelled. Recent messages:worker ews150 ready; Configured build; Validated change; OS: Big Sur (11.7.2), Xcode: 12.5.1; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision; Identifier: 261340@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Downloaded built product; Extracted built product; Killed old processes; run-api-tests (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104017 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98178 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44852 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/12983 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/32396 "Build is being retried. Recent messages:worker ews106 ready; Configured build; Validated change; OS: Big Sur (11.7.2), Xcode: 12.5.1; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision; Identifier: 261340@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Downloaded built product; Extracted built product; Crash collection has quiesced; Killed old processes; Pull request contains relevant changes; Skipped layout-tests; layout-tests (retry)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86672 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9395 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18938 "Built successfully") | [💥 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51977 "An unexpected error occured. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7876 "'git push ...'") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15452 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->