### PR TITLE
TestWebKitAPI.PasteHTML.ReadSelectionFromPasteboard fails when enabling GPU process and UI side composting

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm
@@ -405,7 +405,8 @@ TEST(PasteHTML, ReadSelectionFromPasteboard)
     [generalPasteboard setString:@"Hello world" forType:NSPasteboardTypeString];
 
     auto webView = createWebViewWithCustomPasteboardDataSetting(true);
-    [webView synchronouslyLoadHTMLString:@"<input autofocus>"];
+    [webView synchronouslyLoadHTMLString:@"<input>"];
+    [webView stringByEvaluatingJavaScript:@"document.querySelector('input').focus()"];
     [webView readSelectionFromPasteboard:generalPasteboard];
 
     NSString *inputValue = [webView stringByEvaluatingJavaScript:@"document.querySelector('input').value"];


### PR DESCRIPTION
#### b8c953e93053cdb1b74a3a91c9b0b5a6ee112d48
<pre>
TestWebKitAPI.PasteHTML.ReadSelectionFromPasteboard fails when enabling GPU process and UI side composting
<a href="https://bugs.webkit.org/show_bug.cgi?id=253531">https://bugs.webkit.org/show_bug.cgi?id=253531</a>
&lt;rdar://104037218&gt;

Reviewed by Wenson Hsieh.

The test fails because we are expecting autofocusing step to happen synchronously. Manually focus the element
instead so that this works reliably even when GPU process &amp; UI side compositing are enabled.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/261381@main">https://commits.webkit.org/261381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f32c8baaf1d25f007e50b4ccfbb4864e07ce762

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20518 "Built successfully") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3195 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21885 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/11611 "Build was cancelled. Recent messages:worker ews172 ready; Configured build; Pull request contains relevant changes; Validated change; OS: Ventura (13.2), Xcode: 14.2; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Failed to find identifier") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2576 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16244 "Passed tests") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104059 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98200 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44886 "Passed tests") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13019 "Built successfully") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86695 "14 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13529 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/11611 "Build was cancelled. Recent messages:worker ews172 ready; Configured build; Pull request contains relevant changes; Validated change; OS: Ventura (13.2), Xcode: 14.2; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Failed to find identifier") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18972 "Built successfully") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7923 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15488 "Build was cancelled. Recent messages:worker ews165 ready; Configured build; Validated change; OS: Monterey (12.6.1), Xcode: 14.0; Cleaned up git repository; Cleaned and updated working directory; Updated branch information; Checked out required revision (skipped); Identifier: 261343@main; Skipping applying patch since patch_id isn't provided; Checked out pull request; Killed old processes; Validated change; Compiled WebKit (cancelled)") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->