### PR TITLE
[webkitpy] Fix undefined variable 'self' after 261389@main

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
@@ -44,7 +44,7 @@ def wpt_config_json(port_obj):
     if not fs.isfile(config_wk_filepath):
         return
     config = json.loads(fs.read_text_file(config_wk_filepath))
-    if port_obj.supports_localhost_aliases and not self._port_obj.get_option('disable_wpt_hostname_aliases'):
+    if port_obj.supports_localhost_aliases and not port_obj.get_option('disable_wpt_hostname_aliases'):
         config['browser_host'] = 'web-platform.test'
         config['alternate_hosts'] = {'alt': 'not-web-platform.test'}
     config['ssl']['openssl']['base_path'] = fs.join(port_obj.results_directory(), "_wpt_certs")


### PR DESCRIPTION
#### 58d744e9d380f951f0c68f1c62989ca4b38d77a1
<pre>
[webkitpy] Fix undefined variable &apos;self&apos; after 261389@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=253602">https://bugs.webkit.org/show_bug.cgi?id=253602</a>

Reviewed by Adrian Perez de Castro.

Cannot call &apos;self.__port_obj&apos; since variable &apos;self&apos; doesn&apos;t exist in
context. Use local variable &apos;port_obj&apos; instead.

* Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py:
(wpt_config_json):

Canonical link: <a href="https://commits.webkit.org/261426@main">https://commits.webkit.org/261426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d94f9c57c58df574520555b55ef12a6673dc5c17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120420 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11901 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117451 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99617 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/115115 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45389 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13300 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/194 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13790 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52191 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7951 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15780 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->