### PR TITLE
Expose https://www.w3.org/TR/image-capture/#dom-mediatrackcapabilities-focusdistance

### DIFF
--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt
@@ -17,6 +17,21 @@ audio track capabilities:
   capabilities.sampleRate = { max: 48000, min: 44100 }
   capabilities.volume = { max: 1, min: 0 }
 
+video track capabilities:
+  capabilities.aspectRatio = { max: 3840, min: 0.000 }
+  capabilities.deviceId = <UUID>
+  capabilities.facingMode = [ environment ]
+  capabilities.focusDistance = { min: 0.200 }
+  capabilities.frameRate = { max: 120, min: 1 }
+  capabilities.height = { max: 2160, min: 1 }
+  capabilities.width = { max: 3840, min: 1 }
+
+audio track capabilities:
+  capabilities.deviceId = <UUID>
+  capabilities.echoCancellation = [ true, false ]
+  capabilities.sampleRate = { max: 48000, min: 44100 }
+  capabilities.volume = { max: 1, min: 0 }
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities.html
@@ -91,6 +91,11 @@
 
                 listTrackProperties(mediaStream.getVideoTracks()[0]);
                 listTrackProperties(mediaStream.getAudioTracks()[0]);
+
+                mediaStream = await navigator.mediaDevices.getUserMedia({ audio:true, video:{ facingMode:"environment" } });
+                listTrackProperties(mediaStream.getVideoTracks()[0]);
+                listTrackProperties(mediaStream.getAudioTracks()[0]);
+
                 finishJSTest();
             }
 

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1398,6 +1398,10 @@
 #define HAVE_MEDIAPLAYBACKD 1
 #endif
 
+#if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 120000) || PLATFORM(IOS_FAMILY)
+#define HAVE_AVCAPTUREDEVICE_MINFOCUSLENGTH 1
+#endif
+
 #if (PLATFORM(GTK) || PLATFORM(WPE)) && defined(__has_include)
 #if __has_include(<gio/gdesktopappinfo.h>)
 #define HAVE_GDESKTOPAPPINFO 1

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -224,6 +224,7 @@ static bool hasInvalidGetDisplayMediaConstraint(const MediaConstraints& constrai
         case MediaConstraintType::SampleSize:
         case MediaConstraintType::Volume:
         case MediaConstraintType::EchoCancellation:
+        case MediaConstraintType::FocusDistance:
             // Ignored.
             break;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -292,10 +292,18 @@ static DoubleRange capabilityDoubleRange(const CapabilityValueOrRange& value)
         range.min = value.value().asDouble;
         range.max = range.min;
         break;
-    case CapabilityValueOrRange::DoubleRange:
-        range.min = value.rangeMin().asDouble;
-        range.max = value.rangeMax().asDouble;
+    case CapabilityValueOrRange::DoubleRange: {
+        auto min = value.rangeMin().asDouble;
+        auto max = value.rangeMax().asDouble;
+
+        ASSERT(min != std::numeric_limits<double>::min() || max != std::numeric_limits<double>::max());
+
+        if (min != std::numeric_limits<double>::min())
+            range.min = min;
+        if (max != std::numeric_limits<double>::max())
+            range.max = max;
         break;
+    }
     case CapabilityValueOrRange::Undefined:
     case CapabilityValueOrRange::ULong:
     case CapabilityValueOrRange::ULongRange:
@@ -367,6 +375,8 @@ MediaStreamTrack::TrackCapabilities MediaStreamTrack::getCapabilities() const
         result.deviceId = capabilities.deviceId();
     if (capabilities.supportsGroupId())
         result.groupId = capabilities.groupId();
+    if (capabilities.supportsFocusDistance())
+        result.focusDistance = capabilityDoubleRange(capabilities.focusDistance());
 
     auto settings = m_private->settings();
     if (settings.supportsDisplaySurface() && settings.displaySurface() != DisplaySurfaceType::Invalid)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -133,6 +133,7 @@ public:
         String deviceId;
         String groupId;
         String displaySurface;
+        std::optional<DoubleRange> focusDistance;
     };
     TrackCapabilities getCapabilities() const;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
@@ -73,6 +73,7 @@ enum MediaStreamTrackState { "live", "ended" };
     DOMString deviceId;
     DOMString groupId;
     DOMString displaySurface;
