### PR TITLE
[web-animations] allow an AcceleratedEffect to be cloned

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -42,6 +42,21 @@
 
 namespace WebCore {
 
+AcceleratedEffectKeyframe AcceleratedEffectKeyframe::clone() const
+{
+    RefPtr<TimingFunction> clonedTimingFunction;
+    if (auto* srcTimingFunction = timingFunction.get())
+        clonedTimingFunction = srcTimingFunction->clone();
+
+    return {
+        offset,
+        values.clone(),
+        WTFMove(clonedTimingFunction),
+        compositeOperation,
+        animatedProperties
+    };
+};
+
 WTF_MAKE_ISO_ALLOCATED_IMPL(AcceleratedEffect);
 
 static AcceleratedEffectProperty acceleratedPropertyFromCSSProperty(AnimatableProperty property, const Settings& settings)
@@ -96,7 +111,26 @@ Ref<AcceleratedEffect> AcceleratedEffect::create(Vector<AcceleratedEffectKeyfram
     return adoptRef(*new AcceleratedEffect(WTFMove(keyframes), type, fill, direction, composite, WTFMove(timingFunction), WTFMove(defaultKeyframeTimingFunction), WTFMove(animatedProperties), paused, iterationStart, iterations, playbackRate, delay, endDelay, iterationDuration, activeDuration, endTime, startTime, holdTime));
 }
 
-Ref<AcceleratedEffect> AcceleratedEffect::copyWithProperties(OptionSet<AcceleratedEffectProperty>& propertyFilter)
+Ref<AcceleratedEffect> AcceleratedEffect::clone() const
+{
+    auto clonedKeyframes = m_keyframes.map([](const auto& keyframe) {
+        return keyframe.clone();
+    });
+
+    RefPtr<TimingFunction> clonedTimingFunction;
+    if (auto* timingFunction = m_timingFunction.get())
+        clonedTimingFunction = timingFunction->clone();
+
+    RefPtr<TimingFunction> clonedDefaultKeyframeTimingFunction;
+    if (auto* defaultKeyframeTimingFunction = m_defaultKeyframeTimingFunction.get())
+        clonedDefaultKeyframeTimingFunction = defaultKeyframeTimingFunction->clone();
+
+    auto clonedAnimatedProperties = m_animatedProperties;
+
+    return AcceleratedEffect::create(WTFMove(clonedKeyframes), m_animationType, m_fill, m_direction, m_compositeOperation, WTFMove(clonedTimingFunction), WTFMove(clonedDefaultKeyframeTimingFunction), WTFMove(clonedAnimatedProperties), m_paused, m_iterationStart, m_iterations, m_playbackRate, m_delay, m_endDelay, m_iterationDuration, m_activeDuration, m_endTime, m_startTime, m_holdTime);
+}
+
+Ref<AcceleratedEffect> AcceleratedEffect::copyWithProperties(OptionSet<AcceleratedEffectProperty>& propertyFilter) const
 {
     return adoptRef(*new AcceleratedEffect(*this, propertyFilter));
 }

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -67,6 +67,8 @@ struct AcceleratedEffectKeyframe {
     RefPtr<TimingFunction> timingFunction;
     std::optional<CompositeOperation> compositeOperation;
     OptionSet<AcceleratedEffectProperty> animatedProperties;
+
+    AcceleratedEffectKeyframe clone() const;
 };
 
 class AcceleratedEffect : public RefCounted<AcceleratedEffect> {
@@ -77,7 +79,8 @@ public:
 
     virtual ~AcceleratedEffect() = default;
 
-    WEBCORE_EXPORT Ref<AcceleratedEffect> copyWithProperties(OptionSet<AcceleratedEffectProperty>&);
+    WEBCORE_EXPORT Ref<AcceleratedEffect> clone() const;
+    WEBCORE_EXPORT Ref<AcceleratedEffect> copyWithProperties(OptionSet<AcceleratedEffectProperty>&) const;
 
     // Encoding and decoding support
     const Vector<AcceleratedEffectKeyframe>& keyframes() const { return m_keyframes; }

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -64,6 +64,64 @@ AcceleratedEffectValues::AcceleratedEffectValues(const AcceleratedEffectValues& 
 #endif
 }
 
+AcceleratedEffectValues AcceleratedEffectValues::clone() const
+{
+    auto clonedTransformOrigin = transformOrigin;
+
+    TransformOperations clonedTransform { transform.operations().map([](const auto& operation) {
+        return RefPtr { operation->clone() };
+    }) };
+
+    RefPtr<TransformOperation> clonedTranslate;
+    if (auto* srcTranslate = translate.get())
+        clonedTranslate = srcTranslate->clone();
+
+    RefPtr<TransformOperation> clonedScale;
+    if (auto* srcScale = scale.get())
+        clonedScale = srcScale->clone();
+
+    RefPtr<TransformOperation> clonedRotate;
+    if (auto* srcRotate = rotate.get())
+        clonedRotate = srcRotate->clone();
+
+    RefPtr<PathOperation> clonedOffsetPath;
+    if (auto* srcOffsetPath = offsetPath.get())
+        clonedOffsetPath = srcOffsetPath->clone();
+
+    auto clonedOffsetDistance = offsetDistance;
+    auto clonedOffsetPosition = offsetPosition;
+    auto clonedOffsetAnchor = offsetAnchor;
+    auto clonedOffsetRotate = offsetRotate;
+
+    FilterOperations clonedFilter { filter.operations().map([](const auto& operation) {
+        return RefPtr { operation->clone() };
+    }) };
+
+#if ENABLE(FILTERS_LEVEL_2)
+    FilterOperations clonedBackdropFilter { backdropFilter.operations().map([](const auto& operation) {
+        return RefPtr { operation->clone() };
+    }) };
+#endif
+
+    return {
+        opacity,
+        WTFMove(clonedTransformOrigin),
+        WTFMove(clonedTransform),
+        WTFMove(clonedTranslate),
+        WTFMove(clonedScale),
+        WTFMove(clonedRotate),
+        WTFMove(clonedOffsetPath),
+        WTFMove(clonedOffsetDistance),
+        WTFMove(clonedOffsetPosition),
+        WTFMove(clonedOffsetAnchor),
+        WTFMove(clonedOffsetRotate),
+        WTFMove(clonedFilter),
+#if ENABLE(FILTERS_LEVEL_2)
+        WTFMove(clonedBackdropFilter)
+#endif
+    };
+}
+
 static LengthPoint nonCalculatedLengthPoint(LengthPoint lengthPoint, const IntSize& borderBoxSize)
 {
     if (!lengthPoint.x().isCalculated() && !lengthPoint.y().isCalculated())

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.h
@@ -88,6 +88,8 @@ struct AcceleratedEffectValues {
     {
     }
 
+    WEBCORE_EXPORT AcceleratedEffectValues clone() const;
+
     WEBCORE_EXPORT AcceleratedEffectValues(const AcceleratedEffectValues&);
     AcceleratedEffectValues(const RenderStyle&, const IntRect&);
     AcceleratedEffectValues& operator=(const AcceleratedEffectValues&) = default;

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
@@ -35,6 +35,11 @@
 
 namespace WebCore {
 
+FilterOperations::FilterOperations(Vector<RefPtr<FilterOperation>>&& operations)
+    : m_operations(WTFMove(operations))
+{
+}
+
 bool FilterOperations::operator==(const FilterOperations& other) const
 {
     size_t size = m_operations.size();

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -37,6 +37,9 @@ struct BlendingContext;
 class FilterOperations {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    explicit FilterOperations() { };
+    explicit FilterOperations(Vector<RefPtr<FilterOperation>>&&);
+
     WEBCORE_EXPORT bool operator==(const FilterOperations&) const;
     bool operator!=(const FilterOperations& other) const { return !(*this == other); }
 

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -45,6 +45,15 @@ Ref<ReferencePathOperation> ReferencePathOperation::create(std::optional<Path>&&
     return adoptRef(*new ReferencePathOperation(WTFMove(path)));
 }
 
+Ref<PathOperation> ReferencePathOperation::clone() const
+{
+    if (auto path = this->path()) {
+        auto pathCopy = *path;
+        return adoptRef(*new ReferencePathOperation(WTFMove(pathCopy)));
+    }
+    return adoptRef(*new ReferencePathOperation(std::nullopt));
+}
+
 ReferencePathOperation::ReferencePathOperation(const String& url, const AtomString& fragment, const RefPtr<SVGElement> element)
     : PathOperation(Reference)
     , m_url(url)
@@ -69,6 +78,13 @@ const SVGElement* ReferencePathOperation::element() const
 Ref<RayPathOperation> RayPathOperation::create(float angle, Size size, bool isContaining, FloatRect&& containingBlockBoundingRect, FloatPoint&& position)
 {
     return adoptRef(*new RayPathOperation(angle, size, isContaining, WTFMove(containingBlockBoundingRect), WTFMove(position)));
+}
+
+Ref<PathOperation> RayPathOperation::clone() const
+{
+    auto containingBlockBoundingRect = m_containingBlockBoundingRect;
+    auto position = m_position;
+    return adoptRef(*new RayPathOperation(m_angle, m_size, m_isContaining, WTFMove(containingBlockBoundingRect), WTFMove(position)));
 }
 
 bool RayPathOperation::canBlend(const PathOperation& to) const

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -53,6 +53,8 @@ public:
 
     virtual ~PathOperation() = default;
 
+    virtual Ref<PathOperation> clone() const = 0;
+
     virtual bool operator==(const PathOperation&) const = 0;
     bool operator!=(const PathOperation& o) const { return !(*this == o); }
 
@@ -74,6 +76,7 @@ class ReferencePathOperation final : public PathOperation {
 public:
     static Ref<ReferencePathOperation> create(const String& url, const AtomString& fragment, const RefPtr<SVGElement>);
     WEBCORE_EXPORT static Ref<ReferencePathOperation> create(std::optional<Path>&&);
+    Ref<PathOperation> clone() const final;
     const String& url() const { return m_url; }
     const AtomString& fragment() const { return m_fragment; }
     const SVGElement* element() const;
@@ -107,6 +110,11 @@ public:
     static Ref<ShapePathOperation> create(Ref<BasicShape>&& shape, CSSBoxType referenceBox)
     {
         return adoptRef(*new ShapePathOperation(WTFMove(shape), referenceBox));
+    }
+
+    Ref<PathOperation> clone() const final
+    {
+        return adoptRef(*new ShapePathOperation(m_shape->clone(), m_referenceBox));
     }
 
     bool canBlend(const PathOperation& to) const final
@@ -169,6 +177,12 @@ public:
         return adoptRef(*new BoxPathOperation(WTFMove(path), referenceBox));
     }
 
+    Ref<PathOperation> clone() const final
+    {
+        auto path = m_path;
+        return adoptRef(*new BoxPathOperation(WTFMove(path), m_referenceBox));
+    }
+
     const Path pathForReferenceRect(const FloatRoundedRect& boundingRect) const
     {
         Path path;
@@ -229,6 +243,8 @@ public:
     }
 
     WEBCORE_EXPORT static Ref<RayPathOperation> create(float angle, Size, bool isContaining, FloatRect&& containingBlockBoundingRect, FloatPoint&& position);
+
+    Ref<PathOperation> clone() const final;
 
     float angle() const { return m_angle; }
     Size size() const { return m_size; }

--- a/Source/WebCore/rendering/style/BasicShapes.cpp
+++ b/Source/WebCore/rendering/style/BasicShapes.cpp
@@ -157,6 +157,14 @@ BasicShapeCircle::BasicShapeCircle(BasicShapeCenterCoordinate&& centerX, BasicSh
 {
 }
 
+Ref<BasicShape> BasicShapeCircle::clone() const
+{
+    auto centerX = m_centerX;
+    auto centerY = m_centerY;
+    auto radius = m_radius;
+    return adoptRef(*new BasicShapeCircle(WTFMove(centerX), WTFMove(centerY), WTFMove(radius)));
+}
+
 bool BasicShapeCircle::operator==(const BasicShape& other) const
 {
     if (type() != other.type())
@@ -232,6 +240,15 @@ BasicShapeEllipse::BasicShapeEllipse(BasicShapeCenterCoordinate&& centerX, Basic
     , m_radiusX(WTFMove(radiusX))
     , m_radiusY(WTFMove(radiusY))
 {
+}
+
+Ref<BasicShape> BasicShapeEllipse::clone() const
+{
+    auto centerX = m_centerX;
+    auto centerY = m_centerY;
+    auto radiusX = m_radiusX;
+    auto radiusY = m_radiusY;
+    return adoptRef(*new BasicShapeEllipse(WTFMove(centerX), WTFMove(centerY), WTFMove(radiusX), WTFMove(radiusY)));
 }
 
 bool BasicShapeEllipse::operator==(const BasicShape& other) const
@@ -319,6 +336,12 @@ BasicShapePolygon::BasicShapePolygon(WindRule windRule, Vector<Length>&& values)
 {
 }
 
+Ref<BasicShape> BasicShapePolygon::clone() const
+{
+    auto values = m_values;
+    return adoptRef(*new BasicShapePolygon(m_windRule, WTFMove(values)));
+}
+
 bool BasicShapePolygon::operator==(const BasicShape& other) const
 {
     if (type() != other.type())
@@ -399,6 +422,14 @@ BasicShapePath::BasicShapePath(std::unique_ptr<SVGPathByteStream>&& byteStream, 
 {
 }
 
+Ref<BasicShape> BasicShapePath::clone() const
+{
+    std::unique_ptr<SVGPathByteStream> byteStream;
+    if (m_byteStream)
+        byteStream = m_byteStream->copy();
+    return adoptRef(*new BasicShapePath(WTFMove(byteStream), m_zoom, m_windRule));
+}
+
 const Path& BasicShapePath::path(const FloatRect& boundingBox)
 {
     return cachedTransformedByteStreamPath(*m_byteStream, m_zoom, boundingBox.location());
@@ -457,6 +488,19 @@ BasicShapeInset::BasicShapeInset(Length&& right, Length&& top, Length&& bottom, 
     , m_bottomRightRadius(WTFMove(bottomRightRadius))
     , m_bottomLeftRadius(WTFMove(bottomLeftRadius))
 {
+}
+
+Ref<BasicShape> BasicShapeInset::clone() const
+{
+    auto right = m_right;
+    auto top = m_top;
+    auto bottom = m_bottom;
+    auto left = m_left;
+    auto topLeftRadius = m_topLeftRadius;
+    auto topRightRadius = m_topRightRadius;
+    auto bottomRightRadius = m_bottomRightRadius;
+    auto bottomLeftRadius = m_bottomLeftRadius;
+    return adoptRef(*new BasicShapeInset(WTFMove(right), WTFMove(top), WTFMove(bottom), WTFMove(left), WTFMove(topLeftRadius), WTFMove(topRightRadius), WTFMove(bottomRightRadius), WTFMove(bottomLeftRadius)));
 }
 
 bool BasicShapeInset::operator==(const BasicShape& other) const

--- a/Source/WebCore/rendering/style/BasicShapes.h
+++ b/Source/WebCore/rendering/style/BasicShapes.h
@@ -61,6 +61,8 @@ public:
         Inset
     };
 
+    virtual Ref<BasicShape> clone() const = 0;
+
     virtual Type type() const = 0;
 
     virtual const Path& path(const FloatRect&) = 0;
@@ -172,6 +174,8 @@ public:
     static Ref<BasicShapeCircle> create() { return adoptRef(*new BasicShapeCircle); }
     WEBCORE_EXPORT static Ref<BasicShapeCircle> create(BasicShapeCenterCoordinate&& centerX, BasicShapeCenterCoordinate&& centerY, BasicShapeRadius&&);
 
+    Ref<BasicShape> clone() const final;
+
     const BasicShapeCenterCoordinate& centerX() const { return m_centerX; }
     const BasicShapeCenterCoordinate& centerY() const { return m_centerY; }
     const BasicShapeRadius& radius() const { return m_radius; }
@@ -205,6 +209,8 @@ class BasicShapeEllipse final : public BasicShape {
 public:
     static Ref<BasicShapeEllipse> create() { return adoptRef(*new BasicShapeEllipse); }
     WEBCORE_EXPORT static Ref<BasicShapeEllipse> create(BasicShapeCenterCoordinate&& centerX, BasicShapeCenterCoordinate&& centerY, BasicShapeRadius&& radiusX, BasicShapeRadius&& radiusY);
+
+    Ref<BasicShape> clone() const final;
 
     const BasicShapeCenterCoordinate& centerX() const { return m_centerX; }
     const BasicShapeCenterCoordinate& centerY() const { return m_centerY; }
@@ -243,6 +249,8 @@ public:
     static Ref<BasicShapePolygon> create() { return adoptRef(*new BasicShapePolygon); }
     WEBCORE_EXPORT static Ref<BasicShapePolygon> create(WindRule, Vector<Length>&& values);
 
+    Ref<BasicShape> clone() const final;
+
     const Vector<Length>& values() const { return m_values; }
     const Length& getXAt(unsigned i) const { return m_values[2 * i]; }
     const Length& getYAt(unsigned i) const { return m_values[2 * i + 1]; }
@@ -280,6 +288,8 @@ public:
 
     WEBCORE_EXPORT static Ref<BasicShapePath> create(std::unique_ptr<SVGPathByteStream>&&, float zoom, WindRule);
 
+    Ref<BasicShape> clone() const final;
+
     void setWindRule(WindRule windRule) { m_windRule = windRule; }
     WindRule windRule() const override { return m_windRule; }
 
@@ -313,6 +323,8 @@ class BasicShapeInset final : public BasicShape {
 public:
     static Ref<BasicShapeInset> create() { return adoptRef(*new BasicShapeInset); }
     WEBCORE_EXPORT static Ref<BasicShapeInset> create(Length&& right, Length&& top, Length&& bottom, Length&& left, LengthSize&& topLeftRadius, LengthSize&& topRightRadius, LengthSize&& bottomRightRadius, LengthSize&& bottomLeftRadius);
+
+    Ref<BasicShape> clone() const final;
 
     const Length& top() const { return m_top; }
     const Length& right() const { return m_right; }


### PR DESCRIPTION
#### 97485effe50c457b74329522515d89b8be48bb3b
<pre>
[web-animations] allow an AcceleratedEffect to be cloned
<a href="https://bugs.webkit.org/show_bug.cgi?id=253567">https://bugs.webkit.org/show_bug.cgi?id=253567</a>

Reviewed by Dean Jackson.

When any AcceleratedEffect object will be decoded as part of the remote layer tree transaction,
we will need to transfer ownership to the thread used to resolve animations. We need to clone
any ref-counted object that would otherwise be marked as having been created on the main thread.

* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffectKeyframe::clone const):
(WebCore::AcceleratedEffect::clone const):
(WebCore::AcceleratedEffect::copyWithProperties const):
(WebCore::AcceleratedEffect::copyWithProperties): Deleted.
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::clone const):
(WebCore::nonCalculatedLengthPoint): Deleted.
* Source/WebCore/platform/animation/AcceleratedEffectValues.h:
* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
(WebCore::FilterOperations::FilterOperations):
* Source/WebCore/platform/graphics/filters/FilterOperations.h:
(WebCore::FilterOperations::FilterOperations):
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::ReferencePathOperation::clone const):
(WebCore::RayPathOperation::clone const):
* Source/WebCore/rendering/PathOperation.h:
* Source/WebCore/rendering/style/BasicShapes.cpp:
(WebCore::BasicShapeCircle::clone const):
(WebCore::BasicShapeEllipse::clone const):
(WebCore::BasicShapePolygon::clone const):
(WebCore::BasicShapePath::clone const):
(WebCore::BasicShapeInset::clone const):
* Source/WebCore/rendering/style/BasicShapes.h:

Canonical link: <a href="https://commits.webkit.org/261418@main">https://commits.webkit.org/261418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6974466dc2a766a453716af964d4bf496e7c0dda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3428 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11889 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117439 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104582 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13288 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13778 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52182 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15768 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4333 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->