### PR TITLE
Worklet.prototype.constructor is incorrect

### DIFF
--- a/LayoutTests/fast/worklets/worklet-constructor-expected.txt
+++ b/LayoutTests/fast/worklets/worklet-constructor-expected.txt
@@ -1,0 +1,10 @@
+Tests that Worklet.prototype.constructor is correct.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Worklet.prototype.constructor.name is "Worklet"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/worklets/worklet-constructor.html
+++ b/LayoutTests/fast/worklets/worklet-constructor.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that Worklet.prototype.constructor is correct.");
+
+shouldBeEqualToString("Worklet.prototype.constructor.name", "Worklet");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -1285,9 +1285,9 @@ PASS Worklet interface: existence and properties of interface object
 PASS Worklet interface object length
 PASS Worklet interface object name
 PASS Worklet interface: existence and properties of interface prototype object
-FAIL Worklet interface: existence and properties of interface prototype object's "constructor" property assert_own_property: Worklet.prototype does not have own property "constructor" expected property "constructor" missing
+PASS Worklet interface: existence and properties of interface prototype object's "constructor" property
 PASS Worklet interface: existence and properties of interface prototype object's @@unscopables property
-FAIL Worklet interface: operation addModule(USVString, optional WorkletOptions) assert_own_property: interface prototype object missing non-static operation expected property "addModule" missing
+PASS Worklet interface: operation addModule(USVString, optional WorkletOptions)
 PASS Storage interface: existence and properties of interface object
 PASS Storage interface object length
 PASS Storage interface object name

--- a/Source/WebCore/worklets/Worklet.idl
+++ b/Source/WebCore/worklets/Worklet.idl
@@ -26,7 +26,6 @@
 [
     ActiveDOMObject,
     Exposed=Window,
-    Global=Worklet,
     SkipVTableValidation
 ] interface Worklet {
     Promise<undefined> addModule(USVString moduleURL, optional WorkletOptions options);


### PR DESCRIPTION
#### 1976601ac16287ba145d2457bafb212860d59255
<pre>
Worklet.prototype.constructor is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=253666">https://bugs.webkit.org/show_bug.cgi?id=253666</a>

Reviewed by Don Olmstead.

The bindings generator was generating the property table for the prototype
correctly and it contained the &quot;constructor&quot; property as expected. However,
this property table was unused because Worklet was incorrectly annotated
with &quot;Global=Worklet&quot; in the IDL. As a result, Worklet.prototype.contructor
would be the Object constructor.

This was found due to a build warning indicating that
JSWorkletPrototypeTableValues was unused.

* LayoutTests/fast/worklets/worklet-constructor-expected.txt: Added.
* LayoutTests/fast/worklets/worklet-constructor.html: Added.
* Source/WebCore/worklets/Worklet.idl:

Canonical link: <a href="https://commits.webkit.org/261483@main">https://commits.webkit.org/261483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c95f15202795ca38b39dce2cdbb1cca3f35d8bf0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/449 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22316 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117598 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/104845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13925 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19361 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/52297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7991 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->