### PR TITLE
[UI-side compositing] Fix dynamicDowncast in RemoteScrollingTreeMac::handleWheelEventPhase

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -57,8 +57,9 @@ RemoteScrollingTreeMac::~RemoteScrollingTreeMac() = default;
 
 void RemoteScrollingTreeMac::handleWheelEventPhase(ScrollingNodeID nodeID, PlatformWheelEventPhase phase)
 {
-    RefPtr targetNode = nodeForID(nodeID);
-    dynamicDowncast<ScrollingTreeScrollingNode>(*targetNode)->handleWheelEventPhase(phase);
+    auto* targetNode = nodeForID(nodeID);
+    if (auto* node = dynamicDowncast<ScrollingTreeScrollingNode>(targetNode))
+        node->handleWheelEventPhase(phase);
 }
 
 void RemoteScrollingTreeMac::displayDidRefresh(PlatformDisplayID)


### PR DESCRIPTION
#### bf3c4d5c6bec139ce26eead37cd85343379130d0
<pre>
[UI-side compositing] Fix dynamicDowncast in RemoteScrollingTreeMac::handleWheelEventPhase
<a href="https://bugs.webkit.org/show_bug.cgi?id=253583">https://bugs.webkit.org/show_bug.cgi?id=253583</a>
rdar://106420122

Reviewed by Simon Fraser.

Fix dynamicDowncast in RemoteScrollingTreeMac::handleWheelEventPhase.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::handleWheelEventPhase):

Canonical link: <a href="https://commits.webkit.org/261452@main">https://commits.webkit.org/261452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c03a67d31d72e0f2fe3b543e1d77eddb65a0f756

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120356 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3211 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104507 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45283 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13226 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/133 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9577 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52123 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15704 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4346 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->