### PR TITLE
The InteractionRegion layers' order should match the paint order

### DIFF
--- a/LayoutTests/interaction-region/overlap-expected.txt
+++ b/LayoutTests/interaction-region/overlap-expected.txt
@@ -1,7 +1,3 @@
-Line
-Line
-Line
-Line
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -15,20 +11,12 @@ Line
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (-3,-3) width=36 height=25)
+        (occlusion
+            (rect (0,0) width=200 height=100)
 )
         (borderRadius 0.00),
         (interaction
-            (rect (-3,17) width=36 height=25)
-)
-        (borderRadius 0.00),
-        (interaction
-            (rect (-3,37) width=36 height=25)
-)
-        (borderRadius 0.00),
-        (interaction
-            (rect (-3,57) width=36 height=25)
+            (rect (0,0) width=200 height=100)
 )
         (borderRadius 0.00)])
       )

--- a/LayoutTests/interaction-region/overlap.html
+++ b/LayoutTests/interaction-region/overlap.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+
+    .overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 2;
+        width: 200px;
+        height: 100px;
+        background-color: green;
+        opacity: 0.2;
+    }
+    .fill {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: blue;
+        opacity: 0.2;
+
+        cursor: pointer;
+    }
+</style>
+<body>
+<div class="overlay">
+    <div class="fill"></div>
+</div>
+<div class="overlay">
+    <div class="fill"></div>
+    <div class="fill"></div>
+</div>
+
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/split-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/split-inline-link-expected.txt
@@ -14,10 +14,11 @@ short second line.
 
       (interaction regions [
         (interaction
-            (rect (198,-3) width=31 height=20)
-            (rect (-3,17) width=115 height=5)
-            (rect (198,17) width=31 height=5)
-            (rect (-3,22) width=115 height=20)
+            (rect (198,-3) width=31 height=25)
+)
+        (borderRadius 0.00),
+        (interaction
+            (rect (-3,17) width=115 height=25)
 )
         (borderRadius 0.00)])
       )

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AffineTransform.h"
+#include "IntRectHash.h"
 #include "InteractionRegion.h"
 #include "Node.h"
 #include "Region.h"
@@ -70,7 +71,9 @@ private:
     Vector<IntRect> m_clipStack;
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    HashMap<ElementIdentifier, InteractionRegion> m_interactionRegionsByElement;
+    Vector<InteractionRegion> m_interactionRegions;
+    HashSet<IntRect> m_interactionRects;
+    HashSet<IntRect> m_occlusionRects;
 #endif
 };
 


### PR DESCRIPTION
#### c370b1baf0b3aeaa9f813dd557a60a403bf63e73
<pre>
The InteractionRegion layers&apos; order should match the paint order
<a href="https://bugs.webkit.org/show_bug.cgi?id=253678">https://bugs.webkit.org/show_bug.cgi?id=253678</a>
&lt;rdar://105700167&gt;

Reviewed by Tim Horton.

Propagate the Interaction Regions creation&apos;s order (which matches the
paint order) all the way to the RemoteLayerTree.
The content process is now in charge of ordering/deduping the regions.
And we don&apos;t do per-element region uniting anymore.

* Source/WebCore/rendering/EventRegion.h:
Remove the InteractionRegionByElement HashMap.
Add HashSets to dedupe regions by bounds.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
(WebCore::EventRegionContext::copyInteractionRegionsToEventRegion):
Use a vector to accumulate interaction regions in order.
Prevent duplicated bounds.
(WebCore::EventRegion::dump const):
Remove the test-only ordering code so existing tests cover the actual order.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::insertInteractionRegionLayersForLayer):
Break when the first non-InteractionRegion-layer is encountered.
(They always come first.)
(WebKit::updateLayersForInteractionRegions):
Update the sublayers while maintaining the order we get from the event
region. Reuse existing layers when the bounds match.

* LayoutTests/interaction-region/overlap-expected.txt: Added.
* LayoutTests/interaction-region/overlap.html: Added.
Add a test covering the content-side deduplication.
* LayoutTests/interaction-region/split-inline-link-expected.txt:
* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
Update test after the per-element uniting removal.

Canonical link: <a href="https://commits.webkit.org/261578@main">https://commits.webkit.org/261578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d62cfd6df436cef34ca067db4fa0028224bd4307

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3587 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120520 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3336 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104832 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45540 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13406 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/286 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9713 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8072 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15888 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->