### PR TITLE
REBASELINE REGRESSION(iPad 9th gen): [ iPad Simulator ] 2x editing/selection tests are constant failures.

### DIFF
--- a/LayoutTests/platform/ipad/editing/selection/ios/show-selection-in-transformed-container-2-expected.txt
+++ b/LayoutTests/platform/ipad/editing/selection/ios/show-selection-in-transformed-container-2-expected.txt
@@ -1,0 +1,15 @@
+
+This test verifies that after focusing a visible input field in a display: flex container that has been translated horizontally out of view, the caret is still visible. To run the test manually, tap the input field and check that the caret shows up.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL caretRect.left should be 10. Was 9.
+PASS caretRect.top is 4
+FAIL caretRect.width should be 2. Was 3.
+PASS caretRect.height is 24
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/ipad/editing/selection/ios/show-selection-in-transformed-container-expected.txt
+++ b/LayoutTests/platform/ipad/editing/selection/ios/show-selection-in-transformed-container-expected.txt
@@ -1,0 +1,20 @@
+
+
+Apply transform
+This test verifies that after focusing a visible input field in a body element that has been translated horizontally out of view, the caret is still visible. To run the test manually, first tap the input field and check that the caret shows up. Then, tap the button to apply the CSS transform, tap the input field again, and check that the caret is still visible.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS caretBefore.left is 18
+PASS caretBefore.top is 12
+PASS caretBefore.width is 2
+PASS caretBefore.height is 24
+FAIL caretAfter.left should be 18. Was 17.
+PASS caretAfter.top is 12
+FAIL caretAfter.width should be 2. Was 3.
+PASS caretAfter.height is 24
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+


### PR DESCRIPTION
#### a9d2ee0df5a8ee627e91ebd3b5c2c60c92e55257
<pre>
REBASELINE REGRESSION(iPad 9th gen): [ iPad Simulator ] 2x editing/selection tests are constant failures.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253252">https://bugs.webkit.org/show_bug.cgi?id=253252</a>
rdar://106150327

Unreviewed test gardening.

Fix rebaseline of failing tests.

* LayoutTests/platform/ipad/editing/selection/ios/show-selection-in-transformed-container-2-actual.txt: Added.
* LayoutTests/platform/ipad/editing/selection/ios/show-selection-in-transformed-container-actual.txt: Added.

Canonical link: <a href="https://commits.webkit.org/261347@main">https://commits.webkit.org/261347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d254a91be040b8f278862fb4d11411945506edf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111404 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/20541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/17 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/21909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/11637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117167 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/21909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/17 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/21909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/17 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/104095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/17 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/11637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/18991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/17 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4310 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->