### PR TITLE
REGRESSION(260692@main) 14 Test262 tests fail after this this change

### DIFF
--- a/JSTests/stress/regexp-duplicate-named-captures.js
+++ b/JSTests/stress/regexp-duplicate-named-captures.js
@@ -124,14 +124,11 @@ function testRegExp(re, str, exp, groups)
 {
     testNumber++;
 
-    if (groups)
-        exp.groups = groups;
-
     let actual = re.exec(str);
     let result = compareArray(exp, actual);;
 
-    if (exp.groups) {
-        if (!compareGroups(exp.groups, actual.groups))
+    if (exp) {
+        if (groups && !compareGroups(groups, actual.groups))
             result = false;
     }
 
@@ -186,4 +183,12 @@ testRegExpSyntaxError("(?<A>123)(?:(?<A>456)|(?<A>789))", "", "SyntaxError: Inva
 
 // Test 21
 testRegExpSyntaxError("(?<=\\k<a>a)x", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+testRegExp(/(?<b>.).\k<b>/u, "bab", ["bab", "b"]);
+testRegExp(/(?<b>.).\k<b>/u, "baa", null, null);
+testRegExp(/(?<a>\k<a>\w)../u, "bab", ["bab", "b"], { a: "b" });
+testRegExp(/(?:(?<x>a)|(?<y>a)(?<x>b))(?:(?<z>c)|(?<z>d))/, "abc", ["abc", undefined, "a", "b", "c", undefined], { x: "b", y: "a", z: "c" });
 
+// Test 26
+testRegExp(/(?<=(?:\1|b)(aa))./, "aaaax", ["x", "aa"]);
+testRegExp(/(?<=(?:\2|b)(?<=\1(a))(aa))./, "aaaax", ["x", "a", "aa"]);
+testRegExp(/(?<=((?:\3|b))(?<=\2(a))(aa))./, "aaaax", ["x", "aa", "a", "aa"]);

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -163,11 +163,11 @@ void RegExp::finishCreation(VM& vm)
     }
 
     m_numSubpatterns = pattern.m_numSubpatterns;
-    if (!pattern.m_captureGroupNames.isEmpty() || !pattern.m_namedGroupToParenIndeces.isEmpty()) {
+    if (!pattern.m_captureGroupNames.isEmpty() || !pattern.m_namedGroupToParenIndices.isEmpty()) {
         m_rareData = makeUnique<RareData>();
         m_rareData->m_numDuplicateNamedCaptureGroups = pattern.m_numDuplicateNamedCaptureGroups;
         m_rareData->m_captureGroupNames.swap(pattern.m_captureGroupNames);
-        m_rareData->m_namedGroupToParenIndeces.swap(pattern.m_namedGroupToParenIndeces);
+        m_rareData->m_namedGroupToParenIndices.swap(pattern.m_namedGroupToParenIndices);
     }
 }
 

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -122,8 +122,8 @@ public:
     {
         if (!m_rareData)
             return 0;
-        auto it = m_rareData->m_namedGroupToParenIndeces.find<StringViewHashTranslator>(groupName);
-        if (it == m_rareData->m_namedGroupToParenIndeces.end())
+        auto it = m_rareData->m_namedGroupToParenIndices.find<StringViewHashTranslator>(groupName);
+        if (it == m_rareData->m_namedGroupToParenIndices.end())
             return 0;
         if (it->value.size() == 1)
             return it->value[0];
@@ -208,7 +208,7 @@ private:
         // This first element of the RHS vector is the subpatternId in the non-duplicate case.
         // For the duplicate case, the first element is the namedCaptureGroupId.
         // The remaining elements are the subpatternIds for each of the duplicate groups.
-        HashMap<String, Vector<unsigned>> m_namedGroupToParenIndeces;
+        HashMap<String, Vector<unsigned>> m_namedGroupToParenIndices;
     };
 
     String m_patternString;

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -522,7 +522,6 @@ struct YarrPattern {
     void resetForReparsing()
     {
         m_numSubpatterns = 0;
-        m_numNamedSubpatterns = 0;
         m_initialStartValueFrameLocation = 0;
         m_numDuplicateNamedCaptureGroups = 0;
 
@@ -531,6 +530,7 @@ struct YarrPattern {
         m_containsLookbehinds = false;
         m_containsUnsignedLengthPattern = false;
         m_hasCopiedParenSubexpressions = false;
+        m_hasNamedCaptureGroups = false;
         m_saveInitialStartValue = false;
 
         anycharCached = nullptr;
@@ -548,7 +548,7 @@ struct YarrPattern {
         m_disjunctions.clear();
         m_userCharacterClasses.clear();
         m_captureGroupNames.clear();
-        m_namedGroupToParenIndeces.clear();
+        m_namedGroupToParenIndices.clear();
         m_duplicateNamedGroupForSubpatternId.clear();
     }
 
@@ -701,19 +701,23 @@ struct YarrPattern {
     bool m_containsLookbehinds : 1;
     bool m_containsUnsignedLengthPattern : 1;
     bool m_hasCopiedParenSubexpressions : 1;
+    bool m_hasNamedCaptureGroups : 1;
     bool m_saveInitialStartValue : 1;
     OptionSet<Flags> m_flags;
     unsigned m_numSubpatterns { 0 };
-    unsigned m_numNamedSubpatterns { 0 };
     unsigned m_initialStartValueFrameLocation { 0 };
     unsigned m_numDuplicateNamedCaptureGroups { 0 };
     PatternDisjunction* m_body;
     Vector<std::unique_ptr<PatternDisjunction>, 4> m_disjunctions;
     Vector<std::unique_ptr<CharacterClass>> m_userCharacterClasses;
     Vector<String> m_captureGroupNames;
-    // The first vector entry of m_namedGroupToParenIndeces is the namedSubpatternId.
-    // Subsequent vector entries are the subpatternId(s) when the name is used.
-    HashMap<String, Vector<unsigned>> m_namedGroupToParenIndeces;
+    // The contents of the RHS Vector of m_namedGroupToParenIndices depends on whether the String is a
+    // duplicate named group or not.
+    // For a named group that is only used once in the pattern, the vector size is one and the only entry
+    // is the subpatterenId for a non-duplicate named group.
+    // For a duplicate named group, the size will be greater than 2. The first vector entry it is the
+    // duplicateNamedGroupId. Subsequent vector entries are the subpatternId's for that duplicateNamedGroupId.
+    HashMap<String, Vector<unsigned>> m_namedGroupToParenIndices;
     Vector<unsigned> m_duplicateNamedGroupForSubpatternId;
 
 private:


### PR DESCRIPTION
#### 6a323d41f6f0fd052e9daf911fc4b009ad8d1213
<pre>
REGRESSION(260692@main) 14 Test262 tests fail after this this change
<a href="https://bugs.webkit.org/show_bug.cgi?id=253573">https://bugs.webkit.org/show_bug.cgi?id=253573</a>
rdar://106430729

Reviewed by Ross Kirsling.

This fixes three issues introduced in 260692@main:
 1. Improper handling of non-duplicate named groups.  For the case where a non-duplicate
    group appears between two duplicate named groups, the non-duplicate group&apos;s match is
    accessed as a duplicate named group, by using it&apos;s subpatternId to index into the
    duplicate named group indirect area of the output vector.  This could exceed the range
    of the vector, but always provided the wrong result.  This was fixed by restructuring
    the capture group for name processing in both the renamed addCaptureGroupForName() and
    existing setupNamedCaptures().
 2. When parsing a named back reference where the references subpattern may not have been
    closed, we need to do the same analysis we find for numbered back references as found
    in atomBackReference.  That is searching for an unclosed capture parenthesis that
    contains the current back reference.
 3. We shouldn&apos;t try to convert forward references in a lookbehind when an alternative is
    complete as that is premature.  Waiting for the lookbehind assertion is sufficient.

Updated the regexp-duplicate-named-captures.js test, including the group equality checking.

Also renamed the variables *indeces* =&gt; *indices*.

* JSTests/stress/regexp-duplicate-named-captures.js:
(testRegExp):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::finishCreation):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::addCaptureGroupForName):
(JSC::Yarr::YarrPatternConstructor::tryConvertingForwardReferencesToBackreferences):
(JSC::Yarr::YarrPatternConstructor::atomParenthesesSubpatternBegin):
(JSC::Yarr::YarrPatternConstructor::atomNamedBackReference):
(JSC::Yarr::YarrPatternConstructor::disjunction):
(JSC::Yarr::YarrPatternConstructor::setupNamedCaptures):
(JSC::Yarr::YarrPattern::compile):
(JSC::Yarr::YarrPattern::YarrPattern):
(JSC::Yarr::YarrPatternConstructor::namedCaptureGroupIdForName): Deleted.
(JSC::Yarr::YarrPatternConstructor::setupDuplicateNamedCaptures): Deleted.
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::YarrPattern::resetForReparsing):

Canonical link: <a href="https://commits.webkit.org/261405@main">https://commits.webkit.org/261405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3164c4bf1254379d498b773e58b35706594ec3dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3396 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11857 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117407 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/104503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100141 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13257 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11381 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13747 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101362 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52155 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31529 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7942 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15737 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109401 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26932 "Passed tests") | 
<!--EWS-Status-Bubble-End-->