### PR TITLE
[Win] Don't use FileSystemCF.cpp

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -152,7 +152,9 @@ WTF_EXPORT_PRIVATE bool markPurgeable(const String&);
 WTF_EXPORT_PRIVATE Vector<String> listDirectory(const String& path); // Returns file names, not full paths.
 
 WTF_EXPORT_PRIVATE CString fileSystemRepresentation(const String&);
+#if !PLATFORM(WIN)
 WTF_EXPORT_PRIVATE String stringFromFileSystemRepresentation(const char*);
+#endif
 
 inline bool isHandleValid(const PlatformFileHandle& handle) { return handle != invalidPlatformFileHandle; }
 
@@ -198,7 +200,7 @@ WTF_EXPORT_PRIVATE String decodeFromFilename(const String&);
 
 WTF_EXPORT_PRIVATE bool filesHaveSameVolume(const String&, const String&);
 
-#if USE(CF)
+#if USE(CF) && !PLATFORM(WIN)
 WTF_EXPORT_PRIVATE RetainPtr<CFURLRef> pathAsURL(const String&);
 #endif
 

--- a/Source/WTF/wtf/PlatformWin.cmake
+++ b/Source/WTF/wtf/PlatformWin.cmake
@@ -57,7 +57,6 @@ if (USE_CF)
     )
     list(APPEND WTF_SOURCES
         cf/CFURLExtras.cpp
-        cf/FileSystemCF.cpp
         cf/URLCF.cpp
 
         text/cf/AtomStringImplCF.cpp

--- a/Source/WTF/wtf/cf/FileSystemCF.cpp
+++ b/Source/WTF/wtf/cf/FileSystemCF.cpp
@@ -62,13 +62,7 @@ String FileSystem::stringFromFileSystemRepresentation(const char* fileSystemRepr
 
 RetainPtr<CFURLRef> FileSystem::pathAsURL(const String& path)
 {
-    CFURLPathStyle pathStyle;
-#if PLATFORM(WIN)
-    pathStyle = kCFURLWindowsPathStyle;
-#else
-    pathStyle = kCFURLPOSIXPathStyle;
-#endif
-    return adoptCF(CFURLCreateWithFileSystemPath(nullptr, path.createCFString().get(), pathStyle, FALSE));
+    return adoptCF(CFURLCreateWithFileSystemPath(nullptr, path.createCFString().get(), kCFURLPOSIXPathStyle, FALSE));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -136,22 +136,18 @@ std::optional<WallTime> fileCreationTime(const String& path)
     return WallTime::fromRawSeconds(time);
 }
 
-#if !USE(CF)
-
 CString fileSystemRepresentation(const String& path)
 {
-    auto characters = wcharFrom(StringView(path).upconvertedCharacters());
-    int size = WideCharToMultiByte(CP_ACP, 0, characters, path.length(), 0, 0, 0, 0) - 1;
+    auto characters = StringView(path).upconvertedCharacters();
+    int size = WideCharToMultiByte(CP_ACP, 0, wcharFrom(characters), path.length(), 0, 0, 0, 0);
 
     char* buffer;
     CString string = CString::newUninitialized(size, buffer);
 
-    WideCharToMultiByte(CP_ACP, 0, characters, path.length(), buffer, size, 0, 0);
+    WideCharToMultiByte(CP_ACP, 0, wcharFrom(characters), path.length(), buffer, size, 0, 0);
 
     return string;
 }
-
-#endif // !USE(CF)
 
 static String bundleName()
 {


### PR DESCRIPTION
#### 3cc2ae9e348aa7ff1ff4487f812d8ba2ba2022c4
<pre>
[Win] Don&apos;t use FileSystemCF.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=253556">https://bugs.webkit.org/show_bug.cgi?id=253556</a>

Reviewed by Don Olmstead.

WinCairo is reducing the CF dependency.

Use fileSystemRepresentation in FileSystemWin.cpp. Fixed two bugs. The
return value of upconvertedCharacters had to be retained. The return
value of WideCharToMultiByte is a string length not containing the
null character if cchWideChar is specifed.

Conditioned out stringFromFileSystemRepresentation and pathAsURL
because they are not used for Windows.

* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/PlatformWin.cmake:
* Source/WTF/wtf/cf/FileSystemCF.cpp:
(WTF::FileSystem::pathAsURL):
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::fileSystemRepresentation):

Canonical link: <a href="https://commits.webkit.org/261459@main">https://commits.webkit.org/261459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18a9b16a076f7f037b821c51c5407627a4a75358

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/53 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3247 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120232 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2664 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104174 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/39 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44992 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/99977 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13081 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/37 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86787 "9 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11195 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9477 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101167 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52020 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31503 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7973 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15553 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109205 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26906 "Passed tests") | 
<!--EWS-Status-Bubble-End-->