### PR TITLE
Add OSXChromiumDriver and support extra browser arguments in run-benchmark

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -23,7 +23,7 @@ _log = logging.getLogger(__name__)
 class BenchmarkRunner(object):
     name = 'benchmark_runner'
 
-    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None):
+    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, browser_args=None):
         self._plan_name, self._plan = BenchmarkRunner._load_plan_data(plan_file)
         if 'options' not in self._plan:
             self._plan['options'] = {}
@@ -34,7 +34,7 @@ class BenchmarkRunner(object):
         if timeout_override:
             self._plan['timeout'] = timeout_override
         self._subtests = self.validate_subtests(subtests) if subtests else None
-        self._browser_driver = BrowserDriverFactory.create(platform, browser)
+        self._browser_driver = BrowserDriverFactory.create(platform, browser, browser_args)
         self._browser_path = browser_path
         self._build_dir = os.path.abspath(build_dir) if build_dir else None
         self._diagnose_dir = os.path.abspath(diagnose_dir) if diagnose_dir else None

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -9,6 +9,9 @@ class BrowserDriver(object):
 
     ___metaclass___ = ABCMeta
 
+    def __init__(self, browser_args):
+        self.browser_args = browser_args
+
     @abstractmethod
     def prepare_env(self, config):
         pass

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver_factory.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver_factory.py
@@ -21,7 +21,7 @@ class BrowserDriverFactory(object):
         cls.browser_drivers[platform][browser_name] = browser_driver_class
 
     @classmethod
-    def create(cls, platform, browser_name):
+    def create(cls, platform, browser_name, browser_args):
         if browser_name not in cls.browser_drivers[platform]:
             raise ValueError("Browser \"%s\" is not available on platform \"%s\"" % (browser_name, platform))
-        return cls.browser_drivers[platform][browser_name]()
+        return cls.browser_drivers[platform][browser_name](browser_args)

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py
@@ -71,12 +71,12 @@ class OSXBrowserDriver(BrowserDriver):
 
         self._save_screenshot_to_path(diagnose_directory, 'test-failure-screenshot-{}.jpg'.format(int(time.time())))
 
-    @classmethod
-    def _launch_process(cls, build_dir, app_name, url, args, env=None):
+    def _launch_process(self, build_dir, app_name, url, args, env=None):
         if not build_dir:
             build_dir = '/Applications/'
         app_path = os.path.join(build_dir, app_name)
-
+        if self.browser_args:
+            args += self.browser_args
         _log.info('Launching {} with url {}. args:{}'.format(app_path, url, " ".join(args)))
         # FIXME: May need to be modified for a local build such as setting up DYLD libraries
         args = ['open', '-a', app_path] + args

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py
@@ -97,3 +97,16 @@ class OSXChromeDevDriver(OSXChromeDriverBase):
 
     def launch_args_with_url(self, url):
         return super(OSXChromeDevDriver, self).launch_args_with_url(url) + ['--enable-field-trial-config']
+
+
+class OSXChromiumDriver(OSXChromeDriverBase):
+    process_name = 'Chromium'
+    browser_name = 'chromium'
+    app_name = 'Chromium.app'
+    bundle_id = 'org.chromium.Chromium'
+
+    def _set_chrome_binary_location(self, options, browser_build_path):
+        set_binary_location_impl(options, browser_build_path, self.app_name, self.process_name)
+
+    def launch_args_with_url(self, url):
+        return super(OSXChromiumDriver, self).launch_args_with_url(url)

--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -38,7 +38,7 @@ def default_diagnose_dir():
 
 def config_argument_parser():
     diagnose_directory = default_diagnose_dir()
-    parser = argparse.ArgumentParser(description='Run browser based performance benchmarks. To run a single benchmark in the recommended way, use run-benchmark --plan. To see the available benchmarks, use run-benchmark --list-plans. This script passes through the __XPC variables in its environment to the Safari process.')
+    parser = argparse.ArgumentParser(description='Run browser based performance benchmarks. To run a single benchmark in the recommended way, use run-benchmark --plan. To see the available benchmarks, use run-benchmark --list-plans. This script passes through the __XPC variables in its environment to the Safari process. All other arguments are passed to the browser at launch.')
     mutual_group = parser.add_mutually_exclusive_group(required=True)
     mutual_group.add_argument('--plan', help='Run a specific benchmark plan (e.g. speedometer, jetstream).')
     mutual_group.add_argument('--list-plans', action='store_true', help='List all available benchmark plans.')
