### PR TITLE
[UI-side compositing] Scrolling over the video causes jumpiness after opening the profile menu on YouTube.com

### DIFF
--- a/LayoutTests/fast/scrolling/mac/event-region-prevent-default-with-sublayer-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/event-region-prevent-default-with-sublayer-expected.txt
@@ -1,0 +1,8 @@
+Test scroll over composited layer
+Got wheel event 10
+Got wheel event 100
+PASS windowScrollEventCount is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/event-region-prevent-default-with-sublayer.html
+++ b/LayoutTests/fast/scrolling/mac/event-region-prevent-default-with-sublayer.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+        .box {
+            width: 200px;
+            height: 100px;
+            border: 1px solid black;
+        }
+        
+        .composited {
+/*            transform: translateZ(0);*/
+        }
+    </style>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var windowScrollEventCount = 0;
+
+        async function testScrollOverLayer()
+        {
+            if (!window.eventSender)
+                return;
+
+            debug('Test scroll over composited layer');
+            await UIHelper.mouseWheelScrollAt(100, 50);
+            
+            shouldBe('windowScrollEventCount', '0');
+        }
+        
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+
+            window.addEventListener('scroll', () => {
+                ++windowScrollEventCount;
+            }, false);
+
+            window.addEventListener('wheel', (event) => {
+                debug('Got wheel event ' + event.deltaY);
+                event.preventDefault();
+            }, { passive: false });
+
+            await testScrollOverLayer();
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="composited box"></div>
+    <div id="console"></div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4784,9 +4784,12 @@ void Document::invalidateEventListenerRegions()
     // We don't track style validity for Document and full rebuild is too big of a hammer.
     // Instead just mutate the style directly and trigger a minimal style update.
     auto& rootStyle = renderView()->mutableStyle();
-    Style::Adjuster::adjustEventListenerRegionTypesForRootStyle(rootStyle, *this);
+    auto changed = Style::Adjuster::adjustEventListenerRegionTypesForRootStyle(rootStyle, *this);
 
-    documentElement()->invalidateStyleInternal();
+    if (changed)
+        scheduleFullStyleRebuild();
+    else
+        documentElement()->invalidateStyleInternal();
 }
 
 void Document::invalidateRenderingDependentRegions()

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1285,7 +1285,7 @@ void RenderBlock::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
 
         if (paintInfo.paintBehavior.contains(PaintBehavior::EventRegionIncludeBackground) && visibleToHitTesting()) {
             auto borderRegion = approximateAsRegion(style().getRoundedBorderFor(borderRect));
-            LOG_WITH_STREAM(EventRegions, stream << "RenderBlock " << *this << " uniting region " << borderRegion);
+            LOG_WITH_STREAM(EventRegions, stream << "RenderBlock " << *this << " uniting region " << borderRegion << " event listener types " << style().eventListenerRegionTypes());
             paintInfo.eventRegionContext->unite(borderRegion, *this, style(), isTextControl() && downcast<RenderTextControl>(*this).textFormControlElement().isInnerTextElementEditable());
         }
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -219,13 +219,15 @@ static OptionSet<TouchAction> computeEffectiveTouchActions(const RenderStyle& st
     return sharedTouchActions;
 }
 
-void Adjuster::adjustEventListenerRegionTypesForRootStyle(RenderStyle& rootStyle, const Document& document)
+bool Adjuster::adjustEventListenerRegionTypesForRootStyle(RenderStyle& rootStyle, const Document& document)
 {
     auto regionTypes = computeEventListenerRegionTypes(document, rootStyle, document, { });
     if (auto* window = document.domWindow())
         regionTypes.add(computeEventListenerRegionTypes(document, rootStyle, *window, { }));
 
+    bool changed = regionTypes != rootStyle.eventListenerRegionTypes();
     rootStyle.setEventListenerRegionTypes(regionTypes);
+    return changed;
 }
 
 OptionSet<EventListenerRegionType> Adjuster::computeEventListenerRegionTypes(const Document& document, const RenderStyle& style, const EventTarget& eventTarget, OptionSet<EventListenerRegionType> parentTypes)

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -52,7 +52,7 @@ public:
     void adjustAnimatedStyle(RenderStyle&, OptionSet<AnimationImpact>) const;
 
     static void adjustSVGElementStyle(RenderStyle&, const SVGElement&);
-    static void adjustEventListenerRegionTypesForRootStyle(RenderStyle&, const Document&);
+    static bool adjustEventListenerRegionTypesForRootStyle(RenderStyle&, const Document&);
     static void propagateToDocumentElementAndInitialContainingBlock(Update&, const Document&);
     static std::unique_ptr<RenderStyle> restoreUsedDocumentElementStyleToComputed(const RenderStyle&);
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -1008,6 +1008,9 @@ static void dumpChangedLayers(TextStream& ts, const RemoteLayerTreeTransaction::
         if (layerProperties.changedProperties & LayerChange::UserInteractionEnabledChanged)
             ts.dumpProperty("userInteractionEnabled", layerProperties.userInteractionEnabled);
 
+        if (layerProperties.changedProperties & LayerChange::EventRegionChanged)
+            ts.dumpProperty("eventRegion", layerProperties.eventRegion);
+
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         if (layerProperties.changedProperties & LayerChange::SeparatedChanged)
             ts.dumpProperty("isSeparated", layerProperties.isSeparated);


### PR DESCRIPTION
#### 8165e091f4df59390169d58b88c9f06ed93591ae
<pre>
[UI-side compositing] Scrolling over the video causes jumpiness after opening the profile menu on YouTube.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=253522">https://bugs.webkit.org/show_bug.cgi?id=253522</a>
rdar://104072756

Reviewed by Antti Koivisto.

The addition of an active wheel event handler on the window or document would fail to correctly update
the eventListenerRegionTypes for all elements in the document. This resulted in off-main-thread hit-testing
for scrolling incorrectly assuming that it could do async scrolls, leading to scroll stutter in some
scenarios.

Invalidation after event listener changes on most DOM nodes behaved correctly by virtue of inherited property
handling. But event listeners on the window or document are represented by the root style (set on RenderView)
and this only gets updated when we do a full style rebuild.

So fix Document::invalidateEventListenerRegions() to trigger a full style rebuild if updating
the root style changes the event listener regions types.

* LayoutTests/fast/scrolling/mac/event-region-prevent-default-with-sublayer-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/event-region-prevent-default-with-sublayer.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::invalidateEventListenerRegions):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paintObject): Improve logging.
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustEventListenerRegionTypesForRootStyle):
* Source/WebCore/style/StyleAdjuster.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::dumpChangedLayers): Log event regions.

Canonical link: <a href="https://commits.webkit.org/261439@main">https://commits.webkit.org/261439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/834db87412be497e320f634ba7b13e8c6b9ff86c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/260 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120391 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11866 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3148 "layout-tests (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117416 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45354 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13265 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/161 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9614 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19201 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52158 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7957 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15745 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->