### PR TITLE
Check pixel buffer before dereferencing

### DIFF
--- a/LayoutTests/fast/html/canvas-integer-overflow-expected.txt
+++ b/LayoutTests/fast/html/canvas-integer-overflow-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash

--- a/LayoutTests/fast/html/canvas-integer-overflow.html
+++ b/LayoutTests/fast/html/canvas-integer-overflow.html
@@ -1,0 +1,11 @@
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    let canvas = document.createElement('canvas');
+    let ctx = canvas.getContext('2d');
+    ctx.fillRect(0, 0, (2 ** 28), 1);
+    ctx.drawImage(canvas, 0, 0);
+</script>
+<body>
+    <p>This test passes if it does not crash</p>
+</body>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1065,9 +1065,8 @@ void CanvasRenderingContext2DBase::postProcessPixelBuffer() const
     IntRect dirtyRect { static_cast<int>(m_dirtyRect.x()), static_cast<int>(m_dirtyRect.y()), static_cast<int>(m_dirtyRect.width()) + 1, static_cast<int>(m_dirtyRect.height()) + 1 };
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, toDestinationColorSpace(m_settings.colorSpace) };
     auto pixelBuffer = buffer->getPixelBuffer(format, dirtyRect);
-    if (!is<ByteArrayPixelBuffer>(*pixelBuffer))
+    if (!is<ByteArrayPixelBuffer>(pixelBuffer))
         return;
-
 
     if (canvasBase().postProcessPixelBuffer(*pixelBuffer, false, suppliedColors())) {
         IntSize destOffset { 0, 0 };


### PR DESCRIPTION
#### 682fa4507d4d42682ffc76a8a9703c30dbd91e1d
<pre>
Check pixel buffer before dereferencing
<a href="https://bugs.webkit.org/show_bug.cgi?id=253686">https://bugs.webkit.org/show_bug.cgi?id=253686</a>
rdar://106492794

Reviewed by Aditya Keerthi.

When calculating the area of a rect, there can be an integer overflow
that results in getPixelBuffer returning a nullptr. In this case, we
should return early from postProcessPixelBuffer.

* LayoutTests/fast/html/canvas-integer-overflow-expected.txt: Added.
* LayoutTests/fast/html/canvas-integer-overflow.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::postProcessPixelBuffer const):

Canonical link: <a href="https://commits.webkit.org/261532@main">https://commits.webkit.org/261532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2571120178747f5e63f595aece5b293d9dd59a96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3695 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120612 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3442 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104951 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45619 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13505 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/382 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9786 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52384 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15986 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4377 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->