@@ -60,6 +60,7 @@ def config_argument_parser():
     parser.add_argument('--show-iteration-values', dest='show_iteration_values', action='store_true', help="Show the measured value for each iteration in addition to averages.")
     parser.add_argument('--generate-pgo-profiles', dest="generate_pgo_profiles", action='store_true', help="Collect LLVM profiles for PGO, and copy them to the diagnostics directory.")
     parser.add_argument('--profile', action='store_true', help="Collect profiling traces, and copy them to the diagnostic directory.")
+    parser.add_argument('browser_args', nargs='*', help='Additional arguments to pass to the browser process')
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--browser-path', help='Specify the path to a non-default copy of the target browser as a path to the .app.')
@@ -97,7 +98,8 @@ def run_benchmark_plan(args, plan):
                                     args.platform, args.browser, args.browser_path, args.subtests, args.scale_unit,
                                     args.show_iteration_values, args.device_id, args.diagnose_dir,
                                     args.diagnose_dir if args.generate_pgo_profiles else None,
-                                    args.diagnose_dir if args.profile else None)
+                                    args.diagnose_dir if args.profile else None,
+                                    args.browser_args)
     runner.execute()
 
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -23,10 +23,10 @@ _log = logging.getLogger(__name__)
 class WebServerBenchmarkRunner(BenchmarkRunner):
     name = 'webserver'
 
-    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None):
+    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, browser_args=None):
         self._http_server_driver = HTTPServerDriverFactory.create(platform)
         self._http_server_driver.set_device_id(device_id)
-        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests, scale_unit, show_iteration_values, device_id, diagnose_dir, pgo_profile_output_dir, profile_output_dir)
+        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests, scale_unit, show_iteration_values, device_id, diagnose_dir, pgo_profile_output_dir, profile_output_dir, browser_args)
         if self._diagnose_dir:
             self._http_server_driver.set_http_log(os.path.join(self._diagnose_dir, 'run-benchmark-http.log'))
 

--- a/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_unittest.py
+++ b/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_unittest.py
@@ -43,7 +43,8 @@ class FakeBrowserDriver(BrowserDriver):
     process_search_list = []
     platform = "fake"
 
-    def __init__(self):
+    def __init__(self, browser_args):
+        super(FakeBrowserDriver, self).__init__(browser_args)
         self.process_name = "fake/process"
 
     def prepare_env(self, config):


### PR DESCRIPTION
#### fa4a5245bfbbbbd12c6fd9fea70b4efc83f2023a
<pre>
Add OSXChromiumDriver and support extra browser arguments in run-benchmark
<a href="https://bugs.webkit.org/show_bug.cgi?id=253553">https://bugs.webkit.org/show_bug.cgi?id=253553</a>
rdar://106389711

Reviewed by Stephanie Lewis.

Support running benchmarks against Chromium in run-benchmark. Chromium
is like Chrome, except that it doesn&apos;t use the
--enable-field-trial-config switch, because field trials are enabled by
default.

Additionally, allow extra arguments to be passed to the browser process
through run-benchmark, to facilitate customized testing.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_chrome_driver.py:
(OSXChromiumDriver): Added.

* Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py:
(config_argument_parser): Add benchmark_args argument.

Remaining changes are all plumbing benchmark_args through to the browser
driver.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner.__init__):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py:
(BrowserDriver.__init__):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver_factory.py:
(BrowserDriverFactory.create):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py:
(OSXBrowserDriver._launch_process):
(run_benchmark_plan):
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner.__init__):
* Tools/Scripts/webkitpy/browserperfdash/browserperfdash_unittest.py:
(BrowserPerfDashRunnerTest.test_can_construct_runner_object_minimum_parameters):
(FakeBrowserDriver.__init__):

Canonical link: <a href="https://commits.webkit.org/261697@main">https://commits.webkit.org/261697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c55a199dc6ec4568d44003e821ab5108d5c373b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4028 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120871 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4792 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105290 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/115655 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98831 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/597 "4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45881 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13768 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/639 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/94053 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10128 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52641 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8157 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16242 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->