### PR TITLE
Non-unified build fixes, early March 2023 edition, take two

### DIFF
--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -33,6 +33,7 @@
 #include "GetterSetterAccessCase.h"
 #include "ICStatusUtils.h"
 #include "PolymorphicAccess.h"
+#include "ProxyObjectAccessCase.h"
 #include "StructureInlines.h"
 #include "StructureStubInfo.h"
 #include <wtf/ListDump.h>

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -49,6 +49,7 @@
 #include "RegExpObject.h"
 #include "ScopedArguments.h"
 #include "StringObject.h"
+#include "TypedArrayInlines.h"
 #include <wtf/CommaPrinter.h>
 #include <wtf/StringPrintStream.h>
 

--- a/Source/JavaScriptCore/runtime/BytecodeCacheError.cpp
+++ b/Source/JavaScriptCore/runtime/BytecodeCacheError.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "BytecodeCacheError.h"
 
+#include "JSGlobalObject.h"
 #include <wtf/SafeStrerror.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp
@@ -30,6 +30,8 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "InstructionStream.h"
+#include "VirtualRegister.h"
+#include <wtf/FixedVector.h>
 
 namespace JSC { namespace Wasm {
 

--- a/Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h
+++ b/Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h
@@ -30,6 +30,7 @@
 #include "ExecutionCounter.h"
 #include "InstructionStream.h"
 #include "Options.h"
+#include "VirtualRegister.h"
 #include <wtf/HashMap.h>
 
 namespace JSC { namespace Wasm {

--- a/Source/WebCore/bindings/js/JSAbstractRangeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAbstractRangeCustom.cpp
@@ -29,6 +29,7 @@
 #include "JSDOMWrapperCache.h"
 #include "JSRange.h"
 #include "JSStaticRange.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSCSSStyleValueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSStyleValueCustom.cpp
@@ -41,6 +41,7 @@
 #include "JSCSSUnitValue.h"
 #include "JSCSSUnparsedValue.h"
 #include "JSDOMWrapperCache.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/bindings/js/JSCSSTransformComponentCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSTransformComponentCustom.cpp
@@ -35,6 +35,7 @@
 #include "JSCSSSkewY.h"
 #include "JSCSSTranslate.h"
 #include "JSDOMWrapperCache.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/html/HTMLMapElement.cpp
+++ b/Source/WebCore/html/HTMLMapElement.cpp
@@ -24,6 +24,7 @@
 
 #include "Attribute.h"
 #include "Document.h"
+#include "ElementInlines.h"
 #include "GenericCachedHTMLCollection.h"
 #include "HTMLAreaElement.h"
 #include "HTMLImageElement.h"

--- a/Source/WebCore/html/HTMLOutputElement.cpp
+++ b/Source/WebCore/html/HTMLOutputElement.cpp
@@ -34,6 +34,7 @@
 
 #include "DOMTokenList.h"
 #include "Document.h"
+#include "ElementInlines.h"
 #include "HTMLFormElement.h"
 #include "HTMLNames.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/html/HTMLQuoteElement.cpp
+++ b/Source/WebCore/html/HTMLQuoteElement.cpp
@@ -24,6 +24,7 @@
 #include "HTMLQuoteElement.h"
 
 #include "Document.h"
+#include "ElementInlines.h"
 #include "HTMLNames.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -34,6 +34,7 @@
 #include "BroadcastChannelRegistry.h"
 #include "CacheStorageProvider.h"
 #include "ChromeClient.h"
+#include "ContextMenuClient.h"
 #include "CookieJar.h"
 #include "DatabaseProvider.h"
 #include "DiagnosticLoggingClient.h"

--- a/Source/WebCore/page/PerformanceMark.cpp
+++ b/Source/WebCore/page/PerformanceMark.cpp
@@ -35,6 +35,7 @@
 #include "PerformanceUserTiming.h"
 #include "SerializedScriptValue.h"
 #include "WorkerGlobalScope.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -34,6 +34,10 @@
 #include <WebCore/TransformationMatrix.h>
 #include <wtf/SetForScope.h>
 
+#if USE(GLIB_EVENT_LOOP)
+#include <wtf/glib/RunLoopSourcePriority.h>
+#endif
+
 #if USE(LIBEPOXY)
 #include <epoxy/gl.h>
 #elif USE(OPENGL_ES)


### PR DESCRIPTION
#### a853981dbd7782b16a06eb5d6d315057862b6824
<pre>
Non-unified build fixes, early March 2023 edition, take two
<a href="https://bugs.webkit.org/show_bug.cgi?id=253644">https://bugs.webkit.org/show_bug.cgi?id=253644</a>

Unreviewed non-unified build fixes.

* Source/JavaScriptCore/bytecode/PutByStatus.cpp: Add missing
  ProxyObjectAccessCase.h inclusion.
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp: Add missing
  TypedArrayInlines.h inclusion.
* Source/JavaScriptCore/runtime/BytecodeCacheError.cpp: Add missing
  JSGlobalObject.h inclusion.
* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.cpp: Add
  missing VirtualRegister.h and wtf/FixedVector.h inclusions.
* Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h: Add missing
  VirtualRegister.h inclusion.
* Source/WebCore/bindings/js/JSAbstractRangeCustom.cpp: Add missing
  JavaScriptCore/JSCJSValueInlines.h inclusion.
* Source/WebCore/bindings/js/JSCSSStyleValueCustom.cpp: Ditto.
* Source/WebCore/bindings/js/JSCSSTransformComponentCustom.cpp: Ditto.
* Source/WebCore/html/HTMLMapElement.cpp: Add missing ElementInlines.h
  inclusion.
* Source/WebCore/html/HTMLOutputElement.cpp: Ditto.
* Source/WebCore/html/HTMLQuoteElement.cpp: Ditto.
* Source/WebCore/page/PageConfiguration.cpp: Add missing
  ContextMenuClient.h inclusion.
* Source/WebCore/page/PerformanceMark.cpp: Add missing
  JavaScriptCore/JSCJSValueInlines.h inclusion.
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
  Add missing wtf/glib/RunLoopSourcePriority.h inclusion guarded by
  USE(GLIB_EVENT_LOOP).

Canonical link: <a href="https://commits.webkit.org/261460@main">https://commits.webkit.org/261460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5657ef967aaa78eda4d412e6ee183e9ab6276239

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3185 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117463 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104654 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45419 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100195 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13311 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/201 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11436 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9646 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101417 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52198 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31534 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15792 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109456 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4349 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26940 "Passed tests") | 
<!--EWS-Status-Bubble-End-->