### PR TITLE
Slow scroll adjustment when using a mouse wheel

### DIFF
--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -47,7 +47,16 @@ public:
     // Called by the ScrollableArea when the scroll offset changes.
     void offsetDidChange();
 
-    static int pixelsPerLineStep() { return 40; }
+    static int pixelsPerLineStep()
+    {
+#if PLATFORM(COCOA)
+        return 40;
+#else
+        // https://webkit.org/b/168300
+        return 120;
+#endif
+    }
+
     static float minFractionToStepWhenPaging() { return 0.8; }
     WEBCORE_EXPORT static int maxOverlapBetweenPages();
     static int pageStep(int viewWidthOrHeight, int contentWidthOrHeight) { return std::max(std::max<int>(lroundf(viewWidthOrHeight * Scrollbar::minFractionToStepWhenPaging()), lroundf(contentWidthOrHeight - Scrollbar::maxOverlapBetweenPages())), 1); }


### PR DESCRIPTION
#### 48e9757c00ed0264e251061a8b40a45319016173
<pre>
Slow scroll adjustment when using a mouse wheel
<a href="https://bugs.webkit.org/show_bug.cgi?id=168300">https://bugs.webkit.org/show_bug.cgi?id=168300</a>

Reviewed by NOBODY (OOPS!).

Simple is better than complex! Users are complaining that mouse wheel
scroll is too slow. So let&apos;s scroll 3x faster, except on Apple platforms
where the current slower scroll speed is intentional.

* Source/WebCore/platform/Scrollbar.h:
(WebCore::Scrollbar::pixelsPerLineStep):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48e9757c00ed0264e251061a8b40a45319016173

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/11 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11629 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2601 "113 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104096 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/8 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44920 "4 flakes 128 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13033 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/8 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86735 "10 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9427 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51989 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15504 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->