### PR TITLE
Make WKCookiePolicyAllow map to HTTPCookieAcceptPolicy::OnlyFromMainDocumentDomain

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -129,7 +129,7 @@ static WebCore::HTTPCookieAcceptPolicy toHTTPCookieAcceptPolicy(WKCookiePolicy w
 {
     switch (wkCookiePolicy) {
     case WKCookiePolicyAllow:
-        return WebCore::HTTPCookieAcceptPolicy::AlwaysAccept;
+        return WebCore::HTTPCookieAcceptPolicy::OnlyFromMainDocumentDomain;
     case WKCookiePolicyDisallow:
         return WebCore::HTTPCookieAcceptPolicy::Never;
     }
@@ -139,11 +139,11 @@ static WebCore::HTTPCookieAcceptPolicy toHTTPCookieAcceptPolicy(WKCookiePolicy w
 static WKCookiePolicy toWKCookiePolicy(WebCore::HTTPCookieAcceptPolicy policy)
 {
     switch (policy) {
-    case WebCore::HTTPCookieAcceptPolicy::AlwaysAccept:
+    case WebCore::HTTPCookieAcceptPolicy::OnlyFromMainDocumentDomain:
         return WKCookiePolicyAllow;
     case WebCore::HTTPCookieAcceptPolicy::Never:
         return WKCookiePolicyDisallow;
-    case WebCore::HTTPCookieAcceptPolicy::OnlyFromMainDocumentDomain:
+    case WebCore::HTTPCookieAcceptPolicy::AlwaysAccept:
     case WebCore::HTTPCookieAcceptPolicy::ExclusivelyFromMainDocumentDomain:
         return WKCookiePolicyAllow;
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm
@@ -135,3 +135,68 @@ TEST(WKHTTPCookieStore, CookiePolicy)
     [webView _test_waitForDidFinishNavigation];
     EXPECT_TRUE(requestHadCookie);
 }
+
+TEST(WKHTTPCookieStore, CookiePolicyAllowIsOnlyFromMainDocumentDomain)
+{
+    TestWebKitAPI::HTTPServer server([connectionCount = 0] (TestWebKitAPI::Connection connection) mutable {
+        ++connectionCount;
+        connection.receiveHTTPRequest([connectionCount, connection] (Vector<char>&& request) {
+            String reply;
+            if (connectionCount == 1) {
+                const char* body =
+                "<script>"
+                    "fetch('http://www.example.com', { credentials : 'include' }).then(()=>{ alert('fetched'); }).catch((e)=>{ alert(e); })"
+                "</script>";
+                reply = makeString(
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: ", strlen(body), "\r\n"
+                    "Set-Cookie: a=b\r\n"
+                    "Connection: close\r\n"
+                    "\r\n", body
+                );
+            } else {
+                EXPECT_TRUE(strnstr(request.data(), "GET http://www.example.com/ HTTP/1.1\r\n", request.size()));
+                reply =
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n"
+                    "Set-Cookie: c=d\r\n"
+                    "Access-Control-Allow-Origin: http://www.webkit.org\r\n"
+                    "Access-Control-Allow-Credentials: true\r\n"
+                    "Connection: close\r\n"
+                    "\r\n"_s;
+            }
+            connection.send(WTFMove(reply));
+        });
+    });
+
+    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [dataStoreConfiguration setProxyConfiguration:@{
+        (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
+        (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
+    }];
+    [dataStoreConfiguration setAllowsServerPreconnect:NO];
+    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    auto cookieStore = dataStore.get().httpCookieStore;
+    [cookieStore setCookiePolicy:WKCookiePolicyAllow completionHandler:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:dataStore.get()];
+    // Relax WebKit's third-party cookies blocking policy so the WebKit will use cookie storage's policy
+    // to decide whether third-party cookeis can be stored.
+    [configuration _setShouldRelaxThirdPartyCookieBlocking:true];
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.webkit.org/"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "fetched");
+
+    [cookieStore getAllCookies:[&](NSArray<NSHTTPCookie *> *cookies) {
+        // Ensure example.com's cookie is not stored.
+        EXPECT_EQ([cookies count], 1u);
+        EXPECT_WK_STREQ([[cookies firstObject] domain], @"www.webkit.org");
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}


### PR DESCRIPTION
#### 7b8aecb52228383acdeb378f8cddf999a487f52f
<pre>
Make WKCookiePolicyAllow map to HTTPCookieAcceptPolicy::OnlyFromMainDocumentDomain
<a href="https://bugs.webkit.org/show_bug.cgi?id=253630">https://bugs.webkit.org/show_bug.cgi?id=253630</a>
rdar://106486320

Reviewed by Alex Christensen.

Default policy of NSHTTPCookieStorage is OnlyFromMainDocumentDomain.

* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(toHTTPCookieAcceptPolicy):
(toWKCookiePolicy):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/261515@main">https://commits.webkit.org/261515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e13e58b0f5d8fbd07ccee30d21b836e446c4fb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120527 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115898 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3343 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104841 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45539 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13413 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/293 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9719 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52294 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8019 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15895 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->