### PR TITLE
[Win] WebInspector: enable HAR export and import

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -153,6 +153,10 @@ public:
     const WebCore::FloatRect& sheetRect() const { return m_sheetRect; }
 #endif
 
+#if PLATFORM(WIN)
+    static void showSavePanelForSingleFile(HWND, Vector<WebCore::InspectorFrontendClient::SaveData>&&);
+#endif
+
 #if PLATFORM(GTK)
     GtkWidget* inspectorView() const { return m_inspectorView.get(); };
     void setClient(std::unique_ptr<WebInspectorUIProxyClient>&&);

--- a/Source/WebKit/UIProcess/Inspector/win/RemoteWebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/RemoteWebInspectorUIProxyWin.cpp
@@ -36,6 +36,7 @@
 #include "WebView.h"
 #include <WebCore/InspectorFrontendClient.h>
 #include <WebCore/IntRect.h>
+#include <wtf/FileSystem.h>
 
 namespace WebKit {
 
@@ -131,9 +132,16 @@ WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
     return m_webView->page();
 }
 
+void RemoteWebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&& saveDatas, bool /* forceSaveAs */)
+{
+    // Currently, file saving is only possible with SaveMode::SingleFile.
+    // This is determined in RemoteWebInspectorUI::canSave().
+    ASSERT(saveDatas.size() == 1);
+    WebInspectorUIProxy::showSavePanelForSingleFile(m_frontendHandle, WTFMove(saveDatas));
+}
+
 void RemoteWebInspectorUIProxy::platformResetState() { }
 void RemoteWebInspectorUIProxy::platformBringToFront() { }
-void RemoteWebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&&, bool /* forceSaveAs */) { }
 void RemoteWebInspectorUIProxy::platformLoad(const String&, CompletionHandler<void(const String&)>&& completionHandler) { completionHandler(nullString()); }
 void RemoteWebInspectorUIProxy::platformPickColorFromScreen(CompletionHandler<void(const std::optional<WebCore::Color>&)>&& completionHandler) { completionHandler({ }); }
 void RemoteWebInspectorUIProxy::platformSetSheetRect(const WebCore::FloatRect&) { }

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -47,6 +47,7 @@
 #include <WebCore/WebCoreInstanceHandle.h>
 #include <WebCore/WindowMessageBroadcaster.h>
 #include <WebKit/WKPage.h>
+#include <wtf/FileSystem.h>
 
 namespace WebKit {
 
@@ -71,6 +72,63 @@ static InspectedWindowInfo getInspectedWindowInfo(HWND inspectedWindow, HWND par
     RECT parentRect;
     ::GetClientRect(parentWindow, &parentRect);
     return { rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, parentRect.right - parentRect.left, parentRect.bottom - parentRect.top };
+}
+
+static String systemErrorMessage(DWORD errorCode)
+{
+    if (!errorCode)
+        return emptyString();
+
+    wchar_t* messageBuffer = nullptr;
+    size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr, errorCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL), reinterpret_cast<LPWSTR>(&messageBuffer), 0, nullptr);
+    String message(messageBuffer, size);
+    LocalFree(messageBuffer);
+
+    return message;
+}
+
+void WebInspectorUIProxy::showSavePanelForSingleFile(HWND parentWindow, Vector<WebCore::InspectorFrontendClient::SaveData>&& saveDatas)
+{
+    // Remove custom URI schemes such as "web-inspector://" and also remove the leading "/".
+    URL url { saveDatas[0].url };
+    auto filePath = url.path().substring(1).toString().wideCharacters();
+    filePath.grow(MAX_PATH);
+
+    OPENFILENAME ofn { };
+    ofn.lStructSize = sizeof(OPENFILENAME);
+    ofn.hwndOwner = parentWindow;
+    ofn.lpstrFile = filePath.data();
+    ofn.nMaxFile = MAX_PATH;
+    ofn.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT;
+
+    if (GetSaveFileName(&ofn)) {
+        auto fd = FileSystem::openFile(filePath.data(), FileSystem::FileOpenMode::ReadWrite);
+        if (!FileSystem::isHandleValid(fd))
+            return;
+
+        auto content = saveDatas[0].content.utf8();
+        auto contentSize = content.length();
+        auto bytesWritten = FileSystem::writeToFile(fd, content.data(), contentSize);
+        if (bytesWritten == -1 || bytesWritten != contentSize) {
+            auto message = systemErrorMessage(GetLastError());
+            if (message.isEmpty())
+                message = makeString("Error: writeToFile returns ", bytesWritten, ", contentLength = ", content.length());
+            MessageBox(parentWindow, message.wideCharacters().data(), L"Export HAR", MB_OK | MB_ICONEXCLAMATION);
+        }
+        FileSystem::closeFile(fd);
+    } else {
+        auto errorCode = CommDlgExtendedError();
+        if (errorCode) {
+            String message;
+            // FNERR_INVALIDFILENAME is treated specially because this is a common error.
+            if (errorCode == FNERR_INVALIDFILENAME)
+                message = "Error: A file name is invalid."_s;
+            else
+                message = makeString("Error: ", errorCode);
+            MessageBox(parentWindow, message.wideCharacters().data(), L"Export HAR", MB_OK | MB_ICONEXCLAMATION);
+        }
+    }
 }
 
 void WebInspectorUIProxy::windowReceivedMessage(HWND hwnd, UINT msg, WPARAM, LPARAM lParam)
