### PR TITLE
Clobber first two argument GPRs across OMG loop tier-up check in BBQ JIT

### DIFF
--- a/JSTests/wasm/stress/live-funcref-across-loop-tier-up.js
+++ b/JSTests/wasm/stress/live-funcref-across-loop-tier-up.js
@@ -1,0 +1,33 @@
+//@ requireOptions("--thresholdForOMGOptimizeAfterWarmUp=0")
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (type $0 (func (param funcref)))
+    (import "jsModule" "foo" (func $1 (type $0)))
+    (func (export "bar") (local i32)
+        ref.func $1
+        loop (param funcref)
+            try (param funcref)
+                call 0
+            end
+        end
+    )
+    (elem declare func $1)
+)
+`
+
+function foo(f) {
+    f?.x;
+}
+
+async function test() {
+    let jsModule = { foo };
+    const instance = await instantiate(wat, { jsModule }, { exceptions: true });
+    const { bar } = instance.exports;
+    for (let i = 0; i < 10000; i ++)
+        bar();
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -6208,6 +6208,9 @@ public:
         m_tierUp->outerLoops().append(outerLoops);
         m_outerLoops.append(loopIndex);
 
+        clobber(GPRInfo::argumentGPR0);
+        clobber(GPRInfo::argumentGPR1);
+
         m_jit.move(TrustedImm64(bitwise_cast<uintptr_t>(&m_tierUp->m_counter)), m_scratchGPR);
 
         TierUpCount::TriggerReason* forceEntryTrigger = &(m_tierUp->osrEntryTriggers().last());


### PR DESCRIPTION
#### 73c4a75b5bf16db40a4600874ccb0588591b8819
<pre>
Clobber first two argument GPRs across OMG loop tier-up check in BBQ JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=253584">https://bugs.webkit.org/show_bug.cgi?id=253584</a>
rdar://106360294

Reviewed by Justin Michaud and Yusuke Suzuki.

Our current BBQ JIT implementation only clobbers argumentGPR0 and argumentGPR1
across the entry tier-up check, not loop tier-up checks. This patch adds this
clobbering to loop tier-up checks as well, preventing values in these registers
from being overwritten when we return from the tier-up operation.

* JSTests/wasm/stress/live-funcref-across-loop-tier-up.js: Added.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitLoopTierUpCheck):

Canonical link: <a href="https://commits.webkit.org/261435@main">https://commits.webkit.org/261435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46aa8a28b5eca7df52ed2f83011ce7e48e4dc925

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3306 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120304 "Built successfully") 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22031 "Build is in progress. Recent messages:OS: Monterey (12.6), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Uploaded built product") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/2914 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/79 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45113 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100051 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13162 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/77 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86928 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11278 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9532 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101252 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52060 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31518 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7958 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15636 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109291 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26921 "Passed tests") | 
<!--EWS-Status-Bubble-End-->