### PR TITLE
[WinCairo] Unreviewed test gardening

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -1614,6 +1614,7 @@ imported/w3c/web-platform-tests/xhr [ Skip ]
 inspector [ Skip ]
 inspector/cpu-profiler/ [ Pass ]
 inspector/memory/ [ Pass ]
+ipc [ Skip ]
 js/dom/deep-recursion-test.html [ Failure ]
 mathml [ Skip ]
 media [ Skip ]
@@ -2599,7 +2600,7 @@ editing/style/unbold-in-bold.html [ Failure ]
 
 webkit.org/b/123431 http/tests/css/link-css-disabled-value-with-slow-loading-sheet.html [ Pass Failure ]
 
-fast/html/body-color-legacy-parsing-3.html [ Pass Failure ]
+fast/html/body-color-legacy-parsing-3.html [ Pass ImageOnlyFailure ]
 
 http/tests/websocket/tests/hybi/inspector/binary.html [ Pass Failure ]
 http/tests/websocket/tests/hybi/inspector/send-and-receive.html [ Pass Failure ]
@@ -2619,3 +2620,13 @@ fast/text/multiple-renderers-with-hypen-on-boundary.html [ ImageOnlyFailure ]
 fast/text/soft-hyphen-min-preferred-width.html [ ImageOnlyFailure ]
 fast/text/whitespace/inline-whitespace-wrapping-8.html [ ImageOnlyFailure ]
 webkit.org/b/253547 fast/text/midword-break-before-surrogate-pair.html [ Skip ] # Crash for Debug, Timeout for Release
+
+# Depends on the system fonts
+fast/css/css2-system-fonts.html [ Failure Pass ]
+
+# Failing on WinCairo Debug tester
+fast/text/atsui-multiple-renderers.html [ Failure Pass ]
+fast/text/international/thai-baht-space.html [ Failure Pass ]
+fast/text/international/thai-line-breaks.html [ Failure Pass ]
+
+js/weakref-finalizationregistry.html [ Timeout Pass ]


### PR DESCRIPTION
#### 0ca85354cde350cbaa385bd587c3e1c49f7e3606
<pre>
[WinCairo] Unreviewed test gardening
<a href="https://bugs.webkit.org/show_bug.cgi?id=240439">https://bugs.webkit.org/show_bug.cgi?id=240439</a>

* LayoutTests/platform/wincairo/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/261397@main">https://commits.webkit.org/261397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ad251d3bca62bee093438366dde0e3933580942

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3381 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11841 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117392 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/104481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13243 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13735 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19179 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/52140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15722 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4327 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->