### PR TITLE
Folded i64 comparisons should return i32 in WasmBBQJIT

### DIFF
--- a/JSTests/wasm/stress/comparison-folding-f32.js
+++ b/JSTests/wasm/stress/comparison-folding-f32.js
@@ -1,0 +1,104 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "testEqTrue") (result i32)
+        f32.const 42
+        f32.const 42
+        f32.eq
+    )
+
+    (func (export "testEqFalse") (result i32)
+        f32.const 41
+        f32.const 42
+        f32.eq
+    )
+
+    (func (export "testNeTrue") (result i32)
+        f32.const 41
+        f32.const 42
+        f32.ne
+    )
+
+    (func (export "testNeFalse") (result i32)
+        f32.const 42
+        f32.const 42
+        f32.ne
+    )
+
+    (func (export "testLtTrue") (result i32)
+        f32.const -8
+        f32.const 17
+        f32.lt
+    )
+
+    (func (export "testLtFalse") (result i32)
+        f32.const 17
+        f32.const 9
+        f32.lt
+    )
+
+    (func (export "testLeTrue") (result i32)
+        f32.const 19
+        f32.const 19
+        f32.le
+    )
+
+    (func (export "testLeFalse") (result i32)
+        f32.const 17
+        f32.const 9
+        f32.le
+    )
+
+    (func (export "testGtTrue") (result i32)
+        f32.const 17
+        f32.const -8
+        f32.gt
+    )
+
+    (func (export "testGtFalse") (result i32)
+        f32.const 9
+        f32.const 17
+        f32.gt
+    )
+
+    (func (export "testGeTrue") (result i32)
+        f32.const 19
+        f32.const 19
+        f32.ge
+    )
+
+    (func (export "testGeFalse") (result i32)
+        f32.const 9
+        f32.const 17
+        f32.ge
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const {
+        testEqTrue, testEqFalse, 
+        testNeTrue, testNeFalse,
+        testLtTrue, testLtFalse,
+        testLeTrue, testLeFalse,
+        testGtTrue, testGtFalse,
+        testGeTrue, testGeFalse,
+    } = instance.exports;
+    assert.eq(testEqTrue(), 1);
+    assert.eq(testEqFalse(), 0);
+    assert.eq(testNeTrue(), 1);
+    assert.eq(testNeFalse(), 0);
+    assert.eq(testLtTrue(), 1);
+    assert.eq(testLtFalse(), 0);
+    assert.eq(testLeTrue(), 1);
+    assert.eq(testLeFalse(), 0);
+    assert.eq(testGtTrue(), 1);
+    assert.eq(testGtFalse(), 0);
+    assert.eq(testGeTrue(), 1);
+    assert.eq(testGeFalse(), 0);
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/comparison-folding-f64.js
+++ b/JSTests/wasm/stress/comparison-folding-f64.js
@@ -1,0 +1,104 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "testEqTrue") (result i32)
+        f64.const 42
+        f64.const 42
+        f64.eq
+    )
+
+    (func (export "testEqFalse") (result i32)
+        f64.const 41
+        f64.const 42
+        f64.eq
+    )
+
+    (func (export "testNeTrue") (result i32)
+        f64.const 41
+        f64.const 42
+        f64.ne
+    )
+
+    (func (export "testNeFalse") (result i32)
+        f64.const 42
+        f64.const 42
+        f64.ne
+    )
+
+    (func (export "testLtTrue") (result i32)
+        f64.const -8
+        f64.const 17
+        f64.lt
+    )
+
+    (func (export "testLtFalse") (result i32)
+        f64.const 17
+        f64.const 9
+        f64.lt
+    )
+
+    (func (export "testLeTrue") (result i32)
+        f64.const 19
+        f64.const 19
+        f64.le
+    )
+
+    (func (export "testLeFalse") (result i32)
+        f64.const 17
+        f64.const 9
+        f64.le
+    )
+
+    (func (export "testGtTrue") (result i32)
+        f64.const 17
+        f64.const -8
+        f64.gt
+    )
+
+    (func (export "testGtFalse") (result i32)
+        f64.const 9
+        f64.const 17
+        f64.gt
+    )
+
+    (func (export "testGeTrue") (result i32)
+        f64.const 19
+        f64.const 19
+        f64.ge
+    )
+
+    (func (export "testGeFalse") (result i32)
+        f64.const 9
+        f64.const 17
+        f64.ge
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const {
+        testEqTrue, testEqFalse, 
+        testNeTrue, testNeFalse,
+        testLtTrue, testLtFalse,
+        testLeTrue, testLeFalse,
+        testGtTrue, testGtFalse,
+        testGeTrue, testGeFalse,
+    } = instance.exports;
+    assert.eq(testEqTrue(), 1);
+    assert.eq(testEqFalse(), 0);
+    assert.eq(testNeTrue(), 1);
+    assert.eq(testNeFalse(), 0);
+    assert.eq(testLtTrue(), 1);
+    assert.eq(testLtFalse(), 0);
+    assert.eq(testLeTrue(), 1);
+    assert.eq(testLeFalse(), 0);
+    assert.eq(testGtTrue(), 1);
+    assert.eq(testGtFalse(), 0);
+    assert.eq(testGeTrue(), 1);
+    assert.eq(testGeFalse(), 0);
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/comparison-folding-i32.js
+++ b/JSTests/wasm/stress/comparison-folding-i32.js
@@ -1,0 +1,177 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "testEqTrue") (result i32)
+        i32.const 42
+        i32.const 42
+        i32.eq
+    )
+
+    (func (export "testEqFalse") (result i32)
+        i32.const 41
+        i32.const 42
+        i32.eq
+    )
+
+    (func (export "testNeTrue") (result i32)
+        i32.const 41
+        i32.const 42
+        i32.ne
+    )
+
+    (func (export "testNeFalse") (result i32)
+        i32.const 42
+        i32.const 42
+        i32.ne
+    )
+
+    (func (export "testLtSTrue") (result i32)
+        i32.const -8
+        i32.const 17
+        i32.lt_s
+    )
+
+    (func (export "testLtSFalse") (result i32)
+        i32.const 17
+        i32.const 9
+        i32.lt_s
+    )
+
+    (func (export "testLtUTrue") (result i32)
+        i32.const 9
+        i32.const 17
+        i32.lt_u
+    )
+
+    (func (export "testLtUFalse") (result i32)
+        i32.const -8
+        i32.const 17
+        i32.lt_u
+    )
+
+    (func (export "testLeSTrue") (result i32)
+        i32.const 19
+        i32.const 19
+        i32.le_s
+    )
+
+    (func (export "testLeSFalse") (result i32)
+        i32.const 17
+        i32.const 9
+        i32.le_s
+    )
+
+    (func (export "testLeUTrue") (result i32)
+        i32.const -9
+        i32.const -9
+        i32.le_u
+    )
+
+    (func (export "testLeUFalse") (result i32)
+        i32.const -8
+        i32.const 17
+        i32.le_u
+    )
+
+    (func (export "testGtSTrue") (result i32)
+        i32.const 17
+        i32.const -8
+        i32.gt_s
+    )
+
+    (func (export "testGtSFalse") (result i32)
+        i32.const 9
+        i32.const 17
+        i32.gt_s
+    )
+
+    (func (export "testGtUTrue") (result i32)
+        i32.const 17
+        i32.const 9
+        i32.gt_u
+    )
+
+    (func (export "testGtUFalse") (result i32)
+        i32.const 17
+        i32.const -8
+        i32.gt_u
+    )
+
+    (func (export "testGeSTrue") (result i32)
+        i32.const 19
+        i32.const 19
+        i32.ge_s
+    )
+
+    (func (export "testGeSFalse") (result i32)
+        i32.const 9
+        i32.const 17
+        i32.ge_s
+    )
+
+    (func (export "testGeUTrue") (result i32)
+        i32.const -9
+        i32.const -9
+        i32.ge_u
+    )
+
+    (func (export "testGeUFalse") (result i32)
+        i32.const 17
+        i32.const -8
+        i32.ge_u
+    )
+
+    (func (export "testEqzTrue") (result i32)
+        i32.const 0
+        i32.eqz
+    )
+    
+    (func (export "testEqzFalse") (result i32)
+        i32.const 1
+        i32.eqz
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const {
+        testEqTrue, testEqFalse, 
+        testNeTrue, testNeFalse,
+        testLtSTrue, testLtSFalse,
+        testLtUTrue, testLtUFalse,
+        testLeSTrue, testLeSFalse,
+        testLeUTrue, testLeUFalse,
+        testGtSTrue, testGtSFalse,
+        testGtUTrue, testGtUFalse,
+        testGeSTrue, testGeSFalse,
+        testGeUTrue, testGeUFalse,
+        testEqzTrue, testEqzFalse
+    } = instance.exports;
+    assert.eq(testEqTrue(), 1);
+    assert.eq(testEqFalse(), 0);
+    assert.eq(testNeTrue(), 1);
+    assert.eq(testNeFalse(), 0);
+    assert.eq(testLtSTrue(), 1);
+    assert.eq(testLtSFalse(), 0);
+    assert.eq(testLtUTrue(), 1);
+    assert.eq(testLtUFalse(), 0);
+    assert.eq(testLeSTrue(), 1);
+    assert.eq(testLeSFalse(), 0);
+    assert.eq(testLeUTrue(), 1);
+    assert.eq(testLeUFalse(), 0);
+    assert.eq(testGtSTrue(), 1);
+    assert.eq(testGtSFalse(), 0);
+    assert.eq(testGtUTrue(), 1);
+    assert.eq(testGtUFalse(), 0);
+    assert.eq(testGeSTrue(), 1);
+    assert.eq(testGeSFalse(), 0);
+    assert.eq(testGeUTrue(), 1);
+    assert.eq(testGeUFalse(), 0);
+    assert.eq(testEqzTrue(), 1);
+    assert.eq(testEqzFalse(), 0);
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/comparison-folding-i64.js
+++ b/JSTests/wasm/stress/comparison-folding-i64.js
@@ -1,0 +1,177 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "testEqTrue") (result i32)
+        i64.const 42
+        i64.const 42
+        i64.eq
+    )
+
+    (func (export "testEqFalse") (result i32)
+        i64.const 41
+        i64.const 42
+        i64.eq
+    )
+
+    (func (export "testNeTrue") (result i32)
+        i64.const 41
+        i64.const 42
+        i64.ne
+    )
+
+    (func (export "testNeFalse") (result i32)
+        i64.const 42
+        i64.const 42
+        i64.ne
+    )
+
+    (func (export "testLtSTrue") (result i32)
+        i64.const -8
+        i64.const 17
+        i64.lt_s
+    )
+
+    (func (export "testLtSFalse") (result i32)
+        i64.const 17
+        i64.const 9
+        i64.lt_s
+    )
+
+    (func (export "testLtUTrue") (result i32)
+        i64.const 9
+        i64.const 17
+        i64.lt_u
+    )
+
+    (func (export "testLtUFalse") (result i32)
+        i64.const -8
+        i64.const 17
+        i64.lt_u
+    )
+
+    (func (export "testLeSTrue") (result i32)
+        i64.const 19
+        i64.const 19
+        i64.le_s
+    )
+
+    (func (export "testLeSFalse") (result i32)
+        i64.const 17
+        i64.const 9
+        i64.le_s
+    )
+
+    (func (export "testLeUTrue") (result i32)
+        i64.const -9
+        i64.const -9
+        i64.le_u
+    )
+
+    (func (export "testLeUFalse") (result i32)
+        i64.const -8
+        i64.const 17
+        i64.le_u
+    )
+
+    (func (export "testGtSTrue") (result i32)
+        i64.const 17
+        i64.const -8
+        i64.gt_s
+    )
+
+    (func (export "testGtSFalse") (result i32)
+        i64.const 9
+        i64.const 17
+        i64.gt_s
+    )
+
+    (func (export "testGtUTrue") (result i32)
+        i64.const 17
+        i64.const 9
+        i64.gt_u
+    )
+
+    (func (export "testGtUFalse") (result i32)
+        i64.const 17
+        i64.const -8
+        i64.gt_u
+    )
+
+    (func (export "testGeSTrue") (result i32)
+        i64.const 19
+        i64.const 19
+        i64.ge_s
+    )
+
+    (func (export "testGeSFalse") (result i32)
+        i64.const 9
+        i64.const 17
+        i64.ge_s
+    )
+
+    (func (export "testGeUTrue") (result i32)
+        i64.const -9
+        i64.const -9
+        i64.ge_u
+    )
+
+    (func (export "testGeUFalse") (result i32)
+        i64.const 17
+        i64.const -8
+        i64.ge_u
+    )
+
+    (func (export "testEqzTrue") (result i32)
+        i64.const 0
+        i64.eqz
+    )
+    
+    (func (export "testEqzFalse") (result i32)
+        i64.const 1
+        i64.eqz
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const {
+        testEqTrue, testEqFalse, 
+        testNeTrue, testNeFalse,
+        testLtSTrue, testLtSFalse,
+        testLtUTrue, testLtUFalse,
+        testLeSTrue, testLeSFalse,
+        testLeUTrue, testLeUFalse,
+        testGtSTrue, testGtSFalse,
+        testGtUTrue, testGtUFalse,
+        testGeSTrue, testGeSFalse,
+        testGeUTrue, testGeUFalse,
+        testEqzTrue, testEqzFalse
+    } = instance.exports;
+    assert.eq(testEqTrue(), 1);
+    assert.eq(testEqFalse(), 0);
+    assert.eq(testNeTrue(), 1);
+    assert.eq(testNeFalse(), 0);
+    assert.eq(testLtSTrue(), 1);
+    assert.eq(testLtSFalse(), 0);
+    assert.eq(testLtUTrue(), 1);
+    assert.eq(testLtUFalse(), 0);
+    assert.eq(testLeSTrue(), 1);
+    assert.eq(testLeSFalse(), 0);
+    assert.eq(testLeUTrue(), 1);
+    assert.eq(testLeUFalse(), 0);
+    assert.eq(testGtSTrue(), 1);
+    assert.eq(testGtSFalse(), 0);
+    assert.eq(testGtUTrue(), 1);
+    assert.eq(testGtUFalse(), 0);
+    assert.eq(testGeSTrue(), 1);
+    assert.eq(testGeSFalse(), 0);
+    assert.eq(testGeUTrue(), 1);
+    assert.eq(testGeUFalse(), 0);
+    assert.eq(testEqzTrue(), 1);
+    assert.eq(testEqzFalse(), 0);
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/switch-on-boolean.js
+++ b/JSTests/wasm/stress/switch-on-boolean.js
@@ -1,0 +1,59 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "test") (param i64) (result i64)
+        i64.const 3
+        block (param i64) (result i64)
+            block (param i64) (result i64)
+                local.get 0
+                i64.const 2
+                i64.ne
+                br_table 0 2 2
+            end
+            drop
+            i64.const 4
+        end
+    )
+
+    (func (export "testAlwaysTrue") (result i64)
+        i64.const 3
+        block (param i64) (result i64)
+            block (param i64) (result i64)
+                i64.const 1
+                i64.const 2
+                i64.ne
+                br_table 0 2 2
+            end
+            drop
+            i64.const 4
+        end
+    )
+
+    (func (export "testAlwaysFalse") (result i64)
+        i64.const 3
+        block (param i64) (result i64)
+            block (param i64) (result i64)
+                i64.const 2
+                i64.const 2
+                i64.ne
+                br_table 0 2 2
+            end
+            drop
+            i64.const 4
+        end
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const { test, testAlwaysTrue, testAlwaysFalse } = instance.exports;
+    assert.eq(test(1n), 3n);
+    assert.eq(test(2n), 4n);
+    assert.eq(testAlwaysTrue(), 3n);
+    assert.eq(testAlwaysFalse(), 4n);
+}
+
+assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4958,7 +4958,7 @@ public:
     {
         EMIT_BINARY(
             opcode, TypeKind::I32,
-            BLOCK(Value::fromI64(static_cast<int64_t>(comparator(lhs.asI64(), rhs.asI64())))),
+            BLOCK(Value::fromI32(static_cast<int32_t>(comparator(lhs.asI64(), rhs.asI64())))),
             BLOCK(
                 m_jit.compare64(condition, lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
             ),


### PR DESCRIPTION
#### fb8b78d340d5d473a33c83d7a4c4185872b242b9
<pre>
Folded i64 comparisons should return i32 in WasmBBQJIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=253603">https://bugs.webkit.org/show_bug.cgi?id=253603</a>
rdar://106419423

Reviewed by Yusuke Suzuki.

Makes i64 comparisons in WasmBBQJIT return i32 constants when folded,
instead of i64. Also adds tests exhaustively testing constant folding
for each type and comparison op.

* JSTests/wasm/stress/comparison-folding-f32.js: Added.
(async test):
* JSTests/wasm/stress/comparison-folding-f64.js: Added.
(async test):
* JSTests/wasm/stress/comparison-folding-i32.js: Added.
(async test):
* JSTests/wasm/stress/comparison-folding-i64.js: Added.
(async test):
* JSTests/wasm/stress/switch-on-boolean.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitCompareI64):

Canonical link: <a href="https://commits.webkit.org/261438@main">https://commits.webkit.org/261438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edbbc0c44c60358572d7eec38ec2a2898e564182

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3100 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104360 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45154 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100084 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13200 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/86966 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11320 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9557 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101297 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52162 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31522 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7959 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15677 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109336 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26925 "Passed tests") | 
<!--EWS-Status-Bubble-End-->