### PR TITLE
[MQ4] Implement overflow-block/overflow-inline media query features

### DIFF
--- a/LayoutTests/fast/css/media-query-overflow-block-dynamic-expected.html
+++ b/LayoutTests/fast/css/media-query-overflow-block-dynamic-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html style="color: green;"><p>This text should be green.</p></html>

--- a/LayoutTests/fast/css/media-query-overflow-block-dynamic.html
+++ b/LayoutTests/fast/css/media-query-overflow-block-dynamic.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+    :root {
+        color: blue;
+    }
+    @media (overflow-block: paged) {
+        :root {
+            color: red;
+        }
+    }
+    @media (overflow-block: scroll) {
+        :root {
+            color: green;
+        }
+    }
+    @media (overflow-block: none) {
+        :root {
+            color: red;
+        }
+    }
+</style>
+<p>This text should be green.</p>
+<script>
+addEventListener("load", () => {
+    if (!window.internals)
+        return;
+
+    internals.setPagination("LeftToRightPaginated", 0);
+
+    // Give it a chance to actually render as overflow-block: paged before switching back.
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            internals.setPagination("Unpaginated", 0);
+            document.documentElement.classList.remove("reftest-wait");
+        }, 0);
+    });
+});
+</script>
+</html>

--- a/LayoutTests/fast/css/media-query-overflow-block-paged-expected.html
+++ b/LayoutTests/fast/css/media-query-overflow-block-paged-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html style="color: green;"><p>This text should be green in paginated mode.</p></html>

--- a/LayoutTests/fast/css/media-query-overflow-block-paged.html
+++ b/LayoutTests/fast/css/media-query-overflow-block-paged.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<style>
+    :root {
+        color: blue;
+    }
+    @media (overflow-block: paged) {
+        :root {
+            color: green;
+        }
+    }
+    @media (overflow-block: scroll) {
+        :root {
+            color: red;
+        }
+    }
+    @media (overflow-block: none) {
+        :root {
+            color: red;
+        }
+    }
+</style>
+<p>This text should be green in paginated mode.</p>
+<script>
+if (window.internals)
+    internals.setPagination("LeftToRightPaginated", 0);
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
@@ -1256,20 +1256,20 @@ PASS should_not_apply: all and min-color : 1
 PASS should_not_apply: (bogus)
 PASS should_not_apply: not all and (bogus)
 PASS should_not_apply: only all and (bogus)
-FAIL expression_should_be_known: overflow-block assert_true: expected true got false
-FAIL expression_should_be_known: overflow-block: none assert_true: expected true got false
-FAIL expression_should_be_known: overflow-block: paged assert_true: expected true got false
-FAIL expression_should_be_known: overflow-block: scroll assert_true: expected true got false
+PASS expression_should_be_known: overflow-block
+PASS expression_should_be_known: overflow-block: none
+PASS expression_should_be_known: overflow-block: paged
+PASS expression_should_be_known: overflow-block: scroll
 FAIL expression_should_be_known: overflow-block: optional-paged assert_true: expected true got false
 PASS expression_should_be_parseable: overflow-block: some-random-invalid-thing
 PASS expression_should_be_unknown: overflow-block: some-random-invalid-thing
-FAIL Sanity check for overflow-block assert_not_equals: overflow-block should be equivalent to not (overflow-block: none) got disallowed value false
-FAIL expression_should_be_known: overflow-inline assert_true: expected true got false
-FAIL expression_should_be_known: overflow-inline: none assert_true: expected true got false
-FAIL expression_should_be_known: overflow-inline: scroll assert_true: expected true got false
+PASS Sanity check for overflow-block
+PASS expression_should_be_known: overflow-inline
+PASS expression_should_be_known: overflow-inline: none
+PASS expression_should_be_known: overflow-inline: scroll
 PASS expression_should_be_parseable: overflow-inline: some-random-invalid-thing
 PASS expression_should_be_unknown: overflow-inline: some-random-invalid-thing
