### PR TITLE
Fixes navigator.credentials.preventSilentAccess()

### DIFF
--- a/LayoutTests/http/wpt/credential-management/credentialscontainer-preventSilentAccess-basics.https.html
+++ b/LayoutTests/http/wpt/credential-management/credentialscontainer-preventSilentAccess-basics.https.html
@@ -3,8 +3,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-promise_test(function(t) {
-    return promise_rejects_dom(t, "NotSupportedError",
-            navigator.credentials.preventSilentAccess());
+promise_test(function() {
+    return navigator.credentials.preventSilentAccess()
+            .then((result) => {
+                assert_equals(result, undefined);
+            });
 }, "navigator.credentials.preventSilentAccess().");
 </script>

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -138,7 +138,7 @@ void CredentialsContainer::isCreate(CredentialCreationOptions&& options, Credent
 
 void CredentialsContainer::preventSilentAccess(DOMPromiseDeferred<void>&& promise) const
 {
-    promise.reject(Exception { NotSupportedError, "Not implemented."_s });
+    promise.resolve();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 40294715d0c0e48bf27775eadfe7b76ec2e62250
<pre>
Fixes navigator.credentials.preventSilentAccess()
<a href="https://bugs.webkit.org/show_bug.cgi?id=242002">https://bugs.webkit.org/show_bug.cgi?id=242002</a>

Reviewed by J Pascoe.

This change makes the function resolve rather than throw matching the spec.

* LayoutTests/http/wpt/credential-management/credentialscontainer-preventSilentAccess-basics.https.html:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
 (WebCore::CredentialsContainer::preventSilentAccess const):

Canonical link: <a href="https://commits.webkit.org/264345@main">https://commits.webkit.org/264345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c40228d830a20bda54f3bef2f6195ba14dd5643

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3586 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105068 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45704 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/93317 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9876 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52466 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1757 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->