### PR TITLE
REGRESSION(260575@main): Google Meet Video renders blank (Affects all WebRTC and getUserMedia() rendering)

### DIFF
--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1303,18 +1303,19 @@ void GraphicsLayerCA::setContentsToPlatformLayerHost(LayerHostingContextIdentifi
 void GraphicsLayerCA::setContentsToVideoElement(HTMLVideoElement& videoElement, ContentsLayerPurpose purpose)
 {
 #if HAVE(AVKIT)
-    auto hostingContextID = videoElement.layerHostingContextID();
-    if (hostingContextID != m_layerHostingContextID) {
-        m_contentsLayer = createPlatformVideoLayer(videoElement, this);
-        m_layerHostingContextID = hostingContextID;
+    if (auto hostingContextID = videoElement.layerHostingContextID()) {
+        if (hostingContextID != m_layerHostingContextID) {
+            m_contentsLayer = createPlatformVideoLayer(videoElement, this);
+            m_layerHostingContextID = hostingContextID;
+        }
+        m_contentsLayerPurpose = purpose;
+        m_contentsDisplayDelegate = nullptr;
+        noteSublayersChanged();
+        noteLayerPropertyChanged(ContentsPlatformLayerChanged);
+        return;
     }
-    m_contentsLayerPurpose = purpose;
-    m_contentsDisplayDelegate = nullptr;
-    noteSublayersChanged();
-    noteLayerPropertyChanged(ContentsPlatformLayerChanged);
-#else
-    setContentsToPlatformLayer(videoElement.platformLayer(), purpose);
 #endif
+    setContentsToPlatformLayer(videoElement.platformLayer(), purpose);
 }
 
 void GraphicsLayerCA::setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&& delegate, ContentsLayerPurpose purpose)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -77,8 +77,10 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
 
 #if HAVE(AVKIT)
         if (properties.playerIdentifier && properties.initialSize && properties.naturalSize) {
-            if (auto videoManager = m_drawingArea->page().videoFullscreenManager())
+            if (auto videoManager = m_drawingArea->page().videoFullscreenManager()) {
+                m_videoLayers.add(properties.layerID, *properties.playerIdentifier);
                 return makeWithView(videoManager->createViewWithID(*properties.playerIdentifier, properties.hostingContextID, *properties.initialSize, *properties.naturalSize, properties.hostingDeviceScaleFactor));
+            }
         }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -832,7 +832,7 @@ void MediaPlayerPrivateRemote::load(MediaStreamPrivate&)
 PlatformLayer* MediaPlayerPrivateRemote::platformLayer() const
 {
 #if PLATFORM(COCOA)
-    if (!m_videoLayer) {
+    if (!m_videoLayer && m_layerHostingContextID) {
         m_videoLayer = createVideoLayerRemote(const_cast<MediaPlayerPrivateRemote*>(this), m_layerHostingContextID, m_videoFullscreenGravity, expandedIntSize(m_videoInlineSize));
         m_videoLayerManager->setVideoLayer(m_videoLayer.get(), expandedIntSize(m_videoInlineSize));
     }
@@ -1502,7 +1502,13 @@ LayerHostingContextID MediaPlayerPrivateRemote::hostingContextID() const
 
 void MediaPlayerPrivateRemote::setLayerHostingContextID(LayerHostingContextID inID)
 {
+    if (m_layerHostingContextID == inID)
+        return;
+
     m_layerHostingContextID = inID;
+#if PLATFORM(COCOA)
+    m_videoLayer = nullptr;
+#endif
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 57e51615e4e3388bcf66329ac3591f7121bd20ee
<pre>
REGRESSION(260575@main): Google Meet Video renders blank (Affects all WebRTC and getUserMedia() rendering)
<a href="https://bugs.webkit.org/show_bug.cgi?id=253632">https://bugs.webkit.org/show_bug.cgi?id=253632</a>
rdar://105795272

Reviewed by Eric Carlson.

When creating a layer for remote rendering, if the HTMLMediaElement does not have a valid
layerHostingContextID, try to create a local layer rather than passing over just the contextID.
This results in non-GPU-process hosted MediaPlayers (like all media-stream backed MediaPlayers) to
create a local layer, even when UI-side compositing is enabled. But in the case of GPU-process
hosted media elements, don&apos;t _actually_ create a new layer if we don&apos;t have a valid
layerHostingContextID. Whats more, whenever the layerHostingContextID changes, cause the layer to
get re-created by clearing m_videoLayer.

This exposes a bug in RemoteLayerTreeHostIOS, where added layers are never added to the
m_videoLayers map, so when those layers are removed, resources inside VideoFullscreenManagerProxy
aren&apos;t released.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setContentsToVideoElement):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::platformLayer const):
(WebKit::MediaPlayerPrivateRemote::setLayerHostingContextID):

Canonical link: <a href="https://commits.webkit.org/261455@main">https://commits.webkit.org/261455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2356ff06e6674f768830adf3e1beaed65bed29a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/381 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22255 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/11974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117531 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104728 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/88180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13862 "Failed to checkout and rebase branch from PR 11285") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/11974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52251 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7972 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->