### PR TITLE
[git-webkit] Make remote security level explicit

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.14.4',
+    version='5.14.5',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 14, 4)
+version = Version(5, 14, 5)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -429,13 +429,13 @@ class Setup(Command):
         # Check and configure alternate remotes
         project_remotes = {}
         for config_arg, url in repository.config().items():
-            if not config_arg.startswith('webkitscmpy.remotes'):
+            if not config_arg.startswith('webkitscmpy.remotes') or not config_arg.endswith('url'):
                 continue
 
             for match in [repository.SSH_REMOTE.match(url), repository.HTTP_REMOTE.match(url)]:
                 if not match:
                     continue
-                project_remotes[config_arg.split('.')[-1]] = [
+                project_remotes[config_arg.split('.')[-2]] = [
                     'https://{}/{}.git'.format(match.group('host'), match.group('path')),
                     'http://{}/{}.git'.format(match.group('host'), match.group('path')),
                     'git@{}:{}.git'.format(match.group('host'), match.group('path')),

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -529,9 +529,12 @@ CommitDate: {time_c}
             project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
             os.mkdir(os.path.dirname(project_config))
             with open(project_config, 'w') as f:
-                f.write('[webkitscmpy "remotes"]\n')
-                f.write('    origin = git@github.example.com:WebKit/WebKit.git\n')
-                f.write('    security = git@github.example.com:WebKit/WebKit-security.git\n')
+                f.write('[webkitscmpy "remotes.origin"]\n')
+                f.write('    url = git@github.example.com:WebKit/WebKit.git\n')
+                f.write('    security-level = 0\n')
+                f.write('[webkitscmpy "remotes.security"]\n')
+                f.write('    url = git@github.example.com:WebKit/WebKit-security.git\n')
+                f.write('    security-level = 1\n')
 
             self.assertEqual(local.Git(self.path).source_remotes(), ['origin'])
 
@@ -545,9 +548,12 @@ CommitDate: {time_c}
             project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
             os.mkdir(os.path.dirname(project_config))
             with open(project_config, 'w') as f:
-                f.write('[webkitscmpy "remotes"]\n')
-                f.write('    origin = git@github.example.com:WebKit/WebKit.git\n')
-                f.write('    security = git@github.example.com:WebKit/WebKit-security.git\n')
+                f.write('[webkitscmpy "remotes.origin"]\n')
+                f.write('    url = git@github.example.com:WebKit/WebKit.git\n')
+                f.write('    security-level = 0\n')
+                f.write('[webkitscmpy "remotes.security"]\n')
+                f.write('    url = git@github.example.com:WebKit/WebKit-security.git\n')
+                f.write('    security-level = 1\n')
 
             self.assertEqual(local.Git(self.path).source_remotes(), ['origin', 'security'])
             self.assertEqual(

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/track_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/track_unittest.py
@@ -74,9 +74,12 @@ class TestTrack(testing.PathTestCase):
             project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
             os.mkdir(os.path.dirname(project_config))
             with open(project_config, 'w') as f:
-                f.write('[webkitscmpy "remotes"]\n')
-                f.write('    origin = git@github.example.com:WebKit/WebKit.git\n')
-                f.write('    security = git@github.example.com:WebKit/WebKit-security.git\n')
+                f.write('[webkitscmpy "remotes.origin"]\n')
+                f.write('    url = git@github.example.com:WebKit/WebKit.git\n')
+                f.write('    security-level = 0\n')
+                f.write('[webkitscmpy "remotes.security"]\n')
+                f.write('    url = git@github.example.com:WebKit/WebKit-security.git\n')
+                f.write('    security-level = 1\n')
 
             self.assertEqual(0, program.main(
                 args=('track', 'hidden-branch'),
@@ -103,9 +106,12 @@ class TestTrack(testing.PathTestCase):
             project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
             os.mkdir(os.path.dirname(project_config))
             with open(project_config, 'w') as f:
-                f.write('[webkitscmpy "remotes"]\n')
-                f.write('    origin = git@github.example.com:WebKit/WebKit.git\n')
-                f.write('    security = git@github.example.com:WebKit/WebKit-security.git\n')
+                f.write('[webkitscmpy "remotes.origin"]\n')
+                f.write('    url = git@github.example.com:WebKit/WebKit.git\n')
+                f.write('    security-level = 0\n')
+                f.write('[webkitscmpy "remotes.security"]\n')
+                f.write('    url = git@github.example.com:WebKit/WebKit-security.git\n')
+                f.write('    security-level = 1\n')
 
             self.assertEqual(0, program.main(
                 args=('track', 'eng/hidden'),

--- a/metadata/git_config_extension
+++ b/metadata/git_config_extension
@@ -5,10 +5,15 @@
         history = disabled
         update-fork = true
         auto-check = true
-[webkitscmpy "remotes"]
-        origin = git@github.com:WebKit/WebKit.git
-        security = git@github.com:WebKit/WebKit-security.git
-        apple = git@github.com:apple/WebKit.git
+[webkitscmpy "remotes.origin"]
+        url = git@github.com:WebKit/WebKit.git
+        security-level = 0
+[webkitscmpy "remotes.security"]
+        url = git@github.com:WebKit/WebKit-security.git
+        security-level = 1
+[webkitscmpy "remotes.apple"]
+        url = git@github.com:apple/WebKit.git
+        security-level = 2
 [webkitscmpy "access"]
         apple = apple/teams/WebKit
         security = WebKit/teams/security


### PR DESCRIPTION
#### e6817dacbecca6deef7af88bcc60bd32910aff1a
<pre>
[git-webkit] Make remote security level explicit
<a href="https://bugs.webkit.org/show_bug.cgi?id=253598">https://bugs.webkit.org/show_bug.cgi?id=253598</a>
rdar://106447269

Reviewed by Elliott Williams.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.source_remotes): Sort remotes by security level.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.git): Extract remote URL specifically.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/track_unittest.py:
(TestTrack.test_branch):
(TestTrack.test_eng_branch):
* metadata/git_config_extension: Add explicit security level declarations.

Canonical link: <a href="https://commits.webkit.org/261500@main">https://commits.webkit.org/261500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da1ec4a59eb14a0ab770a02db43af045ae1fad37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/111915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/21045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/115977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/22392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/117675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/22392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/115344 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/22392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/104933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/110668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4364 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->