### PR TITLE
Web Inspector: Fonts Panel: Details section rows for basic properties are misaligned and have inconsistent ordering

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
@@ -164,24 +164,18 @@ body[dir=rtl] .details-section > .header::before {
     margin-inline-start: 3px;
 }
 
-.details-section > .content {
-    display: table;
-    width: 100%;
-    border-spacing: 0;
-    border-collapse: collapse;
-}
-
 .details-section.collapsed > .content {
     display: none;
 }
 
 .details-section > .content > .group {
-    display: table-row-group;
+    display: grid;
+    grid-template-columns: [label] minmax(85px, max-content) [value] 1fr;
     border-bottom: 1px solid var(--border-color);
 }
 
-.details-section > .content > .group:has(.row.font-variation) {
-    display: unset; /* Unsets `display: table-row-group` because it affects sizing of child elements that are grid containers. */
+.details-section > .content > .group > * {
+    grid-column: 1 / -1;
 }
 
 .details-section > .content > .group:last-child {
@@ -192,12 +186,13 @@ body[dir=rtl] .details-section > .header::before {
     background-color: var(--background-color-intermediate);
 }
 
-.details-section > .content > .group > .row.simple {
-    display: table-row;
+.details-section > .content > .group:has(> .row.simple:last-child) {
+    padding-block-end: 3px;
 }
 
-.details-section > .content > .group > .row.simple:last-child > * {
-    padding-bottom: 5px !important;
+.details-section > .content > .group > .row.simple {
+    display: grid;
+    grid-template-columns: subgrid;
 }
 
 .details-section > .content > .group > .row.simple.empty {
@@ -208,34 +203,16 @@ body[dir=rtl] .details-section > .header::before {
     font-size: 10px;
 }
 
-.details-section > .content > .group > .row.simple.empty:last-child {
-    display: table-row;
-}
-
-.details-section > .content > .group > .row.simple.empty:last-child > * {
-    display: table-cell;
-    height: 1px;
-    font-size: 0;
-    color: transparent;
-    padding-top: 0;
-    padding-bottom: 3px !important;
-}
-
-.details-section > .content > .group > .row.simple.empty:last-child > * > * {
-    display: none;
-}
-
 .details-section > .content > .group > .row.simple > * {
-    display: table-cell;
     vertical-align: top;
     padding: 5px 4px 2px;
 }
 
 .details-section > .content > .group > .row.simple > .label {
-    width: 85px;
     padding-inline-start: 6px;
     color: hsl(0, 0%, 20%);
     text-align: end;
+    grid-column: label;
 }
 
 .details-section > .content > .group > .row.simple > .value {
@@ -244,6 +221,7 @@ body[dir=rtl] .details-section > .header::before {
     word-wrap: break-word;
     cursor: text;
     -webkit-user-select: text;
+    grid-column: value;
 }
 
 .details-section > .content > .group > .row.simple > .value .go-to-arrow {

--- a/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.css
@@ -24,7 +24,7 @@
  */
 
 .sidebar > .panel.details.style-font > .content .details-section > .content > .group > .row.simple > .label {
-    width: 105px; /* Width of `Historical Figures` or `Optical Size (opsz)`. */
+    min-width: 105px; /* Width of `Historical Figures` or `Optical Size (opsz)` in English. */
 }
 
 .sidebar > .panel.details.style-font > .content .details-section > .content > .group > .row.simple > .value .secondary {


### PR DESCRIPTION
#### e28ec6e1c7b9072ad40d61248d7a7931a2d97943
<pre>
Web Inspector: Fonts Panel: Details section rows for basic properties are misaligned and have inconsistent ordering
<a href="https://bugs.webkit.org/show_bug.cgi?id=253545">https://bugs.webkit.org/show_bug.cgi?id=253545</a>

Reviewed by Patrick Angle.

This patch refactors the styles for `WI.DetailsSectionGroup` and `WI.DetailsSectionRow`
from using CSS table layout to using CSS Grid.

The table layout was used to ensure that labels and values align neatly in columns
regardless of the length of the each individual label.

Since introducing `WI.FontVariationDetailsSectionRow` in <a href="https://github.com/WebKit/WebKit/pull/8157">https://github.com/WebKit/WebKit/pull/8157</a>
(which has a CSS Grid internal layout), the rows for the basic font properties group
are a mix of `display: table-row` and `display: grid`. The layout of this this group is inconsistent.

This patch replaces the table layout with CSS Grid and removes obsolete styles.

`WI.DetailsSectionRow` with the `.simple` CSS class modifier are used in the Fonts and Node details sidebar panels.

* Source/WebInspectorUI/UserInterface/Views/DetailsSection.css:
(.details-section &gt; .content):
(.details-section &gt; .content &gt; .group):
(.details-section &gt; .content &gt; .group &gt; *):
(.details-section &gt; .content &gt; .group:has(&gt; .row.simple:last-of-type)):
(.details-section &gt; .content &gt; .group &gt; .row.simple):
(.details-section &gt; .content &gt; .group &gt; .row.simple &gt; *):
(.details-section &gt; .content &gt; .group &gt; .row.simple &gt; .label):
(.details-section &gt; .content &gt; .group &gt; .row.simple &gt; .value):
(.details-section &gt; .content &gt; .group:has(.row.font-variation)): Deleted.
(.details-section &gt; .content &gt; .group &gt; .row.simple:last-child &gt; *): Deleted.
(.details-section &gt; .content &gt; .group &gt; .row.simple.empty:last-child): Deleted.
(.details-section &gt; .content &gt; .group &gt; .row.simple.empty:last-child &gt; *): Deleted.
(.details-section &gt; .content &gt; .group &gt; .row.simple.empty:last-child &gt; * &gt; *): Deleted.

Hidden descendant nodes of a hidden `display: table-cell` could still participate in layout.
No longer with CSS Grid.

* Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.css:
(.sidebar &gt; .panel.details.style-font &gt; .content .details-section &gt; .content &gt; .group &gt; .row.simple &gt; .label):

The `min-width: 105px` declaration ensures all labels of simple rows across diffrent groups in the Fonts panel align in English.
If a label in one group is longer than `min-width`, (ex: German), it will influence the column width just for that group.
This ensures alignment remains consistent within groups as with the previous table layout.

Canonical link: <a href="https://commits.webkit.org/261513@main">https://commits.webkit.org/261513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bccbb04a6fbed730f74c2bcc2c1ee692654a81a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111576 "Build is in progress. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3336 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120334 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3094 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104768 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45508 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13197 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/111 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9555 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8020 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15674 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->