### PR TITLE
[UI-side compositing] css3/masking/clip-path-overflow-hidden-bounds.html fails

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.cpp
@@ -107,7 +107,6 @@ bool DisplayList::shouldDumpForFlags(OptionSet<AsTextFlag> flags, ItemHandle ite
 String DisplayList::asText(OptionSet<AsTextFlag> flags) const
 {
     TextStream stream(TextStream::LineMode::MultipleLine, TextStream::Formatting::SVGStyleRect);
-#if !LOG_DISABLED
     for (auto displayListItem : *this) {
         auto [item, itemSizeInBuffer] = displayListItem.value();
         if (!shouldDumpForFlags(flags, item))
@@ -116,9 +115,6 @@ String DisplayList::asText(OptionSet<AsTextFlag> flags) const
         TextStream::GroupScope group(stream);
         dumpItemHandle(stream, item, flags);
     }
-#else
-    UNUSED_PARAM(flags);
-#endif
     return stream.release();
 }
 
@@ -127,13 +123,11 @@ void DisplayList::dump(TextStream& ts) const
     TextStream::GroupScope group(ts);
     ts << "display list";
 
-#if !LOG_DISABLED
     for (auto displayListItem : *this) {
         auto [item, itemSizeInBuffer] = displayListItem.value();
         TextStream::GroupScope group(ts);
         dumpItemHandle(ts, item, { AsTextFlag::IncludePlatformOperations, AsTextFlag::IncludeResourceIdentifiers });
     }
-#endif
 
     ts.startGroup();
     ts << "size in bytes: " << sizeInBytes();

--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.h
@@ -66,7 +66,7 @@ public:
     WEBCORE_EXPORT bool isEmpty() const;
     WEBCORE_EXPORT size_t sizeInBytes() const;
 
-    String asText(OptionSet<AsTextFlag>) const;
+    WEBCORE_EXPORT String asText(OptionSet<AsTextFlag>) const;
 
     const ResourceHeap& resourceHeap() const { return m_resourceHeap; }
 
@@ -127,7 +127,7 @@ void DisplayList::append(Args&&... args)
     itemBuffer().append<T>(std::forward<Args>(args)...);
 }
 
-WTF::TextStream& operator<<(WTF::TextStream&, const DisplayList&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const DisplayList&);
 
 } // DisplayList
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp
@@ -38,6 +38,8 @@ DrawingContext::DrawingContext(const FloatSize& logicalSize, const AffineTransfo
 {
 }
 
+DrawingContext::~DrawingContext() = default;
+
 void DrawingContext::setTracksDisplayListReplay(bool tracksDisplayListReplay)
 {
     m_tracksDisplayListReplay = tracksDisplayListReplay;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.h
@@ -38,6 +38,7 @@ class DrawingContext {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT DrawingContext(const FloatSize& logicalSize, const AffineTransform& initialCTM = { }, const DestinationColorSpace& = DestinationColorSpace::SRGB());
+    WEBCORE_EXPORT ~DrawingContext();
 
     GraphicsContext& context() const { return const_cast<DrawingContext&>(*this).m_context; }
     RecorderImpl& recorder() { return m_context; };

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -450,8 +450,6 @@ void ApplyDeviceScaleFactor::apply(GraphicsContext& context) const
 {
     context.applyDeviceScaleFactor(m_scaleFactor);
 }
-
-#if !LOG_DISABLED
 TextStream& operator<<(TextStream& ts, ItemType type)
 {
     switch (type) {
@@ -1073,7 +1071,6 @@ void dumpItemHandle(TextStream& ts, const ItemHandle& item, OptionSet<AsTextFlag
         break;
     }
 }
-#endif
 
 } // namespace DisplayList
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -1460,7 +1460,6 @@ using DisplayListItem = std::variant
 size_t paddedSizeOfTypeAndItemInBytes(const DisplayListItem&);
 ItemType displayListItemType(const DisplayListItem&);
 
-#if !LOG_DISABLED
 WEBCORE_EXPORT void dumpItem(TextStream&, const Translate&, OptionSet<AsTextFlag>);
 WEBCORE_EXPORT void dumpItem(TextStream&, const Rotate&, OptionSet<AsTextFlag>);
 WEBCORE_EXPORT void dumpItem(TextStream&, const Scale&, OptionSet<AsTextFlag>);
@@ -1539,8 +1538,6 @@ inline TextStream& operator<<(TextStream& ts, const ItemHandle& itemHandle)
 }
 
 TextStream& operator<<(TextStream&, ItemType);
-
-#endif
 
 } // namespace DisplayList
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -61,6 +61,12 @@ Recorder::~Recorder()
     ASSERT(m_stateStack.size() == 1); // If this fires, it indicates mismatched save/restore.
 }
 
