### PR TITLE
[container-queries] Update CSSContainerRule to latest spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-serialization-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Serialization of conditionText assert_equals: expected "\\!-name (inline-size > 200px)" but got "(inline-size > 200px)"
+PASS Serialization of conditionText
 PASS Serialization of inner @container rule
 PASS Serialization of nested @container rule
 PASS Serialization of boolean condition syntax

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization.html
@@ -25,7 +25,7 @@
       ["style(--foo: )", "Empty declaration value"],
       ["STyle(--foo)", "Missing declaration value"],
       ["style((--FOO: BAR) or ( prop: val ))", "Unknown CSS property after 'or'"],
-      ["(--foo: bar)", "Not a style function with space before '('"]
+      ["style (--foo: bar)", "Not a style function with space before '('"]
   ].map((e, i) => [testSheet.sheet.cssRules[i], ...e]);
 
   tests.forEach((t) => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/idlharness-expected.txt
@@ -7,8 +7,14 @@ PASS CSSContainerRule interface object name
 PASS CSSContainerRule interface: existence and properties of interface prototype object
 PASS CSSContainerRule interface: existence and properties of interface prototype object's "constructor" property
 PASS CSSContainerRule interface: existence and properties of interface prototype object's @@unscopables property
+PASS CSSContainerRule interface: attribute containerName
+PASS CSSContainerRule interface: attribute containerQuery
 PASS CSSContainerRule must be primary interface of sheet.cssRules[0]
 PASS Stringification of sheet.cssRules[0]
+PASS CSSContainerRule interface: sheet.cssRules[0] must inherit property "containerName" with the proper type
+PASS CSSContainerRule interface: sheet.cssRules[0] must inherit property "containerQuery" with the proper type
 PASS CSSContainerRule must be primary interface of sheet.cssRules[0].cssRules[0]
 PASS Stringification of sheet.cssRules[0].cssRules[0]
+PASS CSSContainerRule interface: sheet.cssRules[0].cssRules[0] must inherit property "containerName" with the proper type
+PASS CSSContainerRule interface: sheet.cssRules[0].cssRules[0] must inherit property "containerQuery" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSContainerRule.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSContainerRule.tentative-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL @container name (min-width: 100px) {} assert_equals: containerName expected (string) "name" but got (undefined) undefined
-FAIL @container (min-width: 100px) {} assert_equals: containerName expected (string) "" but got (undefined) undefined
+PASS @container name (min-width: 100px) {}
+PASS @container (min-width: 100px) {}
 

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/css-contain-3.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/css-contain-3.idl
@@ -5,4 +5,6 @@
 
 [Exposed=Window]
 interface CSSContainerRule : CSSConditionRule {
+    readonly attribute CSSOMString containerName;
+    readonly attribute CSSOMString containerQuery;
 };

--- a/Source/WebCore/css/CSSContainerRule.cpp
+++ b/Source/WebCore/css/CSSContainerRule.cpp
@@ -61,18 +61,25 @@ String CSSContainerRule::cssText() const
 String CSSContainerRule::conditionText() const
 {
     StringBuilder builder;
-    MQ::serialize(builder, styleRuleContainer().containerQuery().condition);
+    CQ::serialize(builder, styleRuleContainer().containerQuery());
     return builder.toString();
 }
 
-String CSSContainerRule::nameText() const
+String CSSContainerRule::containerName() const
 {
     StringBuilder builder;
-    
+
     auto name = styleRuleContainer().containerQuery().name;
     if (!name.isEmpty())
         serializeIdentifier(name, builder);
 
+    return builder.toString();
+}
+
+String CSSContainerRule::containerQuery() const
+{
+    StringBuilder builder;
+    MQ::serialize(builder, styleRuleContainer().containerQuery().condition);
     return builder.toString();
 }
 

--- a/Source/WebCore/css/CSSContainerRule.h
+++ b/Source/WebCore/css/CSSContainerRule.h
@@ -37,7 +37,8 @@ public:
 
     String cssText() const final;
     String conditionText() const final;
-    String nameText() const;
+    String containerName() const;
+    String containerQuery() const;
 
 private:
     const StyleRuleContainer& styleRuleContainer() const;

--- a/Source/WebCore/css/CSSContainerRule.idl
+++ b/Source/WebCore/css/CSSContainerRule.idl
@@ -23,8 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+typedef USVString CSSOMString;
+
 [
     Exposed=Window
 ] interface CSSContainerRule : CSSConditionRule {
+    readonly attribute CSSOMString containerName;
+    readonly attribute CSSOMString containerQuery;
 };
 


### PR DESCRIPTION
#### d92a59cead8ce716a3c5f52d7d15ea009691e294
<pre>
[container-queries] Update CSSContainerRule to latest spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=253654">https://bugs.webkit.org/show_bug.cgi?id=253654</a>
rdar://106505281

Reviewed by Antti Koivisto.

<a href="https://drafts.csswg.org/css-contain-3/#the-csscontainerrule-interface">https://drafts.csswg.org/css-contain-3/#the-csscontainerrule-interface</a>

- Adds containerName/containerQuery
- Update conditionText to be containerName + containerQuery

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSContainerRule.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/css-contain-3.idl:
Resync interfaces/css-contain-3.idl &amp; at-container-style-serialization.html to upstream WPT, and rebaseline tests accordingly.

* Source/WebCore/css/CSSContainerRule.cpp:
(WebCore::CSSContainerRule::conditionText const): represents containerName + containerQuery
(WebCore::CSSContainerRule::containerName const): renamed from nameText
(WebCore::CSSContainerRule::containerQuery const):
(WebCore::CSSContainerRule::nameText const): Deleted.
* Source/WebCore/css/CSSContainerRule.h:
* Source/WebCore/css/CSSContainerRule.idl:

Canonical link: <a href="https://commits.webkit.org/261453@main">https://commits.webkit.org/261453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7f6497cc2ebb70a578341be4f60e623bcff2cb1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20891 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/375 "Failed to checkout and rebase branch from PR 11308") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3542 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11970 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117525 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/90/builds/375 "Failed to checkout and rebase branch from PR 11308") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104722 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/90/builds/375 "Failed to checkout and rebase branch from PR 11308") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/90/builds/375 "Failed to checkout and rebase branch from PR 11308") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/88151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/90/builds/375 "Failed to checkout and rebase branch from PR 11308") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7970 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->