### PR TITLE
[macOS] Adjust default grammar checking policy

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
@@ -41,6 +41,8 @@ extern NSString *NSTextCheckingSuppressInitialCapitalizationKey;
 - (BOOL)deletesAutospaceBeforeString:(NSString *)string language:(NSString *)language;
 - (void)_preflightChosenSpellServer;
 
++ (BOOL)grammarCheckingEnabled;
+
 @end
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
+++ b/Source/WebKit/UIProcess/mac/TextCheckerMac.mm
@@ -84,12 +84,23 @@ static bool shouldAutomaticDashSubstitutionBeEnabled()
     return [defaults boolForKey:WebAutomaticDashSubstitutionEnabled];
 }
 
+static bool shouldGrammarCheckingBeEnabled()
+{
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+#if USE(NSSPELLCHECKER_GRAMMAR_CHECKING_POLICY)
+    if (![defaults objectForKey:WebGrammarCheckingEnabled])
+        return [NSSpellChecker grammarCheckingEnabled];
+#endif
+
+    return [defaults boolForKey:WebGrammarCheckingEnabled];
+}
+
 static TextCheckerState& mutableState()
 {
     static NeverDestroyed state = [] {
         TextCheckerState initialState;
         initialState.isContinuousSpellCheckingEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:WebContinuousSpellCheckingEnabled] && TextChecker::isContinuousSpellCheckingAllowed();
-        initialState.isGrammarCheckingEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:WebGrammarCheckingEnabled];
+        initialState.isGrammarCheckingEnabled = shouldGrammarCheckingBeEnabled();
         initialState.isAutomaticTextReplacementEnabled = shouldAutomaticTextReplacementBeEnabled();
         initialState.isAutomaticSpellingCorrectionEnabled = shouldAutomaticSpellingCorrectionBeEnabled();
         initialState.isAutomaticQuoteSubstitutionEnabled = shouldAutomaticQuoteSubstitutionBeEnabled();

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -5057,7 +5057,7 @@ IGNORE_WARNINGS_END
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     continuousSpellCheckingEnabled = [defaults boolForKey:WebContinuousSpellCheckingEnabled];
-    grammarCheckingEnabled = [defaults boolForKey:WebGrammarCheckingEnabled];
+    grammarCheckingEnabled = [self _shouldGrammarCheckingBeEnabled];
 
     automaticQuoteSubstitutionEnabled = [self _shouldAutomaticQuoteSubstitutionBeEnabled];
     automaticLinkDetectionEnabled = [defaults boolForKey:WebAutomaticLinkDetectionEnabled];
@@ -5133,6 +5133,16 @@ IGNORE_WARNINGS_END
 {
     automaticDashSubstitutionEnabled = [self _shouldAutomaticDashSubstitutionBeEnabled];
     [[NSSpellChecker sharedSpellChecker] updatePanels];
+}
+
++ (BOOL)_shouldGrammarCheckingBeEnabled
+{
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+#if USE(NSSPELLCHECKER_GRAMMAR_CHECKING_POLICY)
+    if (![defaults objectForKey:WebGrammarCheckingEnabled])
+        return [NSSpellChecker grammarCheckingEnabled];
+#endif
+    return [defaults boolForKey:WebGrammarCheckingEnabled];
 }
 
 + (void)_applicationWillTerminate


### PR DESCRIPTION
#### a33c27806ef78c6bcea0f9c269566730495284f0
<pre>
[macOS] Adjust default grammar checking policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=253581">https://bugs.webkit.org/show_bug.cgi?id=253581</a>
rdar://105739691

Reviewed by Wenson Hsieh.

Update the default grammar checking policy to depend on `NSSpellChecker`.

* Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h:
* Source/WebKit/UIProcess/mac/TextCheckerMac.mm:
(WebKit::shouldGrammarCheckingBeEnabled):
(WebKit::mutableState):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(+[WebView initialize]):
(+[WebView _shouldGrammarCheckingBeEnabled]):

Canonical link: <a href="https://commits.webkit.org/261388@main">https://commits.webkit.org/261388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89201b08f68cf1840bbaf0c5c9d58028666f9336

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3299 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11752 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/2832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117287 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/85 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45105 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13154 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/83 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13653 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52066 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15628 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4325 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->