### PR TITLE
[popover] Fix togglePopover logic

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -1,210 +1,209 @@
-Pop upPop upDialog with popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manual
 Not a popover
 Dialog without popover attribute
 
-FAIL The element <div popover="" id="boolean">Pop up</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="">Pop up</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="auto">Pop up</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="hint">Pop up</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="manual">Pop up</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <article popover="">Different element type</article> should behave as a popover. Element has unexpected visibility state
-FAIL The element <header popover="">Different element type</header> should behave as a popover. Element has unexpected visibility state
-FAIL The element <nav popover="">Different element type</nav> should behave as a popover. Element has unexpected visibility state
-FAIL The element <input type="text" popover="" value="Different element type"> should behave as a popover. Element has unexpected visibility state
-FAIL The element <dialog popover="">Dialog with popover attribute</dialog> should behave as a popover. Element has unexpected visibility state
-FAIL The element <dialog popover="manual">Dialog with popover=manual</dialog> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="true">Invalid popover value - defaults to popover=manual</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="popover">Invalid popover value - defaults to popover=manual</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="invalid">Invalid popover value - defaults to popover=manual</div> should behave as a popover. Element has unexpected visibility state
+PASS The element <div popover="" id="boolean">Pop up</div> should behave as a popover.
+PASS The element <div popover="">Pop up</div> should behave as a popover.
+PASS The element <div popover="auto">Pop up</div> should behave as a popover.
+PASS The element <div popover="hint">Pop up</div> should behave as a popover.
+PASS The element <div popover="manual">Pop up</div> should behave as a popover.
+PASS The element <article popover="">Different element type</article> should behave as a popover.
+PASS The element <header popover="">Different element type</header> should behave as a popover.
+PASS The element <nav popover="">Different element type</nav> should behave as a popover.
+PASS The element <input type="text" popover="" value="Different element type"> should behave as a popover.
+PASS The element <dialog popover="">Dialog with popover attribute</dialog> should behave as a popover.
+PASS The element <dialog popover="manual">Dialog with popover=manual</dialog> should behave as a popover.
+PASS The element <div popover="true">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
+PASS The element <div popover="popover">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
+PASS The element <div popover="invalid">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
 FAIL The element <div>Not a popover</div> should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
 FAIL The element <dialog open="">Dialog without popover attribute</dialog> should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <a popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <a popover> element should behave as a popover.
 FAIL A <a> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <abbr popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <abbr popover> element should behave as a popover.
 FAIL A <abbr> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <address popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <address popover> element should behave as a popover.
 FAIL A <address> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
 FAIL A <area popover> element should behave as a popover. assert_equals: After showPopover(), a popover should be visible: Expected this element to be visible expected true but got false
 FAIL A <area> element should *not* behave as a popover. assert_equals: A non-popover should start out visible: Expected this element to be visible expected true but got false