+    DoubleRange focusDistance;
 };
 
 [

--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -242,6 +242,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::GroupId:
     case MediaConstraintType::DisplaySurface:
     case MediaConstraintType::LogicalSurface:
+    case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -271,6 +272,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::GroupId:
     case MediaConstraintType::DisplaySurface:
     case MediaConstraintType::LogicalSurface:
+    case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -300,6 +302,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::FacingMode:
     case MediaConstraintType::DeviceId:
     case MediaConstraintType::GroupId:
+    case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -331,6 +334,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::EchoCancellation:
     case MediaConstraintType::DisplaySurface:
     case MediaConstraintType::LogicalSurface:
+    case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -540,6 +540,7 @@ double RealtimeMediaSource::fitnessDistance(const MediaConstraint& constraint)
 
     case MediaConstraintType::DisplaySurface:
     case MediaConstraintType::LogicalSurface:
+    case MediaConstraintType::FocusDistance:
         break;
 
     case MediaConstraintType::Unknown:
@@ -679,6 +680,7 @@ void RealtimeMediaSource::applyConstraint(const MediaConstraint& constraint)
         ASSERT(constraint.isBoolean());
         break;
 
+    case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Unknown:
         break;
     }
@@ -872,6 +874,7 @@ bool RealtimeMediaSource::supportsConstraint(const MediaConstraint& constraint)
         return false;
         break;
 
+    case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Unknown:
         // Unknown (or unsupported) constraints should be ignored.
         break;
@@ -912,6 +915,7 @@ bool RealtimeMediaSource::supportsConstraints(const MediaConstraints& constraint
         case MediaConstraintType::GroupId:
         case MediaConstraintType::DisplaySurface:
         case MediaConstraintType::LogicalSurface:
+        case MediaConstraintType::FocusDistance:
         case MediaConstraintType::Unknown:
             m_fitnessScore += distance ? 1 : 2;
             break;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -153,7 +153,7 @@ public:
         ReadWrite = 1,
     };
     
