### PR TITLE
[web-animations] encode filter values for AcceleratedEffectValues

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.h
@@ -65,7 +65,11 @@ struct AcceleratedEffectValues {
     {
     }
 
-    AcceleratedEffectValues(float opacity, LengthPoint&& transformOrigin, TransformOperations&& transform, RefPtr<TransformOperation>&& translate, RefPtr<TransformOperation>&& scale, RefPtr<TransformOperation>&& rotate, RefPtr<PathOperation>&& offsetPath, Length&& offsetDistance, LengthPoint&& offsetPosition, LengthPoint&& offsetAnchor, OffsetRotation&& offsetRotate)
+    AcceleratedEffectValues(float opacity, LengthPoint&& transformOrigin, TransformOperations&& transform, RefPtr<TransformOperation>&& translate, RefPtr<TransformOperation>&& scale, RefPtr<TransformOperation>&& rotate, RefPtr<PathOperation>&& offsetPath, Length&& offsetDistance, LengthPoint&& offsetPosition, LengthPoint&& offsetAnchor, OffsetRotation&& offsetRotate, FilterOperations&& filter
+#if ENABLE(FILTERS_LEVEL_2)
+        , FilterOperations&& backdropFilter
+#endif
+        )
         : opacity(opacity)
         , transformOrigin(WTFMove(transformOrigin))
         , transform(WTFMove(transform))
@@ -77,6 +81,10 @@ struct AcceleratedEffectValues {
         , offsetPosition(WTFMove(offsetPosition))
         , offsetAnchor(WTFMove(offsetAnchor))
         , offsetRotate(WTFMove(offsetRotate))
+        , filter(WTFMove(filter))
+#if ENABLE(FILTERS_LEVEL_2)
+        , backdropFilter(WTFMove(backdropFilter))
+#endif
     {
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4856,6 +4856,10 @@ struct WebCore::AcceleratedEffectValues {
     WebCore::LengthPoint offsetPosition;
     WebCore::LengthPoint offsetAnchor;
     WebCore::OffsetRotation offsetRotate;
+    WebCore::FilterOperations filter;
+#if ENABLE(FILTERS_LEVEL_2)
+    WebCore::FilterOperations backdropFilter;
+#endif
 }
 
 header: <WebCore/AcceleratedEffect.h>


### PR DESCRIPTION
#### 474e834b1b300b17a07c73d192dac4050806f6c5
<pre>
[web-animations] encode filter values for AcceleratedEffectValues
<a href="https://bugs.webkit.org/show_bug.cgi?id=253568">https://bugs.webkit.org/show_bug.cgi?id=253568</a>

Reviewed by Dean Jackson.

* Source/WebCore/platform/animation/AcceleratedEffectValues.h:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/261411@main">https://commits.webkit.org/261411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/790bf16d58feec4cff7c855b422ebecf42991cd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111488 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/92 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120269 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/21994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11725 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/62 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45068 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13121 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/60 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86867 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13626 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9508 "13 flakes 3 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52043 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15593 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4332 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->