### PR TITLE
Improve attachment wide-layout display

### DIFF
--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -126,9 +126,11 @@ private:
 
     RefPtr<HTMLAttachmentElement> m_innerLegacyAttachment;
     RefPtr<HTMLElement> m_containerElement;
+    RefPtr<HTMLElement> m_informationBlock;
     RefPtr<HTMLElement> m_actionTextElement;
     RefPtr<HTMLElement> m_titleElement;
     RefPtr<HTMLElement> m_subtitleElement;
+    RefPtr<HTMLElement> m_saveArea;
     RefPtr<HTMLElement> m_saveButton;
     mutable RefPtr<DOMRectReadOnly> m_saveButtonClientRect;
 

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -24,8 +24,10 @@
 
 div#attachment-container {
     display: grid;
-    max-width: 500px;
-    background-color: lightgray; /* FIXME: Use semantic colors, see rdar://105252500 */
+    gap: 0;
+    grid-template-columns: 68px auto;
+    width: 266px;
+    height: 80px;
     border-radius: 8px;
     font: caption;
     pointer-events: none;
@@ -37,43 +39,114 @@ div#attachment-container::selection {
     background-color: blue; /* FIXME: Use semantic colors, see rdar://105252500 */
 }
 
-attachment#attachment-preview {
-    grid-row: 1 / 4;
+div#attachment-preview-area {
+    grid-row: 1;
     grid-column: 1;
-    align-self: center;
+    width: 40px;
+    height: 52px;
+    padding: 14px;
+    background-color: lightgray; /* FIXME: Use semantic colors, see rdar://105252500 */
+    border-radius: 8px 0px 0px 8px;
+    display: grid;
+    gap: 0;
+    align-items: center;
+    justify-items: center;
+}
+
+attachment#attachment-preview {
+    grid-row: 1;
+    grid-column: 1;
+    max-width: 52px;
+    max-height: 52px;
+    overflow: hidden;
+}
+
+div#attachment-information-area {
+    grid-row: 1;
+    grid-column: 2;
+    height: 80px;
+    padding: 0;
+    background-color: lightgray; /* FIXME: Use semantic colors, see rdar://105252500 */
+    border-radius: 0px 8px 8px 0px;
+    display: grid;
+    gap: 0;
+    align-items: center;
+}
+
+div#attachment-information-block {
+    grid-row: 1;
+    grid-column: 1;
+    margin-left: 4px;
+    margin-right: 24px;
+    margin-top: auto;
+    margin-bottom: auto;
+    display: grid;
+    gap: 0;
 }
 
 div#attachment-action {
     grid-row: 1;
-    grid-column: 2;
+    grid-column: 1;
+    justify-self: stretch;
     font-size: small;
     color: rgb(82, 145, 214); /* FIXME: Use semantic colors, see rdar://105252500 */
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
 }
 
 div#attachment-title {
     grid-row: 2;
-    grid-column: 2;
+    grid-column: 1;
+    justify-self: stretch;
     font-size: small;
+    font-weight: bold;
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
 }
 
 div#attachment-subtitle {
     grid-row: 3;
-    grid-column: 2;
+    grid-column: 1;
+    justify-self: stretch;
     font-size: x-small;
     color: rgb(82, 145, 214); /* FIXME: Use semantic colors, see rdar://105252500 */
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+}
+
+div#attachment-save-area {
+    grid-row: 1 / 4;
+    grid-column: 2;
+    justify-self: end;
+    align-self: center;
+    margin-left: 10px;
 }
 
 button#attachment-save-button {
