### PR TITLE
Fix WPT default config JSON to support H2-only tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/config.default.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/config.default.json
@@ -4,6 +4,7 @@
  "external_host": null,
  "ports":{"http":[8000, "auto"],
           "https":[8443],
+          "h2":[9000],
           "ws":["auto"],
           "wss":["auto"]},
  "check_subdomains": true,


### PR DESCRIPTION
#### 5c6e9256fb25699d30e9e272216179411f087204
<pre>
Fix WPT default config JSON to support H2-only tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=253594">https://bugs.webkit.org/show_bug.cgi?id=253594</a>
rdar://106437906

Reviewed by NOBODY (OOPS!).

In 261079@main I added an `h2` key to `LayoutTests/imported/w3c/resources/config.json` but not to
`LayoutTests/imported/w3c/web-platform-tests/config.json`. This is causing some layout test builders
to fail when trying to read a nonexistent `h2` key.

* LayoutTests/imported/w3c/web-platform-tests/config.default.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c6e9256fb25699d30e9e272216179411f087204

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/162 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3321 "Build is in progress. Recent messages:") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22047 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/11778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/87/builds/3321 "Build is in progress. Recent messages:") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117318 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/95 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45116 "layout-tests (failure)") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100066 "Build is in progress. Recent messages:") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13179 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/93 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13675 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/11778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52076 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15653 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->