-    RealtimeMediaSourceCapabilities(CapabilityValueOrRange&& width, CapabilityValueOrRange&& height, CapabilityValueOrRange&& aspectRatio, CapabilityValueOrRange&& frameRate, Vector<VideoFacingMode>&& facingMode, CapabilityValueOrRange&& volume, CapabilityValueOrRange&& sampleRate, CapabilityValueOrRange&& sampleSize, EchoCancellation&& echoCancellation, AtomString&& deviceId, AtomString&& groupId, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceCapabilities(CapabilityValueOrRange&& width, CapabilityValueOrRange&& height, CapabilityValueOrRange&& aspectRatio, CapabilityValueOrRange&& frameRate, Vector<VideoFacingMode>&& facingMode, CapabilityValueOrRange&& volume, CapabilityValueOrRange&& sampleRate, CapabilityValueOrRange&& sampleSize, EchoCancellation&& echoCancellation, AtomString&& deviceId, AtomString&& groupId, CapabilityValueOrRange&& focusDistance, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(WTFMove(width))
         , m_height(WTFMove(height))
         , m_aspectRatio(WTFMove(aspectRatio))
@@ -165,6 +165,7 @@ public:
         , m_echoCancellation(WTFMove(echoCancellation))
         , m_deviceId(WTFMove(deviceId))
         , m_groupId(WTFMove(groupId))
+        , m_focusDistance(WTFMove(focusDistance))
         , m_supportedConstraints(WTFMove(supportedConstraints))
     {
     }
@@ -220,7 +221,11 @@ public:
     bool supportsGroupId() const { return m_supportedConstraints.supportsGroupId(); }
     const AtomString& groupId() const { return m_groupId; }
     void setGroupId(const AtomString& id)  { m_groupId = id; }
-    
+
+    bool supportsFocusDistance() const { return m_supportedConstraints.supportsFocusDistance(); }
+    const CapabilityValueOrRange& focusDistance() const { return m_focusDistance; }
+    void setFocusDistance(const CapabilityValueOrRange& focusDistance) { m_focusDistance = focusDistance; }
+
     const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const { return m_supportedConstraints; }
     void setSupportedConstraints(const RealtimeMediaSourceSupportedConstraints& constraints) { m_supportedConstraints = constraints; }
 
@@ -236,6 +241,7 @@ private:
     EchoCancellation m_echoCancellation { EchoCancellation::ReadOnly };
     AtomString m_deviceId;
     AtomString m_groupId;
+    CapabilityValueOrRange m_focusDistance;
 
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp
@@ -61,6 +61,8 @@ bool RealtimeMediaSourceSupportedConstraints::supportsConstraint(MediaConstraint
         return supportsDisplaySurface();
     case MediaConstraintType::LogicalSurface:
         return supportsLogicalSurface();
+    case MediaConstraintType::FocusDistance:
+        return supportsFocusDistance();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
@@ -51,6 +51,7 @@ enum class MediaConstraintType : uint8_t {
     GroupId,
     DisplaySurface,
     LogicalSurface,
+    FocusDistance,
 };
 
 class RealtimeMediaSourceSupportedConstraints {
@@ -59,7 +60,7 @@ public:
     {
     }
     
-    RealtimeMediaSourceSupportedConstraints(bool supportsWidth, bool supportsHeight, bool supportsAspectRatio, bool supportsFrameRate, bool supportsFacingMode, bool supportsVolume, bool supportsSampleRate, bool supportsSampleSize, bool supportsEchoCancellation, bool supportsDeviceId, bool supportsGroupId, bool supportsDisplaySurface, bool supportsLogicalSurface)
+    RealtimeMediaSourceSupportedConstraints(bool supportsWidth, bool supportsHeight, bool supportsAspectRatio, bool supportsFrameRate, bool supportsFacingMode, bool supportsVolume, bool supportsSampleRate, bool supportsSampleSize, bool supportsEchoCancellation, bool supportsDeviceId, bool supportsGroupId, bool supportsDisplaySurface, bool supportsLogicalSurface, bool supportsFocusDistance)
         : m_supportsWidth(supportsWidth)
         , m_supportsHeight(supportsHeight)
         , m_supportsAspectRatio(supportsAspectRatio)
@@ -73,6 +74,7 @@ public:
         , m_supportsGroupId(supportsGroupId)
         , m_supportsDisplaySurface(supportsDisplaySurface)
         , m_supportsLogicalSurface(supportsLogicalSurface)
+        , m_supportsFocusDistance(supportsFocusDistance)
     {
     }
 
@@ -117,6 +119,9 @@ public:
 
     bool supportsConstraint(MediaConstraintType) const;
 
+    bool supportsFocusDistance() const { return m_supportsFocusDistance; }
+    void setSupportsFocusDistance(bool value) { m_supportsFocusDistance = value; }
+
 private:
     bool m_supportsWidth { false };
     bool m_supportsHeight { false };
@@ -131,6 +136,7 @@ private:
     bool m_supportsGroupId { false };
     bool m_supportsDisplaySurface { false };
     bool m_supportsLogicalSurface { false };
+    bool m_supportsFocusDistance { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -287,6 +287,17 @@ const RealtimeMediaSourceCapabilities& AVVideoCaptureSource::capabilities()
     if ([videoDevice position] == AVCaptureDevicePositionBack)
         capabilities.addFacingMode(VideoFacingMode::Environment);
 
+#if HAVE(AVCAPTUREDEVICE_MINFOCUSLENGTH)
+    double minimumFocusDistance = [videoDevice minimumFocusDistance];
+    if (minimumFocusDistance != -1.0) {
+        ASSERT(minimumFocusDistance >= 0);
+        auto supportedConstraints = settings().supportedConstraints();
+        supportedConstraints.setSupportsFocusDistance(true);
+        capabilities.setFocusDistance({ minimumFocusDistance / 1000, std::numeric_limits<double>::max() });
+        capabilities.setSupportedConstraints(supportedConstraints);
+    }
+#endif // HAVE(AVCAPTUREDEVICE_MINFOCUSLENGTH)
+
     updateCapabilities(capabilities);
 
     m_capabilities = WTFMove(capabilities);

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -142,9 +142,17 @@ const RealtimeMediaSourceCapabilities& MockRealtimeVideoSource::capabilities()
         RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
 
         if (mockCamera()) {
-            capabilities.addFacingMode(std::get<MockCameraProperties>(m_device.properties).facingMode);
+            auto facingMode = std::get<MockCameraProperties>(m_device.properties).facingMode;
+            capabilities.addFacingMode(facingMode);
             capabilities.setDeviceId(hashedId());
             updateCapabilities(capabilities);
+
+            if (facingMode == VideoFacingMode::Environment) {
+                capabilities.setFocusDistance(CapabilityValueOrRange(0.2, std::numeric_limits<double>::max()));
+                auto supportedConstraints = settings().supportedConstraints();
+                supportedConstraints.setSupportsFocusDistance(true);
+                capabilities.setSupportedConstraints(supportedConstraints);
+            }
         } else if (mockDisplay()) {
             capabilities.setWidth(CapabilityValueOrRange(72, std::get<MockDisplayProperties>(m_device.properties).defaultSize.width()));
             capabilities.setHeight(CapabilityValueOrRange(45, std::get<MockDisplayProperties>(m_device.properties).defaultSize.height()));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4100,6 +4100,7 @@ class WebCore::RealtimeMediaSourceSupportedConstraints {
     bool supportsGroupId();
     bool supportsDisplaySurface();
     bool supportsLogicalSurface();
+    bool supportsFocusDistance();
 };
 
 enum class WebCore::VideoFacingMode : uint8_t {
@@ -4171,6 +4172,7 @@ class WebCore::RealtimeMediaSourceCapabilities {
     WebCore::RealtimeMediaSourceCapabilities::EchoCancellation echoCancellation();
     AtomString deviceId();
     AtomString groupId();
+    WebCore::CapabilityValueOrRange focusDistance();
     WebCore::RealtimeMediaSourceSupportedConstraints supportedConstraints();
 };
 


### PR DESCRIPTION
#### 9e0b3254278178d3a02f9633130eb222fa52d4c9
<pre>
Expose <a href="https://www.w3.org/TR/image-capture/#dom-mediatrackcapabilities-focusdistance">https://www.w3.org/TR/image-capture/#dom-mediatrackcapabilities-focusdistance</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=253645">https://bugs.webkit.org/show_bug.cgi?id=253645</a>
rdar://problem/106497310

Reviewed by Eric Carlson.

Expose focusDistance to allow web developers to disambiguate between various cameras.
In macOS/iOS, we can use <a href="https://developer.apple.com/documentation/avfoundation/avcapturedevice/3751762-minimumfocusdistance?changes=_5">https://developer.apple.com/documentation/avfoundation/avcapturedevice/3751762-minimumfocusdistance?changes=_5</a>, which we can expose as focusDistance.min. We do not have a focusDistance.max so we leave that field undefined.
To do so, we use numeric_values&lt;double&gt;::max as the undefined value.

Covered by updated layout test and updated mock camera.
Mock front camera does not have any focus distance info and mock back camera has min focus distance of 0.2.

* LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt:
* LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities.html:
* Source/WTF/wtf/PlatformHave.h:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::hasInvalidGetDisplayMediaConstraint):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::capabilityDoubleRange):
(WebCore::MediaStreamTrack::getCapabilities const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.idl:
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::MediaTrackConstraintSetMap::set):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::fitnessDistance):
(WebCore::RealtimeMediaSource::applyConstraint):
(WebCore::RealtimeMediaSource::supportsConstraint):
(WebCore::RealtimeMediaSource::supportsConstraints):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::RealtimeMediaSourceCapabilities::RealtimeMediaSourceCapabilities):
(WebCore::RealtimeMediaSourceCapabilities::supportsFocusDistance const):
(WebCore::RealtimeMediaSourceCapabilities::focusDistance const):
(WebCore::RealtimeMediaSourceCapabilities::setFocusDistance):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp:
(WebCore::RealtimeMediaSourceSupportedConstraints::supportsConstraint const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h:
(WebCore::RealtimeMediaSourceSupportedConstraints::RealtimeMediaSourceSupportedConstraints):
(WebCore::RealtimeMediaSourceSupportedConstraints::supportsFocusDistance const):
(WebCore::RealtimeMediaSourceSupportedConstraints::setSupportsFocusDistance):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::capabilities):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::capabilities):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/261624@main">https://commits.webkit.org/261624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a076b1890686fc893213198b0770f04ea01a0dc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120956 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4896 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118112 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105395 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45964 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/100715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/732 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/11982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14550 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102115 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52737 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31910 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8106 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16354 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110154 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27211 "Passed tests") | 
<!--EWS-Status-Bubble-End-->