### PR TITLE
[buildbot] Move SFTP upload code from generate-bundle script to a new script for uploads and document it

### DIFF
--- a/Tools/CISupport/Shared/HOWTO_config_SFTP_uploads.md
+++ b/Tools/CISupport/Shared/HOWTO_config_SFTP_uploads.md
@@ -1,0 +1,259 @@
+
+# How to configure the server for allowing secure SFTP uploads
+
+## Initial setup
+
+### 1. Install openssh server
+
+```
+sudo yum install openssh-server
+```
+
+### 2. Create the system group
+
+We will use a system group named `Buildbot-Upload-Users` to identify all
+the system users that are allowed to upload build products
+
+```
+sudo groupadd --system Buildbot-Upload-Users
+```
+
+### 3. Configure the SSH server as follows
+
+```diff
+--- a/etc/ssh/sshd_config
++++ b/etc/ssh/sshd_config
+@@ -14,7 +14,7 @@
+ # SELinux about this change.
+ # semanage port -a -t ssh_port_t -p tcp #PORTNUMBER
+ #
+-#Port 22
++Port 6214
+ #AddressFamily any
+ #ListenAddress 0.0.0.0
+ #ListenAddress ::
+@@ -76,8 +76,8 @@ ChallengeResponseAuthentication no
+ #KerberosUseKuserok yes
+
+ # GSSAPI options
+-GSSAPIAuthentication yes
+-GSSAPICleanupCredentials no
++#GSSAPIAuthentication yes
++#GSSAPICleanupCredentials no
+ #GSSAPIStrictAcceptorCheck yes
+ #GSSAPIKeyExchange no
+ #GSSAPIEnablek5users no
+@@ -137,3 +137,11 @@ Subsystem  sftp    /usr/libexec/openssh/sftp-server
+ #      AllowTcpForwarding no
+ #      PermitTTY no
+ #      ForceCommand cvs server
++
++Match Group Buildbot-Upload-Users
++    X11Forwarding no
++    AllowTcpForwarding no
++    PasswordAuthentication no
++    AuthorizedKeysFile /etc/ssh/buildbot_authorized_keys/%u
++    ForceCommand internal-sftp
++    ChrootDirectory /var/chroot/buildbot-built-products
+```
+
+In this diff we did the following:
+
+ - Changed the default SSH port from `22` to any other random number (to make it more secure, and avoid the spam of failed log attempts of bots that try to bruteforce passwords on SSH servers)
+ - Disabled `GSSAPI` (it makes the login process more slow and we don't need it)
+ - Added a `Match` block at the end that will apply to all users members of the UNIX group `Buildbot-Upload-Users`
+   - In this match block: we disable forwarding and password auth, we defined where the `authorized_key` file is for each user and we force `internal-sftp` inside a chroot directory
+
+
+### 4. Create the chroot directory
+
+```
+sudo mkdir -p /var/chroot/buildbot-built-products
+sudo chown root:root /var/chroot/buildbot-built-products
+# Note: the main directory for the chroot has to be owned by root, so the users can't write to it.
+```
+
+### 5. Create the directory for storing the users authorized_keys files
+
+```
+sudo mkdir -p /etc/ssh/buildbot_authorized_keys
+```
+
+### 6. Restart the SSH service
+
+```
+sudo systemctl restart openssh-server.service
+```
+
+## Adding new users
+
+### 7. Create a new SSH key pair for the bot
+
+We do this on the bot machine (not in the SSH server machine) and we don't
+set a password for the SSH key, otherwise we can't automate the upload.
+
+```
+# Note: we run this command on the bot machine (not on the SSH server).
+ssh-keygen -f ~/key-for-uploads
+# No password when asked
+# Copy the contents of the public key ~/key-for-uploads.pub to the clipboard
+```
+
+### 8. Create the user, directories and add the SSH public key in the server
+
+We create the user on the server running the SSH service where the uploads should be sent:
+
+```
+# This command are executed on the SSH server, we use variables to make it easier scripting it.
+# Add user name "GTK-Linux-64-bit-Release-Build" and create the required directory for its uploads
+export NEWBUILDBOTUSER=GTK-Linux-64-bit-Release-Build
+sudo adduser --system --gid Buildbot-Upload-Users --shell /sbin/nologin --home-dir / --no-create-home "${NEWBUILDBOTUSER}"
+sudo mkdir "/var/chroot/buildbot-built-products/${NEWBUILDBOTUSER}"
+sudo chown "${NEWBUILDBOTUSER}" "/var/chroot/buildbot-built-products/${NEWBUILDBOTUSER}"
+```
+
+Now add the SSH public key that we created on the bot machine (on `7.` above) in the server:
+
+```
+# Finally save the contents of ~/key-for-uploads.pub (from the clipoard) in its respective file on the SSH server
+cat file-from-bot/key-for-uploads.pub > "/etc/ssh/buildbot_authorized_keys/${NEWBUILDBOTUSER}"
+```
+
+### 9. Test it
+
+Run on the bot:
+
+```
+python3 Tools/CISupport/Shared/transfer-archive-via-sftp \
+	--log-level debug \
+	--server-address sshserver.webkit.org \
+	--server-port 6214 \
+	--remote-dir GTK-Linux-64-bit-Release-Build \
+	--user-name GTK-Linux-64-bit-Release-Build \
+	--ssh-key ~/key-for-uploads \
+	--remote-file test_upload_123.zip  \
+	WebKitBuild/release.zip
+```
+
+If everything worked as expected the zip file should appear on the server at directory:
+
+```
+/var/chroot/buildbot-built-products/GTK-Linux-64-bit-Release-Build
+```
+
+### 10. Debug problems
+
+
+If it doesn't work try to check the syslog of the server to see if openssh-server
+is saying something. This command may be useful
+
+```
+sudo journalctl -f -u openssh-server.service
+```
+
+Another option is stopping the ssh server and launching it manually in the foreground
+to get the logs printed on stdout
+
+```
+sudo systemctl stop openssh-server
+sudo  /usr/sbin/sshd -D -e
+```
+
+### 11. Final tips:
+
+* Semi-automating adding users
+
+Adding new users is repeating the steps of `8.` (above) for each new user, so it is a good
+idea to create a simple shell script that accepts as input the `bot_name` and the contents
+of the bot `ssh public key` and runs those comands creating the system user, the directories
+and setting the `authorized_key` file for it.
+
+* Running the script on production
+
+To deploy this on the bots in production instead of passing the server configuration
+and path to the ssh keys via the command line we simply pass the path to a `json` file
+that contains the remote configuration. Example:
+
+```
+python3 Tools/CISupport/Shared/transfer-archive-via-sftp \
+	--remote-config-file ../../remote-built-product-upload-config.json \
+	--user-name WithProperties("%(buildername)s") \
+	--remote-dir WithProperties("%(buildername)s") \
+	--remote-file WithProperties("%(archive_revision)s.zip") \
+	WithProperties("WebKitBuild/%(configuration)s.zip")
+```
+
+And the config file `remote-built-product-upload-config.json` that is stored in the bot
+contains something like this:
+
+```
+{
+"server_name": "webkit.org",
+"server_address": "sshserver.webkit.org",
+"server_port": "6214",
+"ssh_key": "/home/buildbot/key-for-uploads"
+}
+```
+
+**Note**: the tool supports (and is recommended) that the ssh private key is not passed as a path,
+but instead the binary contents of it are defined in the `json` config file as base64 data.
+Run the command:
+
+```
+# Get the contents of the SSH private key as base64 encoded data (without new lines)
+# On Linux
+cat /home/buildbot/key-for-uploads | base64 -w0
+# On Mac
+cat /home/buildbot/key-for-uploads | base64
+```
+
+And paste the base64 encoded data inside the field `ssh_key` in the `json` file:
+
+```
+{
+"server_name": "webkit.org",
+"server_address": "sshserver.webkit.org",
+"server_port": "6214",
+"ssh_key": "LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0[..REDACTED..]FURSBLRVktLS0tLQo="
+}
+```
+
+Then delete the key from the disk:
+
+```
+rm -f /home/buildbot/key-for-uploads
+```
+
+This way the only file storing sensitive data on the bot is that config file,
+the SSH private key not longer exist on the disk outside of the `json` file.
+This helps to make backups easier and restoring the bot config from scratch.
+
+### 12. Limit SSH access by IP address
+
+As an extra security measure it if the machines uploading the data have known fixed
+public IP address then it is advisable to limit access to the SSH service to only
+this IPs.
+
+This can be done as follows:
+
+1.  By default, deny all hosts.
+
+```
+# cat /etc/hosts.deny
+sshd : ALL
+```
+
+2. Then only allow specific IP address. Example:
+
+```
+# cat /etc/hosts.allow
+sshd : 192.168.0.0/24
+sshd : 127.0.0.1
+sshd : [::1]
+sshd : 52.92.165.64
+```
+
+Another option is using `iptables` (firewall) to limit to specific IP address
+connecting with the SSH port.
+
+More info: https://unix.stackexchange.com/questions/406245/limit-ssh-access-to-specific-clients-by-ip-address

--- a/Tools/CISupport/Shared/transfer-archive-via-sftp
+++ b/Tools/CISupport/Shared/transfer-archive-via-sftp
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2020, 2023 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+
+
+_log = logging.getLogger(__name__)
+LOG_MESSAGE = 25
+
+
+class SftpClient(object):
+
+    def __init__(self, remote_cfg, log_level):
+        self._remote_cfg = remote_cfg
+        self._sftp_quiet = log_level == 'quiet' or log_level == 'minimal'
+
+    def upload(self, local_path_archive_to_transfer):
+
+        def sha256sum(file_path):
+            hash = hashlib.sha256()
+            with open(file_path, 'rb') as f:
+                for chunk in iter(lambda: f.read(4096), b''):
+                    hash.update(chunk)
+            return hash.hexdigest()
+
+        def get_remote_path_value(file_name):
+            return os.path.join(self._remote_cfg.remote_dir, file_name) if self._remote_cfg.remote_dir else file_name
+
+        def human_readable_size(size_in_bytes):
+            size = float(size_in_bytes)
+            for unit in ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']:
+                if abs(size) < 1024.0 or unit == 'PiB':
+                    break
+                size /= 1024.0
+            str_size = '%.0f' % size if size.is_integer() else '%.2f' % size
+            return f'{str_size} {unit}'
+
+        if not os.path.isfile(local_path_archive_to_transfer):
+            raise ValueError(f'Can not access file to transfer at path: {local_path_archive_to_transfer}')
+
+        with tempfile.NamedTemporaryFile(mode='w+b') as ssh_key_file, tempfile.NamedTemporaryFile(mode='w+') as hash_check_file, \
+             tempfile.NamedTemporaryFile(mode='w+') as last_is_file, tempfile.NamedTemporaryFile(mode='w+') as upload_instructions_file:
+
+            remote_archive_name = self._remote_cfg.remote_file if self._remote_cfg.remote_file else os.path.basename(local_path_archive_to_transfer)
+            remote_archive_path = get_remote_path_value(remote_archive_name)
+
+            # In theory NamedTemporaryFile() is already created 0600. But it don't hurts ensuring this again here.
+            os.chmod(ssh_key_file.name, 0o600)
+            ssh_key_file.write(base64.b64decode(self._remote_cfg.ssh_key))
+            ssh_key_file.flush()
+            archive_hash = sha256sum(local_path_archive_to_transfer)
+            if self._remote_cfg.generate_sha256sum:
+                # Generate and upload also a sha256 hash
+                os.chmod(hash_check_file.name, 0o644)
+                hash_check_file.write(f'{archive_hash} {remote_archive_name}\n')
+                hash_check_file.flush()
+            if self._remote_cfg.update_last_is_file:
+                # A LAST-IS file for convenience
+                os.chmod(last_is_file.name, 0o644)
+                last_is_file.write(f'{remote_archive_name}\n')
+                last_is_file.flush()
+            # We pass the filename to the SFTP command inside double quotes below (to deal with spaces in the filename).
+            # So we have to escape any double quoute that may be in the filename when passing it to the SFTP command.
+            remote_archive_path_scaped_quotes = remote_archive_path.replace('"', '\\"')
+            local_path_archive_to_transfer_scaped_quotes = local_path_archive_to_transfer.replace('"', '\\"')
+            # SFTP upload instructions file
+            upload_instructions_file.write('progress\n')
+            upload_instructions_file.write(f'put "{local_path_archive_to_transfer_scaped_quotes}" "{remote_archive_path_scaped_quotes}"\n')
+            if self._remote_cfg.generate_sha256sum:
+                remote_archive_path_no_ext, _ = os.path.splitext(remote_archive_path)
+                remote_archive_path_hash_scaped_quotes = remote_archive_path_no_ext.replace('"', '\\"') + '.sha256sum'
+                upload_instructions_file.write(f'put "{hash_check_file.name}" "{remote_archive_path_hash_scaped_quotes}"\n')
+            if self._remote_cfg.update_last_is_file:
+                remote_last_is_path = get_remote_path_value('LAST-IS')
+                upload_instructions_file.write(f'put "{last_is_file.name}" "{remote_last_is_path}"\n')
+            upload_instructions_file.write('quit\n')
+            upload_instructions_file.flush()
+            # The idea of this is to ensure scp doesn't ask any question (not even on the first run).
+            # This should be secure enough according to https://www.gremwell.com/ssh-mitm-public-key-authentication
+            sftpCommand = ['sftp',
+                           '-o', 'StrictHostKeyChecking=no',
+                           '-o', 'UserKnownHostsFile=/dev/null',
+                           '-o', 'LogLevel=ERROR',
+                           '-P', f'{self._remote_cfg.server_port}',
+                           '-i', ssh_key_file.name,
+                           '-b', upload_instructions_file.name,
+                           f'{self._remote_cfg.user_name}@{self._remote_cfg.server_address}']
+            _log.debug(f'Executing sftp command: {" ".join(sftpCommand)}')
+            size_in_bytes = os.stat(local_path_archive_to_transfer).st_size
+            size_human_str = human_readable_size(size_in_bytes)
+            _log.info(f'Uploading archive to {self._remote_cfg.server_name} as {remote_archive_path} with a size of {size_human_str} and SHA256 hash {archive_hash}')
+            sftp_out = subprocess.DEVNULL if self._sftp_quiet else sys.stdout
+            if subprocess.call(sftpCommand, stdout=sftp_out, stderr=sftp_out) != 0:
+                raise RuntimeError('The sftp command returned non-zero status')
+
+        remote_upload_str = self._remote_cfg.download_url if self._remote_cfg.download_url else self._remote_cfg.server_name
+        _log.log(LOG_MESSAGE, f'Done: archive sucesfully uploaded to {remote_upload_str}')
+        return 0
+
+
+class RemoteConfig(object):
+
+    def __init__(self, remote_config_args, remote_config_file):
+        self._allowed_config_keys = [ 'server_name', 'server_address', 'server_port', 'remote_dir', 'remote_file', 'download_url', 'user_name', 'ssh_key', 'generate_sha256sum', 'update_last_is_file' ]
+        for key_name in self._allowed_config_keys:
+            setattr(self, key_name, None)
+        if remote_config_file:
+            if not os.path.isfile(remote_config_file):
+                raise ValueError(f'Unable to find a file at path: "{remote_config_file}"')
+            remote_data_dict = json.load(open(remote_config_file))
+            remote_data_dot = argparse.Namespace(**remote_data_dict)
+            self._update_config_from_defined_attrs(remote_data_dot)
+        # Defined values from command-line arguments have precedence
+        self._update_config_from_defined_attrs(remote_config_args)
+        # Expand variables, sanity checks and read ssh key if needed.
+        self._expand_variables()
+        self._check_required_values()
+        self._read_ssh_key_if_needed()
+
+    def _read_ssh_key_if_needed(self):
+        def _is_base64(s):
+            try:
+                return base64.b64encode(base64.b64decode(s)).decode(encoding='utf-8') == s
+            except binascii.Error:
+                return False
+
+        if os.path.isfile(self.ssh_key):
+            _log.debug(f'Reading ssh key from path "{self.ssh_key}" ... ')
+            # Read it and store the value as a base64 string
+            with open(self.ssh_key, 'rb') as f:
+                ssh_key_data = base64.b64encode(f.read())
+            self.ssh_key = ssh_key_data.decode(encoding='utf-8')
+        if not _is_base64(self.ssh_key):
+            raise ValueError('The defined value for ssh_key is not valid base64')
+
+    def _check_required_values(self):
+        for required_key_with_value in ['server_address', 'server_port', 'user_name', 'ssh_key']:
+            key_value = getattr(self, required_key_with_value, None)
+            if not key_value:
+                raise ValueError(f'Need to specify a value for {required_key_with_value}')
+        if not self.server_name:
+            self.server_name = self.server_address
+        if isinstance(self.server_port, str):
+            if not self.server_port.isnumeric():
+                raise ValueError(f'Server port needs to be a number but got value "{self.server_port}"')
+            self.server_port = int(self.server_port)
+
+    def _update_config_from_defined_attrs(self, remote_data_dot):
+        for key_name in self._allowed_config_keys:
+            key_value = getattr(remote_data_dot, key_name, None)
+            if key_value:
+                setattr(self, key_name, key_value)
+
+    def _expand_variables(self):
+        variables_to_expand = self._get_config_dict()
+        # Expanding the value of ssh_key should not be allowed.
+        variables_to_expand.pop('ssh_key', None)
+        for key_name in self._allowed_config_keys:
+            key_value = getattr(self, key_name, None)
+            if key_value and isinstance(key_value, str):
+                if  '{' in key_value and '}' in key_value:
+                    expanded_key_value = key_value.format(**variables_to_expand)
+                    if key_value != expanded_key_value:
+                        _log.debug(f'Expanding "{key_name}" from "{key_value}" to "{expanded_key_value}"')
+                        setattr(self, key_name, expanded_key_value)
+
+    def _get_config_dict(self):
+        config_dict = {}
+        for key_name in self._allowed_config_keys:
+            config_dict[key_name] = getattr(self,key_name)
+        return config_dict
+
+    def get_parsed_config_dot(self):
+        return argparse.Namespace(**self._get_config_dict())
+
+    def _print_config_if_debug_log(self):
+        _log.debug('Remote config values:')
+        config_dict = self._get_config_dict()
+        for key_name in config_dict:
+            key_value = config_dict[key_name]
+            if key_name == 'ssh_key':
+                _log.debug(f'    ssh_key => Base64 encoded string with a length of {len(key_value)}')
+            else:
+                _log.debug(f'    {key_name} => {key_value}')
+
+
+def configure_logging(logger, selected_log_level='info'):
+
+    class LogHandler(logging.StreamHandler):
+        def __init__(self, stream):
+             super().__init__(stream)
+
+        def format(self, record):
+            if record.levelno > LOG_MESSAGE:
+                return '%s: %s' % (record.levelname, record.getMessage())
+            return record.getMessage()
+
+    logging.addLevelName(LOG_MESSAGE, 'MESSAGE')
+    if selected_log_level == 'debug':
+        log_level = logging.DEBUG
+    elif selected_log_level == 'info':
+        log_level = logging.INFO
+    elif selected_log_level == 'quiet':
+        log_level = logging.NOTSET
+    elif selected_log_level == 'minimal':
+        log_level = logging.getLevelName(LOG_MESSAGE)
+
+    handler = LogHandler(sys.stdout)
+    logger.addHandler(handler)
+    logger.setLevel(log_level)
+    return handler
+
+
+# The expected format for --remote-config-file is something like:
+# {
+# "server_name": "webkitgtk.org",
+# "server_address": "webkitgtk.intranet-address.local",
+# "server_port": "23",
+# "user_name": "upload-bot-64",
+# "remote_dir" : "x86_64/nightly/Ubuntu-20.04/MiniBrowser",
+# "remote_file": "release.zip",
+# "download_url": "https://{server_name}/built-products/{remote_dir}/{remote_file}",
+# "generate_sha256sum: true,
+# "update_last_is_file": true,
+# "ssh_key": "can be a path to the ssh key or the output of the priv key in base64 (without new lines). E.g. cat ~/.ssh/id_rsa|base64 -w0"
+# }
+#
+
+def main():
+    parser = argparse.ArgumentParser(add_help=True)
+
+    remote_config_args = parser.add_argument_group(title="Remote config arguments", description='The following arguments can be passed as keys in the json file specified with '
+                                                                                    '"--remote-config-file" or as arguments here. The value from the command line has precedence.')
+    remote_config_args.add_argument('--server-name', help='Pretty identifier for the server (to be used on the logs instead of the real address)')
+    remote_config_args.add_argument('--server-address', help='FQDN or IP address of the server')
+    remote_config_args.add_argument('--server-port', type=int, help='SSH port of the server')
+    remote_config_args.add_argument('--remote-dir',  help='Remote directory were to transfer the archive.')
+    remote_config_args.add_argument('--remote-file', help='Remote filename to use for the tranfered archive.')
+    remote_config_args.add_argument('--download-url', help='An URL to be print after sucessfuly transfering the archive. Variables inside {} on the URL are expanded.')
+    remote_config_args.add_argument('--generate-sha256sum', action='store_true', help='If enabled it will upload a .sha256sum file with the SHA256 of the archive uploaded.')
+    remote_config_args.add_argument('--update-last-is-file', action='store_true', help='If enabled it will create/update a file named "LAST-IS" in the remote directory with the name of the remote archive after sucessfuly transfering it.')
+    remote_config_args.add_argument('--user-name', help='User name to use when connecting to the SSH server.')
+    remote_config_args.add_argument('--ssh-key', help='Path to a private SSH key to use.')
+
+    parser.add_argument('--remote-config-file', help='Path to a json file with the config values for the remote server.')
+    parser.add_argument('--log-level', dest='log_level', choices=['quiet', 'minimal', 'info', 'debug'], default='info')
+    parser.add_argument('archive_to_transfer', help='Local path for the file to be transfered via SFTP to the remote server.')
+    args = parser.parse_args()
+
+    configure_logging(_log, args.log_level)
+
+    remote_config_parser = RemoteConfig(args, args.remote_config_file)
+    remote_config_parser._print_config_if_debug_log()
+    dot_remote_config_values = remote_config_parser.get_parsed_config_dot()
+
+    sftp_client = SftpClient(dot_remote_config_values, args.log_level)
+    return sftp_client.upload(args.archive_to_transfer)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -413,26 +413,72 @@ class ArchiveMinifiedBuiltProduct(ArchiveBuiltProduct):
                WithProperties("--platform=%(fullPlatform)s"), WithProperties("--%(configuration)s"), "archive", "--minify"]
 
 
