### PR TITLE
Add WKWebsiteDataStore API to create persistent store

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
@@ -83,6 +83,32 @@ WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
 /*! @abstract Returns the cookie store representing HTTP cookies in this website data store. */
 @property (nonatomic, readonly) WKHTTPCookieStore *httpCookieStore WK_API_AVAILABLE(macos(10.13), ios(11.0));
 
+/*! @abstract Get identifier for a data store.
+ @discussion Returns nil for default and non-persistent data store .
+ */
+@property (nonatomic, readonly, nullable) NSUUID *identifier WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/*! @abstract Get a persistent data store.
+ @param identifier An identifier that is used to uniquely identify the data store.
+ @discussion If a data store with this identifier does not exist yet, it will be created. Returns nil if identifier
+ is invalid.
+*/
++ (WKWebsiteDataStore *)dataStoreForIdentifier:(NSUUID *)identifier WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/*! @abstract Delete a persistent data store.
+ @param identifier An identifier that is used to uniquely identify the data store.
+ @param completionHandler A block to invoke with optional error when the operation completes.
+ @discussion This should be called when the data store is not used any more. Returns error if removal fails
+ to complete. WKWebView using the data store must be released before removal.
+*/
++ (void)removeDataStoreForIdentifier:(NSUUID *)identifier completionHandler:(void(^)(NSError *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/*! @abstract Fetch all data stores identifiers.
+ @param completionHandler A block to invoke with an array of identifiers when the operation completes.
+ @discussion Default or non-persistent data store do not have an identifier.
+*/
++ (void)fetchAllDataStoreIdentifiers:(void(^)(NSArray<NSUUID *> *))completionHandler WK_SWIFT_ASYNC_NAME(getter:allDataStoreIdentifiers()) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 #if __has_include(<Network/proxy_config_private.h>)
 /*! @abstract Sets the proxy configuration to be used for networking in all WKWebViews that use this WKWebsiteDataStore.
  @param proxyConfiguration The proxy configuration to use.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -350,6 +350,29 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     });
 }
 
+- (NSUUID *)identifier
+{
+    return [self _identifier];
+}
+
++ (WKWebsiteDataStore *)dataStoreForIdentifier:(NSUUID *)identifier
+{
+    if (!identifier)
+        return nil;
+
+    return wrapper(WebKit::WebsiteDataStore::dataStoreForIdentifier(UUID(identifier)));
+}
+
++ (void)removeDataStoreForIdentifier:(NSUUID *)identifier completionHandler:(void(^)(NSError *))completionHandler
+{
+    [self _removeDataStoreWithIdentifier:identifier completionHandler:completionHandler];
+}
+
++ (void)fetchAllDataStoreIdentifiers:(void(^)(NSArray<NSUUID *> *))completionHandler
+{
+    [self _fetchAllIdentifiers:completionHandler];
+}
+
 #if HAVE(NW_PROXY_CONFIG)
 - (void)setProxyConfiguration:(nw_proxy_config_t)proxyConfig
 {
@@ -423,7 +446,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 + (void)_removeDataStoreWithIdentifier:(NSUUID *)identifier completionHandler:(void(^)(NSError* error))completionHandler
 {
     if (!identifier)
-        [NSException raise:NSInvalidArgumentException format:@"Identifier cannot be nil"];
+        return completionHandler([NSError errorWithDomain:@"WKWebSiteDataStore" code:WKErrorUnknown userInfo:@{ NSLocalizedDescriptionKey:@"Identifier is nil" }]);
 
     auto completionHandlerCopy = makeBlockPtr(completionHandler);
     WebKit::WebsiteDataStore::removeDataStoreWithIdentifier(UUID(identifier), [completionHandlerCopy](const String& errorString) {

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -246,6 +246,20 @@ RefPtr<WebsiteDataStore> WebsiteDataStore::existingDataStoreForIdentifier(const 
     return nullptr;
 }
 
+#if PLATFORM(COCOA)
+Ref<WebsiteDataStore> WebsiteDataStore::dataStoreForIdentifier(const UUID& uuid)
+{
+    InitializeWebKit2();
+    for (auto* dataStore : allDataStores().values()) {
+        if (dataStore && dataStore->configuration().identifier() == uuid)
+            return Ref { *dataStore };
+    }
+
+    auto configuration = WebsiteDataStoreConfiguration::create(uuid);
+    return WebsiteDataStore::create(WTFMove(configuration), PAL::SessionID::generatePersistentSessionID());
+}
+#endif
+
 void WebsiteDataStore::registerWithSessionIDMap()
 {
     auto result = allDataStores().add(m_sessionID, this);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -125,6 +125,9 @@ public:
     
     static Ref<WebsiteDataStore> createNonPersistent();
     static Ref<WebsiteDataStore> create(Ref<WebsiteDataStoreConfiguration>&&, PAL::SessionID);
+#if PLATFORM(COCOA)
+    static Ref<WebsiteDataStore> dataStoreForIdentifier(const UUID&);
+#endif
 
     WebsiteDataStore(Ref<WebsiteDataStoreConfiguration>&&, PAL::SessionID);
     ~WebsiteDataStore();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -48,6 +48,7 @@ public:
     WebsiteDataStoreConfiguration(IsPersistent, ShouldInitializePaths = ShouldInitializePaths::Yes);
 
 #if PLATFORM(COCOA)
+    static Ref<WebsiteDataStoreConfiguration> create(const UUID& identifier) { return adoptRef(*new WebsiteDataStoreConfiguration(identifier)); }
     WebsiteDataStoreConfiguration(const UUID&);
 #endif
 


### PR DESCRIPTION
#### 74f1364427e0cd5a5bf3d6c866a0c19762cf14fd
<pre>
Add WKWebsiteDataStore API to create persistent store
<a href="https://bugs.webkit.org/show_bug.cgi?id=253590">https://bugs.webkit.org/show_bug.cgi?id=253590</a>
rdar://101314896

Reviewed by Geoffrey Garen.

Add API based on existing SPI.

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore identifier]):
(+[WKWebsiteDataStore dataStoreForIdentifier:]):
(+[WKWebsiteDataStore removeDataStoreForIdentifier:completionHandler:]):
(+[WKWebsiteDataStore fetchAllDataStoreIdentifiers:]):
(+[WKWebsiteDataStore _removeDataStoreWithIdentifier:completionHandler:]):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::dataStoreForIdentifier):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::create):

Canonical link: <a href="https://commits.webkit.org/261443@main">https://commits.webkit.org/261443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/884184a2907a849a1723940091593438907225ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/269 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120396 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11874 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3153 "layout-tests (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117424 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104608 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45376 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13273 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/169 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9619 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52167 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7965 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15753 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->