### PR TITLE
Validate identifier before creating WebsiteDataStore

### DIFF
--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -101,6 +101,7 @@ public:
     WTF_EXPORT_PRIVATE String toString() const;
 
     operator bool() const { return !!m_data; }
+    bool isValid() const { return m_data != emptyValue && m_data != deletedValue; }
 
     UInt128 data() const { return m_data; }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
@@ -90,8 +90,8 @@ WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
 
 /*! @abstract Get a persistent data store.
  @param identifier An identifier that is used to uniquely identify the data store.
- @discussion If a data store with this identifier does not exist yet, it will be created. Returns nil if identifier
- is invalid.
+ @discussion If a data store with this identifier does not exist yet, it will be created. Throws exception if identifier
+ is 0.
 */
 + (WKWebsiteDataStore *)dataStoreForIdentifier:(NSUUID *)identifier WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -358,9 +358,13 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 + (WKWebsiteDataStore *)dataStoreForIdentifier:(NSUUID *)identifier
 {
     if (!identifier)
-        return nil;
+        [NSException raise:NSInvalidArgumentException format:@"Identifier is nil"];
 
-    return wrapper(WebKit::WebsiteDataStore::dataStoreForIdentifier(UUID(identifier)));
+    auto uuid = UUID(identifier);
+    if (!uuid.isValid())
+        [NSException raise:NSInvalidArgumentException format:@"Identifier (%s) is invalid for data store", uuid.toString().utf8().data()];
+
+    return wrapper(WebKit::WebsiteDataStore::dataStoreForIdentifier(uuid));
 }
 
 + (void)removeDataStoreForIdentifier:(NSUUID *)identifier completionHandler:(void(^)(NSError *))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -67,9 +67,13 @@ static void checkURLArgument(NSURL *url)
         return nil;
 
     if (!identifier)
-        [NSException raise:NSInvalidArgumentException format:@"Identifier cannot be nil"];
+        [NSException raise:NSInvalidArgumentException format:@"Identifier is nil"];
 
-    API::Object::constructInWrapper<WebKit::WebsiteDataStoreConfiguration>(self, UUID(identifier));
+    auto uuid = UUID(identifier);
+    if (!uuid.isValid())
+        [NSException raise:NSInvalidArgumentException format:@"Identifier (%s) is invalid for data store", uuid.toString().utf8().data()];
+
+    API::Object::constructInWrapper<WebKit::WebsiteDataStoreConfiguration>(self, uuid);
 
     return self;
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -249,6 +249,8 @@ RefPtr<WebsiteDataStore> WebsiteDataStore::existingDataStoreForIdentifier(const 
 #if PLATFORM(COCOA)
 Ref<WebsiteDataStore> WebsiteDataStore::dataStoreForIdentifier(const UUID& uuid)
 {
+    RELEASE_ASSERT(uuid.isValid());
+
     InitializeWebKit2();
     for (auto* dataStore : allDataStores().values()) {
         if (dataStore && dataStore->configuration().identifier() == uuid)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
@@ -610,4 +610,35 @@ TEST(WKWebsiteDataStorePrivate, FetchWithSize)
     TestWebKitAPI::Util::run(&readyToContinue);
 }
 
+TEST(WKWebsiteDataStore, DataStoreForNilIdentifier)
+{
+    bool hasException = false;
+    @try {
+        auto websiteDataStore = [WKWebsiteDataStore dataStoreForIdentifier:[[NSUUID alloc] initWithUUIDString:@"1234"]];
+        EXPECT_NOT_NULL(websiteDataStore);
+    } @catch (NSException *exception) {
+        EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
+        EXPECT_WK_STREQ(@"Identifier is nil", exception.reason);
+        hasException = true;
+    }
+    EXPECT_TRUE(hasException);
+}
+
+TEST(WKWebsiteDataStore, DataStoreForEmptyIdentifier)
+{
+    bool hasException = false;
+    @try {
+        auto data = [NSMutableData dataWithLength:16];
+        unsigned char* dataBytes = (unsigned char*) [data mutableBytes];
+        auto emptyUUID = [[NSUUID alloc] initWithUUIDBytes:dataBytes];
+        auto websiteDataStore = [WKWebsiteDataStore dataStoreForIdentifier:emptyUUID];
+        EXPECT_NOT_NULL(websiteDataStore);
+    } @catch (NSException *exception) {
+        EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
+        EXPECT_WK_STREQ(@"Identifier (00000000-0000-0000-0000-000000000000) is invalid for data store", exception.reason);
+        hasException = true;
+    }
+    EXPECT_TRUE(hasException);
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -1483,6 +1483,21 @@ TEST(WKWebsiteDataStoreConfiguration, InitWithInvalidIdentifier)
     EXPECT_TRUE(hasException);
 }
 
+TEST(WKWebsiteDataStoreConfiguration, InitWithEmptyIdentifier)
+{
+    bool hasException = false;
+    @try {
+        auto data = [NSMutableData dataWithLength:16];
+        unsigned char* dataBytes = (unsigned char*) [data mutableBytes];
+        auto emptyUUID = [[NSUUID alloc] initWithUUIDBytes:dataBytes];
+        auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:emptyUUID]);
+    } @catch (NSException *exception) {
+        EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
+        hasException = true;
+    }
+    EXPECT_TRUE(hasException);
+}
+
 TEST(WKWebsiteDataStoreConfiguration, SetPathOnConfigurationWithIdentifier)
 {
     bool hasException = false;


### PR DESCRIPTION
#### 04e2f821bf5378751d3e861f44f998ae51fb096b
<pre>
Validate identifier before creating WebsiteDataStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=253667">https://bugs.webkit.org/show_bug.cgi?id=253667</a>
rdar://106514136

Reviewed by Alex Christensen.

NSUUID may not be converted to valid WTF::UUID, so we should validate it before creating WebsiteDataStore.

Test: WKWebsiteDataStore.DataStoreForNilIdentifier
      WKWebsiteDataStore.DataStoreForEmptyIdentifier

* Source/WTF/wtf/UUID.h:
(WTF::UUID::isValid const):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore dataStoreForIdentifier:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration initWithIdentifier:]):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::dataStoreForIdentifier):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/261536@main">https://commits.webkit.org/261536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdd0b83467efeb2f5f500809fcbc94464debc05a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3476 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45649 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100404 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13521 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/399 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11680 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9806 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101678 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52402 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31583 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8032 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16003 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109720 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/26988 "Passed tests") | 
<!--EWS-Status-Bubble-End-->