### PR TITLE
[popover] Use [CEReactions=NotNeeded] for PopoverInvokerElement

### DIFF
--- a/Source/WebCore/html/PopoverInvokerElement.idl
+++ b/Source/WebCore/html/PopoverInvokerElement.idl
@@ -25,6 +25,6 @@
 
 [EnabledBySetting=PopoverAttributeEnabled]
 interface mixin PopoverInvokerElement {
-    [CEReactions, Reflect=popovertarget] attribute Element? popoverTargetElement;
-    [CEReactions] attribute [AtomString] DOMString popoverTargetAction;
+    [CEReactions=NotNeeded, Reflect=popovertarget] attribute Element? popoverTargetElement;
+    [CEReactions=NotNeeded] attribute [AtomString] DOMString popoverTargetAction;
 };


### PR DESCRIPTION
#### 98fbd3e98a40b6d7bb309b4efd6ce9300c233527
<pre>
[popover] Use [CEReactions=NotNeeded] for PopoverInvokerElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=252218">https://bugs.webkit.org/show_bug.cgi?id=252218</a>
rdar://105704615

Reviewed by Ryosuke Niwa.

PopoverInvokerElement is only used by `&lt;button&gt;` and `&lt;input&gt;`, use [CEReactions=NotNeeded] since WebKit does not support customized built-in elements.

* Source/WebCore/html/PopoverInvokerElement.idl:

Canonical link: <a href="https://commits.webkit.org/261385@main">https://commits.webkit.org/261385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7485f70dfae5e51f7ecfb30bec8031bde07c2cae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20691 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22049 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/11779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117321 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45119 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13181 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/86927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11298 "Build is in progress. Recent messages:") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13677 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/11779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/110328 "Build is in progress. Recent messages:") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19122 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7926 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15656 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->