### PR TITLE
[GPU Process] Cache Gradient as a rendering resource

### DIFF
--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.cpp
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.cpp
@@ -30,18 +30,12 @@ namespace WebCore {
 
 Ref<DecomposedGlyphs> DecomposedGlyphs::create(const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode mode, RenderingResourceIdentifier renderingResourceIdentifier)
 {
-    return adoptRef(*new DecomposedGlyphs(glyphs, advances, count, localAnchor, mode, renderingResourceIdentifier));
+    return adoptRef(*new DecomposedGlyphs({ { glyphs, count }, { advances, count }, localAnchor, mode }, renderingResourceIdentifier));
 }
 
 Ref<DecomposedGlyphs> DecomposedGlyphs::create(PositionedGlyphs&& positionedGlyphs, RenderingResourceIdentifier renderingResourceIdentifier)
 {
     return adoptRef(*new DecomposedGlyphs(WTFMove(positionedGlyphs), renderingResourceIdentifier));
-}
-
-DecomposedGlyphs::DecomposedGlyphs(const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode mode, RenderingResourceIdentifier renderingResourceIdentifier)
-    : RenderingResource(renderingResourceIdentifier)
-    , m_positionedGlyphs({ glyphs, count }, { advances, count }, localAnchor, mode)
-{
 }
 
 DecomposedGlyphs::DecomposedGlyphs(PositionedGlyphs&& positionedGlyphs, RenderingResourceIdentifier renderingResourceIdentifier)

--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.h
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "FloatRect.h"
 #include "PositionedGlyphs.h"
 #include "RenderingResource.h"
 
@@ -40,7 +39,6 @@ public:
     const PositionedGlyphs& positionedGlyphs() const { return m_positionedGlyphs; }
 
 private:
-    DecomposedGlyphs(const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode, RenderingResourceIdentifier);
     DecomposedGlyphs(PositionedGlyphs&&, RenderingResourceIdentifier);
 
     PositionedGlyphs m_positionedGlyphs;

--- a/Source/WebCore/platform/graphics/Gradient.cpp
+++ b/Source/WebCore/platform/graphics/Gradient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,13 +35,14 @@
 
 namespace WebCore {
 
-Ref<Gradient> Gradient::create(Data&& data, ColorInterpolationMethod colorInterpolationMethod, GradientSpreadMethod spreadMethod, GradientColorStops&& stops)
+Ref<Gradient> Gradient::create(Data&& data, ColorInterpolationMethod colorInterpolationMethod, GradientSpreadMethod spreadMethod, GradientColorStops&& stops, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
 {
-    return adoptRef(*new Gradient(WTFMove(data), colorInterpolationMethod, spreadMethod, WTFMove(stops)));
+    return adoptRef(*new Gradient(WTFMove(data), colorInterpolationMethod, spreadMethod, WTFMove(stops), renderingResourceIdentifier));
 }
 
-Gradient::Gradient(Data&& data, ColorInterpolationMethod colorInterpolationMethod, GradientSpreadMethod spreadMethod, GradientColorStops&& stops)
-    : m_data { WTFMove(data) }
+Gradient::Gradient(Data&& data, ColorInterpolationMethod colorInterpolationMethod, GradientSpreadMethod spreadMethod, GradientColorStops&& stops, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+    : RenderingResource(renderingResourceIdentifier)
+    , m_data { WTFMove(data) }
     , m_colorInterpolationMethod { colorInterpolationMethod }
     , m_spreadMethod { spreadMethod }
     , m_stops { WTFMove(stops) }
@@ -124,7 +125,7 @@ unsigned Gradient::hash() const
 
 TextStream& operator<<(TextStream& ts, const Gradient& gradient)
 {
-    WTF::switchOn(gradient.m_data,
+    WTF::switchOn(gradient.data(),
         [&] (const Gradient::LinearData& data) {
             ts.dumpProperty("p0", data.point0);
             ts.dumpProperty("p1", data.point1);
@@ -141,10 +142,10 @@ TextStream& operator<<(TextStream& ts, const Gradient& gradient)
             ts.dumpProperty("angle-radians", data.angleRadians);
         }
     );
-    ts.dumpProperty("color-interpolation-method", gradient.m_colorInterpolationMethod);
-    ts.dumpProperty("spread-method", gradient.m_spreadMethod);
-    ts.dumpProperty("stops", gradient.m_stops);
+    ts.dumpProperty("color-interpolation-method", gradient.colorInterpolationMethod());
+    ts.dumpProperty("spread-method", gradient.spreadMethod());
+    ts.dumpProperty("stops", gradient.stops());
     return ts;
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  * Copyright (C) 2008 Torch Mobile, Inc.
  *
@@ -32,6 +32,7 @@
 #include "FloatPoint.h"
 #include "GradientColorStops.h"
 #include "GraphicsTypes.h"
+#include "RenderingResource.h"
 #include <variant>
 #include <wtf/Vector.h>
 
@@ -57,8 +58,7 @@ class AffineTransform;
 class FloatRect;
 class GraphicsContext;
 
-class Gradient : public RefCounted<Gradient> {
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const Gradient&);
+class Gradient : public RenderingResource {
 public:
     struct LinearData {
         FloatPoint point0;
@@ -80,17 +80,16 @@ public:
 
     using Data = std::variant<LinearData, RadialData, ConicData>;
 
-    WEBCORE_EXPORT static Ref<Gradient> create(Data&&, ColorInterpolationMethod, GradientSpreadMethod = GradientSpreadMethod::Pad, GradientColorStops&& = { });
-
-    bool isZeroSize() const;
+    WEBCORE_EXPORT static Ref<Gradient> create(Data&&, ColorInterpolationMethod, GradientSpreadMethod = GradientSpreadMethod::Pad, GradientColorStops&& = { }, std::optional<RenderingResourceIdentifier> = std::nullopt);
 
     const Data& data() const { return m_data; }
+    ColorInterpolationMethod colorInterpolationMethod() const { return m_colorInterpolationMethod; }
+    GradientSpreadMethod spreadMethod() const { return m_spreadMethod; }
+    const GradientColorStops& stops() const { return m_stops; }
 
     WEBCORE_EXPORT void addColorStop(GradientColorStop&&);
 
-    const GradientColorStops& stops() const { return m_stops; }
-    GradientSpreadMethod spreadMethod() const { return m_spreadMethod; }
-    ColorInterpolationMethod colorInterpolationMethod() const { return m_colorInterpolationMethod; }
+    bool isZeroSize() const;
 
     void fill(GraphicsContext&, const FloatRect&);
     void adjustParametersForTiledDrawing(FloatSize&, FloatRect&, const FloatSize& spacing);
@@ -107,7 +106,7 @@ public:
 #endif
 
 private:
-    explicit Gradient(Data&&, ColorInterpolationMethod, GradientSpreadMethod, GradientColorStops&&);
+    Gradient(Data&&, ColorInterpolationMethod, GradientSpreadMethod, GradientColorStops&&, std::optional<RenderingResourceIdentifier>);
 
     void stopsChanged();
 
@@ -121,5 +120,7 @@ private:
     std::optional<GradientRendererCG> m_platformRenderer;
 #endif
 };
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Gradient&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,6 +72,7 @@ public:
 
     GraphicsContextState cloneForRecording() const;
 
+    SourceBrush& fillBrush() { return m_fillBrush; }
     const SourceBrush& fillBrush() const { return m_fillBrush; }
     void setFillBrush(const SourceBrush& brush) { setProperty(Change::FillBrush, &GraphicsContextState::m_fillBrush, brush); }
     void setFillColor(const Color& color) { setProperty(Change::FillBrush, &GraphicsContextState::m_fillBrush, { color }); }
@@ -81,6 +82,7 @@ public:
     WindRule fillRule() const { return m_fillRule; }
     void setFillRule(WindRule fillRule) { setProperty(Change::FillRule, &GraphicsContextState::m_fillRule, fillRule); }
 
+    SourceBrush& strokeBrush() { return m_strokeBrush; }
     const SourceBrush& strokeBrush() const { return m_strokeBrush; }
     void setStrokeBrush(const SourceBrush& brush) { setProperty(Change::StrokeBrush, &GraphicsContextState::m_strokeBrush, brush); }
     void setStrokeColor(const Color& color) { setProperty(Change::StrokeBrush, &GraphicsContextState::m_strokeBrush, { color }); }

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -45,15 +45,12 @@ public:
     WEBCORE_EXPORT void setPlatformImage(PlatformImagePtr&&);
     const PlatformImagePtr& platformImage() const { return m_platformImage; }
 
-    RenderingResourceIdentifier renderingResourceIdentifier() const { return m_renderingResourceIdentifier; }
-
     WEBCORE_EXPORT IntSize size() const;
     bool hasAlpha() const;
     Color singlePixelSolidColor() const;
     WEBCORE_EXPORT DestinationColorSpace colorSpace() const;
 
     void draw(GraphicsContext&, const FloatSize& imageSize, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions&);
-
     void clearSubimages();
 
 private:

--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -44,23 +44,43 @@ public:
 
     virtual ~RenderingResource()
     {
+        if (!hasValidRenderingResourceIdentifier())
+            return;
         for (auto observer : m_observers)
-            observer->releaseRenderingResource(m_renderingResourceIdentifier);
+            observer->releaseRenderingResource(renderingResourceIdentifier());
     }
 
-    RenderingResourceIdentifier renderingResourceIdentifier() const { return m_renderingResourceIdentifier; }
+    bool hasValidRenderingResourceIdentifier() const
+    {
+        return m_renderingResourceIdentifier.has_value();
+    }
 
-    void addObserver(Observer& observer) { m_observers.add(&observer); }
-    void removeObserver(Observer& observer) { m_observers.remove(&observer); }
+    RenderingResourceIdentifier renderingResourceIdentifier() const
+    {
+        ASSERT(m_renderingResourceIdentifier);
+        return *m_renderingResourceIdentifier;
+    }
+
+    void addObserver(Observer& observer)
+    {
+        ASSERT(hasValidRenderingResourceIdentifier());
+        m_observers.add(&observer);
+    }
+
+    void removeObserver(Observer& observer)
+    {
+        ASSERT(hasValidRenderingResourceIdentifier());
+        m_observers.remove(&observer);
+    }
 
 protected:
-    RenderingResource(RenderingResourceIdentifier renderingResourceIdentifier)
+    RenderingResource(std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
         : m_renderingResourceIdentifier(renderingResourceIdentifier)
     {
     }
 
     HashSet<Observer*> m_observers;
-    RenderingResourceIdentifier m_renderingResourceIdentifier;
+    std::optional<RenderingResourceIdentifier> m_renderingResourceIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/SourceBrush.cpp
+++ b/Source/WebCore/platform/graphics/SourceBrush.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,10 +38,8 @@ const AffineTransform& SourceBrush::gradientSpaceTransform() const
 {
     if (!m_brush)
         return identity;
-
-    if (auto* gradient = std::get_if<Brush::LogicalGradient>(&m_brush->brush))
-        return gradient->spaceTransform;
-
+    if (auto* logicalGradient = std::get_if<Brush::LogicalGradient>(&m_brush->brush))
+        return logicalGradient->spaceTransform;
     return identity;
 }
 
@@ -49,9 +47,32 @@ Gradient* SourceBrush::gradient() const
 {
     if (!m_brush)
         return nullptr;
-    if (auto* gradient = std::get_if<Brush::LogicalGradient>(&m_brush->brush))
-        return gradient->gradient.ptr();
+    if (auto* logicalGradient = std::get_if<Brush::LogicalGradient>(&m_brush->brush)) {
+        if (auto* gradient = std::get_if<Ref<Gradient>>(&logicalGradient->gradient))
+            return gradient->ptr();
+    }
     return nullptr;
+}
+
+std::optional<RenderingResourceIdentifier> SourceBrush::gradientIdentifier() const
+{
+    if (!m_brush)
+        return std::nullopt;
+
+    auto* gradient = std::get_if<Brush::LogicalGradient>(&m_brush->brush);
+    if (!gradient)
+        return std::nullopt;
+
+    return WTF::switchOn(gradient->gradient,
+        [] (const Ref<Gradient>& gradient) -> std::optional<RenderingResourceIdentifier> {
+            if (!gradient->hasValidRenderingResourceIdentifier())
+                return std::nullopt;
+            return gradient->renderingResourceIdentifier();
+        },
+        [] (RenderingResourceIdentifier renderingResourceIdentifier) -> std::optional<RenderingResourceIdentifier> {
+            return renderingResourceIdentifier;
+        }
+    );
 }
 
 Pattern* SourceBrush::pattern() const
@@ -65,7 +86,7 @@ Pattern* SourceBrush::pattern() const
 
 void SourceBrush::setGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform)
 {
-    m_brush = { Brush::LogicalGradient { WTFMove(gradient), spaceTransform } };
+    m_brush = { Brush::LogicalGradient { { WTFMove(gradient) }, spaceTransform } };
 }
 
 void SourceBrush::setPattern(Ref<Pattern>&& pattern)

--- a/Source/WebCore/platform/graphics/SourceBrush.h
+++ b/Source/WebCore/platform/graphics/SourceBrush.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,8 +35,11 @@ class SourceBrush {
 public:
     struct Brush {
         struct LogicalGradient {
-            Ref<Gradient> gradient;
+            std::variant<Ref<Gradient>, RenderingResourceIdentifier> gradient;
             AffineTransform spaceTransform;
+
+            template<typename Encoder> void encode(Encoder&) const;
+            template<typename Decoder> static std::optional<LogicalGradient> decode(Decoder&);
         };
 
         std::variant<LogicalGradient, Ref<Pattern>> brush;
@@ -52,9 +55,10 @@ public:
 
     WEBCORE_EXPORT Gradient* gradient() const;
     WEBCORE_EXPORT Pattern* pattern() const;
-    const AffineTransform& gradientSpaceTransform() const;
+    WEBCORE_EXPORT const AffineTransform& gradientSpaceTransform() const;
+    WEBCORE_EXPORT std::optional<RenderingResourceIdentifier> gradientIdentifier() const;
 
-    void setGradient(Ref<Gradient>&&, const AffineTransform& spaceTransform = { });
+    WEBCORE_EXPORT void setGradient(Ref<Gradient>&&, const AffineTransform& spaceTransform = { });
     void setPattern(Ref<Pattern>&&);
 
     bool isInlineColor() const { return !m_brush && m_color.tryGetAsSRGBABytes(); }
@@ -67,7 +71,21 @@ private:
 
 inline bool operator==(const SourceBrush::Brush::LogicalGradient& a, const SourceBrush::Brush::LogicalGradient& b)
 {
-    return a.gradient.ptr() == b.gradient.ptr() && a.spaceTransform == b.spaceTransform;
+    if (a.spaceTransform != b.spaceTransform)
+        return false;
+
+    return WTF::switchOn(a.gradient,
+        [&] (const Ref<Gradient>& aGradient) {
+            if (auto* bGradient = std::get_if<Ref<Gradient>>(&b.gradient))
+                return aGradient.ptr() == bGradient->ptr();
+            return false;
+        },
+        [&] (RenderingResourceIdentifier aRenderingResourceIdentifier) {
+            if (auto* bRenderingResourceIdentifier = std::get_if<RenderingResourceIdentifier>(&b.gradient))
+                return aRenderingResourceIdentifier == *bRenderingResourceIdentifier;
+            return false;
+        }
+    );
 }
 
 inline bool operator!=(const SourceBrush::Brush::LogicalGradient& a, const SourceBrush::Brush::LogicalGradient& b)
@@ -104,6 +122,54 @@ inline bool operator==(const SourceBrush& a, const SourceBrush& b)
 inline bool operator!=(const SourceBrush& a, const SourceBrush& b)
 {
     return !(a == b);
+}
+
+template<class Encoder>
+void SourceBrush::Brush::LogicalGradient::encode(Encoder& encoder) const
+{
+    encoder << spaceTransform;
+
+    WTF::switchOn(gradient,
+        [&] (const Ref<Gradient>& gradient) {
+            if (gradient->hasValidRenderingResourceIdentifier())
+                encoder << true << gradient->renderingResourceIdentifier();
+            else
+                encoder << false << gradient;
+        },
+        [&] (RenderingResourceIdentifier renderingResourceIdentifier) {
+            encoder << true << renderingResourceIdentifier;
+        }
+    );
+}
+
+template<class Decoder>
+std::optional<SourceBrush::Brush::LogicalGradient> SourceBrush::Brush::LogicalGradient::decode(Decoder& decoder)
+{
+    std::optional<AffineTransform> spaceTransform;
+    decoder >> spaceTransform;
+    if (!spaceTransform)
+        return std::nullopt;
+
+    std::optional<bool> hasRenderingResourceIdentifier;
+    decoder >> hasRenderingResourceIdentifier;
+    if (!hasRenderingResourceIdentifier)
+        return std::nullopt;
+
+    if (*hasRenderingResourceIdentifier) {
+        std::optional<RenderingResourceIdentifier> renderingResourceIdentifier;
+        decoder >> renderingResourceIdentifier;
+        if (!renderingResourceIdentifier)
+            return std::nullopt;
+        
+        return { { { *renderingResourceIdentifier }, *spaceTransform } };
+    }
+
+    std::optional<Ref<Gradient>> gradient;
+    decoder >> gradient;
+    if (!gradient)
+        return std::nullopt;
+
+    return { { { WTFMove(*gradient) }, *spaceTransform } };
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, const SourceBrush&);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -110,9 +110,14 @@ private:
         m_resourceHeap.add(font.renderingResourceIdentifier(), Ref { font });
     }
 
-    void cacheDecomposedGlyphs(WebCore::DecomposedGlyphs& decomposedGlyphs)
+    void cacheDecomposedGlyphs(DecomposedGlyphs& decomposedGlyphs)
     {
         m_resourceHeap.add(decomposedGlyphs.renderingResourceIdentifier(), Ref { decomposedGlyphs });
+    }
+
+    void cacheGradient(Gradient& gradient)
+    {
+        m_resourceHeap.add(gradient.renderingResourceIdentifier(), Ref { gradient });
     }
 
     static bool shouldDumpForFlags(OptionSet<AsTextFlag>, ItemHandle);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -257,6 +257,7 @@ public:
 
     WEBCORE_EXPORT SetState(const GraphicsContextState&);
 
+    GraphicsContextState& state() { return m_state; }
     const GraphicsContextState& state() const { return m_state; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -87,11 +87,19 @@ void Recorder::appendStateChangeItem(const GraphicsContextState& state)
     if (state.changes().contains(GraphicsContextState::Change::FillBrush)) {
         if (auto pattern = fillPattern())
             recordResourceUse(pattern->tileImage());
+        else if (auto gradient = fillGradient()) {
+            if (gradient->hasValidRenderingResourceIdentifier())
+                recordResourceUse(*gradient);
+        }
     }
 
     if (state.changes().contains(GraphicsContextState::Change::StrokeBrush)) {
         if (auto pattern = strokePattern())
             recordResourceUse(pattern->tileImage());
+        else if (auto gradient = strokeGradient()) {
+            if (gradient->hasValidRenderingResourceIdentifier())
+                recordResourceUse(*gradient);
+        }
     }
 
     recordSetState(state);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@ class FloatPoint;
 class FloatRect;
 class Font;
 class GlyphBuffer;
+class Gradient;
 class Image;
 class SourceImage;
 class VideoFrame;
@@ -149,6 +150,7 @@ protected:
     virtual bool recordResourceUse(const SourceImage&) = 0;
     virtual bool recordResourceUse(Font&) = 0;
     virtual bool recordResourceUse(DecomposedGlyphs&) = 0;
+    virtual bool recordResourceUse(Gradient&) = 0;
 
     struct ContextState {
         GraphicsContextState state;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -430,6 +430,12 @@ bool RecorderImpl::recordResourceUse(Font& font)
 bool RecorderImpl::recordResourceUse(DecomposedGlyphs& decomposedGlyphs)
 {
     m_displayList.cacheDecomposedGlyphs(decomposedGlyphs);
+    return true;
+}
+
+bool RecorderImpl::recordResourceUse(Gradient& gradient)
+{
+    m_displayList.cacheGradient(gradient);
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -123,6 +123,7 @@ private:
     bool recordResourceUse(const SourceImage&) final;
     bool recordResourceUse(Font&) final;
     bool recordResourceUse(DecomposedGlyphs&) final;
+    bool recordResourceUse(Gradient&) final;
 
     template<typename T, class... Args>
     void append(Args&&... args)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include "DecomposedGlyphs.h"
 #include "Font.h"
+#include "Gradient.h"
 #include "ImageBuffer.h"
 #include "NativeImage.h"
 #include "RenderingResourceIdentifier.h"
@@ -46,6 +47,7 @@ public:
     virtual std::optional<SourceImage> getSourceImage(RenderingResourceIdentifier) const = 0;
     virtual Font* getFont(RenderingResourceIdentifier) const = 0;
     virtual DecomposedGlyphs* getDecomposedGlyphs(RenderingResourceIdentifier) const = 0;
+    virtual Gradient* getGradient(RenderingResourceIdentifier) const = 0;
 };
 
 class LocalResourceHeap : public ResourceHeap {
@@ -68,6 +70,11 @@ public:
     void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<DecomposedGlyphs>&& decomposedGlyphs)
     {
         m_resources.add(renderingResourceIdentifier, WTFMove(decomposedGlyphs));
+    }
+
+    void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<Gradient>&& gradient)
+    {
+        m_resources.add(renderingResourceIdentifier, WTFMove(gradient));
     }
 
     ImageBuffer* getImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier) const final
@@ -104,6 +111,11 @@ public:
         return get<DecomposedGlyphs>(renderingResourceIdentifier);
     }
 
+    Gradient* getGradient(RenderingResourceIdentifier renderingResourceIdentifier) const final
+    {
+        return get<Gradient>(renderingResourceIdentifier);
+    }
+
     void clear()
     {
         m_resources.clear();
@@ -120,9 +132,18 @@ private:
         return std::get<Ref<T>>(iterator->value).ptr();
     }
 
-    using Resource = std::variant<std::monostate, Ref<ImageBuffer>, Ref<NativeImage>, Ref<Font>, Ref<DecomposedGlyphs>>;
+    using Resource = std::variant<
+        std::monostate,
+        Ref<ImageBuffer>,
+        Ref<NativeImage>,
+        Ref<Font>,
+        Ref<DecomposedGlyphs>,
+        Ref<Gradient>
+    >;
+
     HashMap<RenderingResourceIdentifier, Resource> m_resources;
 };
 
-}
-}
+} // namespace DisplayList
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
@@ -57,7 +57,8 @@ Ref<Gradient> RenderSVGResourceLinearGradient::buildGradient(const RenderStyle& 
         Gradient::LinearData { startPoint(m_attributes), endPoint(m_attributes) },
         { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },
         platformSpreadMethodFromSVGType(m_attributes.spreadMethod()),
-        stopsByApplyingColorFilter(m_attributes.stops(), style)
+        stopsByApplyingColorFilter(m_attributes.stops(), style),
+        RenderingResourceIdentifier::generate()
     );
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
@@ -68,7 +68,8 @@ Ref<Gradient> RenderSVGResourceRadialGradient::buildGradient(const RenderStyle& 
         Gradient::RadialData { focalPoint(m_attributes), centerPoint(m_attributes), focalRadius(m_attributes), radius(m_attributes), 1 },
         { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },
         platformSpreadMethodFromSVGType(m_attributes.spreadMethod()),
-        stopsByApplyingColorFilter(m_attributes.stops(), style)
+        stopsByApplyingColorFilter(m_attributes.stops(), style),
+        RenderingResourceIdentifier::generate()
     );
 }
 

--- a/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 #include "QualifiedRenderingResourceIdentifier.h"
 #include <WebCore/DecomposedGlyphs.h>
 #include <WebCore/Font.h>
+#include <WebCore/Gradient.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/NativeImage.h>
 #include <WebCore/ProcessIdentifier.h>
@@ -63,6 +64,11 @@ public:
     void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<WebCore::DecomposedGlyphs>&& decomposedGlyphs)
     {
         add(renderingResourceIdentifier, WTFMove(decomposedGlyphs), m_decomposedGlyphsCount);
+    }
+
+    void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<WebCore::Gradient>&& gradient)
+    {
+        add(renderingResourceIdentifier, WTFMove(gradient), m_gradientCount);
     }
 
     WebCore::ImageBuffer* getImageBuffer(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
@@ -99,6 +105,11 @@ public:
         return get<WebCore::DecomposedGlyphs>(renderingResourceIdentifier);
     }
 
