### PR TITLE
[WGSL] Generate code based on the call graph instead of full AST

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -56,12 +56,12 @@ static void dumpMetalCodeIfNeeded(StringBuilder& stringBuilder)
     }
 }
 
-String generateMetalCode(ShaderModule& module)
+String generateMetalCode(CallGraph& callGraph)
 {
     StringBuilder stringBuilder;
     stringBuilder.append(metalCodePrologue());
 
-    Metal::emitMetalFunctions(stringBuilder, module);
+    Metal::emitMetalFunctions(stringBuilder, callGraph);
 
     dumpMetalCodeIfNeeded(stringBuilder);
 

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
@@ -29,12 +29,12 @@
 
 namespace WGSL {
 
-class ShaderModule;
+class CallGraph;
 
 namespace Metal {
 
 // Can't fail. Any failure checks need to be done earlier, in the backend-agnostic part of the compiler.
-String generateMetalCode(ShaderModule&);
+String generateMetalCode(CallGraph&);
 
 } // namespace Metal
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -30,6 +30,7 @@
 #include "AST.h"
 #include "ASTStringDumper.h"
 #include "ASTVisitor.h"
+#include "CallGraph.h"
 #include "WGSLShaderModule.h"
 
 #include <wtf/SortedArrayMap.h>
@@ -41,9 +42,9 @@ namespace Metal {
 
 class FunctionDefinitionWriter : public AST::Visitor {
 public:
-    FunctionDefinitionWriter(ShaderModule& shaderModule, StringBuilder& stringBuilder)
+    FunctionDefinitionWriter(CallGraph& callGraph, StringBuilder& stringBuilder)
         : m_stringBuilder(stringBuilder)
-        , m_shaderModule(shaderModule)
+        , m_callGraph(callGraph)
     {
     }
 
@@ -51,7 +52,7 @@ public:
 
     using AST::Visitor::visit;
 
-    void visit(ShaderModule&) override;
+    void write();
 
     void visit(AST::Attribute&) override;
     void visit(AST::BuiltinAttribute&) override;
@@ -92,16 +93,19 @@ public:
 
 private:
     StringBuilder& m_stringBuilder;
-    ShaderModule& m_shaderModule;
+    CallGraph& m_callGraph;
     Indentation<4> m_indent { 0 };
     std::optional<AST::StructureRole> m_structRole;
     std::optional<AST::StageAttribute::Stage> m_entryPointStage;
     std::optional<String> m_suffix;
 };
 
-void FunctionDefinitionWriter::visit(ShaderModule& shaderModule)
+void FunctionDefinitionWriter::write()
 {
-    AST::Visitor::visit(shaderModule);
+    for (auto& structure : m_callGraph.ast().structures())
+        visit(structure);
+    for (auto& entryPoint : m_callGraph.entrypoints())
+        visit(entryPoint.m_function);
 }
 
 void FunctionDefinitionWriter::visit(AST::Function& functionDefinition)
@@ -239,7 +243,7 @@ void FunctionDefinitionWriter::visit(AST::GroupAttribute& group)
 {
     unsigned bufferIndex = group.group();
     if (m_entryPointStage.has_value() && *m_entryPointStage == AST::StageAttribute::Stage::Vertex) {
-        auto max = m_shaderModule.configuration().maxBuffersPlusVertexBuffersForVertexStage;
+        auto max = m_callGraph.ast().configuration().maxBuffersPlusVertexBuffersForVertexStage;
         bufferIndex = vertexBufferIndexForBindGroup(bufferIndex, max);
     }
     m_stringBuilder.append("[[buffer(", bufferIndex, ")]]");
@@ -553,10 +557,10 @@ void FunctionDefinitionWriter::visit(AST::ReturnStatement& statement)
     m_stringBuilder.append(";\n");
 }
 
-void emitMetalFunctions(StringBuilder& stringBuilder, ShaderModule& module)
+void emitMetalFunctions(StringBuilder& stringBuilder, CallGraph& callGraph)
 {
-    FunctionDefinitionWriter functionDefinitionWriter(module, stringBuilder);
-    functionDefinitionWriter.visit(module);
+    FunctionDefinitionWriter functionDefinitionWriter(callGraph, stringBuilder);
+    functionDefinitionWriter.write();
 }
 
 } // namespace Metal

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
@@ -29,11 +29,11 @@
 
 namespace WGSL {
 
-class ShaderModule;
+class CallGraph;
 
 namespace Metal {
 
-void emitMetalFunctions(StringBuilder&, ShaderModule&);
+void emitMetalFunctions(StringBuilder&, CallGraph&);
 
 } // namespace Metal
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -110,7 +110,7 @@ inline PrepareResult prepareImpl(ShaderModule& ast, const HashMap<String, Pipeli
 
         {
             PhaseTimer phaseTimer("generateMetalCode", phaseTimes);
-            result.msl = Metal::generateMetalCode(ast);
+            result.msl = Metal::generateMetalCode(callGraph);
         }
     }
 


### PR DESCRIPTION
#### f91396565739ef8714432b1c8aa42f4e95e5d166
<pre>
[WGSL] Generate code based on the call graph instead of full AST
<a href="https://bugs.webkit.org/show_bug.cgi?id=253664">https://bugs.webkit.org/show_bug.cgi?id=253664</a>
rdar://106512158

Reviewed by Myles C. Maxfield.

Currently we generate code for the full AST, including code that might be unreachable
from the entrypoints being compiled. Use the CallGraph instead so we don&apos;t generate
unnecessary code.

* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
(WGSL::Metal::generateMetalCode):
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::FunctionDefinitionWriter):
(WGSL::Metal::FunctionDefinitionWriter::write):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::emitMetalFunctions):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):

Canonical link: <a href="https://commits.webkit.org/261686@main">https://commits.webkit.org/261686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bb8157f05a8d11868b87b1671a2bc01bb7f0e55

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121117 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12880 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118334 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105632 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/879 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14054 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/915 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14737 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52920 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8145 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16573 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->