### PR TITLE
[popover] Fix html/semantics/popovers/popover-types.html WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL manuals do not close popovers Can't find variable: auto
+PASS manuals do not close popovers
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types.html
@@ -5,35 +5,33 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<div>
+<div id="container">
   <div popover>Popover</div>
   <div popover=manual>Async</div>
   <div popover=manual>Async</div>
-  <script>
-  {
-    const auto = document.currentScript.parentElement.querySelector('[popover=""]');
-    const manual = document.currentScript.parentElement.querySelectorAll('[popover=manual]')[0];
-    const manual2 = document.currentScript.parentElement.querySelectorAll('[popover=manual]')[1];
-    function assert_state_1(autoOpen,manualOpen,manual2Open) {
-      assert_equals(auto.matches(':open'),autoOpen,'auto open state is incorrect');
-      assert_equals(manual.matches(':open'),manualOpen,'manual open state is incorrect');
-      assert_equals(manual2.matches(':open'),manual2Open,'manual2 open state is incorrect');
-    }
-    test(() => {
-      assert_state_1(false,false,false);
-      auto.showPopover();
-      assert_state_1(true,false,false);
-      manual.showPopover();
-      assert_state_1(true,true,false);
-      manual2.showPopover();
-      assert_state_1(true,true,true);
-      auto.hidePopover();
-      assert_state_1(false,true,true);
-      manual.hidePopover();
-      assert_state_1(false,false,true);
-      manual2.hidePopover();
-      assert_state_1(false,false,false);
-    },'manuals do not close popovers');
-  }
-  </script>
 </div>
+<script>
+  const auto = container.querySelector('[popover=""]');
+  const manual = container.querySelectorAll('[popover=manual]')[0];
+  const manual2 = container.querySelectorAll('[popover=manual]')[1];
+  function assert_state_1(autoOpen,manualOpen,manual2Open) {
+    assert_equals(auto.matches(':open'),autoOpen,'auto open state is incorrect');
+    assert_equals(manual.matches(':open'),manualOpen,'manual open state is incorrect');
+    assert_equals(manual2.matches(':open'),manual2Open,'manual2 open state is incorrect');
+  }
+  test(() => {
+    assert_state_1(false,false,false);
+    auto.showPopover();
+    assert_state_1(true,false,false);
+    manual.showPopover();
+    assert_state_1(true,true,false);
+    manual2.showPopover();
+    assert_state_1(true,true,true);
+    auto.hidePopover();
+    assert_state_1(false,true,true);
+    manual.hidePopover();
+    assert_state_1(false,false,true);
+    manual2.hidePopover();
+    assert_state_1(false,false,false);
+  }, 'manuals do not close popovers');
+</script>


### PR DESCRIPTION
#### 12e1e3071116b2f98cb1749d1e4f2d923cf53b1a
<pre>
[popover] Fix html/semantics/popovers/popover-types.html WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=253627">https://bugs.webkit.org/show_bug.cgi?id=253627</a>
rdar://106481674

Reviewed by Ryosuke Niwa.

Avoid the `Can&apos;t find variable: auto` error, by removing the extra `{ }` and usages of `document.currentScript`.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types.html:

Canonical link: <a href="https://commits.webkit.org/261403@main">https://commits.webkit.org/261403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dd22e60ee5569737577c7819e564343e74ab6ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3394 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11855 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117405 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/104501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13255 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13745 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52148 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15735 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4328 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->