+    WebCore::Gradient* getGradient(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
+    {
+        return get<WebCore::Gradient>(renderingResourceIdentifier);
+    }
+
     bool removeImageBuffer(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
     {
         return remove<WebCore::ImageBuffer>(renderingResourceIdentifier, m_imageBufferCount);
@@ -119,22 +130,29 @@ public:
         return remove<WebCore::DecomposedGlyphs>(renderingResourceIdentifier, m_decomposedGlyphsCount);
     }
 
+    bool removeGradient(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+    {
+        return remove<WebCore::Gradient>(renderingResourceIdentifier, m_gradientCount);
+    }
+
     void releaseAllResources()
     {
         checkInvariants();
 
-        if (!m_nativeImageCount && !m_fontCount && !m_decomposedGlyphsCount)
+        if (!m_nativeImageCount && !m_fontCount && !m_decomposedGlyphsCount && !m_gradientCount)
             return;
 
         m_resources.removeIf([] (const auto& resource) {
             return std::holds_alternative<Ref<WebCore::NativeImage>>(resource.value)
                 || std::holds_alternative<Ref<WebCore::Font>>(resource.value)
-                || std::holds_alternative<Ref<WebCore::DecomposedGlyphs>>(resource.value);
+                || std::holds_alternative<Ref<WebCore::DecomposedGlyphs>>(resource.value)
+                || std::holds_alternative<Ref<WebCore::Gradient>>(resource.value);
         });
 
         m_nativeImageCount = 0;
         m_fontCount = 0;
         m_decomposedGlyphsCount = 0;
+        m_gradientCount = 0;
 
         checkInvariants();
     }
@@ -194,6 +212,7 @@ private:
         unsigned nativeImageCount = 0;
         unsigned fontCount = 0;
         unsigned decomposedGlyphsCount = 0;
+        unsigned gradientCount = 0;
         for (const auto& pair : m_resources) {
             WTF::switchOn(pair.value, [&] (std::monostate) {
                 ASSERT_NOT_REACHED();
@@ -205,25 +224,36 @@ private:
                 ++fontCount;
             }, [&] (const Ref<WebCore::DecomposedGlyphs>&) {
                 ++decomposedGlyphsCount;
+            }, [&] (const Ref<WebCore::Gradient>&) {
+                ++gradientCount;
             });
         }
         ASSERT(imageBufferCount == m_imageBufferCount);
         ASSERT(nativeImageCount == m_nativeImageCount);
         ASSERT(fontCount == m_fontCount);
         ASSERT(decomposedGlyphsCount == m_decomposedGlyphsCount);
-        ASSERT(m_resources.size() == m_imageBufferCount + m_nativeImageCount + m_fontCount + m_decomposedGlyphsCount);
+        ASSERT(gradientCount == m_gradientCount);
+        ASSERT(m_resources.size() == m_imageBufferCount + m_nativeImageCount + m_fontCount + m_decomposedGlyphsCount + m_gradientCount);
 #endif
     }
 
-    using Resource = std::variant<std::monostate, Ref<WebCore::ImageBuffer>, Ref<WebCore::NativeImage>, Ref<WebCore::Font>, Ref<WebCore::DecomposedGlyphs>>;
+    using Resource = std::variant<
+        std::monostate,
+        Ref<WebCore::ImageBuffer>,
+        Ref<WebCore::NativeImage>,
+        Ref<WebCore::Font>,
+        Ref<WebCore::DecomposedGlyphs>,
+        Ref<WebCore::Gradient>
+    >;
     HashMap<QualifiedRenderingResourceIdentifier, Resource> m_resources;
     WebCore::ProcessIdentifier m_webProcessIdentifier;
     unsigned m_imageBufferCount { 0 };
     unsigned m_nativeImageCount { 0 };
     unsigned m_fontCount { 0 };
     unsigned m_decomposedGlyphsCount { 0 };
+    unsigned m_gradientCount { 0 };
 };
 
 } // namespace WebKit
 