+# UploadBuiltProductViaSftp() is still unused. Check HOWTO_config_SFTP_uploads.md about how to enable it.
+class UploadBuiltProductViaSftp(shell.ShellCommand):
+    command = ["python3", "Tools/CISupport/Shared/transfer-archive-via-sftp",
+               "--remote-config-file", "../../remote-built-product-upload-config.json",
+               "--user-name", WithProperties("%(buildername)s"),
+               "--remote-dir", WithProperties("%(buildername)s"),
+               "--remote-file", WithProperties("%(archive_revision)s.zip"),
+               WithProperties("WebKitBuild/%(configuration)s.zip")]
+    name = "upload-built-product-via-sftp"
+    description = ["uploading built product via sftp"]
+    descriptionDone = ["uploaded built product via sftp"]
+    haltOnFailure = True
+
+
+class UploadMiniBrowserBundleViaSftp(shell.ShellCommand):
+    command = ["python3", "Tools/CISupport/Shared/transfer-archive-via-sftp",
+               "--remote-config-file", "../../remote-minibrowser-bundle-upload-config.json",
+               "--remote-file", WithProperties("MiniBrowser_%(fullPlatform)s_%(archive_revision)s.zip"),
+               WithProperties("WebKitBuild/MiniBrowser_%(fullPlatform)s_%(configuration)s.zip")]
+    name = "upload-minibrowser-bundle-via-sftp"
+    description = ["uploading minibrowser bundle via sftp"]
+    descriptionDone = ["uploaded minibrowser bundle via sftp"]
+    haltOnFailure = False
+
+
+class UploadJSCBundleViaSftp(shell.ShellCommand):
+    command = ["python3", "Tools/CISupport/Shared/transfer-archive-via-sftp",
+               "--remote-config-file", "../../remote-jsc-bundle-upload-config.json",
+               "--remote-file", WithProperties("%(archive_revision)s.zip"),
+               WithProperties("WebKitBuild/jsc_%(fullPlatform)s_%(configuration)s.zip")]
+    name = "upload-jsc-bundle-via-sftp"
+    description = ["uploading jsc bundle via sftp"]
+    descriptionDone = ["uploaded jsc bundle via sftp"]
+    haltOnFailure = False
+
+
 class GenerateJSCBundle(shell.ShellCommand):
     command = ["Tools/Scripts/generate-bundle", "--builder-name", WithProperties("%(buildername)s"),
                "--bundle=jsc", "--syslibs=bundle-all", WithProperties("--platform=%(fullPlatform)s"),
-               WithProperties("--%(configuration)s"), WithProperties("--revision=%(archive_revision)s"),
-               "--remote-config-file", "../../remote-jsc-bundle-upload-config.json"]
+               WithProperties("--%(configuration)s"), WithProperties("--revision=%(archive_revision)s")]
     name = "generate-jsc-bundle"
     description = ["generating jsc bundle"]
     descriptionDone = ["generated jsc bundle"]
     haltOnFailure = False
 
