### PR TITLE
Drop some unnecessary work from ~HTMLInputElement()

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -129,9 +129,6 @@ HTMLImageLoader& HTMLInputElement::ensureImageLoader()
 
 HTMLInputElement::~HTMLInputElement()
 {
-    if (needsSuspensionCallback())
-        document().unregisterForDocumentSuspensionCallbacks(*this);
-
     // Need to remove form association while this is still an HTMLInputElement
     // so that virtual functions are called correctly.
     setForm(nullptr);


### PR DESCRIPTION
#### ff17293b4d27be792cfe0067d181d6a4c2be8937
<pre>
Drop some unnecessary work from ~HTMLInputElement()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253621">https://bugs.webkit.org/show_bug.cgi?id=253621</a>

Reviewed by Ryosuke Niwa.

Stop calling unregisterForDocumentSuspensionCallbacks(), it is unnecessary
since Document::m_documentSuspensionCallbackElements is a WeakHashSet.

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::~HTMLInputElement):

Canonical link: <a href="https://commits.webkit.org/261437@main">https://commits.webkit.org/261437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2647a36df5ee830ea568a26add5c7431b2c9a23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/233 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11840 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3134 "layout-tests (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117391 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45325 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13242 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/146 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9607 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19178 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52139 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7961 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15721 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->