### PR TITLE
REGRESSION(260575@main): TestWebKitAPI.AudioRoutingArbitration.Deletion times out with UI-side-compositing enabled

### DIFF
--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -103,6 +103,7 @@ void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaEl
         textTracks.addEventListener(events.addtrackEvent, *this, false);
         textTracks.addEventListener(events.changeEvent, *this, false);
         textTracks.addEventListener(events.removetrackEvent, *this, false);
+        m_isListening = true;
     }
 
     updateForEventName(eventNameAll());


### PR DESCRIPTION
#### d06c4a736aea572e05d3a84c7dc14b490d42a55d
<pre>
REGRESSION(260575@main): TestWebKitAPI.AudioRoutingArbitration.Deletion times out with UI-side-compositing enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=253670">https://bugs.webkit.org/show_bug.cgi?id=253670</a>
rdar://106322713

Reviewed by Ryosuke Niwa.

When we did the &quot;don&apos;t host layers from the WebContent process&quot; work, we re-used the
PlaybackSessionManager/VideoFullscreenManager codepath from element fullscreen and
picture-in-picture to handle creation and sizing of the video layer in the UI process. This caused
a pre-existing bug where a fullscreened HTMLMediaElement would never be destroyed (due to having
eventListeners) to now apply to all HTMLMediaElements displayed in a page.

The eventListeners aren&apos;t removed because a boolean ivar intended to track whether eventListeners
were added was never set to true. Once that ivar is correctly set, the test passes.

* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::setMediaElement):

Canonical link: <a href="https://commits.webkit.org/261503@main">https://commits.webkit.org/261503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24d3f5277d1cda7de7bcdbf6fd6a5eaa1e73fec2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3564 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/11992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3312 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117554 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16546 "3 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104808 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45522 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13383 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/271 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9703 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52273 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8006 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15865 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->