+    def evaluateCommand(self, cmd):
+        rc = shell.ShellCommand.evaluateCommand(self, cmd)
+        if rc in (SUCCESS, WARNINGS):
+            self.build.addStepsAfterCurrentStep([UploadJSCBundleViaSftp()])
+        return rc
+
 
 class GenerateMiniBrowserBundle(shell.ShellCommand):
     command = ["Tools/Scripts/generate-bundle", "--builder-name", WithProperties("%(buildername)s"),
                "--bundle=MiniBrowser", WithProperties("--platform=%(fullPlatform)s"),
-               WithProperties("--%(configuration)s"), WithProperties("--revision=%(archive_revision)s"),
-               "--remote-config-file", "../../remote-minibrowser-bundle-upload-config.json"]
+               WithProperties("--%(configuration)s"), WithProperties("--revision=%(archive_revision)s")]
     name = "generate-minibrowser-bundle"
     description = ["generating minibrowser bundle"]
     descriptionDone = ["generated minibrowser bundle"]
     haltOnFailure = False
+
+    def evaluateCommand(self, cmd):
+        rc = shell.ShellCommand.evaluateCommand(self, cmd)
+        if rc in (SUCCESS, WARNINGS):
+            self.build.addStepsAfterCurrentStep([UploadMiniBrowserBundleViaSftp()])
+        return rc
 
 
 class ExtractBuiltProduct(shell.ShellCommand):

