### PR TITLE
Reflect trimmed block-start margins in computed style for block-level boxes in block containers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-collapsing-margins-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-collapsing-margins-expected.txt
@@ -1,0 +1,5 @@
+
+PASS container > item 1
+PASS container > item 2
+PASS container > item 3
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-collapsing-margins.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-collapsing-margins.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="trimmed block-start margins for block-level boxes in block containers sould be reflected in computed style">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-start: 10px;
+}
+item {
+    display: block;
+    margin-block-start: 40px;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-end: 100px;
+    height: 0px;
+}
+.large-block-start-margin {
+    margin-block-start: 300px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('container > item')">
+<item style="margin-block-start: 0px;"></item>
+<div id="target">
+<container>
+    <item data-expected-margin-top="0" class="collapsed large-block-start-margin"></item>
+    <item data-expected-margin-top="0" class="collapsed"></item>
+    <item data-expected-margin-top="0"></item>
+</container>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-expected.txt
@@ -1,0 +1,3 @@
+
+PASS .container > div 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-first-child-relative-pos-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-first-child-relative-pos-expected.txt
@@ -1,0 +1,3 @@
+
+PASS .container > div 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-first-child-relative-pos.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-first-child-relative-pos.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="relative positioned block-level first child should have its block-start margin trimmed">
+<style>
+.container {
+    background-color: green;
+    width: min-content;
+    margin-trim: block-start;
+}
+.child {
+    width: 100px;
+    margin-top: 50px;
+    height: 50px;
+    position: relative;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('.container > div')">
+    <div id="target">
+        <div class="container">
+            <div data-expected-margin-top="0" class="child"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-nested-child.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-nested-child.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="">
+<style>
+.trim {
+    margin-trim: block-start;
+}
+container {
+    display: block;
+    margin-block-start: 10px;
+}
+item {
+    display: block;
+    margin-block-start: 40px;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-end: 100px;
+    height: 0px;
+}
+.large-block-start-margin {
+    margin-block-start: 300px;
+}
+.test {}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('.test')">
+<item style="margin-block-start: 0px;"></item>
+<div id="target">
+<container class="trim">
+    <item data-expected-margin-top="0" class="collapsed">
+        <item data-expected-margin-top="0" class="collapsed large-block-start-margin"></item>
+    </item>
+    <container data-expected-margin-top="0">
+        <item data-expected-margin-top="0" class="collapsed">
+            <item class="test" data-offset-y="0"></item>
+        </item>
+    </container>
+</container>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-relative-pos-child-not-trimmed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-relative-pos-child-not-trimmed-expected.txt
@@ -1,0 +1,5 @@
+
+PASS container > item 1
+PASS container > item 2
+PASS container > item 3
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-relative-pos-child-not-trimmed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-relative-pos-child-not-trimmed.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="relative positioned items that are not the block-level first child should not have their margins trimmed">
+<style>
+container {
+    outline: 1px solid black;
+    display: block;
+    margin-trim: block;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-block-start: 50px;
+    background-color: green;
+}
+.first-relative-pos {
+    position: relative;
+    left: 50px;
+    bottom: 50px;
+}
+.second-relative-pos {
+    position: relative;
+    left: 100px;
+    bottom: 200px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('container > item')">
+<div id="target">
+<container>
+    <item data-expected-margin-top="0"></item>
+    <item data-expected-margin-top="50" class="first-relative-pos"></item>
+    <item data-expected-margin-top="50" class="second-relative-pos"></item>
+</container>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="trimmed block-start margins for block-level boxes in block containers sould be reflected in computed style">
+<style>
+.container {
+    background-color: green;
+    width: min-content;
+    margin-trim: block-start;
+}
+.outer {
+    background-color: green;
+    width: 100px;
+    height: 50px;
+}
+.child {
+    width: 100px;
+    margin-top: 50px;
+    height: 50px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('.container > div')">
+    <div class="outer"></div>
+    <div id="target">
+        <div class="container">
+            <div data-expected-margin-top="0" class="child"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3040,6 +3040,24 @@ bool RenderBlock::updateFragmentRangeForBoxChild(const RenderBox& box) const
     return false;
 }
 
+void RenderBlock::setTrimmedMarginForChild(RenderBox &child, MarginTrimType marginTrimType)
+{
+    switch(marginTrimType) {
+        case MarginTrimType::BlockStart: {
+            setMarginBeforeForChild(child, 0_lu);
+            child.markMarginAsTrimmed(MarginTrimType::BlockStart);
+            break;
+        }
+        case MarginTrimType::BlockEnd: {
+            setMarginAfterForChild(child, 0_lu);
+            child.markMarginAsTrimmed(MarginTrimType::BlockEnd);
+            break;
+        }
+        default:
+            ASSERT_NOT_IMPLEMENTED_YET();
+    }
+}
+
 LayoutUnit RenderBlock::collapsedMarginBeforeForChild(const RenderBox& child) const
 {
     // If the child has the same directionality as we do, then we can just return its

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -252,6 +252,7 @@ public:
     void setMarginEndForChild(RenderBox& child, LayoutUnit value) const { child.setMarginEnd(value, &style()); }
     void setMarginBeforeForChild(RenderBox& child, LayoutUnit value) const { child.setMarginBefore(value, &style()); }
     void setMarginAfterForChild(RenderBox& child, LayoutUnit value) const { child.setMarginAfter(value, &style()); }
+    void setTrimmedMarginForChild(RenderBox& child, MarginTrimType);
     LayoutUnit collapsedMarginBeforeForChild(const RenderBox& child) const;
     LayoutUnit collapsedMarginAfterForChild(const RenderBox& child) const;
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1288,14 +1288,14 @@ LayoutUnit RenderBlockFlow::collapseMarginsWithChildInfo(RenderBox* child, Rende
         auto childBlockFlow = dynamicDowncast<RenderBlockFlow>(child);
         if (childBlockFlow)
             childBlockFlow->setMaxMarginBeforeValues(0_lu, 0_lu);
-        child->setMarginBefore(0_lu, &style());
+        setTrimmedMarginForChild(*child, MarginTrimType::BlockStart);
 
         // The margin after for a self collapsing child should also be trimmed so it does not 
         // influence the margins of the first non collapsing child
         if (childIsSelfCollapsing) {
             if (childBlockFlow)
                 childBlockFlow->setMaxMarginAfterValues(0_lu, 0_lu);
-            child->setMarginAfter(0_lu, &style());
+            setTrimmedMarginForChild(*child, MarginTrimType::BlockEnd);
         }
     };
     if (marginInfo.atBeforeSideOfBlock() && style().marginTrim().contains(MarginTrimType::BlockStart))

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1394,6 +1394,28 @@ void RenderBox::clearOverridingLogicalWidthLength()
         gOverridingLogicalWidthLengthMap->remove(this);
 }
 
+void RenderBox::markMarginAsTrimmed(MarginTrimType newTrimmedMargin)
+{
+    ensureRareData().setTrimmedMargins(static_cast<MarginTrimType>(static_cast<unsigned>(rareData().trimmedMargins()) | static_cast<unsigned>(newTrimmedMargin)));
+}
+
+bool RenderBox::hasTrimmedMargin(MarginTrimType marginTrimType) const
+{
+    if (!hasRareData())
+        return false;
+    return static_cast<unsigned>(rareData().trimmedMargins()) & static_cast<unsigned>(marginTrimType);
+}
+
+bool RenderBox::hasTrimmedMarginTop() const
+{
+    ASSERT(containingBlock()->isBlockContainer() && !isFlexItem() && !isGridItem());
+    auto isHorizontalWritingMode = style().isHorizontalWritingMode();
+
+    if (isHorizontalWritingMode == containingBlock()->style().isHorizontalWritingMode())
+        return isHorizontalWritingMode ? hasTrimmedMargin(MarginTrimType::BlockStart) : hasTrimmedMargin(MarginTrimType::InlineStart);
+    return !isHorizontalWritingMode ? hasTrimmedMargin(MarginTrimType::BlockStart) : hasTrimmedMargin(MarginTrimType::InlineStart);
+}
+
 LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(const Length& logicalWidth) const
 {
     auto width = LayoutUnit { logicalWidth.value() };

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -364,6 +364,10 @@ public:
     void clearOverridingLogicalHeightLength();
     void clearOverridingLogicalWidthLength();
 
+     void markMarginAsTrimmed(MarginTrimType);
+     bool hasTrimmedMargin(MarginTrimType) const;
+     bool hasTrimmedMarginTop() const;
+
     LayoutSize offsetFromContainer(RenderElement&, const LayoutPoint&, bool* offsetDependsOnPoint = nullptr) const override;
     
     LayoutUnit adjustBorderBoxLogicalWidthForBoxSizing(const Length& logicalWidth) const;

--- a/Source/WebCore/rendering/RenderIterator.h
+++ b/Source/WebCore/rendering/RenderIterator.h
@@ -44,6 +44,7 @@ public:
 
     bool operator==(const RenderIterator& other) const;
     bool operator!=(const RenderIterator& other) const;
+    bool operator!=(const RenderElement* other) const;
 
     RenderIterator& traverseNext();
     RenderIterator& traverseNextSibling();
@@ -69,6 +70,7 @@ public:
 
     bool operator==(const RenderConstIterator& other) const;
     bool operator!=(const RenderConstIterator& other) const;
+    bool operator!=(const RenderElement* other) const;
 
     RenderConstIterator& traverseNext();
     RenderConstIterator& traverseNextSibling();
@@ -296,6 +298,12 @@ inline bool RenderIterator<T>::operator!=(const RenderIterator& other) const
     return !(*this == other);
 }
 
+template <typename T>
+inline bool RenderIterator<T>::operator!=(const RenderElement* other) const
+{
+    return other != m_current;
+}
+
 // RenderConstIterator
 
 template <typename T>
@@ -379,6 +387,12 @@ template <typename T>
 inline bool RenderConstIterator<T>::operator!=(const RenderConstIterator& other) const
 {
     return !(*this == other);
+}
+
+template <typename T>
+inline bool RenderConstIterator<T>::operator!=(const RenderElement* other) const
+{
+    return m_current != other;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1002,6 +1002,7 @@ private:
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
         ADD_BOOLEAN_BITFIELD(hasSVGTransform, HasSVGTransform);
 #endif
+        ADD_ENUM_BITFIELD(trimmedMargins, TrimmedMargins, MarginTrimType, 4);
 
         // From RenderElement
         std::unique_ptr<ReferencedSVGResources> referencedSVGResources;


### PR DESCRIPTION
#### 238f15519119454d0d8354a7bf3d02235b6a9990
<pre>
Reflect trimmed block-start margins in computed style for block-level boxes in block containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=253606">https://bugs.webkit.org/show_bug.cgi?id=253606</a>
rdar://106452955

Reviewed by NOBODY (OOPS!).

If a block-level box is inside of a block-container that has
margin-trim: block or block-start, then any margins at the block start
edge of the block container should be trimmed (removed). When trying to
check the computed style of these box&apos;s margins, these margins should
have a value of 0 and not their original one.

When checking the computed style for margin-top we can check to see if
it is box in a block container that has had its margin trimmed. This
can be done by checking a set of conditions for the box:
1.) It should be a non-floating block-level box
2.) Its containing block should be a block container
3.) The block container should have block-start trimming specified
4.) It has been positioned at the block-start edge of the block container

If these conditions hold then the box should have had its block-start
margin trimmed during layout and we can reflect it in its computed
style.

This also adds an additional case where a margin property may be
considered layout dependent. Now we need to check if the renderer&apos;s
containing block has the corresponding margin-trim value set to the
margin type. containingBlockHasMarginTrim was added inside of
ComputedStyleExtractor to help with this logic.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-collapsing-margins-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-collapsing-margins.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-first-child-relative-pos-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-first-child-relative-pos.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-relative-pos-child-not-trimmed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-relative-pos-child-not-trimmed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start.html: Added.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::containingBlockHasMarginTrim):
(WebCore::isLayoutDependent):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::isBlockContainer const):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hasTrimmedMargin const):
* Source/WebCore/rendering/RenderBox.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c11c319a8aa42ae469755f4d25a6f98fc536ba5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/112764 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/21954 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1470 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/4575 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121308 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/116834 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/23297 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/13120 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/4575 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/118533 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/23297 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1470 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/105881 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/23297 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1470 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/105881 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/14259 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1470 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/105881 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14958 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/13120 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1470 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/16806 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->