### PR TITLE
Use a WeakPtr for InlineCSSStyleDeclaration::m_parentElement

### DIFF
--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.h
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.h
@@ -28,6 +28,7 @@
 #include "CSSParserContext.h"
 #include "CSSStyleDeclaration.h"
 #include "DeprecatedCSSOMValue.h"
+#include "StyledElement.h"
 #include <memory>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
@@ -48,8 +49,6 @@ public:
     explicit PropertySetCSSStyleDeclaration(MutableStyleProperties& propertySet)
         : m_propertySet(&propertySet)
     { }
-
-    virtual void clearParentElement() { ASSERT_NOT_REACHED(); }
 
     StyleSheetContents* contextStyleSheet() const;
 
@@ -128,20 +127,19 @@ class InlineCSSStyleDeclaration final : public PropertySetCSSStyleDeclaration {
 public:
     InlineCSSStyleDeclaration(MutableStyleProperties& propertySet, StyledElement& parentElement)
         : PropertySetCSSStyleDeclaration(propertySet)
-        , m_parentElement(&parentElement)
+        , m_parentElement(parentElement)
     {
     }
 
 private:
     CSSStyleSheet* parentStyleSheet() const final;
-    StyledElement* parentElement() const final { return m_parentElement; }
-    void clearParentElement() final { m_parentElement = nullptr; }
+    StyledElement* parentElement() const final { return m_parentElement.get(); }
 
     bool willMutate() final WARN_UNUSED_RETURN;
     void didMutate(MutationType) final;
     CSSParserContext cssParserContext() const final;
 
-    StyledElement* m_parentElement;
+    WeakPtr<StyledElement, WeakPtrImplWithEventTargetData> m_parentElement;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -69,11 +69,7 @@ void StyledElement::synchronizeStyleAttributeInternalImpl()
         setSynchronizedLazyAttribute(styleAttr, inlineStyle->asTextAtom());
 }
 
-StyledElement::~StyledElement()
-{
-    if (PropertySetCSSStyleDeclaration* cssomWrapper = inlineStyleCSSOMWrapper())
-        cssomWrapper->clearParentElement();
-}
+StyledElement::~StyledElement() = default;
 
 CSSStyleDeclaration& StyledElement::cssomStyle()
 {


### PR DESCRIPTION
#### a08f9d20cd5351e682ed7c1749c597490d1dae26
<pre>
Use a WeakPtr for InlineCSSStyleDeclaration::m_parentElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=253629">https://bugs.webkit.org/show_bug.cgi?id=253629</a>

Reviewed by Darin Adler.

Use a WeakPtr for InlineCSSStyleDeclaration::m_parentElement. This is safer
than keeping a raw pointer and avoids some work in the StyleElement destructor
to clear this pointer.

* Source/WebCore/css/PropertySetCSSStyleDeclaration.h:
(WebCore::PropertySetCSSStyleDeclaration::clearParentElement): Deleted.
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::~StyledElement): Deleted.

Canonical link: <a href="https://commits.webkit.org/261440@main">https://commits.webkit.org/261440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a86dac44454915ca0029248e42b9b1e1614ae16d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/273 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120392 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11868 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3150 "layout-tests (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117418 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104593 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45367 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13267 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/173 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9615 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52171 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7963 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15747 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->