--- a/Tools/Scripts/generate-bundle
+++ b/Tools/Scripts/generate-bundle
@@ -845,100 +845,7 @@ class BundleCreator(object):
             self._dlopenwrap_make('clean')
 
 
-class BundleUploader(object):
 
-    def __init__(self, bundle_file_path, remote_config_file, bundle_type, platform, configuration, compression_type, revision, log_level):
-        self._bundle_file_path = bundle_file_path
-        self._remote_config_file = remote_config_file
-        self._configuration = configuration
-        self._revision = revision
-        self._bundle_type = bundle_type
-        self._platform = platform
-        self._compression_type = compression_type
-        self._sftp_quiet = log_level == 'quiet' or log_level == 'minimal'
-        if not os.path.isfile(self._remote_config_file):
-            raise ValueError('Can not find remote config file for upload at path %s' % self._remote_config_file)
-
-    def _sha256sum(self, file):
-        hash = hashlib.sha256()
-        with open(file, 'rb') as f:
-            for chunk in iter(lambda: f.read(4096), b''):
-                hash.update(chunk)
-        return hash.hexdigest()
-
-    def _get_osidversion(self):
-        with open('/etc/os-release', 'r') as osrelease_handle:
-            for line in osrelease_handle.readlines():
-                if line.startswith('ID='):
-                    os_id = line.split('=')[1].strip().strip('"')
-                if line.startswith('VERSION_ID='):
-                    version_id = line.split('=')[1].strip().strip('"')
-        assert(os_id)
-        assert(version_id)
-        osidversion = os_id + '-' + version_id
-        assert(' ' not in osidversion)
-        assert(len(osidversion) > 3)
-        return osidversion
-
-    # The expected format for --remote-config-file is something like:
-    # {
-    # "servername": "webkitgtk.org",
-    # "serveraddress": "webkitgtk.intranet-address.local",
-    # "serverport": "23",
-    # "username": "upload-bot-64",
-    # "baseurl": "https://webkitgtk.org/built-products",
-    # "remotepath" : "x86_64/nightly/%(bundletype)s/%(distro_id_ver)s/%(bundletype)s_%(platform)s_%(configuration)s_r%(version)s.%(compression_type)s",
-    # "sshkey": "output of the priv key in base64. E.g. cat ~/.ssh/id_rsa|base64 -w0"
-    # }
-    def upload(self):
-        remote_data = json.load(open(self._remote_config_file))
-        remote_file_bundle_path = remote_data['remotepath'] % { 'bundletype' : self._bundle_type,
-                                                                'configuration' : self._configuration,
-                                                                'compression_type' : self._compression_type,
-                                                                'distro_id_ver' : self._get_osidversion().capitalize(),
-                                                                'platform' : self._platform,
-                                                                'version' : self._revision }
-        with tempfile.NamedTemporaryFile(mode='w+b') as sshkeyfile, tempfile.NamedTemporaryFile(mode='w+') as hashcheckfile, \
-             tempfile.NamedTemporaryFile(mode='w+') as lastisfile, tempfile.NamedTemporaryFile(mode='w+') as uploadinstructionsfile:
-
-            # In theory NamedTemporaryFile() is already created 0600. But it don't hurts ensuring this again here.
-            os.chmod(sshkeyfile.name, 0o600)
-            sshkeyfile.write(base64.b64decode(remote_data['sshkey']))
-            sshkeyfile.flush()
-            # Generate and upload also a sha256 hash
-            hashforbundle = self._sha256sum(self._bundle_file_path)
-            os.chmod(hashcheckfile.name, 0o644)
-            hashcheckfile.write('%s %s\n' % (hashforbundle, os.path.basename(remote_file_bundle_path)))
-            hashcheckfile.flush()
-            # A LAST-IS file for convenience
-            os.chmod(lastisfile.name, 0o644)
-            lastisfile.write('%s\n' % os.path.basename(remote_file_bundle_path))
-            lastisfile.flush()
-            # SFTP upload instructions file
-            uploadinstructionsfile.write('progress\n')
-            uploadinstructionsfile.write('put %s %s\n' % (self._bundle_file_path, remote_file_bundle_path))
-            remote_file_bundle_path_no_ext, _ = os.path.splitext(remote_file_bundle_path)
-            uploadinstructionsfile.write('put %s %s\n' % (hashcheckfile.name, remote_file_bundle_path_no_ext + '.sha256sum'))
-            uploadinstructionsfile.write('put %s %s\n' % (lastisfile.name, os.path.join(os.path.dirname(remote_file_bundle_path), 'LAST-IS')))
-            uploadinstructionsfile.write('quit\n')
-            uploadinstructionsfile.flush()
-            # The idea of this is to ensure scp doesn't ask any question (not even on the first run).
-            # This should be secure enough according to https://www.gremwell.com/ssh-mitm-public-key-authentication
-            sftpCommand = ['sftp',
-                           '-o', 'StrictHostKeyChecking=no',
-                           '-o', 'UserKnownHostsFile=/dev/null',
-                           '-o', 'LogLevel=ERROR',
-                           '-P', remote_data['serverport'],
-                           '-i', sshkeyfile.name,
-                           '-b', uploadinstructionsfile.name,
-                           '%s@%s' % (remote_data['username'], remote_data['serveraddress'])]
-            _log.info('Uploading bundle to %s as %s with sha256 hash %s' % (remote_data['servername'], remote_file_bundle_path, hashforbundle))
-            sftp_out = subprocess.DEVNULL if self._sftp_quiet else sys.stdout
-            if subprocess.call(sftpCommand, stdout=sftp_out, stderr=sftp_out) != 0:
-                raise RuntimeError('The sftp command returned non-zero status')
-
-        _log.log(LOG_MESSAGE, 'Done: archive sucesfully uploaded to %s/%s' % (remote_data['baseurl'], remote_file_bundle_path))
-        return 0
 
 
 def configure_logging(selected_log_level='info'):