+void Recorder::commitRecording()
+{
+    // Fixup the possible pending state.
+    appendStateChangeItemIfNecessary();
+}
+
 void Recorder::appendStateChangeItem(const GraphicsContextState& state)
 {
     ASSERT(state.changes());
@@ -265,6 +271,7 @@ void Recorder::drawPattern(ImageBuffer& imageBuffer, const FloatRect& destRect, 
 
 void Recorder::save()
 {
+    appendStateChangeItemIfNecessary();
     GraphicsContext::save();
     recordSave();
     m_stateStack.append(m_stateStack.last());
@@ -272,6 +279,7 @@ void Recorder::save()
 
 void Recorder::restore()
 {
+    appendStateChangeItemIfNecessary();
     GraphicsContext::restore();
 
     if (!m_stateStack.size())

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -64,6 +64,9 @@ public:
     virtual void convertToLuminanceMask() = 0;
     virtual void transformToColorSpace(const DestinationColorSpace&) = 0;
 
+    // Records possible pending commands. Should be used when recording is known to end.
+    WEBCORE_EXPORT void commitRecording();
+
 protected:
     virtual void recordSave() = 0;
     virtual void recordRestore() = 0;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 		7BA3936C271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */; };
 		7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */; };
 		7BB8BDE428F0781A00129836 /* CompletionHandlerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB8BDDC28F0781A00129836 /* CompletionHandlerTests.cpp */; };
+		7BC8628F29B8B33500217CB5 /* DisplayListRecorderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BC8628729B8B33500217CB5 /* DisplayListRecorderTests.cpp */; };
 		7BE876032919457B00B15289 /* AudioStreamDescriptionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BE875FB2919457B00B15289 /* AudioStreamDescriptionCocoa.mm */; };
 		7BF5017828E55F7A0008BB16 /* StackTraceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */; };
 		7C3965061CDD74F90094DBB8 /* ColorTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C3965051CDD74F90094DBB8 /* ColorTests.cpp */; };
@@ -2776,6 +2777,7 @@
 		7BB754AF274E39A100D00EC1 /* WebCoreTestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCoreTestUtilities.h; sourceTree = "<group>"; };
 		7BB754B0274E39A100D00EC1 /* WebCoreTestUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebCoreTestUtilities.cpp; sourceTree = "<group>"; };
 		7BB8BDDC28F0781A00129836 /* CompletionHandlerTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompletionHandlerTests.cpp; sourceTree = "<group>"; };
+		7BC8628729B8B33500217CB5 /* DisplayListRecorderTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DisplayListRecorderTests.cpp; sourceTree = "<group>"; };
 		7BE875FB2919457B00B15289 /* AudioStreamDescriptionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioStreamDescriptionCocoa.mm; sourceTree = "<group>"; };
 		7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackTraceTest.cpp; sourceTree = "<group>"; };
 		7C1AF7931E8DCBAB002645B9 /* PrepareForMoveToWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PrepareForMoveToWindow.mm; sourceTree = "<group>"; };
@@ -4229,6 +4231,7 @@
 				260BA5781B1D2E7B004FA07C /* DFACombiner.cpp */,
 				260BA57A1B1D2EE2004FA07C /* DFAHelpers.h */,
 				26F6E1EF1ADC749B00DE696B /* DFAMinimizer.cpp */,
+				7BC8628729B8B33500217CB5 /* DisplayListRecorderTests.cpp */,
 				F4094CC625545BD5003D73E3 /* DisplayListTests.cpp */,
 				93915A1624DB66C70019FF43 /* DocumentOrder.cpp */,
 				579651E6216BFD53006EBFE5 /* FidoHidMessageTest.cpp */,
@@ -6272,6 +6275,7 @@
 				AD57AC211DA7465B00FF1BDE /* DidRemoveFrameFromHiearchyInPageCache.cpp in Sources */,
 				F4D5D69525AF8BE400205280 /* DisableAutomaticSpellingCorrection.mm in Sources */,
 				FEC2A85424CE975F00ADBC35 /* DisallowVMEntry.cpp in Sources */,