-#endif
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -373,6 +373,17 @@ void RemoteRenderingBackend::cacheDecomposedGlyphsWithQualifiedIdentifier(Ref<De
     m_remoteResourceCache.cacheDecomposedGlyphs(WTFMove(decomposedGlyphs), decomposedGlyphsIdentifier);
 }
 
+void RemoteRenderingBackend::cacheGradient(Ref<Gradient>&& gradient, RenderingResourceIdentifier renderingResourceIdentifier)
+{
+    cacheGradientWithQualifiedIdentifier(WTFMove(gradient), { renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() });
+}
+
+void RemoteRenderingBackend::cacheGradientWithQualifiedIdentifier(Ref<Gradient>&& gradient, QualifiedRenderingResourceIdentifier gradientResourceIdentifier)
+{
+    ASSERT(!RunLoop::isMain());
+    m_remoteResourceCache.cacheGradient(WTFMove(gradient), gradientResourceIdentifier);
+}
+
 void RemoteRenderingBackend::releaseAllResources()
 {
     ASSERT(!RunLoop::isMain());

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -122,6 +122,7 @@ private:
     void getFilteredImageForImageBuffer(WebCore::RenderingResourceIdentifier, Ref<WebCore::Filter>, CompletionHandler<void(ShareableBitmapHandle&&)>&&);
     void cacheNativeImage(const ShareableBitmapHandle&, WebCore::RenderingResourceIdentifier);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
+    void cacheGradient(Ref<WebCore::Gradient>&&, WebCore::RenderingResourceIdentifier);
     void cacheFont(Ref<WebCore::Font>&&);
     void releaseAllResources();
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier);
@@ -136,6 +137,7 @@ private:
     void getShareableBitmapForImageBufferWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier, WebCore::PreserveResolution, CompletionHandler<void(ShareableBitmapHandle&&)>&&);
     void cacheNativeImageWithQualifiedIdentifier(const ShareableBitmapHandle&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphsWithQualifiedIdentifier(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);
+    void cacheGradientWithQualifiedIdentifier(Ref<WebCore::Gradient>&&, QualifiedRenderingResourceIdentifier);
     void releaseRenderingResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
     void cacheFontWithQualifiedIdentifier(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -33,6 +33,7 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     CacheNativeImage(WebKit::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     CacheFont(Ref<WebCore::Font> font) NotStreamEncodable
     CacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs> decomposedGlyphs) NotStreamEncodable
+    CacheGradient(Ref<WebCore::Gradient> gradient, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     ReleaseAllResources()
     ReleaseRenderingResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -70,6 +70,11 @@ void RemoteResourceCache::cacheDecomposedGlyphs(Ref<DecomposedGlyphs>&& decompos
     m_resourceHeap.add(renderingResourceIdentifier, WTFMove(decomposedGlyphs));
 }
 
+void RemoteResourceCache::cacheGradient(Ref<Gradient>&& gradient, QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+{
+    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(gradient));
+}
+
 NativeImage* RemoteResourceCache::cachedNativeImage(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getNativeImage(renderingResourceIdentifier);
@@ -96,6 +101,11 @@ DecomposedGlyphs* RemoteResourceCache::cachedDecomposedGlyphs(QualifiedRendering
     return m_resourceHeap.getDecomposedGlyphs(renderingResourceIdentifier);
 }
 
+Gradient* RemoteResourceCache::cachedGradient(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
+{
+    return m_resourceHeap.getGradient(renderingResourceIdentifier);
+}
+
 void RemoteResourceCache::releaseAllResources()
 {
     m_resourceHeap.releaseAllResources();
@@ -106,7 +116,8 @@ bool RemoteResourceCache::releaseRenderingResource(QualifiedRenderingResourceIde
     if (m_resourceHeap.removeImageBuffer(renderingResourceIdentifier)
         || m_resourceHeap.removeNativeImage(renderingResourceIdentifier)
         || m_resourceHeap.removeFont(renderingResourceIdentifier)
-        || m_resourceHeap.removeDecomposedGlyphs(renderingResourceIdentifier))
+        || m_resourceHeap.removeDecomposedGlyphs(renderingResourceIdentifier)
+        || m_resourceHeap.removeGradient(renderingResourceIdentifier))
         return true;
 
     // Caching the remote resource should have happened before releasing it.

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -44,12 +44,14 @@ public:
     void cacheNativeImage(Ref<WebCore::NativeImage>&&, QualifiedRenderingResourceIdentifier);
     void cacheFont(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);
+    void cacheGradient(Ref<WebCore::Gradient>&&, QualifiedRenderingResourceIdentifier);
 
     RemoteImageBuffer* cachedImageBuffer(QualifiedRenderingResourceIdentifier) const;
     RefPtr<RemoteImageBuffer> takeImageBuffer(QualifiedRenderingResourceIdentifier);
     WebCore::NativeImage* cachedNativeImage(QualifiedRenderingResourceIdentifier) const;
     WebCore::Font* cachedFont(QualifiedRenderingResourceIdentifier) const;
     WebCore::DecomposedGlyphs* cachedDecomposedGlyphs(QualifiedRenderingResourceIdentifier) const;
+    WebCore::Gradient* cachedGradient(QualifiedRenderingResourceIdentifier) const;
 
     std::optional<WebCore::SourceImage> cachedSourceImage(QualifiedRenderingResourceIdentifier) const;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2021,11 +2021,6 @@ class WebCore::TransformOperations {
     WebCore::GradientColorStops stops();
 }
 
-[Nested, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceBrush::Brush::LogicalGradient {
-    Ref<WebCore::Gradient> gradient;
-    WebCore::AffineTransform spaceTransform;
-}
-
 [Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Pattern::Parameters {
     bool repeatX;
     bool repeatY;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -486,6 +486,17 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(DecomposedGlyphs& decompo
     }
 
     m_renderingBackend->remoteResourceCacheProxy().recordDecomposedGlyphsUse(decomposedGlyphs);
+    return true;
+}
+
+bool RemoteDisplayListRecorderProxy::recordResourceUse(Gradient& gradient)
+{
+    if (UNLIKELY(!m_renderingBackend)) {
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+
+    m_renderingBackend->remoteResourceCacheProxy().recordGradientUse(gradient);
     return true;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -139,6 +139,7 @@ private:
     bool recordResourceUse(const WebCore::SourceImage&) final;
     bool recordResourceUse(WebCore::Font&) final;
     bool recordResourceUse(WebCore::DecomposedGlyphs&) final;
+    bool recordResourceUse(WebCore::Gradient&) final;
 
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, float resolutionScale, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMode>, std::optional<WebCore::RenderingMethod>) const final;
     RefPtr<WebCore::ImageBuffer> createAlignedImageBuffer(const WebCore::FloatSize&, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMethod>) const final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -262,6 +262,12 @@ void RemoteRenderingBackendProxy::cacheDecomposedGlyphs(Ref<DecomposedGlyphs>&& 
     send(Messages::RemoteRenderingBackend::CacheDecomposedGlyphs(WTFMove(decomposedGlyphs)));
 }
 
+void RemoteRenderingBackendProxy::cacheGradient(Ref<Gradient>&& gradient)
+{
+    auto renderingResourceIdentifier = gradient->renderingResourceIdentifier();
+    send(Messages::RemoteRenderingBackend::CacheGradient(WTFMove(gradient), renderingResourceIdentifier));
+}
+
 void RemoteRenderingBackendProxy::releaseAllRemoteResources()
 {
     if (!m_streamConnection)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -98,6 +98,7 @@ public:
     void cacheNativeImage(const ShareableBitmapHandle&, WebCore::RenderingResourceIdentifier);
     void cacheFont(Ref<WebCore::Font>&&);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
+    void cacheGradient(Ref<WebCore::Gradient>&&);
     void releaseAllRemoteResources();
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier);
     void markSurfacesVolatile(Vector<WebCore::RenderingResourceIdentifier>&&, CompletionHandler<void(bool madeAllVolatile)>&&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -29,12 +29,14 @@
 
 #include "RenderingUpdateID.h"
 #include <WebCore/DecomposedGlyphs.h>
+#include <WebCore/Gradient.h>
 #include <WebCore/NativeImage.h>
 #include <WebCore/RenderingResource.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
 class Font;
+class Gradient;
 class ImageBuffer;
 }
 
@@ -57,6 +59,7 @@ public:
     void recordFontUse(WebCore::Font&);
     void recordImageBufferUse(WebCore::ImageBuffer&);
     void recordDecomposedGlyphsUse(WebCore::DecomposedGlyphs&);
+    void recordGradientUse(WebCore::Gradient&);
 
     void didPaintLayers();
 
@@ -72,10 +75,12 @@ private:
     using NativeImageHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::NativeImage>>;
     using FontHashMap = HashMap<WebCore::RenderingResourceIdentifier, uint64_t>;
     using DecomposedGlyphsHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::DecomposedGlyphs>>;
-    
+    using GradientHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::Gradient>>;
+
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier) override;
     void clearNativeImageMap();
     void clearDecomposedGlyphsMap();
+    void clearGradientMap();
 
     void finalizeRenderingUpdateForFonts();
     void prepareForNextRenderingUpdate();
@@ -86,6 +91,7 @@ private:
     NativeImageHashMap m_nativeImages;
     FontHashMap m_fonts;
     DecomposedGlyphsHashMap m_decomposedGlyphs;
+    GradientHashMap m_gradients;
 
     unsigned m_numberOfFontsUsedInCurrentRenderingUpdate { 0 };
 


### PR DESCRIPTION
#### 676af9d86baad80f738db6a3baad2a49099b771a
<pre>
[GPU Process] Cache Gradient as a rendering resource
<a href="https://bugs.webkit.org/show_bug.cgi?id=253599">https://bugs.webkit.org/show_bug.cgi?id=253599</a>
rdar://106447608

Reviewed by Cameron McCormack.

Sending the gradient data to GPUProcess every time it is used forces creating
the platform gradient.

To avoid creating the platform gradient, we are going to cache Gradient as a
rendering resource in GPUProcess. So the object (and its platform gradient) will
stay alive in GPUProcess as long as the WebProcess gradient is alive.

* Source/WebCore/platform/graphics/DecomposedGlyphs.cpp:
(WebCore::DecomposedGlyphs::create):
(): Deleted.
* Source/WebCore/platform/graphics/DecomposedGlyphs.h:
* Source/WebCore/platform/graphics/Gradient.cpp:
(WebCore::Gradient::create):
(WebCore::Gradient::Gradient):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/Gradient.h:
(WebCore::Gradient::create):
(WebCore::Gradient::colorInterpolationMethod const):
(WebCore::Gradient::spreadMethod const):
(WebCore::Gradient::stops const):
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::fillBrush):
(WebCore::GraphicsContextState::strokeBrush):
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/RenderingResource.h:
(WebCore::RenderingResource::~RenderingResource):
(WebCore::RenderingResource::hasValidRenderingResourceIdentifier const):
(WebCore::RenderingResource::renderingResourceIdentifier const):
(WebCore::RenderingResource::addObserver):
(WebCore::RenderingResource::removeObserver):
(WebCore::RenderingResource::RenderingResource):
* Source/WebCore/platform/graphics/SourceBrush.cpp:
(WebCore::SourceBrush::gradientSpaceTransform const):
(WebCore::SourceBrush::gradient const):
(WebCore::SourceBrush::gradientIdentifier const):
(WebCore::SourceBrush::setGradient):
* Source/WebCore/platform/graphics/SourceBrush.h:
(WebCore::SourceBrush::setGradient):
(WebCore::operator==):
(WebCore::SourceBrush::Brush::LogicalGradient::encode const):
(WebCore::SourceBrush::Brush::LogicalGradient::decode):
* Source/WebCore/platform/graphics/displaylists/DisplayList.h:
(WebCore::DisplayList::DisplayList::cacheDecomposedGlyphs):
(WebCore::DisplayList::DisplayList::cacheGradient):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::SetState::state):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::appendStateChangeItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordResourceUse):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h:
(WebCore::DisplayList::LocalResourceHeap::add):
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp:
(WebCore::RenderSVGResourceLinearGradient::buildGradient const):
* Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp:
(WebCore::RenderSVGResourceRadialGradient::buildGradient const):
* Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h:
(WebKit::QualifiedResourceHeap::add):
(WebKit::QualifiedResourceHeap::getGradient const):
(WebKit::QualifiedResourceHeap::removeGradient):
(WebKit::QualifiedResourceHeap::releaseAllResources):
(WebKit::QualifiedResourceHeap::checkInvariants const):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::setState):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::cacheGradient):
(WebKit::RemoteRenderingBackend::cacheGradientWithQualifiedIdentifier):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::cacheGradient):
(WebKit::RemoteResourceCache::cachedGradient const):
(WebKit::RemoteResourceCache::releaseRenderingResource):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::cacheGradient):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::~RemoteResourceCacheProxy):
(WebKit::RemoteResourceCacheProxy::clear):
(WebKit::RemoteResourceCacheProxy::recordGradientUse):
(WebKit::RemoteResourceCacheProxy::releaseRenderingResource):
(WebKit::RemoteResourceCacheProxy::clearGradientMap):
(WebKit::RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed):
(WebKit::RemoteResourceCacheProxy::releaseMemory):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

Canonical link: <a href="https://commits.webkit.org/262185@main">https://commits.webkit.org/262185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78a046762e870ab8246877dcf53f3e0273c16d49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/396 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/603 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/430 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/345 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/388 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/365 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/383 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/195 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/378 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->