### PR TITLE
Update margin box for trimmed block-end boxes in block container and adjust position of self-collapsing children

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-last-child-with-border-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-last-child-with-border-expected.txt
@@ -1,0 +1,4 @@
+
+PASS .collapsed 1
+PASS .collapsed 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-last-child-with-border.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-last-child-with-border.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="border should protect the margins inside a nested block from trimming">
+<style>
+.trim {
+    margin-trim: block;
+}
+container {
+    display: block;
+    width: min-content;
+    outline: 1px solid blue;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 25px;
+}
+.collapsed {
+    block-size: 0px;
+    margin-block: 14px;
+}
+.border {
+    block-size: auto;
+    border: 1px solid black;
+    background-color: green;
+    margin-block-end: 20px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('.collapsed')">
+    <div id="target">
+        <container class="trim">
+            <!-- Since this item has a border, the margins inside cannot collapse through
+                 and should not be trimmed. However, its block-end border that was set
+                 from the style should be trimmed. -->
+            <item class="border">
+                <item style="margin-block: 10px;"></item>
+                <item data-offset-y="58" class="collapsed"></item>
+            </item>
+            <item data-offset-y="59" class="collapsed" style="margin-block: 5px 8px;"></item>
+        </container>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-nested-last-child-with-border-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-nested-last-child-with-border-expected.txt
@@ -1,0 +1,5 @@
+
+PASS .collapsed 1
+PASS .collapsed 2
+PASS .collapsed 3
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-nested-last-child-with-border.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-nested-last-child-with-border.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="border should protect the margins inside a nested block from trimming">
+<style>
+.trim {
+    margin-trim: block;
+    outline: 1px solid blue;
+}
+container {
+    display: block;
+    width: min-content;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 10px;
+    background-color: green;
+}
+.collapsed {
+    block-size: 0px;
+    margin-block: 10px;
+}
+.border {
+    block-size: auto;
+    border: 10px solid black;
+    margin-block-end: 25px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('.collapsed')">
+    <div id="target">
+        <container class="trim">
+            <container>
+                <item></item>
+
+                <!-- This item's block-end margin should be trimmed 
+                     since it will collapse through to the outer container-->
+                <container style="margin-block-end: 300px;">
+                    <!-- However the margins inside this item cannot collapse through due to
+                         the border and should not be trimmed -->
+                    <container class="border"> 
+                        <item style="margin-block-end: 20px;"></item>
+                        <item data-offset-y="58" class="collapsed"></item>
+                    </container>
+                    <item data-offset-y="68" class="collapsed"></item>
+                </container>
+            </container>
+            <item data-offset-y="68" class="collapsed"></item>
+        </container>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-at-bottom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-at-bottom-expected.txt
@@ -1,0 +1,9 @@
+
+PASS .collapsed 1
+PASS .collapsed 2
+PASS .collapsed 3
+PASS .collapsed 4
+PASS .collapsed 5
+PASS .collapsed 6
+PASS .collapsed 7
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-at-bottom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-at-bottom.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="all of the self-collapsing children at the bottom of the block should be positioned at the bottom of the block">
+<style>
+.trim {
+    margin-trim: block;
+}
+container {
+    display: block;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+.collapsed {
+    block-size: 0px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('.collapsed')">
+    <div id="target">
+        <container class="trim">
+            <container>
+                <item></item>
+                <item data-offset-y="58" class="collapsed" style="margin-block: 10px 20px;">
+                    <item data-offset-y="58" class="collapsed" style="margin-block: -40px 50px;"></item>
+                    <item data-offset-y="58" class="collapsed" style="margin-block: 35px 5px;">
+                        <item data-offset-y="58" class="collapsed" style="margin-block: 300px 100px"></item>
+                    </item>
+                </item>
+            </container>
+            <item data-offset-y="58" class="collapsed" style="margin-block: 40px 23px;"></item>
+            <item data-offset-y="58" class="collapsed" style="margin-block: 100px 200px">
+                <item data-offset-y="58" class="collapsed" style="margin-block: -100px -200px;"></item>
+            </item>
+        </container>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-margin-trim-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-margin-trim-expected.txt
@@ -1,0 +1,3 @@
+
+PASS .collapsed 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-margin-trim.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-margin-trim.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-end margins in nested content should be trimmed when they collapse through to the outer block container">
+<style>
+.trim {
+    margin-trim: block;
+}
+container {
+    display: block;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 10px;
+    background-color: green;
+}
+.collapsed {
+    margin-block: 50px 100px;
+    block-size: 0px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('.collapsed')">
+    <div id="target">
+        <container class="trim">
+            <container>
+                <item data-offset-y="8"></item>
+                <container>
+                    <item></item>
+                    <container>
+                        <item></item>
+                        <container class="trim">
+                            <item></item>
+                            <container>
+                                <item></item>
+                                <item data-offset-y="58" class="collapsed"></item>
+                            </container>
+                        </container>
+                    </container>
+                </container>
+            </container>
+        </container>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-expected.txt
@@ -1,0 +1,5 @@
+
+PASS container > item 1
+PASS container > item 2
+PASS container > item 3
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-multiple-times-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-multiple-times-expected.txt
@@ -1,0 +1,3 @@
+
+PASS .collapsed 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-multiple-times.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-multiple-times.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-end margins in nested content should be trimmed when they collapse through to the outer block container">
+<style>
+.trim {
+    margin-trim: block;
+}
+container {
+    display: block;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 10px;
+    background-color: green;
+}
+.collapsed {
+    margin-block: 50px 100px;
+    block-size: 0px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('.collapsed')">
+    <div id="target">
+        <container class="trim">
+            <container>
+                <item data-offset-y="8"></item>
+                <container>
+                    <item></item>
+                    <container>
+                        <item></item>
+                        <container>
+                            <item></item>
+                            <container>
+                                <item></item>
+                                <item data-offset-y="58" class="collapsed"></item>
+                            </container>
+                        </container>
+                    </container>
+                </container>
+            </container>
+        </container>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-once-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-once-expected.txt
@@ -1,0 +1,5 @@
+
+PASS container > item 1
+PASS container > item 2
+PASS container > item 3
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-once.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-once.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-end margins in nested content should be trimmed when they collapse through to the outer block container">
+<style>
+.outer {
+    margin-trim: block;
+}
+container {
+    display: block;
+}
+item {
+    display: block;
+    margin-block-end: 40px;
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-start: 50px;
+    block-size: 0px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('container > item')">
+    <div id="target">
+        <container class="outer">
+            <container>
+                <item data-offset-y="8"></item>
+                <item data-offset-y="58" class="collapsed"></item>
+                <item data-offset-y="58" class="collapsed"></item>
+            </container>
+        </container>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-vert-lr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-vert-lr-expected.txt
@@ -1,0 +1,5 @@
+
+PASS container > item 1
+PASS container > item 2
+PASS container > item 3
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-vert-lr.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="self-collapsing children at end of block with margin-trim block-end should be positioned at the bottom of the block container">
+<style>
+body {
+    writing-mode: vertical-lr;
+}
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-end: 10px;
+}
+item {
+    display: block;
+    margin-block-end: 40px;
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-start: 50px;
+    block-size: 0px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('container > item')">
+    <div id="target">
+        <container>
+            <item data-offset-x="8"></item>
+            <item data-offset-x="58" class="collapsed"></item>
+            <item data-offset-x="58" class="collapsed"></item>
+        </container>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="self-collapsing children at end of block with margin-trim block-end should be positioned at the bottom of the block container">
+<style>
+container {
+    display: block;
+    margin-trim: block;
+    margin-block-end: 10px;
+}
+item {
+    display: block;
+    margin-block-end: 40px;
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-start: 50px;
+    block-size: 0px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('container > item')">
+    <div id="target">
+        <container>
+            <item data-offset-y="8"></item>
+            <item data-offset-y="58" class="collapsed"></item>
+            <item data-offset-y="58" class="collapsed"></item>
+        </container>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -819,9 +819,46 @@ void RenderBlockFlow::layoutBlockChildren(bool relayoutChildren, LayoutUnit& max
         layoutBlockChild(child, marginInfo, previousFloatLogicalBottom, maxFloatLogicalBottom);
     }
     
+    if (style().marginTrim().contains(MarginTrimType::BlockEnd))
+        trimBlockEndChildrenMargins();
     // Now do the handling of the bottom of the block, adding in our bottom border/padding and
     // determining the correct collapsed bottom margin information.
     handleAfterSideOfBlock(beforeEdge, afterEdge, marginInfo);
+}
+
+
+void RenderBlockFlow::trimBlockEndChildrenMargins()
+{
+    ASSERT(style().marginTrim().contains(MarginTrimType::BlockEnd));
+    // If we are trimming the block end margin, we need to make sure we trim the margin of the children
+    // at the end of the block by walking back up the container. Any self collapsing children will also need to
+    // have their position adjusted to below the last non self-collapsing child in its containing block
+    auto* child = lastChildBox();
+    while (child) {
+        if (child->isExcludedFromNormalLayout() || !child->isInFlow()) {
+            child = child->previousSiblingBox();
+            continue;
+        }
+
+        auto* childContainingBlock = child->containingBlock();
+        childContainingBlock->setMarginAfterForChild(*child, 0_lu);
+        if (child->isSelfCollapsingBlock()) {
+            childContainingBlock->setMarginBeforeForChild(*child, 0_lu);
+            childContainingBlock->setLogicalTopForChild(*child, childContainingBlock->logicalHeight());
+            child = child->previousSiblingBox();
+        }  else if (auto* nestedBlock = dynamicDowncast<RenderBlockFlow>(child); nestedBlock && nestedBlock->isBlockContainer() && !nestedBlock->childrenInline() && !nestedBlock->style().marginTrim().contains(MarginTrimType::BlockEnd)) {
+            MarginInfo nestedBlockMarginInfo(*nestedBlock, nestedBlock->borderAndPaddingBefore(), nestedBlock->borderAndPaddingAfter());
+            // The margins *inside* this nested block are protected so we should not introspect and try to
+            // trim any of them.
+            if (!nestedBlockMarginInfo.canCollapseMarginAfterWithChildren())
+                break;
+
+            child = child->lastChildBox();
+        } else
+            // We hit another type of block child that doesn't apply to our search. We can just
+            // end the search since nothing before this block can affect the bottom margin of the outer one we are trimming for.
+            break;
+    }
 }
 
 void RenderBlockFlow::simplifiedNormalFlowLayout()

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -237,6 +237,8 @@ public:
     void adjustPositionedBlock(RenderBox& child, const MarginInfo&);
     void adjustFloatingBlock(const MarginInfo&);
 
+    void trimBlockEndChildrenMargins();
+
     void setStaticInlinePositionForChild(RenderBox& child, LayoutUnit blockOffset, LayoutUnit inlinePosition);
     void updateStaticInlinePositionForChild(RenderBox& child, LayoutUnit logicalTop, IndentTextOrNot shouldIndentText);
 


### PR DESCRIPTION
#### b9ee985deec446b5c3bfb23ea59c90e3c14a814d
<pre>
Update margin box for trimmed block-end boxes in block container and adjust position of self-collapsing children
<a href="https://bugs.webkit.org/show_bug.cgi?id=253679">https://bugs.webkit.org/show_bug.cgi?id=253679</a>
rdar://106524654

Reviewed by Alan Baradlay.

The initial attempt at trimming margins that collapsed through to the
block-end of a block container simply used the MarginInfo for the block
container to &quot;trim,&quot; the margins. This MarginInfo structure held the
margins that collapsed through and would be used with the container&apos;s
actual block-end margin to perform a final margin collapsing. By ignoring
these values we were prohibit the collapsing from occurring with the
block container&apos;s block-end margin.

However, since the margins for the children at the end of the block
container were not actually trimmed (i.e. their m_marginBox still
contained their used margin values), the block container may have
incorrectly positioned self-collapsing children that were also at the
bottom of the block.

container {
    display: block;
    margin-trim: block;
    margin-block-end: 10px;
}
item {
    display: block;
    margin-block-end: 40px;
    inline-size: 50px;
    block-size: 50px;
    background-color: green;
}
.collapsed {
    margin-block-start: 50px;
    block-size: 0px;
}
&lt;/style&gt;
&lt;container&gt;
    &lt;item&gt;&lt;/item&gt;
    &lt;item class=&quot;collapsed&quot;&gt;&lt;/item&gt;
    &lt;item class=&quot;collapsed&quot;&gt;&lt;/item&gt;
&lt;/container&gt;

Here the last two items in the block container are self-collapsing, so
they would normally participate in margin collapsing with the block-end
margin of the first item and the block-end mark of the container itself.
Without margin-trim the collapsed items should have an offset of 100px
from the top of the containing block.

When block-end margin trimming is specified, however, these items will
need to get placed right below the first item since the block-end margin
will be removed from the first item and both block margins will be
trimmed from the last two.

Since we cannot know if a self-collapsing child is at the block-end
of a block container (i.e. there may be another non self-collapsing
child further on in the layout), we need to make these adjustments when
we are handling the after side of the block container. This means we
need to walk back up the children of the container and perform these
adjustments. As we walk up the tree we have 3 scenarios for each child:

1.) The child is a self-collapsing block:
We should trim the before/after margins of this child and make sure its
position is at the bottom of the block right below the last non
self-collapsing child. We do not need to go inside the self-collapsing
children even if they contain more self-collapsing children since those
will already be positioned at the top of their containing block. If they
had any margins they were have collapsed through to the outer most
self-collapsing child.

2.) The child is a nested block
In this case, we will trim its after margin (since it is at the bottom
of the block and everything below it is self-collapsing), but we also
need to check if the margins of its children nested inside can collapse
through with its own after margin. If it cannot (e.g. the nested block
has some border and padding), then we are done since those margins
cannot affect the margins or children outside of their containing block
(the nested block we are checking), and everything before this nested
block cannot affect the bottom of the block.

However, if the margins inside can collapse through, then we need to go
one more level deep (inside of this nested block) and perform the same
logic. This is because those margins could have potentially collapsed
through and affected any self-collapsing children at the bottom of this
nested block as well as the children in the outer one.

3.) The block is some other non-nested and non self-collapsing block.
In this case we can just trim the block-end margin and end our
adjustments since everything before this block cannot impact the bottom
(just like the case with the nested-block that cannot have its children&apos;s
margins collapse through).

In this case, we need to recurse into it and
apply the same type of logic. It is possible that this nested block
container may have its children&apos;s margins at the bottom of the block
contribute to the margin collapsing occurring at the outer block container.

&lt;style&gt;
.outer {
    margin-trim: block;
}
container {
    display: block;
}
item {
    display: block;
    margin-block-end: 40px;
    inline-size: 50px;
    block-size: 50px;
    background-color: green;
}
.collapsed {
    margin-block-start: 50px;
    block-size: 0px;
}
&lt;/style&gt;
&lt;container class=&quot;outer&quot;&gt;
    &lt;container&gt;
        &lt;item data-offset-y=&quot;8&quot;&gt;&lt;/item&gt;
        &lt;item data-offset-y=&quot;58&quot; class=&quot;collapsed&quot;&gt;&lt;/item&gt;
        &lt;item data-offset-y=&quot;58&quot; class=&quot;collapsed&quot;&gt;&lt;/item&gt;
    &lt;/container&gt;
&lt;/container&gt;

Here the outer container has block-end margin trim but there is no
block-end margin set on its last child nor does it have any self
collapsing children at the end of the block. However, it has another
block container nested within its last child. This nested block
container has self-collapsing children at the end of the block that
have their margins collapse through and propagate up to the outer
container.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-last-child-with-border-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-last-child-with-border.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-nested-last-child-with-border-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-nested-last-child-with-border.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-at-bottom-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-at-bottom.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-margin-trim-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-nested-margin-trim.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-multiple-times-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-multiple-times.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-once-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-nested-once.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-vert-lr-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets-vert-lr.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/block-container-block-end-self-collapsing-children-offsets.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlockChildren):
(WebCore::RenderBlockFlow::trimBlockEndChildrenMargins):
* Source/WebCore/rendering/RenderBlockFlow.h:

Canonical link: <a href="https://commits.webkit.org/261750@main">https://commits.webkit.org/261750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b1e22ab16740cd3e52283b902cc3ccfc4222650

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4430 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5582 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118423 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17194 "4 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105730 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46215 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14134 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1000 "1 flakes 6 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/95425 "275 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14818 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10359 "1 flakes 2 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52996 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8200 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16662 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->