### PR TITLE
fast/forms/autofocus-input-css-style-change.html is a flaky failure when enabling GPU process and UI side compositing

### DIFF
--- a/LayoutTests/fast/forms/autofocus-input-css-style-change.html
+++ b/LayoutTests/fast/forms/autofocus-input-css-style-change.html
@@ -11,11 +11,17 @@ input:focus { background: green; }
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();
+    testRunner.waitUntilDone();
 }
 
 requestAnimationFrame(()=>{
-    if (getComputedStyle(test, null).getPropertyValue('background-color') == "rgb(0, 128, 0)")
+    const actualValue = getComputedStyle(test, null).getPropertyValue('background-color');
+    if (actualValue == "rgb(0, 128, 0)")
         result.innerHTML = "PASS";
+    else
+        result.innerHTML = 'FAIL - ' + actualValue;
+    if (window.testRunner)
+        testRunner.notifyDone();
 });
 
 </script>


### PR DESCRIPTION
#### 9f39db908f1eafbd5cfcbe87a38d5262142b6c2e
<pre>
fast/forms/autofocus-input-css-style-change.html is a flaky failure when enabling GPU process and UI side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=253551">https://bugs.webkit.org/show_bug.cgi?id=253551</a>

Reviewed by Aditya Keerthi and Simon Fraser.

The flakiness was due to this test not explicitly waiting for rAF callback. Fix the test to wait for that.

* LayoutTests/fast/forms/autofocus-input-css-style-change.html:

Canonical link: <a href="https://commits.webkit.org/261377@main">https://commits.webkit.org/261377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9133ff34257d8c4f20e79f3d4d3b98a63df6b384

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/40 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3235 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120220 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11666 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104146 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/24 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44958 "2 flakes 157 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13067 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/23 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86760 "14 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9457 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52005 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15538 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4322 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->