### PR TITLE
The 'length' argument of U16_FWD_1 in TextUtil::breakWord is wrong

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -2619,7 +2619,6 @@ fast/text/isolate-ignore.html [ ImageOnlyFailure ]
 fast/text/multiple-renderers-with-hypen-on-boundary.html [ ImageOnlyFailure ]
 fast/text/soft-hyphen-min-preferred-width.html [ ImageOnlyFailure ]
 fast/text/whitespace/inline-whitespace-wrapping-8.html [ ImageOnlyFailure ]
-webkit.org/b/253547 fast/text/midword-break-before-surrogate-pair.html [ Skip ] # Crash for Debug, Timeout for Release
 
 # Depends on the system fonts
 fast/css/css2-system-fonts.html [ Failure Pass ]

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -238,7 +238,7 @@ TextUtil::WordBreakLeft TextUtil::breakWord(const InlineTextBox& inlineTextBox, 
             auto nextUserPerceivedCharacterIndex = [&] (auto index) -> size_t {
                 if (text.is8Bit())
                     return index + 1;
-                U16_FWD_1(text, index, length);
+                U16_FWD_1(text, index, startPosition + length);
                 return index;
             };
 


### PR DESCRIPTION
#### b625b7e2bbd34fd3832e284148c5e1f20b2d1caa
<pre>
The &apos;length&apos; argument of U16_FWD_1 in TextUtil::breakWord is wrong
<a href="https://bugs.webkit.org/show_bug.cgi?id=253547">https://bugs.webkit.org/show_bug.cgi?id=253547</a>

Reviewed by Alan Baradlay.

The test fast/text/midword-break-before-surrogate-pair.html was
failing as the following assertion failure for WinCairo debug, and
timing out by an infinite loop for WinCairo release.

&gt; ASSERTION FAILED: middle &gt;= left &amp;&amp; middle &lt; right
&gt; Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp(276) : WebCore::Layout::TextUtil::breakWord::&lt;lambda_1&gt;::operator ()

U16_FWD_1 in nextUserPerceivedCharacterIndex didn&apos;t work as expected
because the third argument was wrong. It should be a length of the
input string, but &apos;length&apos; is the length of the substring starting at
&apos;startPosition&apos;.

* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::breakWord):

Canonical link: <a href="https://commits.webkit.org/261406@main">https://commits.webkit.org/261406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0965ce9786f7a19f4886db02a252fd7e2f0d1fb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3388 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11848 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117398 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45269 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13249 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/154 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13739 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52149 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7941 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15729 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->