@@ -990,8 +897,6 @@ def main():
     parser.add_argument('--log-level', dest='log_level', choices=['quiet', 'minimal', 'info', 'debug'], default='info')
     parser.add_argument('--revision', action='store', dest='webkit_version')
     parser.add_argument('--builder-name', action='store', dest='builder_name')
-    parser.add_argument('--remote-config-file', action='store', dest='remote_config_file',
-                        help='Optional configuration file with the configuration needed to upload the generated the bundle to a remote server via sftp/ssh.')
     options = parser.parse_args()
 
     flatpakutils.run_in_sandbox_if_available([sys.argv[0], '--flatpak-' + options.platform] + sys.argv[1:])
@@ -1002,11 +907,6 @@ def main():
     bundle_creator = BundleCreator(options.configuration, options.platform, options.bundle_binary, options.syslibs, options.ldd,
                                    not options.no_strip, options.compression, options.destination, options.webkit_version, options.builder_name)
     bundle_file_path = bundle_creator.create()
-
-    if options.remote_config_file is not None:
-        bundle_uploader = BundleUploader(bundle_file_path, options.remote_config_file, options.bundle_binary, options.platform,
-                                         options.configuration, options.compression, options.webkit_version, options.log_level)
-        return bundle_uploader.upload()
     return 0
 
 