-FAIL A <article popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <article popover> element should behave as a popover.
 FAIL A <article> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <aside popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <aside popover> element should behave as a popover.
 FAIL A <aside> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <b popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <b popover> element should behave as a popover.
 FAIL A <b> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <bdi popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <bdi popover> element should behave as a popover.
 FAIL A <bdi> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <bdo popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <bdo popover> element should behave as a popover.
 FAIL A <bdo> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <blockquote popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <blockquote popover> element should behave as a popover.
 FAIL A <blockquote> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <body popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <body popover> element should behave as a popover.
 FAIL A <body> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <button popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <button popover> element should behave as a popover.
 FAIL A <button> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <canvas popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <canvas popover> element should behave as a popover.
 FAIL A <canvas> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <caption popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <caption popover> element should behave as a popover.
 FAIL A <caption> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <cite popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <cite popover> element should behave as a popover.
 FAIL A <cite> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <code popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <code popover> element should behave as a popover.
 FAIL A <code> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <col popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <col popover> element should behave as a popover.
 FAIL A <col> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <colgroup popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <colgroup popover> element should behave as a popover.
 FAIL A <colgroup> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <data popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <data popover> element should behave as a popover.
 FAIL A <data> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <dd popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <dd popover> element should behave as a popover.
 FAIL A <dd> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <del popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <del popover> element should behave as a popover.
 FAIL A <del> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <details popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <details popover> element should behave as a popover.
 FAIL A <details> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <dfn popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <dfn popover> element should behave as a popover.
 FAIL A <dfn> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <div popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <div popover> element should behave as a popover.
 FAIL A <div> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <dl popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <dl popover> element should behave as a popover.
 FAIL A <dl> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <dt popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <dt popover> element should behave as a popover.
 FAIL A <dt> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <em popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <em popover> element should behave as a popover.
 FAIL A <em> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <fieldset popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <fieldset popover> element should behave as a popover.
 FAIL A <fieldset> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <figcaption popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <figcaption popover> element should behave as a popover.
 FAIL A <figcaption> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <figure popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <figure popover> element should behave as a popover.
 FAIL A <figure> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <footer popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <footer popover> element should behave as a popover.
 FAIL A <footer> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <form popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <form popover> element should behave as a popover.
 FAIL A <form> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h1 popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <h1 popover> element should behave as a popover.
 FAIL A <h1> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h2 popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <h2 popover> element should behave as a popover.
 FAIL A <h2> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h3 popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <h3 popover> element should behave as a popover.
 FAIL A <h3> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h4 popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <h4 popover> element should behave as a popover.
 FAIL A <h4> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h5 popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <h5 popover> element should behave as a popover.
 FAIL A <h5> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h6 popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <h6 popover> element should behave as a popover.
 FAIL A <h6> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <header popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <header popover> element should behave as a popover.
 FAIL A <header> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <hr popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <hr popover> element should behave as a popover.
 FAIL A <hr> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <html popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <html popover> element should behave as a popover.
 FAIL A <html> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <i popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <i popover> element should behave as a popover.
 FAIL A <i> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <iframe popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <iframe popover> element should behave as a popover.
 FAIL A <iframe> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <img popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <img popover> element should behave as a popover.
 FAIL A <img> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <input popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <input popover> element should behave as a popover.
 FAIL A <input> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <ins popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <ins popover> element should behave as a popover.
 FAIL A <ins> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <kbd popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <kbd popover> element should behave as a popover.
 FAIL A <kbd> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <label popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <label popover> element should behave as a popover.
 FAIL A <label> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <legend popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <legend popover> element should behave as a popover.
 FAIL A <legend> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <li popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <li popover> element should behave as a popover.
 FAIL A <li> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <main popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <main popover> element should behave as a popover.
 FAIL A <main> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <map popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <map popover> element should behave as a popover.
 FAIL A <map> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <mark popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <mark popover> element should behave as a popover.
 FAIL A <mark> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <menu popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <menu popover> element should behave as a popover.
 FAIL A <menu> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <meter popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <meter popover> element should behave as a popover.
 FAIL A <meter> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <nav popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <nav popover> element should behave as a popover.
 FAIL A <nav> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <object popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <object popover> element should behave as a popover.
 FAIL A <object> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <ol popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <ol popover> element should behave as a popover.
 FAIL A <ol> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
 FAIL A <optgroup popover> element should behave as a popover. assert_equals: After showPopover(), a popover should be visible: Expected this element to be visible expected true but got false
 FAIL A <optgroup> element should *not* behave as a popover. assert_equals: A non-popover should start out visible: Expected this element to be visible expected true but got false
 FAIL A <option popover> element should behave as a popover. assert_equals: After showPopover(), a popover should be visible: Expected this element to be visible expected true but got false
 FAIL A <option> element should *not* behave as a popover. assert_equals: A non-popover should start out visible: Expected this element to be visible expected true but got false
