### PR TITLE
[UI-side compositing] Add UI process SPIs to add page banners

### DIFF
--- a/LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset-header-expected.txt
+++ b/LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset-header-expected.txt
@@ -4,15 +4,15 @@ Wheel event rect:
 (GraphicsLayer
   (position 0.00 46.00)
   (anchor 0.00 0.00)
-  (bounds 800.00 540.00)
+  (bounds 785.00 540.00)
   (children 1
     (GraphicsLayer
-      (bounds 800.00 540.00)
+      (bounds 785.00 540.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=800 height=540)
+        (rect (0,0) width=785 height=540)
       (wheel event listener region
         (rect (28,50) width=100 height=100)
         (non-passive

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -1053,6 +1053,13 @@ GraphicsLayer* FrameView::graphicsLayerForPageScale()
     return backing->graphicsLayer();
 }
 
+GraphicsLayer* FrameView::graphicsLayerForScrolledContents()
+{
+    if (auto* renderView = m_frame->contentRenderer())
+        return renderView->compositor().scrolledContentsLayer();
+    return nullptr;
+}
+
 #if HAVE(RUBBER_BANDING)
 GraphicsLayer* FrameView::graphicsLayerForTransientZoomShadow()
 {

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -170,6 +170,7 @@ public:
 
     WEBCORE_EXPORT GraphicsLayer* graphicsLayerForPlatformWidget(PlatformWidget);
     WEBCORE_EXPORT GraphicsLayer* graphicsLayerForPageScale();
+    WEBCORE_EXPORT GraphicsLayer* graphicsLayerForScrolledContents();
 #if HAVE(RUBBER_BANDING)
     WEBCORE_EXPORT GraphicsLayer* graphicsLayerForTransientZoomShadow();
 #endif
@@ -381,8 +382,8 @@ public:
     WEBCORE_EXPORT static FloatPoint positionForRootContentLayer(const FloatPoint& scrollPosition, const FloatPoint& scrollOrigin, float topContentInset, float headerHeight);
     WEBCORE_EXPORT FloatPoint positionForRootContentLayer() const;
 
-    static float yPositionForHeaderLayer(const FloatPoint& scrollPosition, float topContentInset);
-    static float yPositionForFooterLayer(const FloatPoint& scrollPosition, float topContentInset, float totalContentsHeight, float footerHeight);
+    WEBCORE_EXPORT static float yPositionForHeaderLayer(const FloatPoint& scrollPosition, float topContentInset);
+    WEBCORE_EXPORT static float yPositionForFooterLayer(const FloatPoint& scrollPosition, float topContentInset, float totalContentsHeight, float footerHeight);
 
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT LayoutRect viewportConstrainedObjectsRect() const;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2787,6 +2787,7 @@ void Page::setHeaderHeight(int headerHeight)
     if (!renderView)
         return;
 
+    frameView->updateScrollbars(frameView->scrollPosition());
     frameView->setNeedsLayoutAfterViewConfigurationChange();
     frameView->setNeedsCompositingGeometryUpdate();
 }
@@ -2807,6 +2808,7 @@ void Page::setFooterHeight(int footerHeight)
     if (!renderView)
         return;
 
+    frameView->updateScrollbars(frameView->scrollPosition());
     frameView->setNeedsLayoutAfterViewConfigurationChange();
     frameView->setNeedsCompositingGeometryUpdate();
 }

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -524,6 +524,12 @@ void ScrollingTree::clearLatchedNode()
     m_latchingController.clearLatchedNode();
 }
 
+float ScrollingTree::mainFrameTopContentInset() const
+{
+    Locker locker { m_treeStateLock };
+    return m_rootNode->topContentInset();
+}
+
 FloatPoint ScrollingTree::mainFrameScrollPosition() const
 {
     Locker locker { m_treeStateLock };

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -224,6 +224,8 @@ public:
 
     virtual void removePendingScrollAnimationForNode(ScrollingNodeID) { }
 
+    WEBCORE_EXPORT float mainFrameTopContentInset() const;
+
     WEBCORE_EXPORT FloatPoint mainFrameScrollPosition() const;
 
     WEBCORE_EXPORT OverscrollBehavior mainFrameHorizontalOverscrollBehavior() const;

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -416,6 +416,9 @@ public:
     bool managesScrollbars() const;
     virtual void updateScrollbarSteps();
 
+    // Called to update the scrollbars to accurately reflect the state of the view.
+    void updateScrollbars(const ScrollPosition& desiredPosition);
+
 protected:
     ScrollView();
 
@@ -446,9 +449,6 @@ protected:
     // Subclassed by FrameView to check the writing-mode of the document.
     virtual bool isVerticalDocument() const = 0;
     virtual bool isFlippedDocument() const = 0;
-
-    // Called to update the scrollbars to accurately reflect the state of the view.
-    void updateScrollbars(const ScrollPosition& desiredPosition);
 
     float platformTopContentInset() const;
     void platformSetTopContentInset(float);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -295,6 +295,9 @@ public:
 #if PLATFORM(MAC)
     WebCore::GraphicsLayer::PlatformLayerID pageScalingLayerID() const { return m_pageScalingLayerID.value(); }
     void setPageScalingLayerID(WebCore::GraphicsLayer::PlatformLayerID layerID) { m_pageScalingLayerID = layerID; }
+
+    WebCore::GraphicsLayer::PlatformLayerID scrolledContentsLayerID() const { return m_scrolledContentsLayerID.value(); }
+    void setScrolledContentsLayerID(WebCore::GraphicsLayer::PlatformLayerID layerID) { m_scrolledContentsLayerID = layerID; }
 #endif
 
     uint64_t renderTreeSize() const { return m_renderTreeSize; }
@@ -375,6 +378,7 @@ private:
 
 #if PLATFORM(MAC)
     Markable<WebCore::GraphicsLayer::PlatformLayerID> m_pageScalingLayerID; // Only used for non-delegated scaling.
+    Markable<WebCore::GraphicsLayer::PlatformLayerID> m_scrolledContentsLayerID;
 #endif
 
     double m_pageScaleFactor { 1 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -636,6 +636,7 @@ void RemoteLayerTreeTransaction::encode(IPC::Encoder& encoder) const
 
 #if PLATFORM(MAC)
     encoder << m_pageScalingLayerID;
+    encoder << m_scrolledContentsLayerID;
 #endif
 
     encoder << m_pageScaleFactor;
@@ -748,6 +749,8 @@ bool RemoteLayerTreeTransaction::decode(IPC::Decoder& decoder, RemoteLayerTreeTr
 
 #if PLATFORM(MAC)
     if (!decoder.decode(result.m_pageScalingLayerID))
+        return false;
+    if (!decoder.decode(result.m_scrolledContentsLayerID))
         return false;
 #endif
 
@@ -1054,6 +1057,7 @@ String RemoteLayerTreeTransaction::description() const
 
 #if PLATFORM(MAC)
     ts.dumpProperty("pageScalingLayer", m_pageScalingLayerID);
+    ts.dumpProperty("scrolledContentsLayerID", m_scrolledContentsLayerID);
 #endif
 
     ts.dumpProperty("minimumScaleFactor", m_minimumScaleFactor);

--- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
@@ -88,7 +88,8 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
 #if PLATFORM(MAC)
     encoder << colorSpace;
     encoder << useSystemAppearance;
-    encoder << useFormSemanticContext;
+    encoder << headerBannerHeight;
+    encoder << footerBannerHeight;
 #endif
 
 #if ENABLE(META_VIEWPORT)
@@ -365,6 +366,10 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
     if (!decoder.decode(parameters.useSystemAppearance))
         return std::nullopt;
     if (!decoder.decode(parameters.useFormSemanticContext))
+        return std::nullopt;
+    if (!decoder.decode(parameters.headerBannerHeight))
+        return std::nullopt;
+    if (!decoder.decode(parameters.footerBannerHeight))
         return std::nullopt;
 #endif
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -164,6 +164,8 @@ struct WebPageCreationParameters {
     std::optional<WebCore::DestinationColorSpace> colorSpace;
     bool useSystemAppearance { false };
     bool useFormSemanticContext { false };
+    int headerBannerHeight { 0 };
+    int footerBannerHeight { 0 };
 #endif
 #if ENABLE(META_VIEWPORT)
     bool ignoresViewportScaleLimits;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -713,6 +713,9 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 @property (nonatomic, setter=_setOverlayScrollbarStyle:) _WKOverlayScrollbarStyle _overlayScrollbarStyle WK_API_AVAILABLE(macos(10.13.4));
 @property (strong, nonatomic, setter=_setInspectorAttachmentView:) NSView *_inspectorAttachmentView WK_API_AVAILABLE(macos(10.13.4));
 
+@property (nonatomic, setter=_setHeaderBannerLayer:) CALayer *_headerBannerLayer;
+@property (nonatomic, setter=_setFooterBannerLayer:) CALayer *_footerBannerLayer;
+
 @property (nonatomic, setter=_setThumbnailView:) _WKThumbnailView *_thumbnailView WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setIgnoresAllEvents:) BOOL _ignoresAllEvents WK_API_AVAILABLE(macos(10.13.4));
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1482,6 +1482,32 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     _impl->setInspectorAttachmentView(newView);
 }
 
+- (void)_setHeaderBannerLayer:(CALayer *)headerBannerLayer
+{
+    if (headerBannerLayer)
+        [headerBannerLayer setContentsScale:_page->pageScaleFactor()];
+
+    _impl->setHeaderBannerLayer(headerBannerLayer);
+}
+
+- (CALayer *)_headerBannerLayer
+{
+    return _impl->headerBannerLayer();
+}
+
+- (void)_setFooterBannerLayer:(CALayer *)footerBannerLayer
+{
+    if (footerBannerLayer)
+        [footerBannerLayer setContentsScale:_page->pageScaleFactor()];
+
+    _impl->setFooterBannerLayer(footerBannerLayer);
+}
+
+- (CALayer *)_footerBannerLayer
+{
+    return _impl->footerBannerLayer();
+}
+
 - (void)_setThumbnailView:(_WKThumbnailView *)thumbnailView
 {
     _impl->setThumbnailView(thumbnailView);

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h
@@ -48,8 +48,6 @@
 - (void)_insertText:(id)string replacementRange:(NSRange)replacementRange;
 - (NSRect)_candidateRect;
 
-- (void)_setHeaderBannerHeight:(int)height;
-- (void)_setFooterBannerHeight:(int)height;
 - (NSSet<NSView *> *)_pdfHUDs;
 
 - (void)_retrieveAccessibilityTreeData:(void (^)(NSData *, NSError *))completionHandler;

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
@@ -96,16 +96,6 @@
     _impl->effectiveAppearanceDidChange();
 }
 
-- (void)_setHeaderBannerHeight:(int)height
-{
-    _page->setHeaderBannerHeightForTesting(height);
-}
-
-- (void)_setFooterBannerHeight:(int)height
-{
-    _page->setFooterBannerHeightForTesting(height);
-}
-
 - (NSSet<NSView *> *)_pdfHUDs
 {
 #if ENABLE(UI_PROCESS_PDF_HUD)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -321,6 +321,11 @@ public:
 #endif
 #endif
 
+#if PLATFORM(MAC)
+    virtual CALayer *headerBannerLayer() const = 0;
+    virtual CALayer *footerBannerLayer() const = 0;
+#endif
+
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     virtual void selectionDidChange() = 0;
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -90,6 +90,8 @@ private:
     void createLayer(const RemoteLayerTreeTransaction::LayerCreationProperties&);
     std::unique_ptr<RemoteLayerTreeNode> makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties&);
 
+    bool updateBannerLayers(const RemoteLayerTreeTransaction&);
+
     void layerWillBeRemoved(WebCore::GraphicsLayer::PlatformLayerID);
 
     RemoteLayerBackingStoreProperties::LayerContentsType layerContentsType() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -284,6 +284,11 @@ WebCore::FloatRect RemoteScrollingCoordinatorProxy::computeVisibleContentRect()
     return visibleContentRect;
 }
 
+float RemoteScrollingCoordinatorProxy::topContentInset() const
+{
+    return m_scrollingTree->mainFrameTopContentInset();
+}
+
 WebCore::FloatPoint RemoteScrollingCoordinatorProxy::currentMainFrameScrollPosition() const
 {
     return m_scrollingTree->mainFrameScrollPosition();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -138,7 +138,8 @@ public:
     void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
 
     virtual void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) { }
-    
+
+    float topContentInset() const;
     WebCore::FloatPoint currentMainFrameScrollPosition() const;
     WebCore::FloatRect computeVisibleContentRect();
     WebCore::IntPoint scrollOrigin() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -56,6 +56,8 @@ private:
 
     bool isRemoteLayerTreeDrawingAreaProxyMac() const override { return true; }
 
+    void layoutBannerLayers(const RemoteLayerTreeTransaction&);
+
     void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) override;
 
     void adjustTransientZoom(double, WebCore::FloatPoint) override;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8736,6 +8736,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.colorSpace = pageClient().colorSpace();
     parameters.useSystemAppearance = m_useSystemAppearance;
     parameters.useFormSemanticContext = useFormSemanticContext();
+    parameters.headerBannerHeight = headerBannerHeight();
+    parameters.footerBannerHeight = footerBannerHeight();
 #endif
 
 #if ENABLE(META_VIEWPORT)
@@ -10348,14 +10350,14 @@ void WebPageProxy::setUseSystemAppearance(bool useSystemAppearance)
     send(Messages::WebPage::SetUseSystemAppearance(useSystemAppearance));
 }
     
-void WebPageProxy::setHeaderBannerHeightForTesting(int height)
+void WebPageProxy::setHeaderBannerHeight(int height)
 {
-    send(Messages::WebPage::SetHeaderBannerHeightForTesting(height));
+    send(Messages::WebPage::SetHeaderBannerHeight(height));
 }
 
-void WebPageProxy::setFooterBannerHeightForTesting(int height)
+void WebPageProxy::setFooterBannerHeight(int height)
 {
-    send(Messages::WebPage::SetFooterBannerHeightForTesting(height));
+    send(Messages::WebPage::SetFooterBannerHeight(height));
 }
 
 void WebPageProxy::didEndMagnificationGesture()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -998,6 +998,13 @@ public:
     void setRemoteLayerTreeRootNode(RemoteLayerTreeNode*);
     CALayer *acceleratedCompositingRootLayer() const;
 
+#if PLATFORM(MAC)
+    CALayer *headerBannerLayer() const;
+    CALayer *footerBannerLayer() const;
+    int headerBannerHeight() const;
+    int footerBannerHeight() const;
+#endif
+
     void setTextAsync(const String&);
 
     void insertTextAsync(const String&, const EditingRange& replacementRange, InsertTextOptions&&);
@@ -1669,8 +1676,8 @@ public:
     void handleAcceptedCandidate(WebCore::TextCheckingResult);
     void didHandleAcceptedCandidate();
 
-    void setHeaderBannerHeightForTesting(int);
-    void setFooterBannerHeightForTesting(int);
+    void setHeaderBannerHeight(int);
+    void setFooterBannerHeight(int);
 
     void didEndMagnificationGesture();
 #endif

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -82,6 +82,8 @@ private:
     WebCore::DestinationColorSpace colorSpace() override;
     void setRemoteLayerTreeRootNode(RemoteLayerTreeNode*) override;
     CALayer *acceleratedCompositingRootLayer() const override;
+    CALayer *headerBannerLayer() const override;
+    CALayer *footerBannerLayer() const override;
 
     void processDidExit() override;
     void processWillSwap() override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -629,6 +629,16 @@ CALayer *PageClientImpl::acceleratedCompositingRootLayer() const
     return m_impl->acceleratedCompositingRootLayer();
 }
 
