### PR TITLE
composedPath returns empty array for blur/focus/pagehide/pageshow events on window

### DIFF
--- a/LayoutTests/fast/events/focus-blur-event-path-expected.txt
+++ b/LayoutTests/fast/events/focus-blur-event-path-expected.txt
@@ -1,0 +1,17 @@
+This tests that event.composedPath is not empty for focus/blur events on window.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.type is "focus"
+PASS event.target is iframe.contentWindow
+PASS event.composedPath().length is 1
+PASS event.composedPath()[0] is iframe.contentWindow
+PASS event.type is "blur"
+PASS event.target is iframe.contentWindow
+PASS event.composedPath().length is 1
+PASS event.composedPath()[0] is iframe.contentWindow
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/focus-blur-event-path.html
+++ b/LayoutTests/fast/events/focus-blur-event-path.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<input id="input">
+<script>
+
+description('This tests that event.composedPath is not empty for focus/blur events on window.');
+
+const iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+
+iframe.contentWindow.addEventListener('focus', (event) => {
+    shouldBeEqualToString('event.type', 'focus');
+    shouldBe('event.target', 'iframe.contentWindow');
+    shouldBe('event.composedPath().length', '1');
+    shouldBe('event.composedPath()[0]', 'iframe.contentWindow');
+});
+
+iframe.contentWindow.addEventListener('blur', (event) => {
+    shouldBeEqualToString('event.type', 'blur');
+    shouldBe('event.target', 'iframe.contentWindow');
+    shouldBe('event.composedPath().length', '1');
+    shouldBe('event.composedPath()[0]', 'iframe.contentWindow');
+});
+
+iframe.focus();
+input.focus();
+iframe.remove();
+input.remove();
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/events/pageshow-pagehide-event-path-expected.txt
+++ b/LayoutTests/fast/events/pageshow-pagehide-event-path-expected.txt
@@ -1,0 +1,9 @@
+PASS event.type is "pagehide"
+PASS event.target is document
+PASS event.composedPath().length is 1
+PASS event.composedPath()[0] is window
+PASS event.type is "pageshow"
+PASS event.target is document
+PASS event.composedPath().length is 1
+PASS event.composedPath()[0] is window
+

--- a/LayoutTests/fast/events/pageshow-pagehide-event-path.html
+++ b/LayoutTests/fast/events/pageshow-pagehide-event-path.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+onpageshow = (event) => {
+    if (event.persisted) {
+        shouldBeEqualToString('event.type', 'pageshow');
+        shouldBe('event.target', 'document');
+        shouldBe('event.composedPath().length', '1');
+        shouldBe('event.composedPath()[0]', 'window');
+        window.onpagehide = null;
+        setTimeout(() => {
+            if (window.testRunner)
+                testRunner.notifyDone();            
+        }, 0);
+    }
+}
+
+window.onpagehide = (event) => {
+    shouldBeEqualToString('event.type', 'pagehide');
+    shouldBe('event.target', 'document');
+    shouldBe('event.composedPath().length', '1');
+    shouldBe('event.composedPath()[0]', 'window');
+}
+
+onload = () => {
+    setTimeout(() => {
+        blob = new Blob(['<!DOCTYPE html><script>history.back();</' + 'script>'], { type: "text/html" });
+        location.href = URL.createObjectURL(blob);
+    }, 0);
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -112,7 +112,7 @@ void EventContext::initializeTouchLists()
 bool EventContext::isUnreachableNode(EventTarget* target) const
 {
     // FIXME: Checks also for SVG elements.
-    return is<Node>(target) && !downcast<Node>(*target).isSVGElement() && m_node->isClosedShadowHidden(downcast<Node>(*target));
+    return is<Node>(target) && !downcast<Node>(*target).isSVGElement() && m_node && m_node->isClosedShadowHidden(downcast<Node>(*target));
 }
 
 #endif

--- a/Source/WebCore/dom/EventContext.h
+++ b/Source/WebCore/dom/EventContext.h
@@ -115,7 +115,6 @@ inline EventContext::EventContext(Type type, Node* node, RefPtr<EventTarget>&& c
 inline EventContext::EventContext(Type type, Node* node, EventTarget* currentTarget, EventTarget* origin, int closedShadowDepth)
     : EventContext(type, node, RefPtr { currentTarget }, origin, closedShadowDepth)
 {
-    ASSERT(!is<Node>(currentTarget));
 }
 
 // This variant avoids calling EventTarget::ref() which is a virtual function call.

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -269,6 +269,11 @@ EventPath::EventPath(const Vector<EventTarget*>& targets)
     });
 }
 
