### PR TITLE
Make JavaScriptCore ARC-safe!

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIWrapperObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIWrapperObject.mm
@@ -52,7 +52,7 @@ void JSAPIWrapperObjectHandleOwner::finalize(JSC::Handle<JSC::Unknown> handle, v
     if (!wrapperObject->wrappedObject())
         return;
 
-    JSC::Heap::heap(wrapperObject)->releaseSoon(adoptNS(static_cast<id>(wrapperObject->wrappedObject())));
+    JSC::Heap::heap(wrapperObject)->releaseSoon(adoptNS((__bridge id)((wrapperObject->wrappedObject()))));
     JSC::WeakSet::deallocate(JSC::WeakImpl::asWeakImpl(handle.slot()));
 }
 
@@ -122,7 +122,7 @@ void JSAPIWrapperObject::finishCreation(VM& vm)
 void JSAPIWrapperObject::setWrappedObject(void* wrappedObject)
 {
     ASSERT(!m_wrappedObject);
-    m_wrappedObject = [static_cast<id>(wrappedObject) retain];
+    m_wrappedObject = const_cast<void *>(CFRetain(wrappedObject));
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/API/JSAPIWrapperObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIWrapperObject.mm
@@ -52,7 +52,7 @@ void JSAPIWrapperObjectHandleOwner::finalize(JSC::Handle<JSC::Unknown> handle, v
     if (!wrapperObject->wrappedObject())
         return;
 
-    JSC::Heap::heap(wrapperObject)->releaseSoon(adoptNS((__bridge id)((wrapperObject->wrappedObject()))));
+    JSC::Heap::heap(wrapperObject)->releaseSoon(adoptNS((__bridge id)wrapperObject->wrappedObject()));
     JSC::WeakSet::deallocate(JSC::WeakImpl::asWeakImpl(handle.slot()));
 }
 

--- a/Source/JavaScriptCore/API/JSManagedValue.mm
+++ b/Source/JavaScriptCore/API/JSManagedValue.mm
@@ -119,7 +119,9 @@ static JSManagedValueHandleOwner& managedValueHandleOwner()
     }
 
     [self disconnectValue];
+#if !__has_feature(objc_arc)
     [super dealloc];
+#endif
 }
 
 - (void)didAddOwner:(id)owner

--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -75,10 +75,14 @@ NSString * const JSPropertyDescriptorSetKey = @"set";
 {
     if (_context) {
         JSValueUnprotect([_context JSGlobalContextRef], m_value);
+#if !__has_feature(objc_arc)
         [_context release];
+#endif
         _context = nil;
     }
+#if !__has_feature(objc_arc)
     [super dealloc];
+#endif
 }
 
 - (NSString *)description
