### PR TITLE
A page with one document doing capture and another playing will not handle correctly remote commands

### DIFF
--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1134,7 +1134,8 @@ bool MediaElementSession::allowsPlaybackControlsForAutoplayingAudio() const
 static bool isDocumentPlayingSeveralMediaStreams(Document& document)
 {
     // We restrict to capturing document for now, until we have a good way to state to the UIProcess application that audio rendering is muted from here.
-    return document.activeMediaElementsWithMediaStreamCount() > 1 && MediaProducer::isCapturing(document.mediaState());
+    auto* page = document.page();
+    return document.activeMediaElementsWithMediaStreamCount() > 1 && page && MediaProducer::isCapturing(page->mediaState());
 }
 
 static bool processRemoteControlCommandIfPlayingMediaStreams(Document& document, PlatformMediaSession::RemoteControlCommandType commandType)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		077A5AF3230638A600A7105C /* AccessibilityTestPlugin.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0746645822FF630500E3451A /* AccessibilityTestPlugin.mm */; };
 		0794742D25CB33FD00C597EB /* media-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EB /* media-remote.html */; };
 		0794742D25CB33FD00C597EC /* webrtc-remote.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597EC /* webrtc-remote.html */; };
+		0794742D25CB33FD00C597ED /* webrtc-remote-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */; };
 		0799C34B1EBA3301003B7532 /* disableGetUserMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */; };
 		07C046CA1E4262A8007201E7 /* CARingBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07C046C91E42573E007201E7 /* CARingBuffer.cpp */; };
 		07CE1CF31F06A7E000BF89F5 /* GetUserMediaNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07CE1CF21F06A7E000BF89F5 /* GetUserMediaNavigation.mm */; };
@@ -1893,6 +1894,7 @@
 				F45C640128178AD70090DFAB /* webp-image.html in Copy Resources */,
 				51714EB41CF8C78C004723C4 /* WebProcessKillIDBCleanup-1.html in Copy Resources */,
 				51714EB51CF8C78C004723C4 /* WebProcessKillIDBCleanup-2.html in Copy Resources */,
+				0794742D25CB33FD00C597ED /* webrtc-remote-iframe.html in Copy Resources */,
 				0794742D25CB33FD00C597EC /* webrtc-remote.html in Copy Resources */,
 				536770361CC81B6100D425B1 /* WebScriptObjectDescription.html in Copy Resources */,
 				5120C83E1E67678F0025B250 /* WebsiteDataStoreCustomPaths.html in Copy Resources */,
@@ -1951,6 +1953,7 @@
 		0794740C25CA0BDE00C597EB /* MediaSession.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaSession.mm; sourceTree = "<group>"; };
 		0794742C25CB33B000C597EB /* media-remote.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "media-remote.html"; sourceTree = "<group>"; };
 		0794742C25CB33B000C597EC /* webrtc-remote.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "webrtc-remote.html"; sourceTree = "<group>"; };
+		0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "webrtc-remote-iframe.html"; sourceTree = "<group>"; };
 		0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = disableGetUserMedia.html; sourceTree = "<group>"; };
 		07C046C91E42573E007201E7 /* CARingBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CARingBuffer.cpp; sourceTree = "<group>"; };
 		07CC7DFD2266330800E39181 /* MediaBufferingPolicy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaBufferingPolicy.mm; sourceTree = "<group>"; };
@@ -4822,6 +4825,7 @@
 				F45C63FE28178A530090DFAB /* webp-image.html */,
 				51714EB21CF8C761004723C4 /* WebProcessKillIDBCleanup-1.html */,
 				51714EB31CF8C761004723C4 /* WebProcessKillIDBCleanup-2.html */,
+				0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */,
 				0794742C25CB33B000C597EC /* webrtc-remote.html */,
 				5120C83B1E674E350025B250 /* WebsiteDataStoreCustomPaths.html */,
 				93F79A5928E649EC003E7CEB /* websql-database-tracker.db */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -30,6 +30,8 @@
 #import "HTTPServer.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestNavigationDelegate.h"
+#import "TestProtocol.h"
 #import "TestWKWebView.h"
 #import "UserMediaCaptureUIDelegate.h"
 #import "WKWebViewConfigurationExtras.h"
@@ -1273,6 +1275,8 @@ TEST(WebKit2, DoNotUnmuteWhenTakingAThumbnail)
 #if WK_HAVE_C_SPI
 TEST(WebKit2, WebRTCAndRemoteCommands)
 {
+    [TestProtocol registerWithScheme:@"https"];
+
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
@@ -1297,7 +1301,10 @@ TEST(WebKit2, WebRTCAndRemoteCommands)
     microphoneCaptureStateChange = false;
 
     done = false;
-    [webView loadTestPageNamed:@"webrtc-remote"];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://bundle-file/webrtc-remote.html"]]];
+    [webView _test_waitForDidFinishNavigation];
+
+    TestWebKitAPI::Util::run(&done);
 
     EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateActive));
     EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateActive));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/webrtc-remote-iframe.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/webrtc-remote-iframe.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body onload="startCapture()">
+    <script>
+async function startCapture()
+{
+    const stream = await navigator.mediaDevices.getUserMedia({audio:true, video: true});
+    parent.startCapture(stream);
+}
+    </script>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/webrtc-remote.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/webrtc-remote.html
@@ -2,18 +2,20 @@
 <html>
 <head>
 </head>
-<body onload="startCapture()">
+<body>
+    <iframe src="webrtc-remote-iframe.html" id="myFrame"></iframe>
     <video controls autoplay playsinline muted id="local"></video>
     <br>
     <video controls autoplay playsinline id="remote"></video>
     <script>
-let stream;
-async function startCapture()
+function startCapture(stream)
 {
-    stream = await navigator.mediaDevices.getUserMedia({audio:true, video: true});
     local.srcObject = stream;
     // We emulate the remote stream by cloning the local stream.
     remote.srcObject = stream.clone();
+
+    if (window.webkit)
+        window.webkit.messageHandlers.gum.postMessage("PASS");
 }
 
 async function startPlaying()


### PR DESCRIPTION
#### 89829aa9cfdd0495e87941850dbf64e66a51a1fd
<pre>
A page with one document doing capture and another playing will not handle correctly remote commands
<a href="https://bugs.webkit.org/show_bug.cgi?id=253559">https://bugs.webkit.org/show_bug.cgi?id=253559</a>
rdar://104571980

Reviewed by Eric Carlson.

We are processing the pause/play remote commands as mute/unmute capture in case document is capturing and playing several media streams.
Some video conference websites do capture in one document and play media streams in another document.
Handle this by changing the heuristic to check whether page is capturing instead of the document.

Covered by updated API test.

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::isDocumentPlayingSeveralMediaStreams):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/webrtc-remote-iframe.html: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/webrtc-remote.html:

Canonical link: <a href="https://commits.webkit.org/261414@main">https://commits.webkit.org/261414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b31a7f58a11a42b1d7db4b0ab5b916a0c1b291f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/55 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120234 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2651 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104177 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/38 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/44994 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13083 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/36 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86789 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9481 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52019 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7946 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15555 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->