-    grid-row: 1 / 4;
-    grid-column: 3;
-    align-self: center;
-    /* SF Symbol square.and.arrow.down */
-    background-image: url('data:image/svg+xml,<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="17.334" height="21.5723"><path d="M3.06641 21.084L14.2676 21.084C16.3086 21.084 17.334 20.0684 17.334 18.0566L17.334 8.31055C17.334 6.29883 16.3086 5.2832 14.2676 5.2832L11.543 5.2832L11.543 6.85547L14.2383 6.85547C15.2051 6.85547 15.7617 7.38281 15.7617 8.39844L15.7617 17.9688C15.7617 18.9844 15.2051 19.5117 14.2383 19.5117L3.08594 19.5117C2.10938 19.5117 1.57227 18.9844 1.57227 17.9688L1.57227 8.39844C1.57227 7.38281 2.10938 6.85547 3.08594 6.85547L5.79102 6.85547L5.79102 5.2832L3.06641 5.2832C1.02539 5.2832 0 6.29883 0 8.31055L0 18.0566C0 20.0684 1.02539 21.084 3.06641 21.084ZM8.66211 14.6582C8.86719 14.6582 9.0332 14.5996 9.22852 14.4043L12.5293 11.2109C12.6758 11.0645 12.7637 10.9082 12.7637 10.7031C12.7637 10.3027 12.4512 10.0195 12.0508 10.0195C11.8555 10.0195 11.6602 10.0977 11.5234 10.2539L10.0391 11.8262L9.38477 12.5195L9.44336 11.0547L9.44336 0.761719C9.44336 0.351562 9.08203 0 8.66211 0C8.24219 0 7.89062 0.351562 7.89062 0.761719L7.89062 11.0547L7.94922 12.5195L7.28516 11.8262L5.81055 10.2539C5.67383 10.0977 5.45898 10.0195 5.27344 10.0195C4.86328 10.0195 4.57031 10.3027 4.57031 10.7031C4.57031 10.9082 4.64844 11.0645 4.79492 11.2109L8.0957 14.4043C8.30078 14.5996 8.4668 14.6582 8.66211 14.6582Z" stroke="black"/></svg>');
-    width: 18px;
-    height: 22px;
-    margin: 8px;
-    border: none;
+    width: 28px;
+    height: 28px;
+    margin: 0;
+    border: 1px solid;
     padding: 0;
     background-color: transparent;
     pointer-events: initial;
