### PR TITLE
[popover] checkPopoverValidity should throw NotSupportedError there is no popover attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -15,194 +15,194 @@ PASS The element <dialog popover="manual">Dialog with popover=manual</dialog> sh
 PASS The element <div popover="true">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
 PASS The element <div popover="popover">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
 PASS The element <div popover="invalid">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
-FAIL The element <div>Not a popover</div> should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL The element <dialog open="">Dialog without popover attribute</dialog> should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL The element <div>Not a popover</div> should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
+FAIL The element <dialog open="">Dialog without popover attribute</dialog> should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <a popover> element should behave as a popover.
-FAIL A <a> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <a> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <abbr popover> element should behave as a popover.
-FAIL A <abbr> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <abbr> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <address popover> element should behave as a popover.
-FAIL A <address> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <address> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 FAIL A <area popover> element should behave as a popover. assert_equals: After showPopover(), a popover should be visible: Expected this element to be visible expected true but got false
 FAIL A <area> element should *not* behave as a popover. assert_equals: A non-popover should start out visible: Expected this element to be visible expected true but got false
 PASS A <article popover> element should behave as a popover.
-FAIL A <article> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <article> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <aside popover> element should behave as a popover.
-FAIL A <aside> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <aside> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <b popover> element should behave as a popover.
-FAIL A <b> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <b> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <bdi popover> element should behave as a popover.
-FAIL A <bdi> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <bdi> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <bdo popover> element should behave as a popover.
-FAIL A <bdo> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <bdo> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <blockquote popover> element should behave as a popover.
-FAIL A <blockquote> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <blockquote> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <body popover> element should behave as a popover.
-FAIL A <body> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <body> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <button popover> element should behave as a popover.
-FAIL A <button> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <button> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <canvas popover> element should behave as a popover.
-FAIL A <canvas> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <canvas> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <caption popover> element should behave as a popover.
-FAIL A <caption> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <caption> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <cite popover> element should behave as a popover.
-FAIL A <cite> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <cite> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <code popover> element should behave as a popover.
-FAIL A <code> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <code> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <col popover> element should behave as a popover.
-FAIL A <col> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <col> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <colgroup popover> element should behave as a popover.
-FAIL A <colgroup> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <colgroup> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <data popover> element should behave as a popover.
-FAIL A <data> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <data> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <dd popover> element should behave as a popover.
-FAIL A <dd> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <dd> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <del popover> element should behave as a popover.
-FAIL A <del> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <del> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <details popover> element should behave as a popover.
-FAIL A <details> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <details> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <dfn popover> element should behave as a popover.
-FAIL A <dfn> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <dfn> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <div popover> element should behave as a popover.
-FAIL A <div> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <div> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <dl popover> element should behave as a popover.
-FAIL A <dl> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <dl> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <dt popover> element should behave as a popover.
-FAIL A <dt> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <dt> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <em popover> element should behave as a popover.
-FAIL A <em> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <em> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <fieldset popover> element should behave as a popover.
-FAIL A <fieldset> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <fieldset> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <figcaption popover> element should behave as a popover.
-FAIL A <figcaption> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <figcaption> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <figure popover> element should behave as a popover.
-FAIL A <figure> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <figure> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <footer popover> element should behave as a popover.
-FAIL A <footer> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <footer> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <form popover> element should behave as a popover.
-FAIL A <form> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <form> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <h1 popover> element should behave as a popover.
-FAIL A <h1> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <h1> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <h2 popover> element should behave as a popover.
-FAIL A <h2> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <h2> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <h3 popover> element should behave as a popover.
-FAIL A <h3> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <h3> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <h4 popover> element should behave as a popover.
-FAIL A <h4> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <h4> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <h5 popover> element should behave as a popover.
-FAIL A <h5> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <h5> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <h6 popover> element should behave as a popover.
-FAIL A <h6> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <h6> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <header popover> element should behave as a popover.
-FAIL A <header> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <header> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <hr popover> element should behave as a popover.
-FAIL A <hr> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <hr> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <html popover> element should behave as a popover.
-FAIL A <html> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <html> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <i popover> element should behave as a popover.
-FAIL A <i> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <i> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <iframe popover> element should behave as a popover.
-FAIL A <iframe> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <iframe> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <img popover> element should behave as a popover.
-FAIL A <img> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <img> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <input popover> element should behave as a popover.
-FAIL A <input> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <input> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <ins popover> element should behave as a popover.
-FAIL A <ins> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <ins> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <kbd popover> element should behave as a popover.
-FAIL A <kbd> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <kbd> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <label popover> element should behave as a popover.
-FAIL A <label> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <label> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <legend popover> element should behave as a popover.
-FAIL A <legend> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <legend> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <li popover> element should behave as a popover.
-FAIL A <li> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <li> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <main popover> element should behave as a popover.
-FAIL A <main> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <main> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <map popover> element should behave as a popover.
-FAIL A <map> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <map> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <mark popover> element should behave as a popover.
-FAIL A <mark> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <mark> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <menu popover> element should behave as a popover.
-FAIL A <menu> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <menu> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <meter popover> element should behave as a popover.
-FAIL A <meter> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <meter> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <nav popover> element should behave as a popover.
-FAIL A <nav> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <nav> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <object popover> element should behave as a popover.
-FAIL A <object> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <object> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <ol popover> element should behave as a popover.
-FAIL A <ol> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <ol> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 FAIL A <optgroup popover> element should behave as a popover. assert_equals: After showPopover(), a popover should be visible: Expected this element to be visible expected true but got false
 FAIL A <optgroup> element should *not* behave as a popover. assert_equals: A non-popover should start out visible: Expected this element to be visible expected true but got false
 FAIL A <option popover> element should behave as a popover. assert_equals: After showPopover(), a popover should be visible: Expected this element to be visible expected true but got false
 FAIL A <option> element should *not* behave as a popover. assert_equals: A non-popover should start out visible: Expected this element to be visible expected true but got false
 PASS A <output popover> element should behave as a popover.