@@ -1110,7 +1114,9 @@ JSValueRef valueInternalValue(JSValue * value)
 - (JSValue *)initWithValue:(JSValueRef)value inContext:(JSContext *)context
 {
     if (!value || !context) {
+#if !__has_feature(objc_arc)
         [self release];
+#endif
         return nil;
     }
 
@@ -1118,7 +1124,11 @@ JSValueRef valueInternalValue(JSValue * value)
     if (!self)
         return nil;
 
+#if !__has_feature(objc_arc)
     _context = [context retain];
+#else
+    _context = context;
+#endif
     m_value = value;
     JSValueProtect([_context JSGlobalContextRef], m_value);
     return self;

--- a/Source/JavaScriptCore/API/JSVirtualMachine.mm
+++ b/Source/JavaScriptCore/API/JSVirtualMachine.mm
@@ -125,7 +125,9 @@ static NSMapTable *wrapperCache() WTF_REQUIRES_LOCK(wrapperCacheMutex)
 - (void)dealloc
 {
     JSContextGroupRelease(m_group);
+#if !__has_feature(objc_arc)
     [super dealloc];
+#endif
 }
 
 static id getInternalObjcObject(id object)

--- a/Source/JavaScriptCore/API/JSWrapperMap.mm
+++ b/Source/JavaScriptCore/API/JSWrapperMap.mm
@@ -421,7 +421,9 @@ static void copyPrototypeProperties(JSContext *context, Class objcClass, Protoco
 - (void)dealloc
 {
     JSClassRelease(m_classRef.get());
+#if !__has_feature(objc_arc)
     [super dealloc];
+#endif
 }
 
 static JSC::JSObject* allocateConstructorForCustomClass(JSContext *context, const char* className, Class cls)
@@ -512,9 +514,9 @@ typedef std::pair<JSC::JSObject*, JSC::JSObject*> ConstructorPrototypePair;
         putNonEnumerable(context, constructor, @"prototype", prototype);
 
         Protocol *exportProtocol = getJSExportProtocol();
-        forEachProtocolImplementingProtocol(m_class, exportProtocol, ^(Protocol *protocol, bool&){
-            copyPrototypeProperties(context, m_class, protocol, prototype);
-            copyMethodsToObject(context, m_class, protocol, NO, constructor);
+        forEachProtocolImplementingProtocol(self->m_class, exportProtocol, ^(Protocol *protocol, bool &) {
+            copyPrototypeProperties(context, self->m_class, protocol, prototype);
+            copyMethodsToObject(context, self->m_class, protocol, NO, constructor);
         });
 
         // Set [Prototype].

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -12990,6 +12990,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1C9051430BA9E8A70081E9D0 /* JavaScriptCore.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Debug;
 		};
@@ -12997,6 +12998,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1C9051430BA9E8A70081E9D0 /* JavaScriptCore.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Release;
 		};
@@ -13005,6 +13007,7 @@
 			baseConfigurationReference = 1C9051430BA9E8A70081E9D0 /* JavaScriptCore.xcconfig */;
 			buildSettings = {
 				BUILD_VARIANTS = normal;
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Production;
 		};
@@ -13012,6 +13015,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5DAFD6CB146B686300FBEFB4 /* JSC.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Debug;
 		};
@@ -13019,6 +13023,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5DAFD6CB146B686300FBEFB4 /* JSC.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Release;
 		};
@@ -13026,6 +13031,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5DAFD6CB146B686300FBEFB4 /* JSC.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Production;
 		};
@@ -13449,6 +13455,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1C9051430BA9E8A70081E9D0 /* JavaScriptCore.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Profiling;
 		};
@@ -13478,6 +13485,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5DAFD6CB146B686300FBEFB4 /* JSC.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Profiling;
 		};

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -90,7 +90,7 @@ public:
     template<typename U> RetainPtr(const RetainPtr<U>&);
 
     constexpr RetainPtr(RetainPtr&& o) : m_ptr(toStorageType(o.leakRef())) { }
-    template<typename U> constexpr RetainPtr(RetainPtr<U>&& o) : m_ptr(toStorageType(checkType(o.leakRef()))) { }
+    template<typename U> constexpr RetainPtr(RetainPtr<U>&& o) : m_ptr(toStorageType(o.leakRef())) { }
 
     // Hash table deleted values, which are only constructed and never copied or destroyed.
     constexpr RetainPtr(HashTableDeletedValueType) : m_ptr(hashTableDeletedValue()) { }
@@ -139,8 +139,6 @@ public:
 private:
     enum AdoptTag { Adopt };
     constexpr RetainPtr(PtrType ptr, AdoptTag) : m_ptr(toStorageType(ptr)) { }
-
-    static constexpr PtrType checkType(PtrType ptr) { return ptr; }
 
     static constexpr PtrType hashTableDeletedValue() { return reinterpret_cast<PtrType>(-1); }
 


### PR DESCRIPTION
#### a21d7ebd6e2dba68bc9c22cd873e87d73e837e93
<pre>
Make JavaScriptCore ARC-safe!

Reviewed by NOBODY (OOPS!).

Whatever checkType was supposed to do, all it did was return m_ptr, which is useless,
and the only other constexpr that uses it was RetainPtr.
This also confuses ARC, which could not follow the logic for some reason.

So now JavaScriptCore can run on ARC.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59fc071cfa9db8c439d1129f5c1dfbc631700820

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/1984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2074 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/2908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/2059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2089 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/2054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/2908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2001 "Failed to checkout and rebase branch from PR 11299") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2755 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/1661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/1820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/1895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/2054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2042 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/1773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/1925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2087 "Built successfully") | 
| | | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->