+EventPath::EventPath(EventTarget& target)
+{
+    m_path = { EventContext { EventContext::Type::Normal, nullptr, &target, &target, 0 } };
+}
+
 static Node* moveOutOfAllShadowRoots(Node& startingNode)
 {
     Node* node = &startingNode;

--- a/Source/WebCore/dom/EventPath.h
+++ b/Source/WebCore/dom/EventPath.h
@@ -36,6 +36,7 @@ class EventPath : public CanMakeCheckedPtr {
 public:
     EventPath(Node& origin, Event&);
     explicit EventPath(const Vector<EventTarget*>&);
+    explicit EventPath(EventTarget&);
 
     bool isEmpty() const { return m_path.isEmpty(); }
     size_t size() const { return m_path.size(); }

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -59,6 +59,7 @@
 #include "EventListener.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "EventPath.h"
 #include "FeaturePolicy.h"
 #include "FloatRect.h"
 #include "FocusController.h"
@@ -2372,20 +2373,22 @@ void DOMWindow::dispatchEvent(Event& event, EventTarget* target)
         }
     }
 
-    // FIXME: It doesn't seem right to have the inspector instrumentation here since not all
-    // events dispatched to the window object are guaranteed to flow through this function.
-    // But the instrumentation prevents us from calling EventDispatcher::dispatchEvent here.
     if (target)
         event.setTarget(target);
     else
         event.setTarget(Ref { *this });
 
+    EventPath eventPath { *this };
     event.setCurrentTarget(this);
     event.setEventPhase(Event::AT_TARGET);
     event.resetBeforeDispatch();
+    event.setEventPath(eventPath);
 
     RefPtr<Frame> protectedFrame;
     bool hasListenersForEvent = false;
+    // FIXME: It doesn't seem right to have the inspector instrumentation here since not all
+    // events dispatched to the window object are guaranteed to flow through this function.
+    // But the instrumentation prevents us from calling EventDispatcher::dispatchEvent here.
     if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
         protectedFrame = frame();
         hasListenersForEvent = hasEventListeners(event.type());


### PR DESCRIPTION
#### 80b26f0e3d9ab9f091390232abbdfae07ff82476
<pre>
composedPath returns empty array for blur/focus/pagehide/pageshow events on window
<a href="https://bugs.webkit.org/show_bug.cgi?id=253443">https://bugs.webkit.org/show_bug.cgi?id=253443</a>

Reviewed by Chris Dumez.

The bug was caused by DOMWindow::dispatchEvent not setting the EventPath.

* LayoutTests/fast/events/focus-blur-event-path-expected.txt: Added.
* LayoutTests/fast/events/focus-blur-event-path.html: Added.

* LayoutTests/fast/events/pageshow-pagehide-event-path-expected.txt: Added.
* LayoutTests/fast/events/pageshow-pagehide-event-path.html: Added.

* Source/WebCore/dom/EventContext.cpp:
(WebCore::EventContext::isUnreachableNode const): Added a nullptr check.

* Source/WebCore/dom/EventContext.h:
(WebCore::EventContext::EventContext): Removed the assertion since this assertion
will be wrong after this patch (we sometimes pass Document as currentTarget here).

* Source/WebCore/dom/EventPath.cpp:
(WebCore::EventPath::EventPath): Added a variant which takes a single EventTarget.

* Source/WebCore/dom/EventPath.h:

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::dispatchEvent): Fixed the bug by setting the event path.

Canonical link: <a href="https://commits.webkit.org/261463@main">https://commits.webkit.org/261463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d1877aadef72e6648a8ba09b942de3195c98eb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3489 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120387 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3224 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99588 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45364 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13263 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/162 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/91995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9612 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52160 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15743 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4350 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->