### PR TITLE
Copying text on a GitHub pull request in split mode sometimes lowercases the first letter

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-paste-text-with-trailing-colon-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-paste-text-with-trailing-colon-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that copying the text 'Foo:' and pasting into a plain text field works as expected. To run the test manually, click the button, focus the text field, and paste.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS doneWithPaste became true
+PASS target.value is "Foo:"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click me

--- a/LayoutTests/editing/pasteboard/copy-paste-text-with-trailing-colon.html
+++ b/LayoutTests/editing/pasteboard/copy-paste-text-with-trailing-colon.html
@@ -1,0 +1,49 @@
+<!DOCTYPE> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="initial-scale=1, width=device-width">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that copying the text 'Foo:' and pasting into a plain text field works as expected. To run the test manually, click the button, focus the text field, and paste.");
+    source = document.getElementById("source");
+    target = document.getElementById("target");
+
+    source.addEventListener("click", event => {
+        let span = document.createElement("span");
+        span.textContent = "foo";
+        span.addEventListener("copy", event => {
+            event.clipboardData.setData("text/plain", "Foo:");
+            event.preventDefault()
+        });
+        document.body.appendChild(span);
+        getSelection().selectAllChildren(span);
+        document.execCommand("Copy");
+        span.remove();
+    });
+
+    doneWithPaste = false;
+    target.addEventListener("paste", event => {
+        doneWithPaste = true;
+    });
+
+    if (window.testRunner) {
+        await UIHelper.activateElement(source);
+        target.focus();
+        document.execCommand("Paste");
+    }
+
+    await shouldBecomeEqual("doneWithPaste", "true");
+    shouldBeEqualToString("target.value", "Foo:");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <button id="source">Click me</button>
+    <input type="text" id="target" placeholder="Paste here" />
+</body>
+</html>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1348,6 +1348,8 @@ fast/scrolling/ios/body-overflow-hidden.html [ Pass ImageOnlyFailure ]
 # <rdar://problem/56512107> [ iOS ] Three editing/pasteboard/smart-paste-paragraph tests have been flaky since they landed in r243124 (203264)
 webkit.org/b/203264 [ Release ] editing/pasteboard/smart-paste-paragraph-001.html [ Pass Failure ]
 
+webkit.org/b/253708 editing/pasteboard/copy-paste-text-with-trailing-colon.html [ Failure ]
+
 # Timeout running prompt() because mock implementation is absent.
 webkit.org/b/203572 media/remoteplayback-prompt.html [ Skip ]
 webkit.org/b/203572 media/remoteplayback-target-availability.html [ Skip ]

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4291,8 +4291,10 @@ URL Page::sanitizeLookalikeCharacters(const URL& url, LookalikeCharacterSanitiza
 
 String Page::sanitizeLookalikeCharacters(const String& urlString, LookalikeCharacterSanitizationTrigger trigger) const
 {
-    if (auto url = URL { urlString }; url.isValid())
-        return sanitizeLookalikeCharacters(WTFMove(url), trigger).string();
+    if (auto url = URL { urlString }; url.isValid()) {
+        if (auto sanitizedURL = sanitizeLookalikeCharacters(WTFMove(url), trigger); sanitizedURL != url)
+            return sanitizedURL.string();
+    }
     return urlString;
 }
 


### PR DESCRIPTION
#### cb882e94269522daf1e1df30dc3b93b665844912
<pre>
Copying text on a GitHub pull request in split mode sometimes lowercases the first letter
<a href="https://bugs.webkit.org/show_bug.cgi?id=250119">https://bugs.webkit.org/show_bug.cgi?id=250119</a>
rdar://105603708

Reviewed by Aditya Keerthi.

When running lookalike character sanitization upon pasting text, allow the original text to pass
through unchanged in the case where lookalike character sanitization didn&apos;t adjust the URL.

Test: editing/pasteboard/copy-paste-text-with-trailing-colon.html

* LayoutTests/editing/pasteboard/copy-paste-text-with-trailing-colon-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-paste-text-with-trailing-colon.html: Added.
* LayoutTests/platform/ios-wk2/TestExpectations:

Mark the test as failing on iOS for now, while I investigate a fix in &lt;<a href="https://webkit.org/b/253708">https://webkit.org/b/253708</a>&gt;.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::sanitizeLookalikeCharacters const):

Canonical link: <a href="https://commits.webkit.org/261516@main">https://commits.webkit.org/261516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee1c306eaa7f752b991fa99f1ef8fcbc8aa3e3d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3691 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12179 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117689 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104947 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45616 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13501 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/374 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14099 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52376 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8022 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15982 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->