### PR TITLE
[popover] Throw exception when calling dialog.show() on an open popover

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations-expected.txt
@@ -1,8 +1,8 @@
 Visible button
 
-FAIL Popover combination: Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
-FAIL Popover combination: Open Non-modal Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
+PASS Popover combination: Popover Dialog
+PASS Popover combination: Open Non-modal Popover Dialog
 PASS Popover combination: Fullscreen Popover
-FAIL Popover combination: Fullscreen Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
-FAIL Popover combination: Fullscreen Open Non-modal Popover Dialog assert_throws_dom: Calling show() on an already-showing Popover should throw InvalidStateError function "() => ex.show()" did not throw
+PASS Popover combination: Fullscreen Popover Dialog
+PASS Popover combination: Fullscreen Open Non-modal Popover Dialog
 

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -50,31 +50,35 @@ HTMLDialogElement::HTMLDialogElement(const QualifiedName& tagName, Document& doc
 {
 }
 
-void HTMLDialogElement::show()
+ExceptionOr<void> HTMLDialogElement::show()
 {
     // If the element already has an open attribute, then return.
     if (isOpen())
-        return;
+        return { };
+
+    if (popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Showing)
+        return Exception { InvalidStateError, "Element is already an open popover."_s };
 
     setBooleanAttribute(openAttr, true);
 
     m_previouslyFocusedElement = document().focusedElement();
 
     runFocusingSteps();
+    return { };
 }
 
 ExceptionOr<void> HTMLDialogElement::showModal()
 {
     // If subject already has an open attribute, then throw an "InvalidStateError" DOMException.
     if (isOpen())
-        return Exception { InvalidStateError };
+        return Exception { InvalidStateError, "Element is already open."_s };
 
     // If subject is not connected, then throw an "InvalidStateError" DOMException.
     if (!isConnected())
-        return Exception { InvalidStateError };
+        return Exception { InvalidStateError, "Element is not connected."_s };
 
     if (popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Showing)
-        return Exception { InvalidStateError };
+        return Exception { InvalidStateError, "Element is already an open popover."_s };
 
     // setBooleanAttribute will dispatch a DOMSubtreeModified event.
     // Postpone callback execution that can potentially make the dialog disconnected.

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -39,7 +39,7 @@ public:
     const String& returnValue() const { return m_returnValue; }
     void setReturnValue(String&& value) { m_returnValue = WTFMove(value); }
 
-    void show();
+    ExceptionOr<void> show();
     ExceptionOr<void> showModal();
     void close(const String&);
 


### PR DESCRIPTION
#### af0daf6f720f13d60c71fd01b2981ac7f9fdd8a3
<pre>
[popover] Throw exception when calling dialog.show() on an open popover
<a href="https://bugs.webkit.org/show_bug.cgi?id=253538">https://bugs.webkit.org/show_bug.cgi?id=253538</a>
rdar://106383178

Reviewed by Cameron McCormack.

<a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-show">https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-show</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations-expected.txt:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show):
(WebCore::HTMLDialogElement::showModal):
* Source/WebCore/html/HTMLDialogElement.h:

Canonical link: <a href="https://commits.webkit.org/261351@main">https://commits.webkit.org/261351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1792562b0c217dca6d16c7c72b5269b5e2c332c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20545 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/20 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120194 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11640 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117172 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/20 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104122 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/20 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/44942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13044 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/20 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13550 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18994 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/20 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7869 "'git push ...'") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15515 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->