### PR TITLE
PDF files appear blank grey

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -249,6 +249,7 @@ CARenderCGContext *CARenderCGNew(uint32_t feature_flags);
 CARenderUpdate* CARenderUpdateBegin(void* buffer, size_t, CFTimeInterval, const CVTimeStamp*, uint32_t finished_seed, const CGRect* bounds);
 bool CARenderServerStart();
 mach_port_t CARenderServerGetPort();
+mach_port_t CARenderServerGetServerPort(const char *name);
 void CARenderCGDestroy(CARenderCGContext*);
 void CARenderCGRender(CARenderCGContext*, CARenderUpdate*, CGContextRef);
 void CARenderUpdateAddContext(CARenderUpdate*, CARenderContext*);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -65,6 +65,7 @@
 #import <WebCore/RenderedDocumentMarker.h>
 #import <WebCore/TextIterator.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
 
 #if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
 #include "LibWebRTCCodecs.h"
@@ -91,6 +92,12 @@ void WebPage::platformInitialize(const WebPageCreationParameters& parameters)
 #if USE(LIBWEBRTC)
     LibWebRTCCodecs::setCallbacks(m_page->settings().webRTCPlatformCodecsInGPUProcessEnabled(), m_page->settings().webRTCRemoteVideoFrameEnabled());
     LibWebRTCCodecs::setWebRTCMediaPipelineAdditionalLoggingEnabled(m_page->settings().webRTCMediaPipelineAdditionalLoggingEnabled());
+#endif    
+#if PLATFORM(MAC)
+    // In order to be able to block launchd on macOS, we need to eagerly open up a connection to CARenderServer here.
+    // This is because PDF rendering on macOS requires access to CARenderServer, unless we're in Lockdown mode.
+    if (!WebProcess::singleton().isLockdownModeEnabled())
+        CARenderServerGetServerPort(nullptr);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1400,7 +1400,10 @@
 
 ; Needed for [CAContext remoteContextWithOptions]
 #if HAVE(SANDBOX_STATE_FLAGS)
-(with-filter (require-not (state-flag "EnableExperimentalSandbox"))
+(with-filter
+    (require-any
+        (require-not (lockdown-mode))
+        (require-not (state-flag "EnableExperimentalSandbox")))
     (allow mach-lookup (global-name "com.apple.CARenderServer")))
 #else
 (allow mach-lookup (global-name "com.apple.CARenderServer"))


### PR DESCRIPTION
#### 40b889cce15e0e1fb96b285ff60044350abf6018
<pre>
PDF files appear blank grey
<a href="https://bugs.webkit.org/show_bug.cgi?id=253616">https://bugs.webkit.org/show_bug.cgi?id=253616</a>
rdar://106342101

Reviewed by Geoffrey Garen.

PDF files appear blank grey with experimental sandbox enabled. This is caused by the experimental
sandbox blocking communication with launchd, which is required to do a Mach lookup of CARenderServer.
Access to CARenderServer is required by PDFKit, unless we are in Lockdown mode. To fix this we can
eagerly open up a connection to CARenderServer when not in Lockdown mode. In Lockdown mode,
CARenderServer should be blocked.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::platformInitialize):
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/261470@main">https://commits.webkit.org/261470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/148d1720df4b88e4725f51a5b45cf444cd1cb15b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3375 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11835 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99566 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45305 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13237 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/141 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87741 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13729 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9585 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52133 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7983 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15716 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->