### PR TITLE
Set structureHeapAddressSize for PlayStation

### DIFF
--- a/Source/JavaScriptCore/PlatformPlayStation.cmake
+++ b/Source/JavaScriptCore/PlatformPlayStation.cmake
@@ -1,10 +1,5 @@
 include(inspector/remote/Socket.cmake)
 
-# This overrides the default value of 1GB for the structure heap address size
-list(APPEND JavaScriptCore_DEFINITIONS
-    STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB=128
-)
-
 # This overrides the default x64 value of 1GB for the memory pool size
 list(APPEND JavaScriptCore_PRIVATE_DEFINITIONS
     FIXED_EXECUTABLE_MEMORY_POOL_SIZE_IN_MB=64

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -47,6 +47,8 @@ static_assert(MACH_VM_MAX_ADDRESS_RAW == MACH_VM_MAX_ADDRESS);
 #if !ENABLE(STRUCTURE_ID_WITH_SHIFT)
 #if defined(STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB) && STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB > 0
 constexpr uintptr_t structureHeapAddressSize = STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB * MB;
+#elif PLATFORM(PLAYSTATION)
+constexpr uintptr_t structureHeapAddressSize = 128 * MB;
 #elif PLATFORM(IOS_FAMILY) && CPU(ARM64) && !CPU(ARM64E)
 constexpr uintptr_t structureHeapAddressSize = 512 * MB;
 #else


### PR DESCRIPTION
#### 46b269f04c845b16c27710770b3a30645ba35bb9
<pre>
Set structureHeapAddressSize for PlayStation
<a href="https://bugs.webkit.org/show_bug.cgi?id=253535">https://bugs.webkit.org/show_bug.cgi?id=253535</a>

Reviewed by Fujii Hironori.

Set the value of `structureHeapAddressSize` to 128 MB. This value was
being set through `STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB` but has been
constant for awhile so just set the value directly for
`PLATFORM(PLAYSTATION)`. This fixes an issue where the value wasn&apos;t
being set when compiling `WebCoreTestSupport`.

Leaving `STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB` in the code in case any
additional tweaks are needed by ports.

* Source/JavaScriptCore/PlatformPlayStation.cmake:
* Source/JavaScriptCore/runtime/StructureID.h:

Canonical link: <a href="https://commits.webkit.org/261476@main">https://commits.webkit.org/261476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5278128e256618c70b05007c490868a9a02ea17f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20928 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/415 "Failed to checkout and rebase branch from PR 11192") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22286 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117564 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/90/builds/415 "Failed to checkout and rebase branch from PR 11192") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/90/builds/415 "Failed to checkout and rebase branch from PR 11192") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/104817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/100275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/90/builds/415 "Failed to checkout and rebase branch from PR 11192") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/11530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13891 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101520 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19332 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/90/builds/415 "Failed to checkout and rebase branch from PR 11192") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/31556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7984 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109560 "Built successfully") | 
| | | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/26960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->