### PR TITLE
Drop some unnecessary work from ~Element()

### DIFF
--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
@@ -39,7 +39,7 @@ Ref<InlineStylePropertyMap> InlineStylePropertyMap::create(StyledElement& elemen
 }
 
 InlineStylePropertyMap::InlineStylePropertyMap(StyledElement& element)
-    : m_element(&element)
+    : m_element(element)
 {
 }
 
@@ -135,11 +135,6 @@ void InlineStylePropertyMap::clear()
 {
     if (m_element)
         m_element->removeAllInlineStyleProperties();
-}
-
-void InlineStylePropertyMap::clearElement()
-{
-    m_element = nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.h
@@ -44,12 +44,11 @@ public:
     bool setCustomProperty(Document&, const AtomString& property, Ref<CSSVariableReferenceValue>&&) final;
     void removeCustomProperty(const AtomString& property) final;
     void clear() final;
-    void clearElement() final;
 
 private:
     explicit InlineStylePropertyMap(StyledElement&);
 
-    StyledElement* m_element;
+    WeakPtr<StyledElement, WeakPtrImplWithEventTargetData> m_element;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/StylePropertyMap.h
+++ b/Source/WebCore/css/typedom/StylePropertyMap.h
@@ -38,8 +38,6 @@ public:
     ExceptionOr<void> remove(Document&, const AtomString& property);
     virtual void clear() = 0;
 
-    virtual void clearElement() { }
-
 protected:
     virtual void removeProperty(CSSPropertyID) = 0;
     virtual void removeCustomProperty(const AtomString&) = 0;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -262,14 +262,6 @@ Element::~Element()
 
     if (hasSyntheticAttrChildNodes())
         detachAllAttrNodesFromElement();
-
-    if (hasRareData()) {
-        if (auto* map = elementRareData()->attributeStyleMap())
-            map->clearElement();
-    }
-
-    if (hasLangAttrKnownToMatchDocumentElement())
-        document().removeElementWithLangAttrMatchingDocumentElement(*this);
 }
 
 inline ElementRareData& Element::ensureElementRareData()


### PR DESCRIPTION
#### e3a1c73970eebd3325cc5ea0625632f4379a3be1
<pre>
Drop some unnecessary work from ~Element()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253657">https://bugs.webkit.org/show_bug.cgi?id=253657</a>

Reviewed by Ryosuke Niwa.

Use a WeakPtr for InlineStylePropertyMap::m_element so the the Element
destructor doesn&apos;t have to reset this pointer.

Also, stop calling Document::removeElementWithLangAttrMatchingDocumentElement()
since Document::m_elementsWithLangAttrMatchingDocumentElement is a WeakHashSet.

* Source/WebCore/css/typedom/InlineStylePropertyMap.cpp:
(WebCore::InlineStylePropertyMap::InlineStylePropertyMap):
(WebCore::InlineStylePropertyMap::clearElement): Deleted.
* Source/WebCore/css/typedom/InlineStylePropertyMap.h:
* Source/WebCore/css/typedom/StylePropertyMap.h:
(WebCore::StylePropertyMap::clearElement): Deleted.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::~Element):

Canonical link: <a href="https://commits.webkit.org/261468@main">https://commits.webkit.org/261468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f87f91e326ff0655bad20cfe335277253afc6998

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3541 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11969 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117524 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104721 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45465 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/248 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/88143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13857 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7982 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15843 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->