### PR TITLE
[UI-side compositing] Scrolling triggers more layouts via updating the layout viewport

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrolling-triggerered-layouts-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrolling-triggerered-layouts-expected.txt
@@ -1,0 +1,7 @@
+
+Test that scrolling doesn't trigger a layout per scroll
+PASS layoutCount <= 4 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+fixed

--- a/LayoutTests/fast/scrolling/mac/scrolling-triggerered-layouts.html
+++ b/LayoutTests/fast/scrolling/mac/scrolling-triggerered-layouts.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 10000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+        }
+        
+        .fixed {
+            position: fixed;
+            top: 0;
+        }
+    </style>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        var jsTestIsAsync = true;
+
+        async function doMouseWheelScroll()
+        {
+            await UIHelper.renderingUpdate();
+
+            await UIHelper.startMonitoringWheelEvents();
+            eventSender.mouseMoveTo(100, 100);
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "began", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
+            await UIHelper.waitForScrollCompletion();
+
+            await UIHelper.renderingUpdate();
+        }
+
+        let layoutCount = 0;
+        async function scrollTest()
+        {
+            debug('');
+            debug("Test that scrolling doesn't trigger a layout per scroll");
+
+            const initialLayoutCount = internals.layoutCount;
+            await doMouseWheelScroll();
+            const finalLayoutCount = internals.layoutCount;
+            layoutCount = finalLayoutCount - initialLayoutCount;
+            shouldBeTrue('layoutCount <= 4');
+            if (layoutCount > 4)
+                debug('saw ' + layoutCount + ' layouts')
+            finishJSTest();
+        }
+
+        window.addEventListener('load', scrollTest, false);
+    </script>
+</head>
+<body>
+    <div class="fixed">fixed</div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -65,7 +65,7 @@ constexpr auto debugScrollingStateTreeAsTextBehaviors = OptionSet<ScrollingState
     ScrollingStateTreeAsTextBehavior::IncludeLayerIDs, ScrollingStateTreeAsTextBehavior::IncludeNodeIDs, ScrollingStateTreeAsTextBehavior::IncludeLayerPositions
 };
 
-enum class ScrollingLayerPositionAction {
+enum class ScrollingLayerPositionAction : uint8_t {
     Set,
     SetApproximate,
     Sync

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -204,7 +204,7 @@ void RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll()
         bool isLastUpdate = i == scrollUpdates.size() - 1;
 
         LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll - node " << update.nodeID << " scroll position " << update.scrollPosition << " isLastUpdate " << isLastUpdate);
-        m_webPageProxy.sendWithAsyncReply(Messages::RemoteScrollingCoordinator::ScrollPositionChangedForNode(update.nodeID, update.scrollPosition, update.updateLayerPositionAction == ScrollingLayerPositionAction::Sync), [weakThis = WeakPtr { *this }, isLastUpdate] {
+        m_webPageProxy.sendWithAsyncReply(Messages::RemoteScrollingCoordinator::ScrollPositionChangedForNode(update.nodeID, update.scrollPosition, update.layoutViewportOrigin, update.updateLayerPositionAction == ScrollingLayerPositionAction::Sync), [weakThis = WeakPtr { *this }, isLastUpdate] {
             if (!weakThis)
                 return;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -80,7 +80,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     
     // Respond to UI process changes.
-    void scrollPositionChangedForNode(WebCore::ScrollingNodeID, const WebCore::FloatPoint& scrollPosition, bool syncLayerPosition, CompletionHandler<void()>&&);
+    void scrollPositionChangedForNode(WebCore::ScrollingNodeID, const WebCore::FloatPoint& scrollPosition, std::optional<WebCore::FloatPoint> layoutViewportOrigin, bool syncLayerPosition, CompletionHandler<void()>&&);
     void animatedScrollDidEndForNode(WebCore::ScrollingNodeID);
     void currentSnapPointIndicesChangedForNode(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 messages -> RemoteScrollingCoordinator {
-    ScrollPositionChangedForNode(uint64_t nodeID, WebCore::FloatPoint scrollPosition, bool syncLayerPosition) -> ()
+    ScrollPositionChangedForNode(uint64_t nodeID, WebCore::FloatPoint scrollPosition, std::optional<WebCore::FloatPoint> layoutViewportOrigin, bool syncLayerPosition) -> ()
     AnimatedScrollDidEndForNode(uint64_t nodeID);
     CurrentSnapPointIndicesChangedForNode(uint64_t nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
     ScrollingStateInUIProcessChanged(WebKit::RemoteScrollingUIState uiState);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -109,11 +109,11 @@ void RemoteScrollingCoordinator::buildTransaction(RemoteScrollingCoordinatorTran
 }
 
 // Notification from the UI process that we scrolled.
-void RemoteScrollingCoordinator::scrollPositionChangedForNode(ScrollingNodeID nodeID, const FloatPoint& scrollPosition, bool syncLayerPosition, CompletionHandler<void()>&& completionHandler)
+void RemoteScrollingCoordinator::scrollPositionChangedForNode(ScrollingNodeID nodeID, const FloatPoint& scrollPosition, std::optional<FloatPoint> layoutViewportOrigin, bool syncLayerPosition, CompletionHandler<void()>&& completionHandler)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinator::scrollingTreeNodeDidScroll " << nodeID << " to " << scrollPosition);
+    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinator::scrollingTreeNodeDidScroll " << nodeID << " to " << scrollPosition << " layoutViewportOrigin " << layoutViewportOrigin);
 
-    auto scrollUpdate = ScrollUpdate { nodeID, scrollPosition, { }, ScrollUpdateType::PositionUpdate, syncLayerPosition ? ScrollingLayerPositionAction::Sync : ScrollingLayerPositionAction::Set };
+    auto scrollUpdate = ScrollUpdate { nodeID, scrollPosition, layoutViewportOrigin, ScrollUpdateType::PositionUpdate, syncLayerPosition ? ScrollingLayerPositionAction::Sync : ScrollingLayerPositionAction::Set };
     applyScrollUpdate(WTFMove(scrollUpdate));
 
     completionHandler();


### PR DESCRIPTION
#### 7fe0d61af3920c468be5647625f59343f30aa253
<pre>
[UI-side compositing] Scrolling triggers more layouts via updating the layout viewport
<a href="https://bugs.webkit.org/show_bug.cgi?id=253690">https://bugs.webkit.org/show_bug.cgi?id=253690</a>
rdar://106535756

Reviewed by Ryosuke Niwa.

With UI-side compositing, we see more layouts happening while scrolling than before. These layouts
are triggered by FrameView::updateLayoutViewport() when it computes a new layout viewport origin.

With the non-UI-side configuration, this doesn&apos;t happen because we get a new layout viewport origin
from the scrolling tree via AsyncScrollingCoordinator::applyScrollPositionUpdate() and
updateScrollPositionAfterAsyncScroll(), and apply this in reconcileScrollingState() with a
FrameView::TriggerLayoutOrNot::No flag.

To fix this for UI-side compositing, we can simply pass the new layout viewport origin from the
scrolling tree in the UI process back to the web process, and follow the same code path.

* LayoutTests/fast/scrolling/mac/scrolling-triggerered-layouts-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/scrolling-triggerered-layouts.html: Added.
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h: Drive-by enum size fix.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::scrollPositionChangedForNode):

Canonical link: <a href="https://commits.webkit.org/261504@main">https://commits.webkit.org/261504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc9dfc85feef9f751074f192c4830ee394909785

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3365 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104865 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45557 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/312 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9736 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52314 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8008 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15917 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->