### PR TITLE
[GPU Process] Have one copy of NativeImage when it is shared between WebProcess and GPUProcess

### DIFF
--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -706,12 +706,15 @@ void HTMLImageElement::setDecoding(AtomString&& decodingMode)
 String HTMLImageElement::decoding() const
 {
     switch (decodingMode()) {
+    case DecodingMode::Auto:
+        break;
+    case DecodingMode::SynchronousThumbnail:
+        ASSERT_NOT_REACHED();
+        break;
     case DecodingMode::Synchronous:
         return "sync"_s;
     case DecodingMode::Asynchronous:
         return "async"_s;
-    case DecodingMode::Auto:
-        break;
     }
     return autoAtom();
 }

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2004, 2005, 2006, 2008, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -135,13 +135,13 @@ void BitmapImage::setCurrentFrameDecodingStatusIfNecessary(DecodingStatus decodi
     m_currentFrameDecodingStatus = decodingStatus;
 }
 
-RefPtr<NativeImage> BitmapImage::frameImageAtIndexCacheIfNeeded(size_t index, SubsamplingLevel subsamplingLevel)
+RefPtr<NativeImage> BitmapImage::frameImageAtIndexCacheIfNeeded(size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& decodingOptions)
 {
     if (!frameHasFullSizeNativeImageAtIndex(index, subsamplingLevel)) {
         LOG(Images, "BitmapImage::%s - %p - url: %s [subsamplingLevel was %d, resampling]", __FUNCTION__, this, sourceURL().string().utf8().data(), static_cast<int>(frameSubsamplingLevelAtIndex(index)));
         invalidatePlatformData();
     }
-    return m_source->frameImageAtIndexCacheIfNeeded(index, subsamplingLevel);
+    return m_source->frameImageAtIndexCacheIfNeeded(index, subsamplingLevel, decodingOptions);
 }
 
 RefPtr<NativeImage> BitmapImage::nativeImage(const DestinationColorSpace&)
@@ -254,8 +254,8 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
     if (options.decodingMode() == DecodingMode::Asynchronous) {
         ASSERT(!m_currentFrame || !canAnimate());
 
-        bool frameIsCompatible = frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, DecodingOptions(sizeForDrawing));
-        bool frameIsBeingDecoded = frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(m_currentFrame, DecodingOptions(sizeForDrawing));
+        bool frameIsCompatible = frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, DecodingOptions(DecodingMode::Asynchronous, sizeForDrawing));
+        bool frameIsBeingDecoded = frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(m_currentFrame, DecodingOptions(DecodingMode::Asynchronous, sizeForDrawing));
 
         // If the current frame is incomplete, a new request for decoding this frame has to be made even if
         // it is currently being decoded. New data may have been received since the previous request was made.
@@ -268,7 +268,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
         if (m_currentFrameDecodingStatus == DecodingStatus::Decoding)
             result = ImageDrawResult::DidRequestDecoding;
 
-        if (!frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, DecodingOptions(DecodingMode::Asynchronous))) {
+        if (!frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, DecodingOptions(DecodingMode::Asynchronous, sizeForDrawing))) {
             if (m_showDebugBackground)
                 fillWithSolidColor(context, destRect, Color::yellow.colorWithAlphaByte(128), options.compositeOperator());
             return result;
@@ -290,8 +290,8 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
         if (m_currentFrameDecodingStatus == DecodingStatus::Invalid)
             m_source->destroyIncompleteDecodedData();
         
-        bool frameIsCompatible = frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, DecodingOptions(sizeForDrawing));
-        bool frameIsBeingDecoded = frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(m_currentFrame, DecodingOptions(DecodingMode::Asynchronous));
+        bool frameIsCompatible = frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, DecodingOptions(DecodingMode::Asynchronous, sizeForDrawing));
+        bool frameIsBeingDecoded = frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(m_currentFrame, DecodingOptions(DecodingMode::Asynchronous, sizeForDrawing));
         
         if (frameIsCompatible) {
             image = frameImageAtIndex(m_currentFrame);
@@ -303,11 +303,14 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
                 LOG(Images, "BitmapImage::%s - %p - url: %s [waiting for async decoding to finish]", __FUNCTION__, this, sourceURL().string().utf8().data());
             }
             return ImageDrawResult::DidRequestDecoding;
