### PR TITLE
REGRESSION (260927@main): CGDisplayList image buffers no longer use the correct RenderingMode

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -193,10 +193,10 @@ static RenderingMode renderingModeForCGContext(CGContextRef cgContext, GraphicsC
     return RenderingMode::Unaccelerated;
 }
 
-GraphicsContextCG::GraphicsContextCG(CGContextRef cgContext, CGContextSource source)
+GraphicsContextCG::GraphicsContextCG(CGContextRef cgContext, CGContextSource source, std::optional<RenderingMode> knownRenderingMode)
     : GraphicsContext(GraphicsContextState::basicChangeFlags, coreInterpolationQuality(cgContext))
     , m_cgContext(cgContext)
-    , m_renderingMode(renderingModeForCGContext(cgContext, source))
+    , m_renderingMode(knownRenderingMode.value_or(renderingModeForCGContext(cgContext, source)))
     , m_isLayerCGContext(source == GraphicsContextCG::CGContextFromCALayer)
 {
     if (!cgContext)

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -38,7 +38,7 @@ public:
         Unknown,
         CGContextFromCALayer
     };
-    GraphicsContextCG(CGContextRef, CGContextSource = CGContextSource::Unknown);
+    GraphicsContextCG(CGContextRef, CGContextSource = CGContextSource::Unknown, std::optional<RenderingMode> knownRenderingMode = std::nullopt);
 
     ~GraphicsContextCG();
 

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
@@ -36,7 +36,7 @@ namespace WebKit {
 
 using UseCGDisplayListImageCache = WebCore::ImageBufferCreationContext::UseCGDisplayListImageCache;
 
-class CGDisplayListImageBufferBackend final : public WebCore::ImageBufferCGBackend, public ImageBufferBackendHandleSharing {
+class CGDisplayListImageBufferBackend : public WebCore::ImageBufferCGBackend, public ImageBufferBackendHandleSharing {
     WTF_MAKE_ISO_ALLOCATED(CGDisplayListImageBufferBackend);
     WTF_MAKE_NONCOPYABLE(CGDisplayListImageBufferBackend);
 public:
@@ -56,7 +56,7 @@ public:
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
 
 protected:
-    CGDisplayListImageBufferBackend(const Parameters&, const WebCore::ImageBufferCreationContext&);
+    CGDisplayListImageBufferBackend(const Parameters&, const WebCore::ImageBufferCreationContext&, WebCore::RenderingMode);
 
     unsigned bytesPerRow() const final;
 
@@ -65,6 +65,17 @@ protected:
 
     mutable std::unique_ptr<WebCore::GraphicsContext> m_context;
     RetainPtr<id> m_resourceCache;
+    WebCore::RenderingMode m_renderingMode;
+};
+
+class CGDisplayListAcceleratedImageBufferBackend final : public CGDisplayListImageBufferBackend {
+    WTF_MAKE_ISO_ALLOCATED(CGDisplayListAcceleratedImageBufferBackend);
+    WTF_MAKE_NONCOPYABLE(CGDisplayListAcceleratedImageBufferBackend);
+public:
+    static std::unique_ptr<CGDisplayListAcceleratedImageBufferBackend> create(const CGDisplayListImageBufferBackend::Parameters&, const WebCore::ImageBufferCreationContext&);
+
+protected:
+    CGDisplayListAcceleratedImageBufferBackend(const Parameters&, const WebCore::ImageBufferCreationContext&, WebCore::RenderingMode);
 };
 
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -370,7 +370,10 @@ void RemoteLayerBackingStore::ensureFrontBuffer()
         ImageBufferCreationContext creationContext;
         creationContext.useCGDisplayListImageCache = m_parameters.useCGDisplayListImageCache;
         // FIXME: This should use colorSpace(), not hardcode sRGB.
-        m_displayListBuffer = ImageBuffer::create<CGDisplayListImageBufferBackend>(m_parameters.size, m_parameters.scale, DestinationColorSpace::SRGB(), pixelFormat(), RenderingPurpose::DOM, WTFMove(creationContext));
+        if (type() == RemoteLayerBackingStore::Type::IOSurface)
+            m_displayListBuffer = ImageBuffer::create<CGDisplayListAcceleratedImageBufferBackend>(m_parameters.size, m_parameters.scale, DestinationColorSpace::SRGB(), pixelFormat(), RenderingPurpose::DOM, WTFMove(creationContext));
+        else
+            m_displayListBuffer = ImageBuffer::create<CGDisplayListImageBufferBackend>(m_parameters.size, m_parameters.scale, DestinationColorSpace::SRGB(), pixelFormat(), RenderingPurpose::DOM, WTFMove(creationContext));
     }
 #endif
 }


### PR DESCRIPTION
#### 64b45387dcf2f1fc528028eee0aff2beee9c4f63
<pre>
REGRESSION (260927@main): CGDisplayList image buffers no longer use the correct RenderingMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=253624">https://bugs.webkit.org/show_bug.cgi?id=253624</a>
rdar://106452687

Reviewed by Simon Fraser.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::GraphicsContextCG):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
Make it possible for a client who knows its CGContext&apos;s rendering mode to specify it
up front, instead of calculating it from the context (since sometimes it is impossible
to tell given only the context -- e.g. in the case of a display list, which could be
replayed into a software or accelerated context).

* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
(WebKit::GraphicsContextCGDisplayList::GraphicsContextCGDisplayList):
(WebKit::CGDisplayListImageBufferBackend::create):
(WebKit::CGDisplayListImageBufferBackend::CGDisplayListImageBufferBackend):
(WebKit::m_renderingMode):
(WebKit::CGDisplayListImageBufferBackend::context):
(WebKit::CGDisplayListAcceleratedImageBufferBackend::create):
(WebKit::CGDisplayListAcceleratedImageBufferBackend::CGDisplayListAcceleratedImageBufferBackend):
Add a new CGDisplayListAcceleratedImageBufferBackend backend that just inherits everything
from CGDisplayListImageBufferBackend, but overrides the RenderingMode that the GraphicsContextCG
is created with.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::ensureFrontBuffer):
Create the appropriate type of CGDisplayList{Accelerated}ImageBufferBackend
based on the type of the main buffer.

Canonical link: <a href="https://commits.webkit.org/261412@main">https://commits.webkit.org/261412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90b3dfe65d83f717744f4d5c65ccad3a37192c3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111628 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120371 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11842 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117393 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99574 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/152 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45289 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13244 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/149 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52142 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7943 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15723 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->