+CALayer *PageClientImpl::headerBannerLayer() const
+{
+    return m_impl->headerBannerLayer();
+}
+
+CALayer *PageClientImpl::footerBannerLayer() const
+{
+    return m_impl->footerBannerLayer();
+}
+
 RefPtr<ViewSnapshot> PageClientImpl::takeViewSnapshot(std::optional<WebCore::IntRect>&&)
 {
     return m_impl->takeViewSnapshot();

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -395,6 +395,30 @@ CALayer *WebPageProxy::acceleratedCompositingRootLayer() const
     return pageClient().acceleratedCompositingRootLayer();
 }
 
+CALayer *WebPageProxy::headerBannerLayer() const
+{
+    return pageClient().headerBannerLayer();
+}
+
+CALayer *WebPageProxy::footerBannerLayer() const
+{
+    return pageClient().footerBannerLayer();
+}
+
+int WebPageProxy::headerBannerHeight() const
+{
+    if (auto *headerBannerLayer = this->headerBannerLayer())
+        return headerBannerLayer.frame.size.height;
+    return 0;
+}
+
+int WebPageProxy::footerBannerHeight() const
+{
+    if (auto *footerBannerLayer = this->footerBannerLayer())
+        return footerBannerLayer.frame.size.height;
+    return 0;
+}
+
 static NSString *temporaryPDFDirectoryPath()
 {
     static NeverDestroyed path = [] {

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -473,6 +473,11 @@ public:
     void setThumbnailView(_WKThumbnailView *);
     _WKThumbnailView *thumbnailView() const { return m_thumbnailView; }
 
+    void setHeaderBannerLayer(CALayer *);
+    CALayer *headerBannerLayer() const { return m_headerBannerLayer.get(); }
+    void setFooterBannerLayer(CALayer *);
+    CALayer *footerBannerLayer() const { return m_footerBannerLayer.get(); }
+
     void setInspectorAttachmentView(NSView *);
     NSView *inspectorAttachmentView();
     
@@ -865,6 +870,9 @@ private:
 
     RetainPtr<CALayer> m_rootLayer;
     RetainPtr<NSView> m_layerHostingView;
+
+    RetainPtr<CALayer> m_headerBannerLayer;
+    RetainPtr<CALayer> m_footerBannerLayer;
 
     _WKThumbnailView *m_thumbnailView { nullptr };
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3739,6 +3739,36 @@ void WebViewImpl::setAcceleratedCompositingRootLayer(CALayer *rootLayer)
     [CATransaction commit];
 }
 
+void WebViewImpl::setHeaderBannerLayer(CALayer *headerBannerLayer)
+{
+    if (m_headerBannerLayer)
+        [m_headerBannerLayer removeFromSuperlayer];
+
+    m_headerBannerLayer = headerBannerLayer;
+
+    // If WebPage has not been created yet, WebPageCreationParameters.headerBannerHeight
+    // will be used to adjust the page content size.
+    if (page().hasRunningProcess()) {
+        int headerBannerHeight = headerBannerLayer ? headerBannerLayer.frame.size.height : 0;
+        page().setHeaderBannerHeight(headerBannerHeight);
+    }
+}
+
+void WebViewImpl::setFooterBannerLayer(CALayer *footerBannerLayer)
+{
+    if (m_footerBannerLayer)
+        [m_footerBannerLayer removeFromSuperlayer];
+
+    m_footerBannerLayer = footerBannerLayer;
+
+    // If WebPage has not been created yet, WebPageCreationParameters.footerBannerHeight
+    // will be used to adjust the page content size.
+    if (page().hasRunningProcess()) {
+        int footerBannerHeight = footerBannerLayer ? footerBannerLayer.frame.size.height : 0;
+        page().setFooterBannerHeight(footerBannerHeight);
+    }
+}
+
 void WebViewImpl::setThumbnailView(_WKThumbnailView *thumbnailView)
 {
     ASSERT(!m_thumbnailView || !thumbnailView);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -809,6 +809,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #if PLATFORM(MAC)
     setUseSystemAppearance(parameters.useSystemAppearance);
     setUseFormSemanticContext(parameters.useFormSemanticContext);
+    setHeaderBannerHeight(parameters.headerBannerHeight);
+    setFooterBannerHeight(parameters.footerBannerHeight);
 #endif
 
     // If the page is created off-screen, its visibilityState should be prerender.
@@ -2650,17 +2652,19 @@ void WebPage::showPageBanners()
         m_footerBanner->showIfHidden();
 }
 
-void WebPage::setHeaderBannerHeightForTesting(int height)
+#endif // !PLATFORM(IOS_FAMILY)
+
+#if PLATFORM(MAC)
+void WebPage::setHeaderBannerHeight(int height)
 {
     corePage()->setHeaderHeight(height);
 }
 
-void WebPage::setFooterBannerHeightForTesting(int height)
+void WebPage::setFooterBannerHeight(int height)
 {
     corePage()->setFooterHeight(height);
 }
-
-#endif // !PLATFORM(IOS_FAMILY)
+#endif
 
 void WebPage::takeSnapshot(IntRect snapshotRect, IntSize bitmapSize, uint32_t options, CompletionHandler<void(const WebKit::ShareableBitmapHandle&)>&& completionHandler)
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -726,9 +726,11 @@ public:
 
     void hidePageBanners();
     void showPageBanners();
-    
-    void setHeaderBannerHeightForTesting(int);
-    void setFooterBannerHeightForTesting(int);
+#endif
+
+#if PLATFORM(MAC)
+    void setHeaderBannerHeight(int);
+    void setFooterBannerHeight(int);
 #endif
 
     WebCore::IntPoint screenToRootView(const WebCore::IntPoint&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -555,8 +555,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
     SemanticContextDidChange(bool useFormSemanticContext)
 
-    SetHeaderBannerHeightForTesting(int height)
-    SetFooterBannerHeightForTesting(int height)
+    SetHeaderBannerHeight(int height)
+    SetFooterBannerHeight(int height)
 
     DidEndMagnificationGesture()
 #endif

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -111,6 +111,12 @@ void RemoteLayerTreeDrawingAreaMac::willCommitLayerTree(RemoteLayerTreeTransacti
         return;
 
     transaction.setPageScalingLayerID(renderViewGraphicsLayer->primaryLayerID());
+
+    auto* scrolledContentsLayer = frameView->graphicsLayerForScrolledContents();
+    if (!scrolledContentsLayer)
+        return;
+
+    transaction.setScrolledContentsLayerID(scrolledContentsLayer->primaryLayerID());
 }
 
 } // namespace WebKit

--- a/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		2DC37343198B62D300EC33E9 /* SettingsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DC37342198B62D300EC33E9 /* SettingsController.m */; };
 		51E244FA11EFCE07008228D1 /* MBToolbarItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 51E244F911EFCE07008228D1 /* MBToolbarItem.m */; };
 		5C9332AF24C1349C0036DECE /* SecurityInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9332AE24C1349C0036DECE /* SecurityInterface.framework */; };
