### PR TITLE
[LFC][IFC] Basic support for shape-outside

### DIFF
--- a/Source/WebCore/layout/floats/FloatingState.h
+++ b/Source/WebCore/layout/floats/FloatingState.h
@@ -62,8 +62,11 @@ public:
         bool isInFormattingContextOf(const ElementBox& formattingContextRoot) const;
 
         Rect rectWithMargin() const { return BoxGeometry::marginBoxRect(m_absoluteBoxGeometry); }
+        Rect borderBoxRect() const { return BoxGeometry::borderBoxRect(m_absoluteBoxGeometry); }
         BoxGeometry::HorizontalMargin horizontalMargin() const { return m_absoluteBoxGeometry.horizontalMargin(); }
         PositionInContextRoot bottom() const { return { rectWithMargin().bottom() }; }
+
+        const Shape* shape() const { return m_layoutBox ? m_layoutBox->shape() : nullptr; }
 
 #if ASSERT_ENABLED
         const Box* floatBox() const { return m_layoutBox.get(); }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -68,6 +68,7 @@
 #include "RenderTheme.h"
 #include "RenderView.h"
 #include "Settings.h"
+#include "ShapeOutsideInfo.h"
 #include <wtf/Assertions.h>
 
 namespace WebCore {
@@ -405,6 +406,11 @@ void LineLayout::updateLayoutBoxDimensions(const RenderBox& replacedOrInlineBloc
             baseline = replacedOrInlineBlock.style().metricsOfPrimaryFont().ascent();
         }
         layoutBox.setBaselineForIntegration(roundToInt(baseline));
+    }
+
+    if (ShapeOutsideInfo::isEnabledFor(replacedOrInlineBlock)) {
+        auto shape = makeShapeForShapeOutside(replacedOrInlineBlock);
+        layoutBox.setShape(WTFMove(shape));
     }
 }
 

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -442,6 +442,18 @@ std::optional<LayoutUnit> Box::columnWidth() const
     return rareData().columnWidth;
 }
 
+const Shape* Box::shape() const
+{
+    if (!hasRareData())
+        return nullptr;
+    return rareData().shape.get();
+}
+
+void Box::setShape(std::unique_ptr<Shape> shape)
+{
+    ensureRareData().shape = WTFMove(shape);
+}
+
 void Box::setCachedGeometryForLayoutState(LayoutState& layoutState, std::unique_ptr<BoxGeometry> geometry) const
 {
     ASSERT(!m_cachedLayoutState);

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+class Shape;
+
 namespace Layout {
 
 class ElementBox;
@@ -176,6 +178,9 @@ public:
     void setIsInlineIntegrationRoot() { m_isInlineIntegrationRoot = true; }
     void setIsFirstChildForIntegration(bool value) { m_isFirstChildForIntegration = value; }
 
+    const Shape* shape() const;
+    void setShape(std::unique_ptr<Shape>);
+
     bool canCacheForLayoutState(const LayoutState&) const;
     BoxGeometry* cachedGeometryForLayoutState(const LayoutState&) const;
     void setCachedGeometryForLayoutState(LayoutState&, std::unique_ptr<BoxGeometry>) const;
@@ -199,6 +204,7 @@ private:
         CellSpan tableCellSpan;
         std::optional<LayoutUnit> columnWidth;
         std::unique_ptr<RenderStyle> firstLineStyle;
+        std::unique_ptr<Shape> shape;
     };
 
     bool hasRareData() const { return m_hasRareData; }


### PR DESCRIPTION
#### a35d5737773453b705543bb528321594f70dda92
<pre>
[LFC][IFC] Basic support for shape-outside
<a href="https://bugs.webkit.org/show_bug.cgi?id=253561">https://bugs.webkit.org/show_bug.cgi?id=253561</a>
rdar://106416578

Reviewed by Alan Baradlay.

Add (somewhat incomplete) IFC and integration support for shape-outside.
Not enabled yet.

* Source/WebCore/layout/floats/FloatingContext.cpp:
(WebCore::Layout::FloatingContext::constraints const):
* Source/WebCore/layout/floats/FloatingState.h:
(WebCore::Layout::FloatingState::FloatItem::borderBoxRect const):
(WebCore::Layout::FloatingState::FloatItem::shape const):

Use the shape for constraints if present.

* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForChild):
(WebCore::LayoutIntegration::canUseForLineLayoutWithReason):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateLayoutBoxDimensions):

Update the shape.

* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::shape const):
(WebCore::Layout::Box::setShape):

Save shape to rare data.

* Source/WebCore/layout/layouttree/LayoutBox.h:

Canonical link: <a href="https://commits.webkit.org/261371@main">https://commits.webkit.org/261371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b268dced18b1643812fd991b4fd77ede42b4a23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/62 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11697 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117221 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104186 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/46 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45000 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13092 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/44 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86802 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13596 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9485 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52027 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7887 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15563 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->