+				7BC8628F29B8B33500217CB5 /* DisplayListRecorderTests.cpp in Sources */,
 				F4094CC725545BD5003D73E3 /* DisplayListTests.cpp in Sources */,
 				F457275E25578D06007ACA34 /* DisplayListTestsCG.cpp in Sources */,
 				93915A1724DB66C70019FF43 /* DocumentOrder.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include <WebCore/DestinationColorSpace.h>
+#include <WebCore/DisplayListDrawingContext.h>
+#include <WebCore/GraphicsContext.h>
+#include <WebCore/ImageBuffer.h>
+#include <WebCore/InMemoryDisplayList.h>
+#include <wtf/StdLibExtras.h>
+
+#if PLATFORM(COCOA)
+#include <WebCore/GraphicsContextCG.h>
+#endif
+
+namespace TestWebKitAPI {
+
+constexpr unsigned testContextWidth = 77;
+constexpr unsigned testContextHeight = 88;
+
+static RefPtr<WebCore::ImageBuffer> createReferenceTarget()
+{
+    auto colorSpace = WebCore::DestinationColorSpace::SRGB();
+    auto pixelFormat = WebCore::PixelFormat::BGRA8;
+    WebCore::FloatSize logicalSize { testContextWidth, testContextHeight };
+    float scale = 1;
+    return WebCore::ImageBuffer::create(logicalSize, WebCore::RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+}
+
+namespace {
+
+class TestDrawingContext : public WebCore::DisplayList::DrawingContext {
+public:
+    TestDrawingContext(WebCore::FloatSize logicalSize)
+        : WebCore::DisplayList::DrawingContext { logicalSize }
+        , m_writingClient { makeUnique<WebCore::DisplayList::InMemoryDisplayList::WritingClient>() }
+        , m_readingClient { makeUnique<WebCore::DisplayList::InMemoryDisplayList::ReadingClient>() }
+    {
+        displayList().setItemBufferWritingClient(m_writingClient.get());
+        displayList().setItemBufferReadingClient(m_readingClient.get());
+    }
+
+private:
+    std::unique_ptr<WebCore::DisplayList::InMemoryDisplayList::WritingClient> m_writingClient;
+    std::unique_ptr<WebCore::DisplayList::InMemoryDisplayList::ReadingClient> m_readingClient;
+};
+
+}
+
+static std::unique_ptr<TestDrawingContext> createDisplayListTarget()
+{
+    return makeUnique<TestDrawingContext>(WebCore::FloatSize { testContextWidth, testContextHeight });
+}
+
+// Function that applies same functor to two contexts. BifurbicatedGraphicsContext seems to have missing features.
+template<typename F>
+void forBoth(WebCore::GraphicsContext& a, WebCore::GraphicsContext& b, F&& func)
+{
+    func(a);
+    func(b);
+}
+
+#define FOR_EVERY_GRAPHICS_CONTEXT_STATE(MACRO) \
+    MACRO(fillBrush) \
+    MACRO(fillRule) \
+    MACRO(strokeBrush) \
+    MACRO(strokeThickness) \
+    MACRO(strokeStyle) \
+    MACRO(dropShadow) \
+    MACRO(style) \
+    MACRO(compositeMode) \
+    MACRO(alpha) \
+    MACRO(textDrawingMode) \
+    MACRO(imageInterpolationQuality) \
+    MACRO(shouldAntialias) \
+    MACRO(shouldSmoothFonts) \
+    MACRO(shouldSubpixelQuantizeFonts) \
+    MACRO(shadowsIgnoreTransforms) \
+    MACRO(drawLuminanceMask) \
+    MACRO(clipBounds) \
+    MACRO(isInTransparencyLayer) \
+    MACRO(scaleFactor)
+
+// FIXME: Currently using ImageBuffer, which applies custom CTM over the default.
+//        MACRO(getCTM)
+// FIXME: Move away from FOR_ macro because it doesn't survive ifdefs
+//        MACRO(useDarkAppearance)
+
+static testing::AssertionResult checkEqualState(WebCore::GraphicsContext& a, WebCore::GraphicsContext& b)
+{
+#define CHECK_STATE(STATE) \
+    if (a.STATE() != b.STATE()) \
+        return testing::AssertionFailure() << "State " #STATE " does not match.";
+    FOR_EVERY_GRAPHICS_CONTEXT_STATE(CHECK_STATE);
+#undef CHECK_STATE
+    return testing::AssertionSuccess();
+}
+
+namespace {
+
+template<typename Operation>
+class DisplayListRecorderResultStateTest : public testing::Test {
+protected:
+    Operation operation() { return Operation { }; }
+    String operationDescription() { return Operation::description(); }
+};
+
+struct NoCommands {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+    }
+
+    static String description()
+    {
+        return ""_s;
+    }
+};
+
+struct ChangeAntialias {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setShouldAntialias(false);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [should-antialias])
+  (should-antialias 0)))DL"_s;            
+    }
+};
+
+struct ChangeAntialiasBeforeSave {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setShouldAntialias(false);
+        c.save(); // This is being tested. The previous antialias == false should be restored on matching restore().
+        c.fillRect({ 0, 0, 5.5f, 5.7f });
+        c.restore();
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [should-antialias])
+  (should-antialias 0))
+(save)
+(fill-rect
+  (rect at (0,0) size 5.50x5.70))
+(restore))DL"_s;
+    }
+};
+
+struct ChangeAntialiasBeforeAndAfterSave {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setShouldAntialias(false);
+        c.save(); // This is being tested. The previous antialias == false should be restored on matching restore().
+        c.setShouldAntialias(true);
+        c.fillRect({ 0, 0, 5.5f, 5.7f });
+        c.restore();
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [should-antialias])
+  (should-antialias 0))
+(save)
+(set-state
+  (change-flags [should-antialias])
+  (should-antialias 1))
+(fill-rect
+  (rect at (0,0) size 5.50x5.70))
+(restore))DL"_s;
+    }
+};
+
+struct ChangeAntialiasInEmptySaveRestore {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.save();
+        c.setShouldAntialias(false);
+        c.restore(); // This is being tested. The previous antialias == false should be restored on restore().
+    }
+
+    static String description()
+    {
+        return R"DL(
+(save)
+(set-state
+  (change-flags [should-antialias])
+  (should-antialias 0))
+(restore))DL"_s;
+    }
+};
+
+using AllOperations = testing::Types<NoCommands, ChangeAntialias, ChangeAntialiasBeforeSave, ChangeAntialiasBeforeAndAfterSave, ChangeAntialiasInEmptySaveRestore>;
+
+}
+
+TYPED_TEST_SUITE_P(DisplayListRecorderResultStateTest);
+
+TYPED_TEST_P(DisplayListRecorderResultStateTest, StateThroughDisplayListIsPreserved)
+{
+    auto refTarget = createReferenceTarget();
+    auto& ref = refTarget->context();
+    auto testedTarget = createDisplayListTarget();
+    auto& tested = testedTarget->recorder();
+    EXPECT_TRUE(checkEqualState(ref, tested));
+
+    forBoth(ref, tested, this->operation());
+
+    EXPECT_TRUE(checkEqualState(ref, tested));
+
+    tested.commitRecording();
+
+    auto resultTarget = createReferenceTarget();
+    auto& result = resultTarget->context();
+
+    auto description = testedTarget->displayList().asText({ WebCore::DisplayList::AsTextFlag::IncludePlatformOperations }).stripWhiteSpace();
+    auto expectedDescription = this->operationDescription().stripWhiteSpace();
+    EXPECT_EQ(expectedDescription, description);
+
+    testedTarget->replayDisplayList(result);
+    EXPECT_TRUE(checkEqualState(ref, result));
+
+    // Unwind the stack in case the test-case tested state middle of the save/restore pair.
+    // FIXME: It should be ok to destroy GraphicsContext in the middle of save / restore.
+    while (ref.stackSize()) {
+        forBoth(ref, tested, [](WebCore::GraphicsContext& c) {
+            c.restore();
+        });
+    }
+    while (result.stackSize())
+        result.restore();
+}
+
+REGISTER_TYPED_TEST_SUITE_P(DisplayListRecorderResultStateTest, StateThroughDisplayListIsPreserved);
+
+INSTANTIATE_TYPED_TEST_SUITE_P(DisplayListRecorderTest, DisplayListRecorderResultStateTest, AllOperations);
+
+}


### PR DESCRIPTION
#### 0ccc458e846190c097901782265d11d9631c234a
<pre>
[UI-side compositing] css3/masking/clip-path-overflow-hidden-bounds.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=253575">https://bugs.webkit.org/show_bug.cgi?id=253575</a>
rdar://106115074

Reviewed by Said Abou-Hallawa.

Display list recorder would batch state changes and only emit a state
change item when a draw would need.  This algorithm would hoist state
changes made outside of save/restore blocks to be applied inside:
  ASSERT_TRUE(c.shouldAntialias());
  c.setShouldAntialias(false);
  c.save();
  c.fillRect({..});
  c.restore();

Would become:
  c.save();
  c.setShouldAntialias(false);
  c.fillRect({..});
  c.restore();

For tests like clip-path-overflow-hidden-bounds.html this would fail
on GPUP DOM rendering with layout tests.
The tests would not fail interactively.
This is because the browsers run with device scale &gt; 1, and layout test
runner tests with device scale == 1.
The most noticeable errors due to state change problems were the antialias
toggles. Clipping, for example, toggles these when the device scale == 1
but not otherwise.

* Source/WebCore/platform/graphics/displaylists/DisplayList.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp:
* Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::commitRecording):
(WebCore::DisplayList::Recorder::save):
(WebCore::DisplayList::Recorder::restore):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp: Added.
(TestWebKitAPI::createReferenceTarget):
(TestWebKitAPI::createDisplayListTarget):
(TestWebKitAPI::forBoth):
(TestWebKitAPI::checkEqualState):
(TestWebKitAPI::TYPED_TEST_P):

Canonical link: <a href="https://commits.webkit.org/261451@main">https://commits.webkit.org/261451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a66b7b6a1d114e0f8ddec06bd23b45b59cd321c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111663 "29 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120400 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11879 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117429 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104615 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45387 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13278 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/176 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9622 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52174 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7971 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15758 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->