### PR TITLE
Optimize matchIntegrityMetadata()

### DIFF
--- a/Source/WebCore/loader/ResourceCryptographicDigest.h
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.h
@@ -37,10 +37,11 @@ class CachedResource;
 class FragmentedSharedBuffer;
 
 struct ResourceCryptographicDigest {
-    enum class Algorithm {
+    static constexpr unsigned algorithmCount = 3;
+    enum class Algorithm : uint8_t {
         SHA256 = 1 << 0,
         SHA384 = 1 << 1,
-        SHA512 = 1 << 2,
+        SHA512 = 1 << (algorithmCount - 1),
     };
 
     // Number of bytes to hold SHA-512 digest

--- a/Source/WebCore/loader/SubresourceIntegrity.cpp
+++ b/Source/WebCore/loader/SubresourceIntegrity.cpp
@@ -162,10 +162,8 @@ static Vector<EncodedResourceCryptographicDigest> strongestMetadataFromSet(Vecto
     return result;
 }
 
-bool matchIntegrityMetadata(const CachedResource& resource, const String& integrityMetadataList)
+bool matchIntegrityMetadataSlow(const CachedResource& resource, const String& integrityMetadataList)
 {
-    // FIXME: Consider caching digests on the CachedResource rather than always recomputing it.
-
     // 1. Let parsedMetadata be the result of parsing metadataList.
     auto parsedMetadata = parseIntegrityMetadata(integrityMetadataList);
     
@@ -183,8 +181,6 @@ bool matchIntegrityMetadata(const CachedResource& resource, const String& integr
 
     // 5. Let metadata be the result of getting the strongest metadata from parsedMetadata.
     auto metadata = strongestMetadataFromSet(WTFMove(*parsedMetadata));
-
-    const auto* sharedBuffer = resource.resourceBuffer();
     
     // 6. For each item in metadata:
     for (auto& item : metadata) {
@@ -195,7 +191,7 @@ bool matchIntegrityMetadata(const CachedResource& resource, const String& integr
         auto expectedValue = decodeEncodedResourceCryptographicDigest(item);
 
         // 3. Let actualValue be the result of applying algorithm to response.
-        auto actualValue = cryptographicDigestForSharedBuffer(algorithm, sharedBuffer);
+        auto actualValue = resource.cryptographicDigest(algorithm);
 
         // 4. If actualValue is a case-sensitive match for expectedValue, return true.
         if (expectedValue && actualValue.value == expectedValue->value)

--- a/Source/WebCore/loader/SubresourceIntegrity.h
+++ b/Source/WebCore/loader/SubresourceIntegrity.h
@@ -34,8 +34,15 @@ namespace WebCore {
 
 class CachedResource;
 
-bool matchIntegrityMetadata(const CachedResource&, const String& integrityMetadata);
+bool matchIntegrityMetadataSlow(const CachedResource&, const String& integrityMetadata);
 String integrityMismatchDescription(const CachedResource&, const String& integrityMetadata);
 std::optional<Vector<EncodedResourceCryptographicDigest>> parseIntegrityMetadata(const String& integrityMetadata);
+
+inline bool matchIntegrityMetadata(const CachedResource& resource, const String& integrityMetadata)
+{
+    if (LIKELY(integrityMetadata.isEmpty()))
+        return true;
+    return matchIntegrityMetadataSlow(resource, integrityMetadata);
+}
 
 }

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -25,6 +25,7 @@
 #include "CacheValidation.h"
 #include "CachedResourceClient.h"
 #include "FrameLoaderTypes.h"
+#include "ResourceCryptographicDigest.h"
 #include "ResourceError.h"
 #include "ResourceLoadPriority.h"
 #include "ResourceLoaderIdentifier.h"
@@ -302,6 +303,8 @@ public:
     virtual void previewResponseReceived(const ResourceResponse&);
 #endif
 
+    ResourceCryptographicDigest cryptographicDigest(ResourceCryptographicDigest::Algorithm) const;
+
 protected:
     // CachedResource constructor that may be used when the CachedResource can already be filled with response data.
     CachedResource(const URL&, Type, PAL::SessionID, const CookieJar*);
@@ -313,6 +316,8 @@ protected:
     virtual void didReplaceSharedBufferContents() { }
 
     virtual void setBodyDataFrom(const CachedResource&);
+
+    void clearCachedCryptographicDigests();
 
 private:
     class Callback;
@@ -418,6 +423,8 @@ private:
     bool m_deleted { false };
     unsigned m_lruIndex { 0 };
 #endif
+
+    mutable std::array<std::optional<ResourceCryptographicDigest>, ResourceCryptographicDigest::algorithmCount> m_cryptographicDigests;
 };
 
 class CachedResource::Callback {


### PR DESCRIPTION
#### efab2420412f966978181e4acf1dac6f3c63c049
<pre>
Optimize matchIntegrityMetadata()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253528">https://bugs.webkit.org/show_bug.cgi?id=253528</a>

Reviewed by Ryosuke Niwa.

Optimize matchIntegrityMetadata():
- Avoid a function call when the integrityMetadata string is empty, which is the
  common case.
- Cache the cryptographic digest on the CachedResource to avoid repeated crypto
  operations for the same resource. This impacts 3 sub-resources on Speedometer
  which now leverage the cache instead of recomputing every time.

* Source/WebCore/loader/ResourceCryptographicDigest.h:
* Source/WebCore/loader/SubresourceIntegrity.cpp:
(WebCore::matchIntegrityMetadataSlow):
(WebCore::matchIntegrityMetadata): Deleted.
* Source/WebCore/loader/SubresourceIntegrity.h:
(WebCore::matchIntegrityMetadata):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::setBodyDataFrom):
(WebCore::CachedResource::finishLoading):
(WebCore::CachedResource::error):
(WebCore::CachedResource::clearCachedCryptographicDigests):
(WebCore::CachedResource::cryptographicDigest const):
* Source/WebCore/loader/cache/CachedResource.h:

Canonical link: <a href="https://commits.webkit.org/261392@main">https://commits.webkit.org/261392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fbe9c3e14067806608e11e006ed62a6e892ff27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/15 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3210 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120189 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2613 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104147 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/9 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44961 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13038 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/9 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86763 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9462 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51990 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7933 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15509 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->