-FAIL A <output popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <output popover> element should behave as a popover.
 FAIL A <output> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <p popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <p popover> element should behave as a popover.
 FAIL A <p> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <pre popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <pre popover> element should behave as a popover.
 FAIL A <pre> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <progress popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <progress popover> element should behave as a popover.
 FAIL A <progress> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <q popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <q popover> element should behave as a popover.
 FAIL A <q> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <rt popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <rt popover> element should behave as a popover.
 FAIL A <rt> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <ruby popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <ruby popover> element should behave as a popover.
 FAIL A <ruby> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <s popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <s popover> element should behave as a popover.
 FAIL A <s> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <samp popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <samp popover> element should behave as a popover.
 FAIL A <samp> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <section popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <section popover> element should behave as a popover.
 FAIL A <section> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <select popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <select popover> element should behave as a popover.
 FAIL A <select> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <small popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <small popover> element should behave as a popover.
 FAIL A <small> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <source popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <source popover> element should behave as a popover.
 FAIL A <source> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <span popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <span popover> element should behave as a popover.
 FAIL A <span> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <strong popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <strong popover> element should behave as a popover.
 FAIL A <strong> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <sub popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <sub popover> element should behave as a popover.
 FAIL A <sub> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <sup popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <sup popover> element should behave as a popover.
 FAIL A <sup> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <summary popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <summary popover> element should behave as a popover.
 FAIL A <summary> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <table popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <table popover> element should behave as a popover.
 FAIL A <table> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <tbody popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <tbody popover> element should behave as a popover.
 FAIL A <tbody> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <td popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <td popover> element should behave as a popover.
 FAIL A <td> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <textarea popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <textarea popover> element should behave as a popover.
 FAIL A <textarea> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <tfoot popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <tfoot popover> element should behave as a popover.
 FAIL A <tfoot> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <th popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <th popover> element should behave as a popover.
 FAIL A <th> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <thead popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <thead popover> element should behave as a popover.
 FAIL A <thead> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <time popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <time popover> element should behave as a popover.
 FAIL A <time> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <tr popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <tr popover> element should behave as a popover.
 FAIL A <tr> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <track popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <track popover> element should behave as a popover.
 FAIL A <track> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <u popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <u popover> element should behave as a popover.
 FAIL A <u> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <ul popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <ul popover> element should behave as a popover.
 FAIL A <ul> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <var popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <var popover> element should behave as a popover.
 FAIL A <var> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <video popover> element should behave as a popover. Element has unexpected visibility state
+PASS A <video popover> element should behave as a popover.
 FAIL A <video> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
 PASS IDL attribute reflection
-FAIL Popover attribute value should be case insensitive Element has unexpected visibility state
-FAIL Changing attribute values for popover should work Element has unexpected visibility state
+FAIL Popover attribute value should be case insensitive assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing attribute values for popover should work
 FAIL Changing attribute values should close open popovers assert_false: expected false got true
 PASS Removing a visible popover=auto element from the document should close the popover
 PASS A showing popover=auto does not match :modal

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1412,7 +1412,10 @@ ExceptionOr<void> HTMLElement::togglePopover(std::optional<bool> force)
     if (popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Showing && !force.value_or(false))
         return hidePopover();
 
-    return showPopover();
+    if (popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Hidden && force.value_or(true))
+        return showPopover();
+
+    return { };
 }
 
 void HTMLElement::popoverAttributeChanged(const AtomString& value)


### PR DESCRIPTION
#### ceff29ca59cd4e21c257ff93e282d27f00fd7eb0
<pre>
[popover] Fix togglePopover logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=253574">https://bugs.webkit.org/show_bug.cgi?id=253574</a>

Reviewed by Tim Nguyen.

Fix togglePopover logic for step 2 in the method steps [1].

[1] <a href="https://html.spec.whatwg.org/multipage/popover.html#dom-togglepopover">https://html.spec.whatwg.org/multipage/popover.html#dom-togglepopover</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::togglePopover):

Canonical link: <a href="https://commits.webkit.org/261386@main">https://commits.webkit.org/261386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65824604d925ec1bd08a6e092381f2c178c393a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3301 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11754 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117290 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/86 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45117 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Running layout-tests; Running upload-test-results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13156 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/84 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13655 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52067 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7927 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15630 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->