### PR TITLE
[web-animations] improve FilterOperations copy code in AcceleratedEffectValues

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -55,12 +55,14 @@ AcceleratedEffectValues::AcceleratedEffectValues(const AcceleratedEffectValues& 
     offsetAnchor = src.offsetAnchor;
     offsetRotate = src.offsetRotate;
 
-    for (auto& srcFilterOperation : src.filter.operations())
-        filter.operations().append(srcFilterOperation.copyRef());
+    filter.setOperations(src.filter.operations().map([](const auto& operation) {
+        return operation.copyRef();
+    }));
 
 #if ENABLE(FILTERS_LEVEL_2)
-    for (auto& srcBackdropFilterOperation : src.backdropFilter.operations())
-        backdropFilter.operations().append(srcBackdropFilterOperation.copyRef());
+    backdropFilter.setOperations(src.backdropFilter.operations().map([](const auto& operation) {
+        return operation.copyRef();
+    }));
 #endif
 }
 
@@ -166,12 +168,14 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
         offsetDistance = { path ? path->length() : 0.0f, LengthType:: Fixed };
     }
 
-    for (auto srcFilterOperation : style.filter().operations())
-        filter.operations().append(srcFilterOperation.copyRef());
+    filter.setOperations(style.filter().operations().map([](const auto& operation) {
+        return operation.copyRef();
+    }));
 
 #if ENABLE(FILTERS_LEVEL_2)
-    for (auto srcBackdropFilterOperation : style.backdropFilter().operations())
-        backdropFilter.operations().append(srcBackdropFilterOperation.copyRef());
+    backdropFilter.setOperations(style.backdropFilter().operations().map([](const auto& operation) {
+        return operation.copyRef();
+    }));
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -47,6 +47,7 @@ public:
 
     Vector<RefPtr<FilterOperation>>& operations() { return m_operations; }
     const Vector<RefPtr<FilterOperation>>& operations() const { return m_operations; }
+    void setOperations(Vector<RefPtr<FilterOperation>>&& operations) { m_operations = WTFMove(operations); }
 
     bool isEmpty() const { return m_operations.isEmpty(); }
     size_t size() const { return m_operations.size(); }


### PR DESCRIPTION
#### 96550ab8a6fb4d854961e6841d9385ff10f9a1c8
<pre>
[web-animations] improve FilterOperations copy code in AcceleratedEffectValues
<a href="https://bugs.webkit.org/show_bug.cgi?id=253569">https://bugs.webkit.org/show_bug.cgi?id=253569</a>

Reviewed by Dean Jackson.

Add a setter for operations on FilterOperations and use map to create a new set
of operations where we call copyRef() on each operation.

* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/platform/graphics/filters/FilterOperations.h:
(WebCore::FilterOperations::setOperations):

Canonical link: <a href="https://commits.webkit.org/261457@main">https://commits.webkit.org/261457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f146079f78f745f678de2f09c60ab0f008e52726

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3498 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11895 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117445 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104659 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/192 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45420 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13294 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/188 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9633 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19229 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52186 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15774 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4348 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->