### PR TITLE
TestWebKitAPI.VideoControlsManager.VideoControlsManagerMultipleVideosSwitchControlledVideoWhenScrolling fails when enabling GPU process and UI side compositing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm
@@ -246,6 +246,8 @@ TEST(VideoControlsManager, VideoControlsManagerMultipleVideosSwitchControlledVid
         [webView stringByEvaluatingJavaScript:@"scrollToSecondView()"];
     }];
 
+    [webView waitForNextPresentationUpdate];
+
     EXPECT_TRUE([[webView controlledElementID] isEqualToString:@"second"]);
 }
 


### PR DESCRIPTION
#### 434f1c87148f204d7e26bf9968626572c8e3458c
<pre>
TestWebKitAPI.VideoControlsManager.VideoControlsManagerMultipleVideosSwitchControlledVideoWhenScrolling fails when enabling GPU process and UI side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=253548">https://bugs.webkit.org/show_bug.cgi?id=253548</a>
rdar://104037601

Reviewed by Wenson Hsieh and Jer Noble.

Wait for a presentation update after scrolling to the second video.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/VideoControlsManager.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/261384@main">https://commits.webkit.org/261384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88c7cc0147011c29eb69b115b5acf33ea20f2985

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/26 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120201 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11649 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104116 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/16 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44936 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13051 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/16 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86731 "11 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9442 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/51997 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7925 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15522 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->