### PR TITLE
TestWebKitAPI.FontManagerTests.ChangeTypingAttributesWithInspectorBar fails when enabling GPU process and UI side compositing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm
@@ -397,6 +397,7 @@ TEST(FontManagerTests, ChangeTypingAttributesWithInspectorBar)
     auto inspectorBar = adoptNS([[TestInspectorBar alloc] initWithWebView:webView.get()]);
     {
         [webView selectAll:nil];
+        [webView waitForNextPresentationUpdate];
         NSFont *originalFont = [webView typingAttributes][NSFontAttributeName];
         EXPECT_WK_STREQ("Times", originalFont.familyName);
         EXPECT_EQ(16, originalFont.pointSize);


### PR DESCRIPTION
#### f87ff411fbe1f1a9b6f478151f2cea2d2fbb5c7b
<pre>
TestWebKitAPI.FontManagerTests.ChangeTypingAttributesWithInspectorBar fails when enabling GPU process and UI side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=253541">https://bugs.webkit.org/show_bug.cgi?id=253541</a>
&lt;rdar://104037176&gt;

Reviewed by Wenson Hsieh.

The test was failing because we were trying to update font name whilst the editor state hasn&apos;t been updated yet.
Fixed the test by waiting for the presentation update at the beginning of the test.

* Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/261378@main">https://commits.webkit.org/261378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d2b4cc02dd6c35d30a40ada78a37aca90645c40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/21 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120195 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11641 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104142 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/12 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44957 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13045 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/12 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86755 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13551 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9436 "1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/18995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51993 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15516 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4321 "") | | | | 
<!--EWS-Status-Bubble-End-->