+		72945D0229B7F204006ACF75 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72945D0129B7F204006ACF75 /* QuartzCore.framework */; };
 		7CA379421AC381C10079DC37 /* ExtensionManagerWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CA379401AC381C10079DC37 /* ExtensionManagerWindowController.m */; };
 		7CA379431AC381C10079DC37 /* ExtensionManagerWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7CA379411AC381C10079DC37 /* ExtensionManagerWindowController.xib */; };
 		BC329487116A92E2008635D0 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = BC329486116A92E2008635D0 /* main.m */; };
@@ -64,6 +65,7 @@
 		51E244F811EFCE07008228D1 /* MBToolbarItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBToolbarItem.h; sourceTree = "<group>"; };
 		51E244F911EFCE07008228D1 /* MBToolbarItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBToolbarItem.m; sourceTree = "<group>"; };
 		5C9332AE24C1349C0036DECE /* SecurityInterface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SecurityInterface.framework; path = System/Library/Frameworks/SecurityInterface.framework; sourceTree = SDKROOT; };
+		72945D0129B7F204006ACF75 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		7CA3793F1AC381C10079DC37 /* ExtensionManagerWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ExtensionManagerWindowController.h; path = mac/ExtensionManagerWindowController.h; sourceTree = "<group>"; };
 		7CA379401AC381C10079DC37 /* ExtensionManagerWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ExtensionManagerWindowController.m; path = mac/ExtensionManagerWindowController.m; sourceTree = "<group>"; };
 		7CA379411AC381C10079DC37 /* ExtensionManagerWindowController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = ExtensionManagerWindowController.xib; path = mac/ExtensionManagerWindowController.xib; sourceTree = "<group>"; };
@@ -84,6 +86,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72945D0229B7F204006ACF75 /* QuartzCore.framework in Frameworks */,
 				5C9332AF24C1349C0036DECE /* SecurityInterface.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -161,6 +164,7 @@
 			children = (
 				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
 				1AFFEF761860EE6800DA465E /* Cocoa.framework */,
