### PR TITLE
Fix flushing constants to StackArguments in WasmBBQJIT

### DIFF
--- a/JSTests/wasm/stress/constant-overlaps-stack-argument.js
+++ b/JSTests/wasm/stress/constant-overlaps-stack-argument.js
@@ -1,0 +1,35 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func $0 (result i64 i64 i64 i64 i64 i64 i64 i64 i64)
+        i64.const 1
+        i64.const 2
+        i64.const 3
+        i64.const 4
+        i64.const 5
+        i64.const 6
+        i64.const 7
+        i64.const 8
+        i64.const 9
+    )
+    (func (export "test") (result i64)
+        call $0
+        drop
+        i64.const 42
+        block
+            nop
+        end
+        return
+    )
+)
+`;
+
+async function test() {
+  const instance = await instantiate(wat, {}, { simd: true });
+  const { test } = instance.exports;
+  assert.eq(test(), 42n);
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/spilled-block-argument.js
+++ b/JSTests/wasm/stress/spilled-block-argument.js
@@ -1,0 +1,114 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test_i32") (local i32 i32)
+        i32.const 42
+        local.set 1
+
+        local.get 0 ;; 32 locals should require all GPRs on all platforms
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 1 ;; here's the value we actually care about
+
+        block (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            i32.const 1
+            i32.add
+            br 0
+        end
+
+        i32.const 43
+        i32.eq
+        br_if 0
+        unreachable
+    )
+
+    (func (export "test_f32") (local f32 f32)
+        f32.const 42.0
+        local.set 1
+
+        local.get 0 ;; 32 locals should require all FPRs on all platforms
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 0
+        local.get 1 ;; here's the value we actually care about
+
+        block (param f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32) (result f32)
+            f32.neg
+            br 0
+        end
+
+        f32.const -42.0
+        f32.eq
+        br_if 0
+        unreachable
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const { test_i32, test_f32 } = instance.exports;
+    test_i32();
+    test_f32();
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/spilled-block-result.js
+++ b/JSTests/wasm/stress/spilled-block-result.js
@@ -1,0 +1,117 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test_i32") (local i32 i32)
+        i32.const 42
+        local.set 1
+
+        block (result i32)
+            block (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                local.get 0 ;; 32 locals should use up all GPRs on all platforms
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 1 ;; here's the value we actually care about
+            end
+
+            i32.const 1
+            i32.add
+            br 0
+        end
+
+        i32.const 43
+        i32.eq
+        br_if 0
+        unreachable
+    )
+
+    (func (export "test_f32") (local f32 f32)
+        f32.const 42.0
+        local.set 1
+
+        block (result f32)
+            block (result f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32)
+                local.get 0 ;; 32 locals should use up all FPRs on all platforms
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 0
+                local.get 1 ;; here's the value we actually care about
+            end
+            f32.neg
+            br 0
+        end
+
+        f32.const -42.0
+        f32.eq
+        br_if 0
+        unreachable
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const { test_i32, test_f32 } = instance.exports;
+    test_i32();
+    test_f32();
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/spilled-constant-block-argument.js
+++ b/JSTests/wasm/stress/spilled-constant-block-argument.js
@@ -1,0 +1,108 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test_i32")
+        i32.const 1 ;; 32 values should be sufficient to require stack arguments on all platforms
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 1
+        i32.const 42 ;; here's the value we actually care about
+
+        block (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)
+            i32.const 1
+            i32.add
+            br 0
+        end
+
+        i32.const 43
+        i32.eq
+        br_if 0
+        unreachable
+    )
+
+    (func (export "test_f32")
+        f32.const 1.0 ;; 32 values should be sufficient to require stack arguments on all platforms
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 1.0
+        f32.const 42.0 ;; here's the value we actually care about
+
+        block (param f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32) (result f32)
+            f32.neg
+            br 0
+        end
+
+        f32.const -42.0
+        f32.eq
+        br_if 0
+        unreachable
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const { test_i32, test_f32 } = instance.exports;
+    test_i32();
+    test_f32();
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/spilled-constant-block-result.js
+++ b/JSTests/wasm/stress/spilled-constant-block-result.js
@@ -1,0 +1,110 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test_i32")
+        block (result i32)
+            block (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
+                i32.const 1 ;; 32 values should be sufficient to require stack arguments on all platforms
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 1
+                i32.const 42 ;; here's the value we actually care about
+            end
+            i32.const 1
+            i32.add
+            br 0
+        end
+
+        i32.const 43
+        i32.eq
+        br_if 0
+        unreachable
+    )
+
+    (func (export "test_f32")
+        block (result f32)
+            block (result f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32 f32)
+                f32.const 1.0 ;; 32 values should be sufficient to require stack arguments on all platforms
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 1.0
+                f32.const 42.0 ;; here's the value we actually care about
+            end
+            f32.neg
+            br 0
+        end
+
+        f32.const -42.0
+        f32.eq
+        br_if 0
+        unreachable
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const { test_i32, test_f32 } = instance.exports;
+    test_i32();
+    test_f32();
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -8318,7 +8318,7 @@ private:
     {
         ASSERT(constant.isConst());
 
-        if (loc.isStack() || loc.isGlobal())
+        if (loc.isMemory())
             return emitStoreConst(constant, loc);
 
         ASSERT(loc.isRegister());
@@ -8714,9 +8714,9 @@ private:
     {
         // Called whenever a value is popped from the expression stack. Mostly, we
         // use this to release the registers temporaries are bound to.
-        Location result = locationOf(value);
-        if (value.isTemp() && result.isRegister())
-            unbind(value, result);
+        Location location = locationOf(value);
+        if (value.isTemp() && location != canonicalSlot(value))
+            unbind(value, location);
     }
 
     Location allocateRegister(TypeKind type)


### PR DESCRIPTION
#### 65f37957e2718b0104e2a3bb13086626dafe23d5
<pre>
Fix flushing constants to StackArguments in WasmBBQJIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=253530">https://bugs.webkit.org/show_bug.cgi?id=253530</a>
rdar://106358707

Reviewed by Yusuke Suzuki.

The current WASM BBQ JIT trips some assertions when constants are flushed at the
end of a block in certain circumstances. Specifically, if a temp was previously
bound to a StackArgument, then was popped and replaced with a constant, the constant
will flush to the StackArgument slot which is wrong and caught by the assertion.

This patch addresses two issues: first, we shouldn&apos;t actually fail an assertion here,
it&apos;s totally fine in theory to store a constant in a stack argument location. But the
reason we flush to a StackArgument to begin with is that BBQ JIT doesn&apos;t correctly
unbind temporaries from StackArgument slots when they are popped - with this patch, we
should now always restore temps to their canonical slots if they are bound elsewhere
and popped.

* JSTests/wasm/stress/constant-overlaps-stack-argument.js: Added.
* JSTests/wasm/stress/spilled-block-argument.js: Added.
* JSTests/wasm/stress/spilled-block-result.js: Added.
* JSTests/wasm/stress/spilled-constant-block-argument.js: Added.
* JSTests/wasm/stress/spilled-constant-block-result.js: Added.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitMoveConst):
(JSC::Wasm::BBQJIT::consume):

Canonical link: <a href="https://commits.webkit.org/261358@main">https://commits.webkit.org/261358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0579e7f57c589e9536db8c1c2ba214d96af5f13d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/8 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120183 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11626 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117157 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104075 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98212 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/4 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44900 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99928 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13031 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/4 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86702 "10 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11145 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9425 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101115 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51985 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31494 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7875 "'git push ...'") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15501 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109153 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26896 "Passed tests") | 
<!--EWS-Status-Bubble-End-->