@@ -401,9 +459,12 @@ void WebInspectorUIProxy::platformShowCertificate(const WebCore::CertificateInfo
     notImplemented();
 }
 
-void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&&, bool /* forceSaveAs */)
+void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&& saveDatas, bool /* forceSaveAs */)
 {
-    notImplemented();
+    // Currently, file saving is only possible with SaveMode::SingleFile.
+    // This is determined in WebInspectorUI::canSave().
+    ASSERT(saveDatas.size() == 1);
+    WebInspectorUIProxy::showSavePanelForSingleFile(m_inspectedViewWindow, WTFMove(saveDatas));
 }
 
 void WebInspectorUIProxy::platformLoad(const String&, CompletionHandler<void(const String&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/win/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.cpp
@@ -27,12 +27,15 @@
 #include "config.h"
 #include "PageClientImpl.h"
 
+#include "APIOpenPanelParameters.h"
 #include "DrawingAreaProxyCoordinatedGraphics.h"
 #include "WebContextMenuProxyWin.h"
+#include "WebOpenPanelResultListenerProxy.h"
 #include "WebPageProxy.h"
 #include "WebPopupMenuProxyWin.h"
 #include "WebView.h"
 #include <WebCore/DOMPasteAccess.h>
+#include <WebCore/LocalizedStrings.h>
 #include <WebCore/NotImplemented.h>
 
 #if USE(GRAPHICS_LAYER_WC)
@@ -230,6 +233,69 @@ void PageClientImpl::pageClosed()
 void PageClientImpl::preferencesDidChange()
 {
     notImplemented();
+}
+
+bool PageClientImpl::handleRunOpenPanel(WebPageProxy*, WebFrameProxy*, const FrameInfoData&, API::OpenPanelParameters* parameters, WebOpenPanelResultListenerProxy* listener)
+{
+    ASSERT(parameters);
+    ASSERT(listener);
+
+    HWND viewWindow = viewWidget();
+    if (!IsWindow(viewWindow))
+        return false;
+
+    // When you call GetOpenFileName, if the size of the buffer is too small,
+    // MSDN says that the first two bytes of the buffer contain the required size for the file selection, in bytes or characters
+    // So we can assume the required size can't be more than the maximum value for a short.
+    constexpr size_t maxFilePathsListSize = USHRT_MAX;
+
+    bool isAllowMultipleFiles = parameters->allowMultipleFiles();
+    Vector<wchar_t> fileBuffer(isAllowMultipleFiles ? maxFilePathsListSize : MAX_PATH);
+
+    OPENFILENAME ofn { };
+
+    // Need to zero out the first char of fileBuffer so GetOpenFileName doesn't think it's an initialization string
+    fileBuffer[0] = L'\0';
+
+    ofn.lStructSize = sizeof(ofn);
+    ofn.hwndOwner = viewWindow;
+    ofn.lpstrFile = fileBuffer.data();
+    ofn.nMaxFile = fileBuffer.size();
+    auto dialogTitle = uploadFileText();
+    auto dialogTitleCharacters = dialogTitle.wideCharacters(); // Retain buffer long enough to make the GetOpenFileName call
+    ofn.lpstrTitle = dialogTitleCharacters.data();
+    ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_EXPLORER;
+    if (isAllowMultipleFiles)
+        ofn.Flags |= OFN_ALLOWMULTISELECT;
+
+    if (GetOpenFileName(&ofn)) {
+        Vector<String> fileList;
+        auto p = fileBuffer.data();
+        auto length = wcslen(p);
+        auto firstValue = String(p, length);
+
+        // The value set in the buffer depends on whether one or more files are actually selected, regardless of the OFN_ALLOWMULTISELECT flag.
+        // The number of selected files cannot be determined by the flags, so check the character at address nOffsetFile - 1.
+        // This character is the path separator if only one file is selected, or the null character if multiple files are selected.
+        if (!*(p + ofn.nFileOffset - 1)) {
+            // If multiple files are selected, the first value is the directory name, the second and subsequent values are the file names.
+            p += length + 1;
+            while (*p) {
+                length = wcslen(p);
+                String fileName(p, length);
+                fileList.append(FileSystem::pathByAppendingComponent(firstValue, WTFMove(fileName)));
+                p += length + 1;
+            }
+        } else
+            // If only one file is selected, one full path string is set in the buffer.
+            fileList.append(WTFMove(firstValue));
+
+        ASSERT(fileList.size());
+        listener->chooseFiles(fileList);
+        return true;
+    }
+    // FIXME: Show some sort of error if too many files are selected and the buffer is too small. For now, this will fail silently.
+    return false;
 }
 
 void PageClientImpl::didChangeContentSize(const IntSize& size)

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -99,6 +99,8 @@ private:
     void exitAcceleratedCompositingMode() override;
     void updateAcceleratedCompositingMode(const LayerTreeContext&) override;
 
+    bool handleRunOpenPanel(WebPageProxy*, WebFrameProxy*, const FrameInfoData&, API::OpenPanelParameters*, WebOpenPanelResultListenerProxy*) override;
+
     void didChangeContentSize(const WebCore::IntSize&) override;
     void didCommitLoadForMainFrame(const String& mimeType, bool useCustomContentProvider) override;
     void didFirstVisuallyNonEmptyLayoutForMainFrame() override;

--- a/Source/WebKit/WebProcess/Inspector/win/RemoteWebInspectorUIWin.cpp
+++ b/Source/WebKit/WebProcess/Inspector/win/RemoteWebInspectorUIWin.cpp
@@ -33,8 +33,17 @@
 namespace WebKit {
 using namespace WebCore;
 
-bool RemoteWebInspectorUI::canSave(InspectorFrontendClient::SaveMode)
+bool RemoteWebInspectorUI::canSave(InspectorFrontendClient::SaveMode saveMode)
 {
+    switch (saveMode) {
+    case InspectorFrontendClient::SaveMode::SingleFile:
+        return true;
+
+    case InspectorFrontendClient::SaveMode::FileVariants:
+        return false;
+    }
+
+    ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/WebKit/WebProcess/Inspector/win/WebInspectorUIWin.cpp
+++ b/Source/WebKit/WebProcess/Inspector/win/WebInspectorUIWin.cpp
@@ -33,8 +33,17 @@
 namespace WebKit {
 using namespace WebCore;
 
-bool WebInspectorUI::canSave(InspectorFrontendClient::SaveMode)
+bool WebInspectorUI::canSave(InspectorFrontendClient::SaveMode saveMode)
 {
+    switch (saveMode) {
+    case InspectorFrontendClient::SaveMode::SingleFile:
+        return true;
+
+    case InspectorFrontendClient::SaveMode::FileVariants:
+        return false;
+    }
+
+    ASSERT_NOT_REACHED();
     return false;
 }
 


### PR DESCRIPTION
#### 8cc207109df127720f2ac10fb8d49fd0d78bfed9
<pre>
[Win] WebInspector: enable HAR export and import
<a href="https://bugs.webkit.org/show_bug.cgi?id=253552">https://bugs.webkit.org/show_bug.cgi?id=253552</a>

Reviewed by Fujii Hironori.

Add file open dialog implementations for both Export and Import.
And, canSave() now returns true so that the Export button can be pressed.

* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/win/RemoteWebInspectorUIProxyWin.cpp:
(WebKit::RemoteWebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp:
(WebKit::systemErrorMessage):
(WebKit::WebInspectorUIProxy::showSavePanelForSingleFile):
(WebKit::WebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/win/PageClientImpl.cpp:
(WebKit::PageClientImpl::handleRunOpenPanel):
* Source/WebKit/UIProcess/win/PageClientImpl.h:
* Source/WebKit/WebProcess/Inspector/win/RemoteWebInspectorUIWin.cpp:
(WebKit::RemoteWebInspectorUI::canSave):
* Source/WebKit/WebProcess/Inspector/win/WebInspectorUIWin.cpp:
(WebKit::WebInspectorUI::canSave):

Canonical link: <a href="https://commits.webkit.org/261609@main">https://commits.webkit.org/261609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07e74d7db2406eda39ecd9f8c5f2c28ed403eccc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/934 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/4082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12497 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/4082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118066 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/100107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/105351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/105351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/692 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/105351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14508 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52696 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8093 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16309 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->