+        } else if (options.decodingMode() == DecodingMode::SynchronousThumbnail) {
+            image = frameImageAtIndexCacheIfNeeded(m_currentFrame, m_currentSubsamplingLevel, { options.decodingMode(), sizeForDrawing });
+            LOG(Images, "BitmapImage::%s - %p - url: %s [an image frame will be decoded synchronously as a thumbnail]", __FUNCTION__, this, sourceURL().string().utf8().data());
         } else {
-            image = frameImageAtIndexCacheIfNeeded(m_currentFrame, m_currentSubsamplingLevel);
+            image = frameImageAtIndexCacheIfNeeded(m_currentFrame, m_currentSubsamplingLevel, options.decodingMode());
             LOG(Images, "BitmapImage::%s - %p - url: %s [an image frame will be decoded synchronously]", __FUNCTION__, this, sourceURL().string().utf8().data());
         }
-        
+
         if (!image) // If it's too early we won't have an image yet.
             return ImageDrawResult::DidNothing;
 
@@ -496,7 +499,7 @@ BitmapImage::StartAnimationStatus BitmapImage::internalStartAnimation()
     // through the callback newFrameNativeImageAvailableAtIndex(). Otherwise, advanceAnimation() will be called
     // when the timer fires and m_currentFrame will be advanced to nextFrame since it is not being decoded.
     if (shouldUseAsyncDecodingForAnimatedImages()) {
-        if (frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(nextFrame, m_currentSubsamplingLevel, DecodingOptions(std::optional<IntSize>())))
+        if (frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(nextFrame, m_currentSubsamplingLevel, DecodingMode::Asynchronous))
             LOG(Images, "BitmapImage::%s - %p - url: %s [cachedFrameCount = %ld nextFrame = %ld]", __FUNCTION__, this, sourceURL().string().utf8().data(), ++m_cachedFrameCount, nextFrame);
         else {
             m_source->requestFrameAsyncDecodingAtIndex(nextFrame, m_currentSubsamplingLevel);
@@ -587,8 +590,8 @@ void BitmapImage::decode(Function<void()>&& callback)
         }
 
         // The animated image has not been displayed. In this case, either the first frame has not been decoded yet or the animation has not started yet.
-        bool frameIsCompatible = frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, std::optional<IntSize>());
-        bool frameIsBeingDecoded = frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(m_currentFrame, std::optional<IntSize>());
+        bool frameIsCompatible = frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, DecodingMode::Asynchronous);
+        bool frameIsBeingDecoded = frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(m_currentFrame, DecodingMode::Asynchronous);
 
         if (frameIsCompatible)
             internalStartAnimation();
@@ -599,8 +602,8 @@ void BitmapImage::decode(Function<void()>&& callback)
         return;
     }
 
-    bool frameIsCompatible = frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, std::optional<IntSize>());
-    bool frameIsBeingDecoded = frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(m_currentFrame, std::optional<IntSize>());
+    bool frameIsCompatible = frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, DecodingMode::Asynchronous);
+    bool frameIsBeingDecoded = frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(m_currentFrame, DecodingMode::Asynchronous);
     
     if (frameIsCompatible)
         callDecodingCallbacks();
@@ -651,7 +654,7 @@ void BitmapImage::imageFrameAvailableAtIndex(size_t index)
         ++m_decodeCountForTesting;
 
     // Call m_decodingCallbacks only if the image frame was decoded with the native size.
-    if (frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, std::optional<IntSize>()))
+    if (frameHasDecodedNativeImageCompatibleWithOptionsAtIndex(m_currentFrame, m_currentSubsamplingLevel, DecodingMode::Asynchronous))
         callDecodingCallbacks();
 
     if (imageObserver())

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2004, 2005, 2006, 2013 Apple Inc.  All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc.  All rights reserved.
  * Copyright (C) 2008-2009 Torch Mobile, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -163,7 +163,7 @@ private:
     WEBCORE_EXPORT BitmapImage(ImageObserver* = nullptr);
 
     RefPtr<NativeImage> frameImageAtIndex(size_t index) { return m_source->frameImageAtIndex(index); }
