### PR TITLE
[GLib] Warning on WebKitNetworkSession documentation; old API version should not build migration docs for new API version

### DIFF
--- a/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
@@ -37,9 +37,4 @@ show_class_hierarchy = true
 [source-location]
 base_url = "https://github.com/WebKit/WebKit/tree/main"
 
-[extra]
-content_files = [
-    "migrating-to-webkitgtk-6.0.md"
-]
-
 urlmap_file = "gtk@GTK_API_VERSION@-urlmap.js"


### PR DESCRIPTION
#### c004cfb0077e68721e7b67204ab3da488efe545d
<pre>
[GLib] Warning on WebKitNetworkSession documentation; old API version should not build migration docs for new API version
<a href="https://bugs.webkit.org/show_bug.cgi?id=252468">https://bugs.webkit.org/show_bug.cgi?id=252468</a>

Reviewed by Carlos Garcia Campos.

I thought I had removed this in 261349@main but apparently I forgot. The
migration guide belongs only in the documentation of the new API
version, not the old version.

* Source/WebKit/gtk/gtk3-webkitgtk.toml.in:

Canonical link: <a href="https://commits.webkit.org/261433@main">https://commits.webkit.org/261433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24d50b304225a13febb923efd1098c71aa866840

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120434 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11919 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117469 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104664 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13317 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/206 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13807 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52203 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7955 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15798 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->