### PR TITLE
Whitespace incorrectly suppressed inside table

### DIFF
--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -446,7 +446,7 @@ bool RenderTreeUpdater::textRendererIsNeeded(const Text& textNode)
     if (is<RenderText>(renderingParent.previousChildRenderer))
         return true;
     // This text node has nothing but white space. We may still need a renderer in some cases.
-    if (parentRenderer.isTable() || parentRenderer.isTableRow() || parentRenderer.isTableSection() || parentRenderer.isRenderTableCol() || parentRenderer.isFrameSet() || parentRenderer.isRenderGrid() || (parentRenderer.isFlexibleBox() && !parentRenderer.isRenderButton()))
+    if (parentRenderer.isTableRow() || parentRenderer.isTableSection() || parentRenderer.isRenderTableCol() || parentRenderer.isFrameSet() || parentRenderer.isRenderGrid() || (parentRenderer.isFlexibleBox() && !parentRenderer.isRenderButton()))
         return false;
     if (parentRenderer.style().preserveNewline()) // pre/pre-wrap/pre-line always make renderers.
         return true;


### PR DESCRIPTION
<pre>
Whitespace incorrectly suppressed inside table
<a href="https://bugs.webkit.org/show_bug.cgi?id=251178">https://bugs.webkit.org/show_bug.cgi?id=251178</a>
rdar://problem/104934417

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit to Gecko / Firefox by removing 'isTable', where WebKit was
suppressing 'whitespace' incorrectly inside table leading to incorrect behavior being
against web-specification as highlighted in below issue link [*]:

[*] <a href="https://github.com/w3c/csswg-drafts/issues/8358">https://github.com/w3c/csswg-drafts/issues/8358</a>

* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(RenderTreeUpdater::textRendererIsNeeded): Remove 'isTable'
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/whitespace-001.html: Add Testcase
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/whitespace-001-ref.html: Add Testcase Reference from WPT GitHub
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/whitespace-001-expected.html: Add Testcase ### Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ece2c976517bd0a9baeb89748084c8082140f40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7473 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10395 "1 flakes 99 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7421 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8116 "2 new passes 9 flakes 11 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9025 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5459 "2 flakes 2 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6638 "1 flakes 1 failures") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6742 "1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9623 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7227 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->