-    RefPtr<NativeImage> frameImageAtIndexCacheIfNeeded(size_t, SubsamplingLevel = SubsamplingLevel::Default);
+    RefPtr<NativeImage> frameImageAtIndexCacheIfNeeded(size_t, SubsamplingLevel = SubsamplingLevel::Default, const DecodingOptions& = { });
 
     // Called to invalidate cached data. When |destroyAll| is true, we wipe out
     // the entire frame buffer cache and tell the image source to destroy

--- a/Source/WebCore/platform/graphics/DecodingOptions.h
+++ b/Source/WebCore/platform/graphics/DecodingOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc.  All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,122 +27,52 @@
 
 #include "IntSize.h"
 #include <optional>
-#include <variant>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 
 enum class DecodingMode : uint8_t {
     Auto,
+    SynchronousThumbnail,
     Synchronous,
     Asynchronous
 };
 
 class DecodingOptions {
 public:
-    explicit DecodingOptions(DecodingMode decodingMode = DecodingMode::Auto)
-        : m_decodingModeOrSize(decodingMode)
+    DecodingOptions(DecodingMode decodingMode = DecodingMode::Synchronous, const std::optional<IntSize>& sizeForDrawing = std::nullopt)
+        : m_decodingMode(decodingMode)
+        , m_sizeForDrawing(sizeForDrawing)
     {
     }
 
-    DecodingOptions(const std::optional<IntSize>& sizeForDrawing)
-        : m_decodingModeOrSize(sizeForDrawing)
-    {
-    }
+    bool operator==(const DecodingOptions&) const = default;
 
-    bool operator==(const DecodingOptions& other) const
-    {
-        return m_decodingModeOrSize == other.m_decodingModeOrSize;
-    }
+    DecodingMode decodingMode() const { return m_decodingMode; }
+    bool isAuto() const { return m_decodingMode == DecodingMode::Auto; }
+    bool isSynchronous() const { return m_decodingMode == DecodingMode::Synchronous || m_decodingMode == DecodingMode::SynchronousThumbnail; }
+    bool isAsynchronous() const { return m_decodingMode == DecodingMode::Asynchronous; }
 
-    bool isAuto() const
-    {
-        return hasDecodingMode() && std::get<DecodingMode>(m_decodingModeOrSize) == DecodingMode::Auto;
-    }
-    
-    bool isSynchronous() const
-    {
-        return hasDecodingMode() && std::get<DecodingMode>(m_decodingModeOrSize) == DecodingMode::Synchronous;
-    }
+    std::optional<IntSize> sizeForDrawing() const { return m_sizeForDrawing; }
+    bool hasFullSize() const { return !m_sizeForDrawing; }
+    bool hasSizeForDrawing() const { return !!m_sizeForDrawing; }
 
-    bool isAsynchronous() const
+    bool isCompatibleWith(const DecodingOptions& other) const
     {
-        return hasDecodingMode() && std::get<DecodingMode>(m_decodingModeOrSize) == DecodingMode::Asynchronous;
-    }
-
-    bool isAsynchronousCompatibleWith(const DecodingOptions& decodingOptions) const
-    {
-        if (isAuto() || decodingOptions.isAuto())
+        if (isAuto() || other.isAuto())
             return false;
 
-        // Comparing DecodingOptions with isAsynchronous() should not happen.
-        ASSERT(!isAsynchronous());
-        if (isAsynchronous() || decodingOptions.isSynchronous())
-            return false;
-        
-        // If the image was synchronously decoded, then it should fit any size.
-        // If we want an image regardless of its size, then the current decoded
-        // image should be fine.
-        if (isSynchronous() || decodingOptions.isAsynchronous())
-            return true;
-
-        ASSERT(decodingOptions.hasSize());
-        if (decodingOptions.hasFullSize())
-            return hasFullSize();
-
-        ASSERT(decodingOptions.hasSizeForDrawing());
         if (hasFullSize())
             return true;
 
-        ASSERT(hasSizeForDrawing());
-        return maxDimension(*sizeForDrawing()) >= maxDimension(*decodingOptions.sizeForDrawing());
-    }
+        if (other.hasFullSize())
+            return false;
 
-    bool hasFullSize() const
-    {
-        return hasSize() && !sizeForDrawing();
-    }
-
-    bool hasSizeForDrawing() const
-    {
-        return hasSize() && sizeForDrawing();
-    }
-
-    std::optional<IntSize> sizeForDrawing() const
-    {
-        ASSERT(hasSize());
-        return std::get<std::optional<IntSize>>(m_decodingModeOrSize);
-    }
-
-    static int maxDimension(const IntSize& size)
-    {
-        return std::max(size.width(), size.height());
+        return sizeForDrawing()->maxDimension() >= other.sizeForDrawing()->maxDimension();
     }
 
 private:
-    template<typename T>
-    bool has() const
-    {
-        return std::holds_alternative<T>(m_decodingModeOrSize);
-    }
-
-    bool hasDecodingMode() const
-    {
-        return has<DecodingMode>();
-    }
-
-    bool hasSize() const
-    {
-        return has<std::optional<IntSize>>();
-    }
-
-    // Four states of the decoding:
-    // - Synchronous: DecodingMode::Synchronous
-    // - Asynchronous + anySize: DecodingMode::Asynchronous
-    // - Asynchronous + intrinsicSize: an empty std::optional<IntSize>>
-    // - Asynchronous + sizeForDrawing: a none empty std::optional<IntSize>>
-    using DecodingModeOrSize = std::variant<DecodingMode, std::optional<IntSize>>;
-    DecodingModeOrSize m_decodingModeOrSize;
+    DecodingMode m_decodingMode;
+    std::optional<IntSize> m_sizeForDrawing;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -256,6 +256,8 @@ public:
 
     virtual bool needsCachedNativeImageInvalidationWorkaround(RenderingMode) { return true; }
 
+    virtual DecodingMode preferredImageDecodingMode() const { return DecodingMode::Synchronous; }
+
     WEBCORE_EXPORT virtual void drawSystemImage(SystemImage&, const FloatRect&);
 
     WEBCORE_EXPORT ImageDrawResult drawImage(Image&, const FloatPoint& destination, const ImagePaintingOptions& = { ImageOrientation::Orientation::FromImage });

--- a/Source/WebCore/platform/graphics/ImageFrame.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc.  All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -108,12 +108,12 @@ bool ImageFrame::hasNativeImage(const std::optional<SubsamplingLevel>& subsampli
 
 bool ImageFrame::hasFullSizeNativeImage(const std::optional<SubsamplingLevel>& subsamplingLevel) const
 {
-    return hasNativeImage(subsamplingLevel) && (m_decodingOptions.isSynchronous() || m_decodingOptions.hasFullSize());
+    return hasNativeImage(subsamplingLevel) && m_decodingOptions.hasFullSize();
 }
 
 bool ImageFrame::hasDecodedNativeImageCompatibleWithOptions(const std::optional<SubsamplingLevel>& subsamplingLevel, const DecodingOptions& decodingOptions) const
 {
-    return hasNativeImage(subsamplingLevel) && m_decodingOptions.isAsynchronousCompatibleWith(decodingOptions);
+    return hasNativeImage(subsamplingLevel) && m_decodingOptions.isCompatibleWith(decodingOptions);
 }
 
 Color ImageFrame::singlePixelSolidColor() const

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -124,7 +124,7 @@ public:
 
     RefPtr<NativeImage> createFrameImageAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default);
     RefPtr<NativeImage> frameImageAtIndex(size_t);
-    RefPtr<NativeImage> frameImageAtIndexCacheIfNeeded(size_t, SubsamplingLevel = SubsamplingLevel::Default);
+    RefPtr<NativeImage> frameImageAtIndexCacheIfNeeded(size_t, SubsamplingLevel = SubsamplingLevel::Default, const DecodingOptions& = { });
 
 private:
     ImageSource(BitmapImage*, AlphaOption = AlphaOption::Premultiplied, GammaAndColorProfileOption = GammaAndColorProfileOption::Applied);
@@ -172,7 +172,7 @@ private:
     SynchronizedFixedQueue<ImageFrameRequest, BufferSize>& frameRequestQueue();
 
     const ImageFrame& frameAtIndex(size_t index) { return index < m_frames.size() ? m_frames[index] : ImageFrame::defaultFrame(); }
-    const ImageFrame& frameAtIndexCacheIfNeeded(size_t, ImageFrame::Caching, const std::optional<SubsamplingLevel>& = { });
+    const ImageFrame& frameAtIndexCacheIfNeeded(size_t, ImageFrame::Caching, const std::optional<SubsamplingLevel>& = { }, const DecodingOptions& = { });
 
     void dump(TextStream&);
 

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -41,12 +41,19 @@ NativeImage::NativeImage(PlatformImagePtr&& platformImage, RenderingResourceIden
     : m_platformImage(WTFMove(platformImage))
     , m_renderingResourceIdentifier(renderingResourceIdentifier)
 {
+    ASSERT(m_platformImage);
 }
 
 NativeImage::~NativeImage()
 {
     for (auto observer : m_observers)
         observer->releaseNativeImage(m_renderingResourceIdentifier);
+}
+
+void NativeImage::setPlatformImage(PlatformImagePtr&& platformImage)
+{
+    ASSERT(platformImage);
+    m_platformImage = WTFMove(platformImage);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -57,7 +57,9 @@ public:
 
     WEBCORE_EXPORT ~NativeImage();
 
+    WEBCORE_EXPORT void setPlatformImage(PlatformImagePtr&&);
     const PlatformImagePtr& platformImage() const { return m_platformImage; }
+
     RenderingResourceIdentifier renderingResourceIdentifier() const { return m_renderingResourceIdentifier; }
 
     WEBCORE_EXPORT IntSize size() const;

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -89,7 +89,7 @@ static RetainPtr<CFMutableDictionaryRef> createImageSourceMetadataOptions()
     return options;
 }
     
-static RetainPtr<CFMutableDictionaryRef> createImageSourceAsyncOptions()
+static RetainPtr<CFMutableDictionaryRef> createImageSourceThumbnailOptions()
 {
     RetainPtr<CFMutableDictionaryRef> options = createImageSourceOptions();
     CFDictionarySetValue(options.get(), kCGImageSourceShouldCacheImmediately, kCFBooleanTrue);
@@ -108,7 +108,7 @@ static RetainPtr<CFMutableDictionaryRef> appendImageSourceOption(RetainPtr<CFMut
 
 static RetainPtr<CFMutableDictionaryRef> appendImageSourceOption(RetainPtr<CFMutableDictionaryRef>&& options, const IntSize& sizeForDrawing)
 {
-    unsigned maxDimension = DecodingOptions::maxDimension(sizeForDrawing);
+    unsigned maxDimension = sizeForDrawing.maxDimension();
     RetainPtr<CFNumberRef> maxDimensionNumber = adoptCF(CFNumberCreate(nullptr, kCFNumberIntType, &maxDimension));
     CFDictionarySetValue(options.get(), kCGImageSourceThumbnailMaxPixelSize, maxDimensionNumber.get());
     return WTFMove(options);
@@ -131,9 +131,9 @@ static RetainPtr<CFDictionaryRef> imageSourceOptions(SubsamplingLevel subsamplin
     return appendImageSourceOption(adoptCF(CFDictionaryCreateMutableCopy(nullptr, 0, options)), subsamplingLevel);
 }
 
-static RetainPtr<CFDictionaryRef> imageSourceAsyncOptions(SubsamplingLevel subsamplingLevel, const IntSize& sizeForDrawing)
+static RetainPtr<CFDictionaryRef> imageSourceThumbnailOptions(SubsamplingLevel subsamplingLevel, const IntSize& sizeForDrawing)
 {
-    static const auto options = createImageSourceAsyncOptions().leakRef();
+    static const auto options = createImageSourceThumbnailOptions().leakRef();
     return appendImageSourceOptions(adoptCF(CFDictionaryCreateMutableCopy(nullptr, 0, options)), subsamplingLevel, sizeForDrawing);
 }
 
@@ -521,24 +521,24 @@ PlatformImagePtr ImageDecoderCG::createFrameImageAtIndex(size_t index, Subsampli
     RetainPtr<CFDictionaryRef> options;
     RetainPtr<CGImageRef> image;
 
-    auto size = frameSizeAtIndex(index, SubsamplingLevel::Default);
+    ASSERT(decodingOptions.decodingMode() != DecodingMode::Auto);
 
-    if (!decodingOptions.isSynchronous()) {
-        // Don't consider the subsamplingLevel when comparing the image native size with sizeForDrawing.
-        
-        if (decodingOptions.hasSizeForDrawing()) {
-            // See which size is smaller: the image native size or the sizeForDrawing.
-            std::optional<IntSize> sizeForDrawing = decodingOptions.sizeForDrawing();
-            if (sizeForDrawing.value().unclampedArea() < size.unclampedArea())
-                size = sizeForDrawing.value();
-        }
-        
-        options = imageSourceAsyncOptions(subsamplingLevel, size);
-        image = adoptCF(CGImageSourceCreateThumbnailAtIndex(m_nativeDecoder.get(), index, options.get()));
-    } else {
+    if (decodingOptions.decodingMode() == DecodingMode::Synchronous && !decodingOptions.sizeForDrawing()) {
         // Decode an image synchronously for its native size.
         options = imageSourceOptions(subsamplingLevel);
         image = adoptCF(CGImageSourceCreateImageAtIndex(m_nativeDecoder.get(), index, options.get()));
+    } else {
+        auto size = frameSizeAtIndex(index, SubsamplingLevel::Default);
+
+        // Don't consider the subsamplingLevel when comparing the image native size with sizeForDrawing.
+        if (auto sizeForDrawing = decodingOptions.sizeForDrawing()) {
+            // See which size is smaller: the image native size or the decodingSize.
+            if (sizeForDrawing->unclampedArea() < size.unclampedArea())
+                size = *sizeForDrawing;
+        }
+
+        options = imageSourceThumbnailOptions(subsamplingLevel, size);
+        image = adoptCF(CGImageSourceCreateThumbnailAtIndex(m_nativeDecoder.get(), index, options.get()));
     }
     
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3624,6 +3624,7 @@ enum class WebCore::RTCPriorityType : uint8_t {
 
 [AdditionalEncoder=StreamConnectionEncoder] enum class WebCore::DecodingMode : uint8_t {
     Auto,
+    SynchronousThumbnail,
     Synchronous,
     Asynchronous
 };

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -80,6 +80,18 @@ RenderingMode RemoteDisplayListRecorderProxy::renderingMode() const
     return m_imageBuffer ? m_imageBuffer->renderingMode() : RenderingMode::Unaccelerated;
 }
 
+DecodingMode RemoteDisplayListRecorderProxy::preferredImageDecodingMode() const
+{
+    if (!m_imageBuffer)
+        return DecodingMode::Synchronous;
+
+    auto renderingPurpose = m_imageBuffer->renderingPurpose();
+    if (renderingPurpose == RenderingPurpose::DOM || renderingPurpose == RenderingPurpose::LayerBacking)
+        return DecodingMode::SynchronousThumbnail;
+
+    return DecodingMode::Synchronous;
+}
+
 void RemoteDisplayListRecorderProxy::recordSave()
 {
     send(Messages::RemoteDisplayListRecorder::Save());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -60,6 +60,8 @@ private:
 
     WebCore::RenderingMode renderingMode() const final;
 
+    WebCore::DecodingMode preferredImageDecodingMode() const final;
+
     void recordSave() final;
     void recordRestore() final;
     void recordTranslate(float x, float y) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -118,7 +118,13 @@ void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
     if (!handle)
         return;
 
+    auto platformImage = bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
+    if (!platformImage)
+        return;
+
+    image.setPlatformImage(WTFMove(platformImage));
     handle->takeOwnershipOfMemory(MemoryLedger::Graphics);
+
     m_nativeImages.add(image.renderingResourceIdentifier(), image);
 
     // Set itself as an observer to NativeImage, so releaseNativeImage()


### PR DESCRIPTION
#### 00ca303e33743e31bf973aa44a6506aa30ac7f97
<pre>
[GPU Process] Have one copy of NativeImage when it is shared between WebProcess and GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=253655">https://bugs.webkit.org/show_bug.cgi?id=253655</a>
rdar://106505650

Reviewed by Simon Fraser.

Since WebProcess has to share the local PlatformImage with GPUProcess through
ShareableBitmap, we can get rid of the local PlatformImage and have both processes
use the ShareableBitmap.

For GPUProcess, we can ensure we decode the PlatformImage for sizeForDrawing
instead of decoding it for the full size.

Also this patch simplifies DecodingOptions and make have explicit DecodingMode
and sizeForDrawing. This will make DecodingOptions::isCompatibleWith() simpler
and can be used for synchronous and asynchronous decoding mode.

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::decoding const):
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::frameImageAtIndexCacheIfNeeded):
(WebCore::BitmapImage::draw):
(WebCore::BitmapImage::internalStartAnimation):
(WebCore::BitmapImage::decode):
(WebCore::BitmapImage::imageFrameAvailableAtIndex):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/DecodingOptions.h:
(WebCore::DecodingOptions::DecodingOptions):
(WebCore::DecodingOptions::decodingMode const):
(WebCore::DecodingOptions::isAuto const):
(WebCore::DecodingOptions::isSynchronous const):
(WebCore::DecodingOptions::isAsynchronous const):
(WebCore::DecodingOptions::sizeForDrawing const):
(WebCore::DecodingOptions::hasFullSize const):
(WebCore::DecodingOptions::hasSizeForDrawing const):
(WebCore::DecodingOptions::isCompatibleWith const):
(WebCore::DecodingOptions::operator== const): Deleted.
(WebCore::DecodingOptions::isAsynchronousCompatibleWith const): Deleted.
(WebCore::DecodingOptions::maxDimension): Deleted.
(WebCore::DecodingOptions::has const): Deleted.
(WebCore::DecodingOptions::hasDecodingMode const): Deleted.
(WebCore::DecodingOptions::hasSize const): Deleted.
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::preferredImageDecodingMode const):
* Source/WebCore/platform/graphics/ImageFrame.cpp:
(WebCore::ImageFrame::hasFullSizeNativeImage const):
(WebCore::ImageFrame::hasDecodedNativeImageCompatibleWithOptions const):
* Source/WebCore/platform/graphics/ImageSource.cpp:
(WebCore::ImageSource::requestFrameAsyncDecodingAtIndex):
(WebCore::ImageSource::frameAtIndexCacheIfNeeded):
(WebCore::ImageSource::frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex):
(WebCore::ImageSource::frameImageAtIndexCacheIfNeeded):
* Source/WebCore/platform/graphics/ImageSource.h:
* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::NativeImage::NativeImage):
(WebCore::NativeImage::setPlatformImage):
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::createImageSourceThumbnailOptions):
(WebCore::appendImageSourceOption):
(WebCore::imageSourceThumbnailOptions):
(WebCore::ImageDecoderCG::createFrameImageAtIndex):
(WebCore::createImageSourceAsyncOptions): Deleted.
(WebCore::imageSourceAsyncOptions): Deleted.
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::decodingModeForImageDraw const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::preferredImageDecodingMode const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):

Canonical link: <a href="https://commits.webkit.org/261700@main">https://commits.webkit.org/261700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf825bb840e24f802743af1af19ca375130e430a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4307 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5439 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118299 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105590 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/842 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46102 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14022 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/879 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14704 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8164 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16540 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->