### PR TITLE
SVG text in RTL mixes characters

### DIFF
--- a/LayoutTests/svg/text/bidi-dir-rtl-expected.html
+++ b/LayoutTests/svg/text/bidi-dir-rtl-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg xmlns="http://www.w3.org/2000/svg" style="width: 135px; height: 45px;">
+    <text y="16" x="70" text-anchor="end">(blah(1 - 0</text>
+</svg>

--- a/LayoutTests/svg/text/bidi-dir-rtl.html
+++ b/LayoutTests/svg/text/bidi-dir-rtl.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg xmlns="http://www.w3.org/2000/svg" style="width: 135px; height: 45px;">
+    <text y="16" x="70" direction="rtl">0 - blah(1)</text>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2006 Oliver Hunt <ojh16@student.canterbury.ac.nz>
- * Copyright (C) 2006 Apple Inc.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  * Copyright (C) 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2011 Torch Mobile (Beijing) CO. Ltd. All rights reserved.
@@ -260,21 +261,11 @@ static inline void swapItemsInLayoutAttributes(SVGTextLayoutAttributes* firstAtt
     SVGCharacterDataMap::iterator itLast = lastAttributes->characterDataMap().find(lastPosition + 1);
     bool firstPresent = itFirst != firstAttributes->characterDataMap().end();
     bool lastPresent = itLast != lastAttributes->characterDataMap().end();
-    if (!firstPresent && !lastPresent)
+    // We only want to perform the swap if both inline boxes are absolutely positioned.
+    if (!firstPresent || !lastPresent)
         return;
 
-    if (firstPresent && lastPresent) {
-        std::swap(itFirst->value, itLast->value);
-        return;
-    }
-
-    if (firstPresent && !lastPresent) {
-        lastAttributes->characterDataMap().set(lastPosition + 1, itFirst->value);
-        return;
-    }
-
-    // !firstPresent && lastPresent
-    firstAttributes->characterDataMap().set(firstPosition + 1, itLast->value);
+    std::swap(itFirst->value, itLast->value);
 }
 
 static inline void findFirstAndLastAttributesInVector(Vector<SVGTextLayoutAttributes*>& attributes, RenderSVGInlineText* firstContext, RenderSVGInlineText* lastContext,


### PR DESCRIPTION
#### 46f0f6ec886e357152e65e5d78428422ce6d4194
<pre>
SVG text in RTL mixes characters

<a href="https://bugs.webkit.org/show_bug.cgi?id=246888">https://bugs.webkit.org/show_bug.cgi?id=246888</a>
rdar://problem/101695671

Reviewed by Nikolas Zimmermann.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=167777

Only swap positions if both characters actually are absolute positioned.

When re-ordering inline boxes within a &quot;line&quot;, character-based absolute
positioning attributes are re-ordered to match. However, when attempting
to re-order/swap a inline box that does have a absolute positioning
attribute (and is of length 1) with one that doesn&apos;t, the positioning
attribute is copied rather than swapped - leading to additional chunks
being created and consequently additional adjustments being performed.
However, swapping is not needed/required in this case, since the attribute
is already in the correct (logical) position.
To mitigate this, only perform the attribute swap if both characters
(and consequently inline boxes) have attributes in the first place.

* Source/WebCore/rendering/svg/SVGRootInlineBox:
(SVGRootInlineBox::swapItemsInLayoutAttributes): Update to remove conditions about First and Last Positions
* LayoutTests/svg/text/bidi-dir-rtl.html: Added Test Case
* LayoutTests/svg/text/bidi-dir-rtl-expected.html: Added Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/261495@main">https://commits.webkit.org/261495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4ed2037bd82cc0695bb8851d42a84e2920fb19b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/7 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120182 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2596 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/5 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44899 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13030 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/5 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86701 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9496 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8000 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15500 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->