### PR DESCRIPTION
#### c3827e6cc0dc1f5ccca8ff43fc50544878155265
<pre>
[buildbot] Move SFTP upload code from generate-bundle script to a new script for uploads and document it
<a href="https://bugs.webkit.org/show_bug.cgi?id=253537">https://bugs.webkit.org/show_bug.cgi?id=253537</a>

Reviewed by Aakash Jain.

Remove the SFTP upload code from the script `generate-bundle`
and create a new script dedicated to do the SFTP uploads.

Adjust the buildbot steps so now a new step is added after
sucessfully executing `generate-bundle` step to upload the
bundle generated with the new script. Add also unit tests.

Add also detailed documentation about how the SSH server should
be configured to enable the uploads via SFTP from the workers
in a secure way.

The step `UploadBuiltProductViaSftp()` added on build-webkit-org/steps.py
is still not used. Is added as an example of how the step should
look if we end uploading the built-product via SFTP.

* Tools/CISupport/Shared/HOWTO_config_SFTP_uploads.md: Added.
* Tools/CISupport/Shared/transfer-archive-via-sftp: Added.
* Tools/CISupport/build-webkit-org/steps.py:
(ArchiveMinifiedBuiltProduct):
(UploadBuiltProductViaSftp):
(UploadMiniBrowserBundleViaSftp):
(UploadJSCBundleViaSftp):
(GenerateJSCBundle):
(GenerateJSCBundle.start):
(GenerateJSCBundle.evaluateCommand):
(GenerateMiniBrowserBundle):
(GenerateMiniBrowserBundle.start):
(GenerateMiniBrowserBundle.evaluateCommand):
* Tools/CISupport/build-webkit-org/steps_unittest.py:
* Tools/Scripts/generate-bundle:

Canonical link: <a href="https://commits.webkit.org/261448@main">https://commits.webkit.org/261448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2f3c4b110b1e98babc219eca601b0e8b64f7483

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111753 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/20884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22243 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/11963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/117518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104714 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/11963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/110524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4344 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->