### PR TITLE
Fix result height when folding select in WasmBBQJIT

### DIFF
--- a/JSTests/wasm/stress/foldable-select.js
+++ b/JSTests/wasm/stress/foldable-select.js
@@ -1,0 +1,35 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "testZero") (result i32)
+        i32.const 1
+        i32.const 2
+        i32.const 0
+        select
+        global.get $x
+        i32.trunc_f32_s
+        i32.add
+    )
+    (func (export "testNonzero") (result i32)
+        i32.const 1
+        i32.const 2
+        i32.const 1
+        select
+        global.get $x
+        i32.trunc_f32_s
+        i32.add
+    )
+    (global $x f32 f32.const 42.0)
+)
+`;
+
+async function test() {
+  const instance = await instantiate(wat, {}, {});
+  const { testZero, testNonzero } = instance.exports;
+  assert.eq(testZero(), 44);
+  assert.eq(testNonzero(), 43);
+}
+
+assert.asyncTest(test());


### PR DESCRIPTION
#### c0310d30906b1c4f724f8074bbf1211e6a9cc1e7
<pre>
Fix result height when folding select in WasmBBQJIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=253592">https://bugs.webkit.org/show_bug.cgi?id=253592</a>
rdar://106420016

Reviewed by Michael Saboff and Yusuke Suzuki.

Currently, when BBQ JIT folds a select instruction, it naively selects
between the Value operands it was given based on the constant condition.
This can sometimes result in a resulting temp with an incorrect stack
height.

This patch changes select to consume all operands, not just the one we
didn&apos;t select, similar to the non-folded case. It also sets the result
to the right temp index, if applicable (we can still return a constant,
where the height of the value is irrelevant), and allocates it
independently. Finally, this patch also includes some semi-related
changes to the BBQ JIT move helpers, allowing them to be used to move
values between any two Locations, instead of the current implementation
which requires the source operand to be a Value.

* JSTests/wasm/stress/foldable-select.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addSelect):
(JSC::Wasm::BBQJIT::emitStore):
(JSC::Wasm::BBQJIT::emitMoveMemory):
(JSC::Wasm::BBQJIT::emitMoveRegister):
(JSC::Wasm::BBQJIT::emitLoad):
(JSC::Wasm::BBQJIT::emitMove):

Canonical link: <a href="https://commits.webkit.org/261461@main">https://commits.webkit.org/261461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7253ec23114c18876767547023205875b6d86b86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3318 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120316 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3077 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104747 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/94 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100063 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13176 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/92 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11292 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13672 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9540 "6 flakes 2 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101269 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52075 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31521 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7975 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15650 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109308 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26924 "Passed tests") | 
<!--EWS-Status-Bubble-End-->