-FAIL A <output> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <output> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <p popover> element should behave as a popover.
-FAIL A <p> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <p> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <pre popover> element should behave as a popover.
-FAIL A <pre> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <pre> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <progress popover> element should behave as a popover.
-FAIL A <progress> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <progress> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <q popover> element should behave as a popover.
-FAIL A <q> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <q> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <rt popover> element should behave as a popover.
-FAIL A <rt> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <rt> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <ruby popover> element should behave as a popover.
-FAIL A <ruby> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <ruby> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <s popover> element should behave as a popover.
-FAIL A <s> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <s> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <samp popover> element should behave as a popover.
-FAIL A <samp> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <samp> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <section popover> element should behave as a popover.
-FAIL A <section> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <section> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <select popover> element should behave as a popover.
-FAIL A <select> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <select> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <small popover> element should behave as a popover.
-FAIL A <small> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <small> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <source popover> element should behave as a popover.
-FAIL A <source> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <source> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <span popover> element should behave as a popover.
-FAIL A <span> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <span> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <strong popover> element should behave as a popover.
-FAIL A <strong> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <strong> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <sub popover> element should behave as a popover.
-FAIL A <sub> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <sub> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <sup popover> element should behave as a popover.
-FAIL A <sup> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <sup> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <summary popover> element should behave as a popover.
-FAIL A <summary> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <summary> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <table popover> element should behave as a popover.
-FAIL A <table> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <table> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <tbody popover> element should behave as a popover.
-FAIL A <tbody> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <tbody> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <td popover> element should behave as a popover.
-FAIL A <td> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <td> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <textarea popover> element should behave as a popover.
-FAIL A <textarea> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <textarea> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <tfoot popover> element should behave as a popover.
-FAIL A <tfoot> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <tfoot> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <th popover> element should behave as a popover.
-FAIL A <th> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <th> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <thead popover> element should behave as a popover.
-FAIL A <thead> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <thead> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <time popover> element should behave as a popover.
-FAIL A <time> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <time> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <tr popover> element should behave as a popover.
-FAIL A <tr> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <tr> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <track popover> element should behave as a popover.
-FAIL A <track> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <track> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <u popover> element should behave as a popover.
-FAIL A <u> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <u> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <ul popover> element should behave as a popover.
-FAIL A <ul> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <ul> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <var popover> element should behave as a popover.
-FAIL A <var> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <var> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS A <video popover> element should behave as a popover.
-FAIL A <video> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL A <video> element should *not* behave as a popover. assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS IDL attribute reflection
-FAIL Popover attribute value should be case insensitive assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+FAIL Popover attribute value should be case insensitive assert_throws_dom: Calling togglePopover on a non-popover should throw NotSupported function "() => nonPopover.togglePopover()" did not throw
 PASS Changing attribute values for popover should work
 FAIL Changing attribute values should close open popovers assert_false: expected false got true
 PASS Removing a visible popover=auto element from the document should close the popover
@@ -235,7 +235,7 @@ FAIL Changing a popover from auto to undefined (via attr), and then auto during 
 FAIL Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
 FAIL Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected (string) "null" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then auto during 'beforetoggle' works
 FAIL Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "auto"
 FAIL Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "auto"
@@ -260,7 +260,7 @@ FAIL Changing a popover from manual to undefined (via attr), and then auto durin
 FAIL Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
 FAIL Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected (string) "null" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from manual to undefined (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then auto during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then invalid during 'beforetoggle' works
@@ -279,13 +279,13 @@ FAIL Changing a popover from auto to invalid (via idl), and then undefined durin
 FAIL Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
 FAIL Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
 FAIL Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then auto during 'beforetoggle' works
 FAIL Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "auto"
 FAIL Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "auto"
@@ -304,11 +304,11 @@ PASS Changing a popover from manual to invalid (via idl), and then undefined dur
 FAIL Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
 FAIL Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
 FAIL Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from manual to undefined (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via idl), and then undefined during 'beforetoggle' works
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1215,7 +1215,7 @@ ExceptionOr<Ref<ElementInternals>> HTMLElement::attachInternals()
 static ExceptionOr<void> checkPopoverValidity(Element& element, PopoverVisibilityState expectedState)
 {
     if (!element.hasAttributeWithoutSynchronization(HTMLNames::popoverAttr))
-        return Exception { InvalidStateError, "Element does not have the popover attribute"_s };
+        return Exception { NotSupportedError, "Element does not have the popover attribute"_s };
 
     if (!element.isConnected())
         return Exception { InvalidStateError, "Element is not connected"_s };


### PR DESCRIPTION
#### 948622825d7d12af91a7436b2fa97c22d37c3267
<pre>
[popover] checkPopoverValidity should throw NotSupportedError there is no popover attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=253596">https://bugs.webkit.org/show_bug.cgi?id=253596</a>
rdar://106447978

Reviewed by Darin Adler.

<a href="https://html.spec.whatwg.org/#check-popover-validity">https://html.spec.whatwg.org/#check-popover-validity</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::checkPopoverValidity):

Canonical link: <a href="https://commits.webkit.org/261402@main">https://commits.webkit.org/261402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25ab5d1114ae3b33cab9bf5467b1d745fb1b4b8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3368 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11828 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117379 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45249 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13232 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/135 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13724 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52126 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7937 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15710 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->