### PR TITLE
[ iOS ] imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html is a constant failure.

### DIFF
--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -1,211 +1,26 @@
-Pop upPop upDialog with popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manualInvalid popover value - defaults to popover=manual
 Not a popover
 Dialog without popover attribute
 
-FAIL The element <div popover="" id="boolean">Pop up</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="">Pop up</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="auto">Pop up</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="hint">Pop up</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="manual">Pop up</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <article popover="">Different element type</article> should behave as a popover. Element has unexpected visibility state
-FAIL The element <header popover="">Different element type</header> should behave as a popover. Element has unexpected visibility state
-FAIL The element <nav popover="">Different element type</nav> should behave as a popover. Element has unexpected visibility state
-FAIL The element <input type="text" popover="" value="Different element type"> should behave as a popover. Element has unexpected visibility state
-FAIL The element <dialog popover="">Dialog with popover attribute</dialog> should behave as a popover. Element has unexpected visibility state
-FAIL The element <dialog popover="manual">Dialog with popover=manual</dialog> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="true">Invalid popover value - defaults to popover=manual</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="popover">Invalid popover value - defaults to popover=manual</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div popover="invalid">Invalid popover value - defaults to popover=manual</div> should behave as a popover. Element has unexpected visibility state
-FAIL The element <div>Not a popover</div> should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL The element <dialog open="">Dialog without popover attribute</dialog> should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <a popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <a> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <abbr popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <abbr> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <address popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <address> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <area popover> element should behave as a popover. assert_equals: After showPopover(), a popover should be visible: Expected this element to be visible expected true but got false
-FAIL A <area> element should *not* behave as a popover. assert_equals: A non-popover should start out visible: Expected this element to be visible expected true but got false
-FAIL A <article popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <article> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <aside popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <aside> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <b popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <b> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <bdi popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <bdi> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <bdo popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <bdo> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <blockquote popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <blockquote> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <body popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <body> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <button popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <button> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <canvas popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <canvas> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <caption popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <caption> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <cite popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <cite> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <code popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <code> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <col popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <col> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <colgroup popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <colgroup> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <data popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <data> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <dd popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <dd> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <del popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <del> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <details popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <details> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <dfn popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <dfn> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <div popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <div> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <dl popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <dl> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <dt popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <dt> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <em popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <em> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <fieldset popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <fieldset> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <figcaption popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <figcaption> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <figure popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <figure> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <footer popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <footer> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <form popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <form> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h1 popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <h1> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h2 popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <h2> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h3 popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <h3> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h4 popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <h4> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h5 popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <h5> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <h6 popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <h6> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <header popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <header> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <hr popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <hr> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <html popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <html> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <i popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <i> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <iframe popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <iframe> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <img popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <img> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <input popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <input> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <ins popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <ins> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <kbd popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <kbd> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <label popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <label> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <legend popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <legend> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <li popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <li> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <main popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <main> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <map popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <map> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <mark popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <mark> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <menu popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <menu> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <meter popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <meter> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <nav popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <nav> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <object popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <object> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <ol popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <ol> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <optgroup popover> element should behave as a popover. assert_equals: After showPopover(), a popover should be visible: Expected this element to be visible expected true but got false
-FAIL A <optgroup> element should *not* behave as a popover. assert_equals: A non-popover should start out visible: Expected this element to be visible expected true but got false
-FAIL A <option popover> element should behave as a popover. assert_equals: After showPopover(), a popover should be visible: Expected this element to be visible expected true but got false
-FAIL A <option> element should *not* behave as a popover. assert_equals: A non-popover should start out visible: Expected this element to be visible expected true but got false
-FAIL A <output popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <output> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <p popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <p> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <pre popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <pre> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <progress popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <progress> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <q popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <q> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <rt popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <rt> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <ruby popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <ruby> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <s popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <s> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <samp popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <samp> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <section popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <section> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <select popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <select> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <small popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <small> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <source popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <source> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <span popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <span> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <strong popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <strong> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <sub popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <sub> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <sup popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <sup> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <summary popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <summary> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <table popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <table> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <tbody popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <tbody> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <td popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <td> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <textarea popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <textarea> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <tfoot popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <tfoot> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <th popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <th> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <thead popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <thead> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <time popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <time> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <tr popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <tr> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <track popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <track> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <u popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <u> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <ul popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <ul> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <var popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <var> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL A <video popover> element should behave as a popover. Element has unexpected visibility state
-FAIL A <video> element should *not* behave as a popover. assert_throws_dom: Calling showPopover on a non-popover should throw NotSupported function "() => nonPopover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS The element <div popover="" id="boolean">Pop up</div> should behave as a popover.
+PASS The element <div popover="">Pop up</div> should behave as a popover.
+PASS The element <div popover="auto">Pop up</div> should behave as a popover.
+PASS The element <div popover="hint">Pop up</div> should behave as a popover.
+PASS The element <div popover="manual">Pop up</div> should behave as a popover.
+PASS The element <article popover="">Different element type</article> should behave as a popover.
+PASS The element <header popover="">Different element type</header> should behave as a popover.
+PASS The element <nav popover="">Different element type</nav> should behave as a popover.
+PASS The element <input type="text" popover="" value="Different element type"> should behave as a popover.
+PASS The element <dialog popover="">Dialog with popover attribute</dialog> should behave as a popover.
+PASS The element <dialog popover="manual">Dialog with popover=manual</dialog> should behave as a popover.
+PASS The element <div popover="true">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
+PASS The element <div popover="popover">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
+PASS The element <div popover="invalid">Invalid popover value - defaults to popover=manual</div> should behave as a popover.
+PASS The element <div>Not a popover</div> should *not* behave as a popover.
+PASS The element <dialog open="">Dialog without popover attribute</dialog> should *not* behave as a popover.
 PASS IDL attribute reflection
