### PR TITLE
Regression(258149@main) 1Password autofill is broken on nytimes.com

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -160,6 +160,35 @@ TEST(SiteIsolation, LoadingCallbacksAndPostMessage)
     Util::run(&done);
 }
 
+TEST(SiteIsolation, QueryFramesStateAfterNavigating)
+{
+    HTTPServer server({
+        { "/page1.html"_s, { "<iframe src='subframe1.html'></iframe><iframe src='subframe2.html'></iframe><iframe src='subframe3.html'></iframe>"_s } },
+        { "/page2.html"_s, { "<iframe src='subframe4.html'></iframe>"_s } },
+        { "/subframe1.html"_s, { "SubFrame1"_s } },
+        { "/subframe2.html"_s, { "SubFrame2"_s } },
+        { "/subframe3.html"_s, { "SubFrame3"_s } },
+        { "/subframe4.html"_s, { "SubFrame4"_s } }
+    }, HTTPServer::Protocol::Http);
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero]);
+    [webView synchronouslyLoadRequest:server.request("/page1.html"_s)];
+    __block bool done = false;
+    [webView _frames:^(_WKFrameTreeNode *mainFrame) {
+        EXPECT_EQ(mainFrame.childFrames.count, 3U);
+        done = true;
+    }];
+    Util::run(&done);
+
+    [webView synchronouslyLoadRequest:server.request("/page2.html"_s)];
+    done = false;
+    [webView _frames:^(_WKFrameTreeNode *mainFrame) {
+        EXPECT_EQ(mainFrame.childFrames.count, 1U);
+        done = true;
+    }];
+    Util::run(&done);
+}
+
 TEST(SiteIsolation, NavigatingCrossOriginIframeToSameOrigin)
 {
     HTTPServer server({


### PR DESCRIPTION
#### e3cbd8226eccb0d445356822f24de7b62db26ee9
<pre>
Regression(258149@main) 1Password autofill is broken on nytimes.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=253576">https://bugs.webkit.org/show_bug.cgi?id=253576</a>
rdar://106316283

Reviewed by Timothy Hatcher.

Before 258149@main, the [WKWebView _frames:completionHander:] SPI was relying
on the WebProcess&apos;s FrameTree to return the state of the frames as a tree.
However, after the refactoring in 258149@main, we do the tree traversal on
the UIProcess side and IPC each frame independently. To do this traversal,
we rely on WebFrameProxy::m_childFrames.

However, we have a bug where WebFrameProxy::m_childFrames could contain
subframes from previous pages that were previously visited in this view.
The reason for this is that the main frame (and thus the main WebFrameProxy)
gets reused on navigation. However, WebFrameProxy::m_childFrames is not getting
cleared whenever the frame navigates.

I initially tried to clear m_childFrames when a load gets committed in the
frame. However, this introduced crashes when restoring a back/forward cache
entry. The reason for this is that we currently don&apos;t notify the UIProcess
when restoring frames from the back/forward cache. As a result, m_childFrames
would not correctly get re-populated after restoring a back/forward cache
entry and it would lead to issues later on.

To make the fix as minimal and as safe as possible for the branch, I am opting
to update WebFrameProxy::getFrameInfo() to filter out frameData for frames
whose parentFrameID doesn&apos;t match the current frame&apos;s ID. This makes sure
that we only report about iframes that are currently in the frame tree, just
like we used to before 258149@main.

In a follow-up, we should refactor this to make sure that m_childFrames is
an accurate and current representation of the frame tree, since we&apos;re going
to rely on it more and more for site isolation.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didCommitLoad):
(WebKit::WebFrameProxy::didFailLoad):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/261429@main">https://commits.webkit.org/261429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b72503b5017ad498b2b1ad337713af5ad492f1bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11876 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117426 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45371 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13275 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/170 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13765 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52168 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/7952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15755 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4339 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->