+				72945D0129B7F204006ACF75 /* QuartzCore.framework */,
 				5C9332AE24C1349C0036DECE /* SecurityInterface.framework */,
 				DD403C5328500F6400D899FC /* WebKit.framework */,
 			);

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -532,8 +532,27 @@ static BOOL areEssentiallyEqual(double a, double b)
     
     preferences._visibleDebugOverlayRegions = visibleOverlayRegions;
 
-    [_webView _setHeaderBannerHeight:[settings isSpaceReservedForBanners] ? testHeaderBannerHeight : 0];
-    [_webView _setFooterBannerHeight:[settings isSpaceReservedForBanners] ? testFooterBannerHeight : 0];
+    int headerBannerHeight = [settings isSpaceReservedForBanners] ? testHeaderBannerHeight : 0;
+    if (!headerBannerHeight)
+        [_webView _setHeaderBannerLayer:nil];
+    else {
+        CALayer *headerBannerLayer = [[CALayer alloc] init];
+        [headerBannerLayer setBounds:CGRectMake(0, 0, 0, headerBannerHeight)];
+        [headerBannerLayer setAnchorPoint:CGPointZero];
+        [headerBannerLayer setBackgroundColor:[NSColor colorWithSRGBRed:172. / 255. green:221 / 255. blue:222. / 255. alpha:1].CGColor];
+        [_webView _setHeaderBannerLayer:headerBannerLayer];
+    }
+
+    int footerBannerHeight = [settings isSpaceReservedForBanners] ? testFooterBannerHeight : 0;
+    if (!footerBannerHeight)
+        [_webView _setFooterBannerLayer:nil];
+    else {
+        CALayer *footerBannerLayer = [[CALayer alloc] init];
+        [footerBannerLayer setBounds:CGRectMake(0, 0, 0, footerBannerHeight)];
+        [footerBannerLayer setAnchorPoint:CGPointZero];
+        [footerBannerLayer setBackgroundColor:[NSColor colorWithSRGBRed:116. / 255. green:187. / 255. blue:251. / 255. alpha:1].CGColor];
+        [_webView _setFooterBannerLayer:footerBannerLayer];
+    }
 }
 
 - (void)updateTitle:(NSString *)title


