### PR TITLE
[popover] Fix popover-attribute-basic.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -34,31 +34,31 @@ PASS Changing a popover from auto to auto (via attr), and then manual during 'be
 PASS Changing a popover from auto to auto (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "manual"
+PASS Changing a popover from auto to manual (via attr), and then auto during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then manual during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "manual"
-FAIL Changing a popover from auto to manual (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected "null" but got "manual"
-FAIL Changing a popover from auto to manual (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to invalid (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "invalid"
-FAIL Changing a popover from auto to invalid (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "invalid"
+PASS Changing a popover from auto to manual (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via attr), and then undefined during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then invalid during 'beforetoggle' works
-FAIL Changing a popover from auto to invalid (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected "null" but got "invalid"
-FAIL Changing a popover from auto to invalid (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to null (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "null"
-FAIL Changing a popover from auto to null (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "null"
-FAIL Changing a popover from auto to null (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "null"
+PASS Changing a popover from auto to invalid (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via attr), and then undefined during 'beforetoggle' works
+PASS Changing a popover from auto to null (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from auto to null (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to null (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then null during 'beforetoggle' works
-FAIL Changing a popover from auto to null (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to undefined (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected (string) "null" but got (object) null
+PASS Changing a popover from auto to null (via attr), and then undefined during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then auto during 'beforetoggle' works
-FAIL Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "auto"
-FAIL Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "auto"
-FAIL Changing a popover from manual to auto (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected "null" but got "auto"
-FAIL Changing a popover from manual to auto (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
+PASS Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then auto during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then invalid during 'beforetoggle' works
@@ -74,41 +74,41 @@ PASS Changing a popover from manual to null (via attr), and then manual during '
 PASS Changing a popover from manual to null (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to null (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to null (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to undefined (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected (string) "null" but got (object) null
+PASS Changing a popover from manual to undefined (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then auto during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "manual"
+PASS Changing a popover from auto to manual (via idl), and then auto during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then manual during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "manual"
-FAIL Changing a popover from auto to manual (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to manual (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to invalid (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "invalid"
-FAIL Changing a popover from auto to invalid (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "invalid"
+PASS Changing a popover from auto to manual (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via idl), and then undefined during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then invalid during 'beforetoggle' works
-FAIL Changing a popover from auto to invalid (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to invalid (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
+PASS Changing a popover from auto to invalid (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via idl), and then undefined during 'beforetoggle' works
+PASS Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
+PASS Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "auto"
-FAIL Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "auto"
-FAIL Changing a popover from manual to auto (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from manual to auto (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
+PASS Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then auto during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then invalid during 'beforetoggle' works
@@ -119,14 +119,14 @@ PASS Changing a popover from manual to invalid (via idl), and then manual during
 PASS Changing a popover from manual to invalid (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to invalid (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to invalid (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
+PASS Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
+PASS Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then undefined during 'beforetoggle' works
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-change-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-change-type-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Changing the popover attribute should always update the auto/manual behavior.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-change-type.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-change-type.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/issues/9034">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/html/semantics/popovers/resources/popover-utils.js"></script>
+
+<body style="margin: 0px">
+
+<div id=mypopover>popover</div>
+
+<script>
+promise_test(async () => {
+  const mypopover = document.getElementById('mypopover');
+
+  mypopover.popover = "manual";
+  mypopover.showPopover();
+
+  await new Promise(resolve => {
+    mypopover.addEventListener("beforetoggle", (e) => {
+      if (e.newState === "closed") {
+        mypopover.remove();
+        requestAnimationFrame(() => {
+          document.body.append(mypopover);
+          mypopover.showPopover();
+          resolve();
+        });
+      }
+    }, {once: true});
+
+    mypopover.popover = "auto";
+  });
+
+  assert_true(mypopover.matches(':popover-open'),
+    'The popover should be open after the toggling sequence.');
+
+  await new test_driver.send_keys(mypopover,'\uE00C'); // Escape
+
+  assert_false(mypopover.matches(':popover-open'),
+    'The popover should light dismiss because it is in the auto state.');
+}, 'Changing the popover attribute should always update the auto/manual behavior.');
+</script>
+
+</body>

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -34,31 +34,31 @@ PASS Changing a popover from auto to auto (via attr), and then manual during 'be
 PASS Changing a popover from auto to auto (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "manual"
+FAIL Changing a popover from auto to manual (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to manual (via attr), and then manual during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "manual"
-FAIL Changing a popover from auto to manual (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected "null" but got "manual"
-FAIL Changing a popover from auto to manual (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to invalid (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "invalid"
-FAIL Changing a popover from auto to invalid (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "invalid"
+PASS Changing a popover from auto to manual (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to invalid (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from auto to invalid (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then invalid during 'beforetoggle' works
-FAIL Changing a popover from auto to invalid (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected "null" but got "invalid"
-FAIL Changing a popover from auto to invalid (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to null (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "null"
-FAIL Changing a popover from auto to null (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "null"
-FAIL Changing a popover from auto to null (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "null"
+PASS Changing a popover from auto to invalid (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to null (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from auto to null (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to null (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then null during 'beforetoggle' works
-FAIL Changing a popover from auto to null (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to undefined (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected (string) "null" but got (object) null
+PASS Changing a popover from auto to null (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to auto (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "auto"
-FAIL Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "auto"
-FAIL Changing a popover from manual to auto (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected "null" but got "auto"
-FAIL Changing a popover from manual to auto (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
+PASS Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then auto during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then invalid during 'beforetoggle' works
@@ -74,41 +74,41 @@ PASS Changing a popover from manual to null (via attr), and then manual during '
 PASS Changing a popover from manual to null (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to null (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to null (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to undefined (via attr), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected (string) "null" but got (object) null
+FAIL Changing a popover from manual to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then auto during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "manual"
+FAIL Changing a popover from auto to manual (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to manual (via idl), and then manual during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "manual"
-FAIL Changing a popover from auto to manual (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to manual (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to invalid (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected "auto" but got "invalid"
-FAIL Changing a popover from auto to invalid (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "invalid"
+PASS Changing a popover from auto to manual (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to manual (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to invalid (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from auto to invalid (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then invalid during 'beforetoggle' works
-FAIL Changing a popover from auto to invalid (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to invalid (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
+PASS Changing a popover from auto to invalid (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to invalid (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
+FAIL Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to auto (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "auto"
-FAIL Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "auto"
-FAIL Changing a popover from manual to auto (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
-FAIL Changing a popover from manual to auto (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" did not throw
+PASS Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to auto (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then auto during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then invalid during 'beforetoggle' works
@@ -119,14 +119,14 @@ PASS Changing a popover from manual to invalid (via idl), and then manual during
 PASS Changing a popover from manual to invalid (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to invalid (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to invalid (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
+FAIL Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
-FAIL Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
-FAIL Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
+FAIL Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then undefined during 'beforetoggle' works
 

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-change-type-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-change-type-expected.txt
@@ -1,0 +1,4 @@
+popover
+
+FAIL Changing the popover attribute should always update the auto/manual behavior. assert_false: The popover should light dismiss because it is in the auto state. expected false got true
+


### PR DESCRIPTION
#### e6f61f306afaa4ee95dc36040e166bfd037cfe75
<pre>
[popover] Fix popover-attribute-basic.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=253673">https://bugs.webkit.org/show_bug.cgi?id=253673</a>

Reviewed by Tim Nguyen.

In popoverAttributeChanged when hiding the popover make sure we fire beforetoggle event.
Since this event may end up changing the popover attribute again, recompute the type
after hiding the popover.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-change-type-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-change-type.html: Added.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-change-type-expected.txt: Added.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::checkPopoverValidity):
(WebCore::HTMLElement::popoverAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/263188@main">https://commits.webkit.org/263188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14b34f2c4087acf7505bef3377cc963012c33716

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4139 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4052 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/3975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3797 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5151 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3472 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5190 "9 flakes 136 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4922 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3934 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/3975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3472 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/949 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->