-FAIL Popover attribute value should be case insensitive Element has unexpected visibility state
-FAIL Changing attribute values for popover should work Element has unexpected visibility state
-FAIL Changing attribute values should close open popovers assert_false: expected false got true
+PASS Popover attribute value should be case insensitive
+PASS Changing attribute values for popover should work
+PASS Changing attribute values should close open popovers
 PASS Removing a visible popover=auto element from the document should close the popover
 PASS A showing popover=auto does not match :modal
 PASS Removing a visible popover=manual element from the document should close the popover
@@ -236,7 +51,7 @@ FAIL Changing a popover from auto to undefined (via attr), and then auto during 
 FAIL Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
 FAIL Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected (string) "null" but got (object) null
-FAIL Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to auto (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 FAIL Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "auto"
 FAIL Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "auto"
@@ -261,7 +76,7 @@ FAIL Changing a popover from manual to undefined (via attr), and then auto durin
 FAIL Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
 FAIL Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works assert_equals: Content attribute expected (string) "null" but got (object) null
-FAIL Changing a popover from manual to undefined (via attr), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from manual to undefined (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then auto during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then invalid during 'beforetoggle' works
@@ -280,13 +95,13 @@ FAIL Changing a popover from auto to invalid (via idl), and then undefined durin
 FAIL Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
 FAIL Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
 FAIL Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to auto (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 FAIL Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected "manual" but got "auto"
 FAIL Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected "invalid" but got "auto"
@@ -305,11 +120,11 @@ PASS Changing a popover from manual to invalid (via idl), and then undefined dur
 FAIL Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
 FAIL Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works assert_equals: Content attribute expected (string) "auto" but got (object) null
 FAIL Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works assert_equals: Content attribute expected (string) "manual" but got (object) null
 FAIL Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works assert_equals: Content attribute expected (string) "invalid" but got (object) null
-FAIL Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
-FAIL Changing a popover from manual to undefined (via idl), and then undefined during 'beforetoggle' works assert_throws_dom: We should have removed the popover attribute, so showPopover should throw function "() => popover.showPopover()" threw object "InvalidStateError: Element does not have the popover attribute" that is not a DOMException NotSupportedError: property "code" is equal to 11, expected 9
+PASS Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to undefined (via idl), and then undefined during 'beforetoggle' works
 


### PR DESCRIPTION
#### 268be348f38ba96af2fd4aca26a26623d38c8f0c
<pre>
[ iOS ] imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253668">https://bugs.webkit.org/show_bug.cgi?id=253668</a>
rdar://106515368

Unreviewed test gardening.

Rebaseline of failing test.

* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:

Canonical link: <a href="https://commits.webkit.org/261477@main">https://commits.webkit.org/261477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/197a64575ba28f926095ccf33568d3771ebc8ae6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/111821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/20949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/3589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/22305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/3589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/117586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/22305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/22305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/104835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/104835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/13913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4355 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->