### PR TITLE
[WPE] Fix build for Ubuntu 20.04 after 261349@main

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -218,6 +218,7 @@ set(WPE_WEB_PROCESS_EXTENSION_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/webkit-web-process-extension.h.in
+    ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in
 )
 
 if (ENABLE_2022_GLIB_API)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2012 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#if PLATFORM(GTK) && USE(GTK4)
+#ifdef __WEBKIT_H__
+#error "Headers <webkit/webkit.h> and <webkit/webkit-web-process-extension.h> cannot be included together."
+#endif
+#elif PLATFORM(GTK)
+#ifdef __WEBKIT_2_H__
+#error "Headers <webkit2/webkit2.h> and <webkit2/webkit-web-extension.h> cannot be included together."
+#endif
+#elif PLATFORM(WPE) && ENABLE(2022_GLIB_API)
+#ifdef __WEBKIT_H__
+#error "Headers <wpe/webkit.h> and <wpe/webkit-web-process-extension.h> cannot be included together."
+#endif
+#elif PLATFORM(WPE)
+#ifdef __WEBKIT_H__
+#error "Headers <wpe/webkit.h> and <wpe/webkit-web-extension.h> cannot be included together."
+#endif
+#endif
+
+#ifndef __WEBKIT_WEB_PROCESS_EXTENSION_H__
+#define __WEBKIT_WEB_PROCESS_EXTENSION_H__
+
+#define __WEBKIT_WEB_PROCESS_EXTENSION_H_INSIDE__
+
+#if !ENABLE(2022_GLIB_API)
+#include <@API_INCLUDE_PREFIX@/WebKitConsoleMessage.h>
+#endif
+#include <@API_INCLUDE_PREFIX@/WebKitContextMenu.h>
+#include <@API_INCLUDE_PREFIX@/WebKitContextMenuActions.h>
+#include <@API_INCLUDE_PREFIX@/WebKitContextMenuItem.h>
+#include <@API_INCLUDE_PREFIX@/WebKitFrame.h>
+#include <@API_INCLUDE_PREFIX@/WebKitScriptWorld.h>
+#include <@API_INCLUDE_PREFIX@/WebKitURIRequest.h>
+#include <@API_INCLUDE_PREFIX@/WebKitURIResponse.h>
+#include <@API_INCLUDE_PREFIX@/WebKitUserMessage.h>
+#include <@API_INCLUDE_PREFIX@/WebKitVersion.h>
+#include <@API_INCLUDE_PREFIX@/WebKitWebEditor.h>
+#if !ENABLE(2022_GLIB_API)
+#include <@API_INCLUDE_PREFIX@/WebKitWebExtension.h>
+#endif
+#include <@API_INCLUDE_PREFIX@/WebKitWebFormManager.h>
+#include <@API_INCLUDE_PREFIX@/WebKitWebHitTestResult.h>
+#include <@API_INCLUDE_PREFIX@/WebKitWebPage.h>
+#include <@API_INCLUDE_PREFIX@/WebKitWebProcessEnumTypes.h>
+#if ENABLE(2022_GLIB_API)
+#include <@API_INCLUDE_PREFIX@/WebKitWebProcessExtension.h>
+#else
+#include <@API_INCLUDE_PREFIX@/WebKitWebExtensionAutocleanups.h>
+#endif
+
+#undef __WEBKIT_WEB_PROCESS_EXTENSION_H_INSIDE__
+
+#endif


### PR DESCRIPTION
#### 37c32c7842c0b666bb6a4d39e56e88297ebe8a73
<pre>
[WPE] Fix build for Ubuntu 20.04 after 261349@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=226665">https://bugs.webkit.org/show_bug.cgi?id=226665</a>

Reviewed by NOBODY (OOPS!).

Build was failing because header &apos;webkit-web-extension.h&apos; was not generated.

Generate &apos;webkit-web-extension.h&apos; out of template.

* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-extension.h.in: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37c32c7842c0b666bb6a4d39e56e88297ebe8a73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120406 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11885 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117435 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104624 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45390 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13284 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/186 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13774 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52184 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15764 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->