### PR TITLE
Summary element is not focusable with tabindex

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/tabindex-focus-flag-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/tabindex-focus-flag-expected.txt
@@ -26,14 +26,14 @@ PASS img should not be focusable by default.
 PASS A with tabindex=0 should be focusable.
 PASS a with tabindex=0 should be focusable.
 PASS text with tabindex=0 should be focusable.
-FAIL SUMMARY#summary-out-tabindex0 with tabindex=0 should be focusable. assert_equals: expected Element node <summary tabindex="0" id="summary-out-tabindex0"></summary> but got Element node <text tabindex="0"></text>
-FAIL SUMMARY#summary-second-tabindex0 with tabindex=0 should be focusable. assert_equals: expected Element node <summary tabindex="0" id="summary-second-tabindex0"></sum... but got Element node <text tabindex="0"></text>
+PASS SUMMARY#summary-out-tabindex0 with tabindex=0 should be focusable.
+PASS SUMMARY#summary-second-tabindex0 with tabindex=0 should be focusable.
 PASS IMG with tabindex=0 should be focusable.
 PASS A with tabindex=-1 should be focusable.
 PASS a with tabindex=-1 should be focusable.
 PASS text with tabindex=-1 should be focusable.
-FAIL SUMMARY#summary-out-tabindex-negative with tabindex=-1 should be focusable. assert_equals: expected Element node <summary tabindex="-1" id="summary-out-tabindex-negative"... but got Element node <text tabindex="-1"></text>
-FAIL SUMMARY#summary-second-tabindex-negative with tabindex=-1 should be focusable. assert_equals: expected Element node <summary tabindex="0" id="summary-second-tabindex-negativ... but got Element node <text tabindex="-1"></text>
+PASS SUMMARY#summary-out-tabindex-negative with tabindex=-1 should be focusable.
+PASS SUMMARY#summary-second-tabindex-negative with tabindex=-1 should be focusable.
 PASS IMG with tabindex=-1 should be focusable.
 PASS A with tabindex=invalid should not be focusable.
 PASS A#with-href with tabindex=invalid should be focusable.

--- a/Source/WebCore/html/HTMLSummaryElement.cpp
+++ b/Source/WebCore/html/HTMLSummaryElement.cpp
@@ -111,7 +111,7 @@ int HTMLSummaryElement::defaultTabIndex() const
 
 bool HTMLSummaryElement::supportsFocus() const
 {
-    return isActiveSummary();
+    return isActiveSummary() || HTMLElement::supportsFocus();
 }
 
 void HTMLSummaryElement::defaultEventHandler(Event& event)


### PR DESCRIPTION
#### 1c49120b32b382c185f215ada1bc96342a89f83e
<pre>
Summary element is not focusable with tabindex

<a href="https://bugs.webkit.org/show_bug.cgi?id=253680">https://bugs.webkit.org/show_bug.cgi?id=253680</a>

Reviewed by Aditya Keerthi.

This patch aligns WebKit to Gecko / Firefox and Blink / Chromium by adding &apos;HTMLElement::supportsFocus&apos;
similar to other elements to enable &apos;summary&apos; element being focusable with tabindex on element.

* Source/WebKit/html/HTMLSummaryElement.cpp:
(HTMLSummaryElement::supportsFocus):
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/tabindex-focus-flag-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/261497@main">https://commits.webkit.org/261497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1cda0855c4bc29fe67507ae9b2addad8229d08c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12015 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3334 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104833 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45534 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13407 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/287 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9715 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52289 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8001 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15889 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->