### PR TITLE
[UI-side compositing] Crash in displaylink::addObserver()

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -101,11 +101,20 @@ RemoteLayerTreeEventDispatcher::RemoteLayerTreeEventDispatcher(RemoteScrollingCo
 {
 }
 
-RemoteLayerTreeEventDispatcher::~RemoteLayerTreeEventDispatcher() = default;
+RemoteLayerTreeEventDispatcher::~RemoteLayerTreeEventDispatcher()
+{
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    ASSERT(!m_momentumEventDispatcher);
+#endif
+    ASSERT(!m_displayRefreshObserverID);
+}
 
 // This must be called to break the cycle between RemoteLayerTreeEventDispatcherDisplayLinkClient and this.
 void RemoteLayerTreeEventDispatcher::invalidate()
 {
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    m_momentumEventDispatcher = nullptr;
+#endif
     stopDisplayLinkObserver();
     m_displayLinkClient->invalidate();
     m_displayLinkClient = nullptr;
@@ -296,6 +305,7 @@ void RemoteLayerTreeEventDispatcher::startOrStopDisplayLinkOnMainThread()
 
 void RemoteLayerTreeEventDispatcher::startDisplayLinkObserver()
 {
+    ASSERT(m_displayLinkClient);
     if (m_displayRefreshObserverID)
         return;
 


### PR DESCRIPTION
#### 355ad2b87eea27d6ec982e9806101addb30ad652
<pre>
[UI-side compositing] Crash in displaylink::addObserver()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253543">https://bugs.webkit.org/show_bug.cgi?id=253543</a>
rdar://59960084

Reviewed by Tim Horton.

When destroying a RemoteLayerTreeEventDispatcher, we destroy the MomentumEventDispatcher which calls back
into the RemoteLayerTreeEventDispatcher to stop the display link, but this ends in a &quot;start or stop&quot; function,
which tries to start one if the scrolling tree has an animated scroll.

Prevent this by clearing the MomentumEventDispatcher in `invalidate()`, before we explicitly stop the display
link. Add some assertions to verify that we&apos;ve cleared the MomentumEventDispatcher in the destructor, and that
we don&apos;t call startDisplayLinkObserver() after nulling out the client.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::~RemoteLayerTreeEventDispatcher):
(WebKit::RemoteLayerTreeEventDispatcher::invalidate):
(WebKit::RemoteLayerTreeEventDispatcher::startOrStopDisplayLinkOnMainThread):
(WebKit::RemoteLayerTreeEventDispatcher::startDisplayLinkObserver):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:

Canonical link: <a href="https://commits.webkit.org/261404@main">https://commits.webkit.org/261404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b2a96ec3b3c99217ca9a855b21bb4bbcf097cc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120368 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11838 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117389 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45259 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13240 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/145 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13732 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52138 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7940 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15719 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->