-FAIL Sanity check for overflow-inline assert_not_equals: overflow-inline should be equivalent to not (overflow-inline: none) got disallowed value false
+PASS Sanity check for overflow-inline
 FAIL expression_should_be_known: update assert_true: expected true got false
 FAIL expression_should_be_known: update: none assert_true: expected true got false
 FAIL expression_should_be_known: update: slow assert_true: expected true got false

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1226,6 +1226,11 @@ interlace
 // none
 active
 
+// (overflow-block/inline:) media feature.
+// none
+// scroll
+paged
+
 // blend modes
 // normal
 multiply

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -689,6 +689,37 @@ const FeatureSchema& displayMode()
 }
 #endif
 
+const FeatureSchema& overflowBlock()
+{
+    static MainThreadNeverDestroyed<IdentifierSchema> schema {
+        "overflow-block"_s,
+        Vector { CSSValueNone, CSSValueScroll, CSSValuePaged },
+        [](auto& context) {
+            // FIXME: Match none when scrollEnabled is set to false by UIKit.
+            bool usesPaginatedMode = [&] {
+                auto& frame = *context.document.frame();
+                auto* frameView = frame.view();
+                return frameView && frameView->pagination().mode != PaginationMode::Unpaginated;
+            }();
+            return MatchingIdentifiers { usesPaginatedMode ? CSSValuePaged : CSSValueScroll };
+        }
+    };
+    return schema;
+}
+
+const FeatureSchema& overflowInline()
+{
+    static MainThreadNeverDestroyed<IdentifierSchema> schema {
+        "overflow-inline"_s,
+        Vector { CSSValueNone, CSSValueScroll },
+        [](auto&) {
+            // FIXME: Match none when scrollEnabled is set to false by UIKit.
+            return MatchingIdentifiers { CSSValueScroll };
+        }
+    };
+    return schema;
+}
+
 #if ENABLE(DARK_MODE_CSS)
 const FeatureSchema& prefersColorScheme()
 {
@@ -727,6 +758,8 @@ Vector<const FeatureSchema*> allSchemas()
         &hover(),
         &invertedColors(),
         &monochrome(),
+        &overflowBlock(),
+        &overflowInline(),
         &orientation(),
         &pointer(),
         &prefersContrast(),

--- a/Source/WebCore/css/query/MediaQueryFeatures.h
+++ b/Source/WebCore/css/query/MediaQueryFeatures.h
@@ -49,6 +49,8 @@ const FeatureSchema& hover();
 const FeatureSchema& invertedColors();
 const FeatureSchema& monochrome();
 const FeatureSchema& orientation();
+const FeatureSchema& overflowBlock();
+const FeatureSchema& overflowInline();
 const FeatureSchema& pointer();
 const FeatureSchema& prefersContrast();
 const FeatureSchema& prefersDarkInterface();


### PR DESCRIPTION
#### 3f9d91e4ed1d08b947d964a91254b65e2046ab08
<pre>
[MQ4] Implement overflow-block/overflow-inline media query features
<a href="https://bugs.webkit.org/show_bug.cgi?id=253662">https://bugs.webkit.org/show_bug.cgi?id=253662</a>
rdar://106511968

Reviewed by Darin Adler.

<a href="https://drafts.csswg.org/mediaqueries-4/#mf-overflow-block">https://drafts.csswg.org/mediaqueries-4/#mf-overflow-block</a>
<a href="https://drafts.csswg.org/mediaqueries-4/#mf-overflow-inline">https://drafts.csswg.org/mediaqueries-4/#mf-overflow-inline</a>

* LayoutTests/fast/css/media-query-overflow-block-dynamic-expected.html: Added.
* LayoutTests/fast/css/media-query-overflow-block-dynamic.html: Added.
* LayoutTests/fast/css/media-query-overflow-block-paged-expected.html: Added.
* LayoutTests/fast/css/media-query-overflow-block-paged.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::overflowBlock):
(WebCore::MQ::Features::overflowInline):
* Source/WebCore/css/query/MediaQueryFeatures.h:

Canonical link: <a href="https://commits.webkit.org/263088@main">https://commits.webkit.org/263088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81fd03331c520314a15d8a7c229e4ebb647118b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3104 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3612 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4815 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3199 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3175 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3258 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3626 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3199 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/863 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->