### PR TITLE
Scripts: Use webbrowser package in Python to open a URL in a web browser

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py
@@ -24,6 +24,7 @@ import contextlib
 import io
 import logging
 import sys
+import webbrowser
 
 if not sys.platform.startswith('win'):
     import readline
@@ -165,16 +166,25 @@ class Terminal(object):
                 sys.stderr.write('User aborted URL open\n')
                 return False
 
-        if sys.platform.startswith('win'):
-            process = run(['start', url])
+        if (url.startswith('http://') or url.startswith('https://')):
+            try:
+                webbrowser.open(url)
+                return True
+            except webbrowser.Error:
+                sys.stderr.write(
+                    "Failed to open '{}' in the browser, continuing\n".format(url))
+                return False
         else:
-            # TODO: Use shutil directly when Python 2.7 is removed
-            from whichcraft import which
-            if sys.platform.startswith('linux') and which('xdg-open'):
-                process = run(['xdg-open', url])
+            if sys.platform.startswith('win'):
+                process = run(['explorer', url])
             else:
-                process = run(['open', url])
-        return True if process.returncode == 0 else False
+                # TODO: Use shutil directly when Python 2.7 is removed
+                from whichcraft import which
+                if sys.platform.startswith('linux') and which('xdg-open'):
+                    process = run(['xdg-open', url])
+                else:
+                    process = run(['open', url])
+            return True if process.returncode == 0 else False
 
     class Text(object):
         value = lambda value: '\033[{}m'.format(value)

--- a/Tools/Scripts/webkitpy/common/system/user.py
+++ b/Tools/Scripts/webkitpy/common/system/user.py
@@ -175,6 +175,7 @@ class User(object):
             return False
 
     def open_url(self, url):
-        if not self.can_open_url():
+        try:
+            webbrowser.open(url)
+        except webbrowser.Error:
             _log.warn("Failed to open %s" % url)
-        webbrowser.open(url)


### PR DESCRIPTION
#### 82bd766bd89d5a7865183ae72be484db7e27126f
<pre>
Scripts: Use webbrowser package in Python to open a URL in a web browser
<a href="https://bugs.webkit.org/show_bug.cgi?id=253515">https://bugs.webkit.org/show_bug.cgi?id=253515</a>

Reviewed by Jonathan Bedard.

I made a mistake. Because &quot;start&quot; worked on the command line, I assumed
that it would work under the Terminal.run() command. Now I realize this
is not what actually happens. Instead of reverting that commit, commit
<a href="https://commits.webkit.org/261332@main">https://commits.webkit.org/261332@main</a>, I am instead introducing a
proper fix, which is using the URL and opening it in a browser via the
webbrowser package.

* Tools\Scripts\libraries\webkitcorepy\webkitcorepy\terminal.py: Change
  &apos;start&apos; back to &apos;explorer.&apos; Teach open_url to call the webbrowser
  url method to open webpages if the scheme is http or https.

* Tools\Scripts\webkitpy\common\system\user.py: Inline redundant method.

Canonical link: <a href="https://commits.webkit.org/261687@main">https://commits.webkit.org/261687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/375cb7b415df3297fb99029a7af7decb802515e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4347 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12884 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118338 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105637 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/115992 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/885 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14058 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/921 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14741 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/111334 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52926 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8150 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16577 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->