+    border-radius: 50%;
+}
+
+div#attachment-save-icon {
+    /* SF Symbol square.and.arrow.down */
+    background-image: url('data:image/svg+xml,<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="17.334" height="21.5723"><path d="M3.06641 21.084L14.2676 21.084C16.3086 21.084 17.334 20.0684 17.334 18.0566L17.334 8.31055C17.334 6.29883 16.3086 5.2832 14.2676 5.2832L11.543 5.2832L11.543 6.85547L14.2383 6.85547C15.2051 6.85547 15.7617 7.38281 15.7617 8.39844L15.7617 17.9688C15.7617 18.9844 15.2051 19.5117 14.2383 19.5117L3.08594 19.5117C2.10938 19.5117 1.57227 18.9844 1.57227 17.9688L1.57227 8.39844C1.57227 7.38281 2.10938 6.85547 3.08594 6.85547L5.79102 6.85547L5.79102 5.2832L3.06641 5.2832C1.02539 5.2832 0 6.29883 0 8.31055L0 18.0566C0 20.0684 1.02539 21.084 3.06641 21.084ZM8.66211 14.6582C8.86719 14.6582 9.0332 14.5996 9.22852 14.4043L12.5293 11.2109C12.6758 11.0645 12.7637 10.9082 12.7637 10.7031C12.7637 10.3027 12.4512 10.0195 12.0508 10.0195C11.8555 10.0195 11.6602 10.0977 11.5234 10.2539L10.0391 11.8262L9.38477 12.5195L9.44336 11.0547L9.44336 0.761719C9.44336 0.351562 9.08203 0 8.66211 0C8.24219 0 7.89062 0.351562 7.89062 0.761719L7.89062 11.0547L7.94922 12.5195L7.28516 11.8262L5.81055 10.2539C5.67383 10.0977 5.45898 10.0195 5.27344 10.0195C4.86328 10.0195 4.57031 10.3027 4.57031 10.7031C4.57031 10.9082 4.64844 11.0645 4.79492 11.2109L8.0957 14.4043C8.30078 14.5996 8.4668 14.6582 8.66211 14.6582Z" stroke="black"/></svg>');
+    background-repeat: no-repeat;
+    background-size: 70%;
+    background-position: center;
+    width: 18px;
+    height: 22px;
+    margin: auto;
 }

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -40,42 +40,44 @@ namespace WebCore {
 
 #if PLATFORM(MAC)
 
-const CGFloat attachmentIconSize = 48;
-const CGFloat attachmentIconBackgroundPadding = 6;
-const CGFloat attachmentIconBackgroundSize = attachmentIconSize + attachmentIconBackgroundPadding;
-const CGFloat attachmentIconSelectionBorderThickness = 1;
-const CGFloat attachmentIconBackgroundRadius = 3;
-const CGFloat attachmentIconToTitleMargin = 2;
+constexpr CGFloat attachmentIconSize = 48;
+constexpr CGFloat attachmentIconBackgroundPadding = 6;
+constexpr CGFloat attachmentIconBackgroundSize = attachmentIconSize + attachmentIconBackgroundPadding;
+constexpr CGFloat attachmentIconSelectionBorderThickness = 1;
+constexpr CGFloat attachmentIconBackgroundRadius = 3;
+constexpr CGFloat attachmentIconToTitleMargin = 2;
+
+constexpr CGFloat attachmentImageOnlyIconSize = 52;
 
 constexpr auto attachmentIconBackgroundColor = Color::black.colorWithAlphaByte(30);
 constexpr auto attachmentIconBorderColor = Color::white.colorWithAlphaByte(125);
 
-const CGFloat attachmentTitleFontSize = 12;
-const CGFloat attachmentTitleBackgroundRadius = 3;
-const CGFloat attachmentTitleBackgroundPadding = 3;
-const CGFloat attachmentTitleMaximumWidth = 100 - (attachmentTitleBackgroundPadding * 2);
-const CFIndex attachmentTitleMaximumLineCount = 2;
+constexpr CGFloat attachmentTitleFontSize = 12;
+constexpr CGFloat attachmentTitleBackgroundRadius = 3;
+constexpr CGFloat attachmentTitleBackgroundPadding = 3;
+constexpr CGFloat attachmentTitleMaximumWidth = 100 - (attachmentTitleBackgroundPadding * 2);
+constexpr CFIndex attachmentTitleMaximumLineCount = 2;
 
 constexpr auto attachmentTitleInactiveBackgroundColor = SRGBA<uint8_t> { 204, 204, 204 };
 constexpr auto attachmentTitleInactiveTextColor = SRGBA<uint8_t> { 100, 100, 100 };
 
-const CGFloat attachmentSubtitleFontSize = 10;
-const int attachmentSubtitleWidthIncrement = 10;
+constexpr CGFloat attachmentSubtitleFontSize = 10;
+constexpr int attachmentSubtitleWidthIncrement = 10;
 constexpr auto attachmentSubtitleTextColor = SRGBA<uint8_t> { 82, 145, 214 };
 
-const CGFloat attachmentProgressBarWidth = 30;
-const CGFloat attachmentProgressBarHeight = 5;
-const CGFloat attachmentProgressBarOffset = -9;
-const CGFloat attachmentProgressBarBorderWidth = 1;
+constexpr CGFloat attachmentProgressBarWidth = 30;
+constexpr CGFloat attachmentProgressBarHeight = 5;
+constexpr CGFloat attachmentProgressBarOffset = -9;
+constexpr CGFloat attachmentProgressBarBorderWidth = 1;
 constexpr auto attachmentProgressBarBackgroundColor = Color::black.colorWithAlphaByte(89);
 constexpr auto attachmentProgressBarFillColor = Color::white;
 constexpr auto attachmentProgressBarBorderColor = Color::black.colorWithAlphaByte(128);
 
-const CGFloat attachmentPlaceholderBorderRadius = 5;
+constexpr CGFloat attachmentPlaceholderBorderRadius = 5;
 constexpr auto attachmentPlaceholderBorderColor = Color::black.colorWithAlphaByte(56);
-const CGFloat attachmentPlaceholderBorderWidth = 2;
-const CGFloat attachmentPlaceholderBorderDashLength = 6;
-const CGFloat attachmentMargin = 3;
+constexpr CGFloat attachmentPlaceholderBorderWidth = 2;
+constexpr CGFloat attachmentPlaceholderBorderDashLength = 6;
+constexpr CGFloat attachmentMargin = 3;
 
 static Color titleTextColorForAttachment(const RenderAttachment& attachment, AttachmentLayoutStyle style)
 {
@@ -163,6 +165,13 @@ void AttachmentLayout::layOutSubtitle(const RenderAttachment& attachment)
 AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, AttachmentLayoutStyle layoutStyle)
     : style(layoutStyle)
 {
+    if (attachment.attachmentElement().isImageOnly()) {
+        iconRect = FloatRect(0, 0, attachmentImageOnlyIconSize, attachmentImageOnlyIconSize);
+        iconBackgroundRect = iconRect;
+        attachmentRect = encloseRectToDevicePixels(iconBackgroundRect, attachment.document().deviceScaleFactor());
+        return;
+    }
+
     excludeTypographicLeading = false;
     layOutTitle(attachment);
     layOutSubtitle(attachment);
@@ -189,22 +198,22 @@ AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, Attachmen
 
 #if PLATFORM(IOS_FAMILY)
 
-const CGSize attachmentSize = { 160, 119 };
+constexpr CGSize attachmentSize = { 160, 119 };
 
-const CGFloat attachmentBorderRadius = 16;
+constexpr CGFloat attachmentBorderRadius = 16;
 constexpr auto attachmentBorderColor = SRGBA<uint8_t> { 204, 204, 204 };
 static CGFloat attachmentBorderThickness = 1;
 
 constexpr auto attachmentProgressColor = SRGBA<uint8_t> { 222, 222, 222 };
-const CGFloat attachmentProgressBorderThickness = 3;
+constexpr CGFloat attachmentProgressBorderThickness = 3;
 
-const CGFloat attachmentProgressSize = 36;
-const CGFloat attachmentIconSize = 48;
+constexpr CGFloat attachmentProgressSize = 36;
+constexpr CGFloat attachmentIconSize = 48;
 
-const CGFloat attachmentItemMargin = 8;
+constexpr CGFloat attachmentItemMargin = 8;
 
-const CGFloat attachmentWrappingTextMaximumWidth = 140;
-const CFIndex attachmentWrappingTextMaximumLineCount = 2;
+constexpr CGFloat attachmentWrappingTextMaximumWidth = 140;
+constexpr CFIndex attachmentWrappingTextMaximumLineCount = 2;
 
 static BOOL getAttachmentProgress(const RenderAttachment& attachment, float& progress)
 {

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1621,7 +1621,7 @@ bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintIn
     if (validProgress && progress)
         paintAttachmentProgress(attachment, context, layout, progress);
 
-    if (usePlaceholder)
+    if (usePlaceholder && !element.isImageOnly())
         paintAttachmentPlaceholderBorder(attachment, context, layout);
 
     return true;


### PR DESCRIPTION
#### d0509c40b6a5d54a51c30b85c72cda34efda4077
<pre>
Improve attachment wide-layout display
<a href="https://bugs.webkit.org/show_bug.cgi?id=253687">https://bugs.webkit.org/show_bug.cgi?id=253687</a>
rdar://problem/106534843

Reviewed by Aditya Keerthi.

Some work towards the target vspecs:
- More complex shadow DOM tree that mirrors the specs.
- macOS rendering displays just an icon, with the new size.
- Better handling of long labels.

* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::attachmentPreviewAreaIdentifier):
(WebCore::attachmentInformationAreaIdentifier):
(WebCore::attachmentInformationBlockIdentifier):
(WebCore::attachmentSaveAreaIdentifier):
(WebCore::attachmentSaveIconIdentifier):
(WebCore::createContainedElement):
(WebCore::HTMLAttachmentElement::ensureModernShadowTree):
(WebCore::HTMLAttachmentElement::updateSaveButton):
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-container):
(div#attachment-preview-area):
(attachment#attachment-preview):
(div#attachment-information-area):
(div#attachment-information-block):
(div#attachment-action):
(div#attachment-title):
(div#attachment-subtitle):
(div#attachment-save-area):
(button#attachment-save-button):
(div#attachment-save-icon):
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::AttachmentLayout::AttachmentLayout):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::paintAttachment):

Canonical link: <a href="https://commits.webkit.org/261665@main">https://commits.webkit.org/261665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0dbbfef99b98155cfeb65bc7060358d0bc5c36f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4086 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4860 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118071 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105355 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45935 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13821 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/701 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14512 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52705 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8128 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16314 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->