### PR TITLE
Refactor dispatching of pagehideEvent and pageshowEvent

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1258,6 +1258,7 @@ public:
     void queueTaskToDispatchEventOnWindow(TaskSource, Ref<Event>&&);
     void enqueueOverflowEvent(Ref<Event>&&);
     void dispatchPageshowEvent(PageshowEventPersistence);
+    void dispatchPagehideEvent(PageshowEventPersistence);
     WEBCORE_EXPORT void enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&&);
     void enqueueHashchangeEvent(const String& oldURL, const String& newURL);
     void dispatchPopstateEvent(RefPtr<SerializedScriptValue>&& stateObject);
@@ -2261,6 +2262,9 @@ private:
 
     unsigned m_activeParserCount { 0 };
     unsigned m_styleRecalcCount { 0 };
+
+    enum class PageStatus : uint8_t { None, Shown, Hidden };
+    PageStatus m_lastPageStatus { PageStatus::None };
 
     DocumentClasses m_documentClasses;
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3492,7 +3492,7 @@ void FrameLoader::dispatchUnloadEvents(UnloadEventPolicy unloadEventPolicy)
         if (m_pageDismissalEventBeingDispatched == PageDismissalType::None) {
             if (unloadEventPolicy == UnloadEventPolicy::UnloadAndPageHide) {
                 m_pageDismissalEventBeingDispatched = PageDismissalType::PageHide;
-                m_frame.document()->domWindow()->dispatchEvent(PageTransitionEvent::create(eventNames().pagehideEvent, m_frame.document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache), m_frame.document());
+                m_frame.document()->dispatchPagehideEvent(m_frame.document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache ? PageshowEventPersisted : PageshowEventNotPersisted);
             }
 
             // This takes care of firing the visibilitychange event and making sure the document is reported as hidden.

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -467,9 +467,6 @@ private:
     String m_status;
     String m_defaultStatus;
 
-    enum class PageStatus { None, Shown, Hidden };
-    PageStatus m_lastPageStatus { PageStatus::None };
-
 #if PLATFORM(IOS_FAMILY)
     unsigned m_scrollEventListenerCount { 0 };
 #endif

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -646,8 +646,8 @@ void Frame::dispatchPageHideEventBeforePause()
     if (!isMainFrame())
         return;
 
-    Page::forEachDocumentFromMainFrame(*this, [pagehideEvent = eventNames().pagehideEvent, mainDocument = document()](Document& document) {
-        document.domWindow()->dispatchEvent(PageTransitionEvent::create(pagehideEvent, true), mainDocument);
+    Page::forEachDocumentFromMainFrame(*this, [](Document& document) {
+        document.dispatchPagehideEvent(PageshowEventPersisted);
     });
 }
 
@@ -657,8 +657,8 @@ void Frame::dispatchPageShowEventBeforeResume()
     if (!isMainFrame())
         return;
 
-    Page::forEachDocumentFromMainFrame(*this, [pageshowEvent = eventNames().pageshowEvent, mainDocument = document()](Document& document) {
-        document.domWindow()->dispatchEvent(PageTransitionEvent::create(pageshowEvent, true), mainDocument);
+    Page::forEachDocumentFromMainFrame(*this, [](Document& document) {
+        document.dispatchPageshowEvent(PageshowEventPersisted);
     });
 }
 


### PR DESCRIPTION
#### 3bd88829cdb91ac7a72bdf44cda12f5a96ad1170
<pre>
Refactor dispatching of pagehideEvent and pageshowEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=253682">https://bugs.webkit.org/show_bug.cgi?id=253682</a>

Reviewed by Chris Dumez.

Consolidate the code to dispatch pagehide and pageshow events to Document,
and also move m_lastPageStatus from DOMWindow to Document.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::dispatchPageshowEvent):
(WebCore::Document::dispatchPagehideEvent):
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::dispatchUnloadEvents):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::dispatchAllPendingUnloadEvents):
(WebCore::DOMWindow::dispatchEvent):
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::Frame::dispatchPageHideEventBeforePause): These are only used in WebKit1 on iOS.
(WebCore::Frame::dispatchPageShowEventBeforeResume): Ditto.

Canonical link: <a href="https://commits.webkit.org/261529@main">https://commits.webkit.org/261529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/984207c34c5207c121ea276675ae61ad3e29624d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3454 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117706 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104965 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45635 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13514 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/385 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14186 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52387 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15995 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4376 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->