### PR TITLE
[Cocoa] Navigating to next Netflix video results in wrong size, empty content

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -594,9 +594,9 @@ RetainPtr<WKLayerHostView> VideoFullscreenManagerProxy::createLayerHostViewWithI
         model->setLayerHostView(view);
 
         [view layer].masksToBounds = NO;
-        [view layer].frame = CGRectMake(0, 0, initialSize.width(), initialSize.height());
         [view layer].name = @"WKLayerHostView layer";
     }
+    [view layer].frame = CGRectMake(0, 0, initialSize.width(), initialSize.height());
     [view setContextID:videoLayerID];
     return view;
 }


### PR DESCRIPTION
#### 20ae459b703acc37f665e11a8dea2d823a64b6a7
<pre>
[Cocoa] Navigating to next Netflix video results in wrong size, empty content
<a href="https://bugs.webkit.org/show_bug.cgi?id=253611">https://bugs.webkit.org/show_bug.cgi?id=253611</a>
rdar://82229550

Reviewed by Eric Carlson.

When a video layer already exists, and VideoFullscreenManagerProxy is asked to create
one, instead of simply bailing out early, set the layer&apos;s frame.

* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenManagerProxy::createLayerHostViewWithID):

Canonical link: <a href="https://commits.webkit.org/261446@main">https://commits.webkit.org/261446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/923f50bae759fbfc0f9eda960fc33227b923eae9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11867 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117417 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104594 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45372 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13266 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/163 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9616 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52161 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7966 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15746 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->