### PR TITLE
Add "streaming" attribute to ManagedMediaSource object

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-streaming-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-streaming-expected.txt
@@ -1,11 +1,14 @@
 
 RUN(video.src = URL.createObjectURL(source))
 EVENT(sourceopen)
+EXPECTED (source.streaming == 'true') OK
 EVENT(startstreaming)
 RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
 RUN(sourceBuffer.appendBuffer(loader.initSegment()))
 EVENT(update)
 EVENT(endstreaming)
+EXPECTED (source.streaming == 'false') OK
 EVENT(startstreaming)
+EXPECTED (source.streaming == 'true') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-managedmse-streaming.html
+++ b/LayoutTests/media/media-source/media-managedmse-streaming.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
 <html>
 <head>
-    <title>managedmediasource-memoryPressure</title>
+    <title>managedmediasource-streaming</title>
     <script src="../../media/media-source/media-source-loader.js"></script>
     <script src="../../media/video-test.js"></script>
     <script src="../../media/utilities.js"></script>
@@ -31,10 +31,14 @@
                     break;
             }
 
+            waitFor(video, 'error').then(failTest);
+
             source = new ManagedMediaSource();
             run('video.src = URL.createObjectURL(source)');
-            await Promise.all([waitFor(source, 'sourceopen'), waitFor(source, 'startstreaming') ]);
-            waitFor(video, 'error').then(failTest);
+
+            await waitFor(source, 'sourceopen');
+            testExpected('source.streaming', true);
+            await waitFor(source, 'startstreaming');
 
             run('sourceBuffer = source.addSourceBuffer(loader.type())');
 
@@ -49,8 +53,12 @@
                 await once(sourceBuffer, 'update');
                 sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1);
             } while (!done);
+            testExpected('source.streaming', false);
 
-            waitForEventOnceOn(source, 'startstreaming', endTest);
+            waitForEventOnceOn(source, 'startstreaming', () => {
+                testExpected('source.streaming', true);
+                endTest();
+            });
 
             sourceBuffer.remove(video.currentTime, video.currentTime + 5);
         } catch (e) {

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -46,6 +46,8 @@ public:
 
     static bool isTypeSupported(ScriptExecutionContext&, const String& type);
 
+    bool streaming() const { return m_streaming; }
+
     bool isManaged() const final { return true; }
 
 private:

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
@@ -46,6 +46,7 @@ enum PreferredQuality {
     readonly attribute BufferingPolicy buffering;
     readonly attribute PreferredQuality quality;
 
+    readonly attribute boolean streaming;
     attribute EventHandler onstartstreaming;
     attribute EventHandler onendstreaming;
 


### PR DESCRIPTION
#### 7bd9c17a7a5a790fc04ca2983033c737257a3927
<pre>
Add &quot;streaming&quot; attribute to ManagedMediaSource object
<a href="https://bugs.webkit.org/show_bug.cgi?id=253474">https://bugs.webkit.org/show_bug.cgi?id=253474</a>
rdar://106332050

Reviewed by Jer Noble.

Similar to the &quot;updating&quot; attribute found on SourceBuffer with the `update`
and `updateend` event ; we have a `streaming` attribute paired with the
`startstreaming` and `endstreaming` events.

* LayoutTests/media/media-source/media-managedmse-streaming-expected.txt:
* LayoutTests/media/media-source/media-managedmse-streaming.html:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.h:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.idl:

Canonical link: <a href="https://commits.webkit.org/261366@main">https://commits.webkit.org/261366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de36a92cb748b1c7274c00c48ae23408465902a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/36 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120212 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11661 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117190 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104137 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98238 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/23 "1 flakes 5 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44952 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13062 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/22 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86758 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13568 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9454 "8 flakes 3 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7885 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15533 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->