### PR TITLE
Use WeakPtr for SpinButtonElement::m_spinButtonOwner

### DIFF
--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -83,8 +83,6 @@ TextFieldInputType::TextFieldInputType(Type type, HTMLInputElement& element)
 
 TextFieldInputType::~TextFieldInputType()
 {
-    if (m_innerSpinButton)
-        m_innerSpinButton->removeSpinButtonOwner();
 #if ENABLE(DATALIST_ELEMENT)
     closeSuggestions();
 #endif

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -51,7 +51,7 @@ using namespace HTMLNames;
 
 inline SpinButtonElement::SpinButtonElement(Document& document, SpinButtonOwner& spinButtonOwner)
     : HTMLDivElement(divTag, document, CreateSpinButtonElement)
-    , m_spinButtonOwner(&spinButtonOwner)
+    , m_spinButtonOwner(spinButtonOwner)
     , m_capturing(false)
     , m_upDownState(Indeterminate)
     , m_pressStartingState(Indeterminate)

--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -29,6 +29,7 @@
 #include "HTMLDivElement.h"
 #include "PopupOpeningObserver.h"
 #include "Timer.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -41,7 +42,7 @@ public:
         Up,
     };
 
-    class SpinButtonOwner {
+    class SpinButtonOwner : public CanMakeWeakPtr<SpinButtonOwner> {
     public:
         virtual ~SpinButtonOwner() = default;
         virtual void focusAndSelectSpinButtonOwner() = 0;
@@ -57,7 +58,7 @@ public:
     static Ref<SpinButtonElement> create(Document&, SpinButtonOwner&);
     UpDownState upDownState() const { return m_upDownState; }
     void releaseCapture();
-    void removeSpinButtonOwner() { m_spinButtonOwner = 0; }
+    void removeSpinButtonOwner() { m_spinButtonOwner = nullptr; }
 
     void step(int amount);
     
@@ -84,7 +85,7 @@ private:
     bool shouldRespondToMouseEvents() const;
     bool isMouseFocusable() const override { return false; }
 
-    SpinButtonOwner* m_spinButtonOwner;
+    WeakPtr<SpinButtonOwner> m_spinButtonOwner;
     bool m_capturing;
     UpDownState m_upDownState;
     UpDownState m_pressStartingState;


### PR DESCRIPTION
#### 8dd0783192ba48a76f5736dd9919858e1fe47052
<pre>
Use WeakPtr for SpinButtonElement::m_spinButtonOwner
<a href="https://bugs.webkit.org/show_bug.cgi?id=253652">https://bugs.webkit.org/show_bug.cgi?id=253652</a>

Reviewed by Darin Adler.

* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::~TextFieldInputType):
* Source/WebCore/html/shadow/SpinButtonElement.cpp:
(WebCore::SpinButtonElement::SpinButtonElement):
* Source/WebCore/html/shadow/SpinButtonElement.h:

Canonical link: <a href="https://commits.webkit.org/261462@main">https://commits.webkit.org/261462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef3b3e0918dcbeb72e1110dd06ee149bc4a86d78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120461 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11950 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117500 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104696 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98454 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/226 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45448 "2 flakes 135 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13345 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/227 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/87909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13838 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7976 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15827 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->