### PR TITLE
[web-animations] add CAPresentationModifier and CAPresentationModifierGroup declarations to QuartzCoreSPI

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -38,6 +38,7 @@
 
 #ifdef __OBJC__
 
+#import <QuartzCore/CAAnimationPrivate.h>
 #import <QuartzCore/CAContext.h>
 #import <QuartzCore/CALayerHost.h>
 #import <QuartzCore/CALayerPrivate.h>
@@ -120,6 +121,16 @@ typedef struct _CARenderContext CARenderContext;
 
 @end
 
+@interface CAPresentationModifierGroup : NSObject
++ (instancetype)groupWithCapacity:(NSUInteger)capacity;
+- (void)flush;
+@end
+
+@interface CAPresentationModifier : NSObject
+- (instancetype)initWithKeyPath:(NSString *)keyPath initialValue:(id)value additive:(BOOL)additive group:(CAPresentationModifierGroup *)group;
+@property (strong) id value;
+@end
+
 @interface CALayer ()
 - (CAContext *)context;
 - (void)setContextId:(uint32_t)contextID;
@@ -127,6 +138,8 @@ typedef struct _CARenderContext CARenderContext;
 - (void *)regionBeingDrawn;
 - (void)reloadValueForKeyPath:(NSString *)keyPath;
 - (void)setCornerRadius:(CGFloat)cornerRadius;
+- (void)addPresentationModifier:(CAPresentationModifier *)modifier;
+- (void)removePresentationModifier:(CAPresentationModifier *)modifier;
 @property BOOL allowsGroupBlending;
 @property BOOL allowsHitTesting;
 @property BOOL canDrawConcurrently;


### PR DESCRIPTION
#### 1ba0cc385061f803848dc722a91664854b491537
<pre>
[web-animations] add CAPresentationModifier and CAPresentationModifierGroup declarations to QuartzCoreSPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=253564">https://bugs.webkit.org/show_bug.cgi?id=253564</a>

Reviewed by Dean Jackson.

We&apos;re going to use CAPresentationModifier and CAPresentationModifierGroup for the threaded animation
resolution work. We need to add the required methods to QuartzCoreSPI.h.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:

Canonical link: <a href="https://commits.webkit.org/261410@main">https://commits.webkit.org/261410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d60d2b632a4069b695428ce69441d585e58abaf1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/94 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11781 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117253 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16326 "7 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104235 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98282 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/60 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45041 "3 flakes 136 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13123 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/58 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86837 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9545 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52041 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15595 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4330 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->