### PR DESCRIPTION
#### 16b186659066d6935156abc2fe6f2fa979fa6207
<pre>
[UI-side compositing] Add UI process SPIs to add page banners
<a href="https://bugs.webkit.org/show_bug.cgi?id=253554">https://bugs.webkit.org/show_bug.cgi?id=253554</a>
rdar://101040993

Reviewed by Simon Fraser.

The client of WKWebView will provide CALayers for the page banners. Their heights
will adjust the page scroll rectangle.

Two members will be added to WebPageCreationParameters to communicate the header
and footer heights with core Page if they are are set before creating the WebPage
by the WebProcess.

RemoteLayerTreeHost::updateLayerTree() will add the banners as sub-layers to the
scrolledContentsLayer. Because it is not defined in the UIProcess, its layerID
will be added to RemoteLayerTreeTransaction.

RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree() will ensure the position
and the width of the banner layers are adjusted if the totalContentHeight or the
contentWidth change.

Mini browser will be used to test this feature manually. It will create two dummy
CALayers and call the WKWebView SPI when the setting: &quot;Reserve Space For Banners&quot;
is checked. It will call the SPI with nil pointer if this setting is unchecked.

* LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset-header-expected.txt:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::graphicsLayerForScrolledContents):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setHeaderHeight):
(WebCore::Page::setFooterHeight):
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::mainFrameTopContentInset const):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/platform/ScrollView.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::scrolledContentsLayerID const):
(WebKit::RemoteLayerTreeTransaction::setScrolledContentsLayerID):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::encode const):
(WebKit::RemoteLayerTreeTransaction::decode):
(WebKit::RemoteLayerTreeTransaction::description const):
* Source/WebKit/Shared/WebPageCreationParameters.cpp:
(WebKit::WebPageCreationParameters::encode const):
(WebKit::WebPageCreationParameters::decode):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setHeaderBannerLayer:]):
(-[WKWebView _headerBannerLayer]):
(-[WKWebView _setFooterBannerLayer:]):
(-[WKWebView _footerBannerLayer]):
* Source/WebKit/UIProcess/API/mac/WKWebViewPrivateForTestingMac.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm:
(-[WKWebView _setHeaderBannerHeight:]): Deleted.
(-[WKWebView _setFooterBannerHeight:]): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateBannerLayers):
(WebKit::RemoteLayerTreeHost::updateLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::topContentInset const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::setHeaderBannerHeight):
(WebKit::WebPageProxy::setFooterBannerHeight):
(WebKit::WebPageProxy::setHeaderBannerHeightForTesting): Deleted.
(WebKit::WebPageProxy::setFooterBannerHeightForTesting): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::headerBannerLayer const):
(WebKit::PageClientImpl::footerBannerLayer const):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::headerBannerLayer const):
(WebKit::WebPageProxy::footerBannerLayer const):
(WebKit::WebPageProxy::headerBannerHeight const):
(WebKit::WebPageProxy::footerBannerHeight const):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
(WebKit::WebViewImpl::headerBannerLayer const):
(WebKit::WebViewImpl::footerBannerLayer const):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::setHeaderBannerLayer):
(WebKit::WebViewImpl::setFooterBannerLayer):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::setHeaderBannerHeight):
(WebKit::WebPage::setFooterBannerHeight):
(WebKit::WebPage::setHeaderBannerHeightForTesting): Deleted.
(WebKit::WebPage::setFooterBannerHeightForTesting): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::willCommitLayerTree):
* Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj:
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController didChangeSettings]):

Canonical link: <a href="https://commits.webkit.org/261597@main">https://commits.webkit.org/261597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/195dd9d121a778c7bdce273cd23a999e04adb0b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120799 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4372 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105204 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45814 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13688 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/563 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14367 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52562 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8087 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16158 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->