### PR TITLE
[macOS] Use cleanup timer when suspending web content process

### DIFF
--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1550,11 +1550,16 @@ void WebProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estim
         platformMediaSessionManager->processWillSuspend();
 #endif
 
+#if ENABLE(NON_VISIBLE_WEBPROCESS_MEMORY_CLEANUP_TIMER)
+    if (!m_nonVisibleProcessMemoryCleanupTimer.isActive())
+        m_nonVisibleProcessMemoryCleanupTimer.startOneShot(nonVisibleProcessMemoryCleanupDelay);
+#else
     if (!m_suppressMemoryPressureHandler) {
         MemoryPressureHandler::singleton().releaseMemory(Critical::Yes, Synchronous::Yes);
         for (auto& page : m_pageMap.values())
             page->releaseMemory(Critical::Yes);
     }
+#endif
 
     freezeAllLayerTrees();
 


### PR DESCRIPTION
#### 3e3affb5f89da96db5089433656cfbe4aa5903d6
<pre>
[macOS] Use cleanup timer when suspending web content process
<a href="https://bugs.webkit.org/show_bug.cgi?id=253527">https://bugs.webkit.org/show_bug.cgi?id=253527</a>
rdar://problem/106376732

Reviewed by Chris Dumez.

We should use the m_nonVisibleProcessMemoryCleanupTimer to cleanup unnecessary memory on suspension instead of immediately cleaning up. This fixes a plt regression for warm runs where we make heavy use of the WebProcess cache. We should also consider doing this on iOS.

* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::prepareToSuspend):

Canonical link: <a href="https://commits.webkit.org/261354@main">https://commits.webkit.org/261354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9baeb9df128f2847fdb617167a7e762fcd5899b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20501 "Built successfully") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120159 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11594 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117127 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104049 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98193 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44876 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13002 "Built successfully") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86689 "15 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9406 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18956 "Built successfully") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7872 "'git push ...'") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15471 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->