### PR TITLE
fast/events/wheel/wheel-event-destroys-frame.html times out when enabling UI side compositing

### DIFF
--- a/LayoutTests/fast/events/wheel/wheel-event-destroys-frame.html
+++ b/LayoutTests/fast/events/wheel/wheel-event-destroys-frame.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="../../../resources/ui-helper.js"></script>
     <script>
         if (window.testRunner) {
             testRunner.waitUntilDone();
             testRunner.dumpAsText();
         }
 
-        function frameLoaded(iframe)
+        async function frameLoaded(iframe)
         {
             iframe.contentWindow.addEventListener('wheel', function() {
                 // Removing the window during event firing causes crash.
@@ -23,6 +24,8 @@
 
             var iframeTarget = document.getElementById('iframe');
             var iframeBounds = iframeTarget.getBoundingClientRect();
+
+            await UIHelper.ensurePresentationUpdate();
 
             eventSender.mouseMoveTo(iframeBounds.left + 10, iframeBounds.top + 10);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -1, 'began', 'none');


### PR DESCRIPTION
#### fd458c327e9db7fd7fd8025c59200f6f70330646
<pre>
fast/events/wheel/wheel-event-destroys-frame.html times out when enabling UI side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=253558">https://bugs.webkit.org/show_bug.cgi?id=253558</a>
&lt;rdar://106116803&gt;

Reviewed by Simon Fraser.

Wait for the presentation update before start trying to scroll.

* LayoutTests/fast/events/wheel/wheel-event-destroys-frame.html:

Canonical link: <a href="https://commits.webkit.org/261393@main">https://commits.webkit.org/261393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0344f422f5664f0b3887ee58eec288d47055ff22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3323 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120321 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11780 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117323 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104405 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/102 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/100 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13678 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52083 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15658 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4326 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->