### PR TITLE
document.adoptNode is a no-op when called on a template element's document fragment

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/adoption.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/adoption.window-expected.txt
@@ -1,6 +1,6 @@
 
 PASS appendChild() and DocumentFragment with host
-PASS adoptNode() and DocumentFragment with host
+FAIL adoptNode() and DocumentFragment with host assert_equals: expected Document node with 0 children but got Document node with 2 children
 PASS appendChild() and DocumentFragment
 PASS adoptNode() and DocumentFragment
 PASS appendChild() and ShadowRoot

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Template content should throw when its ancestor is being appended.
-PASS Template content should throw exception when its ancestor in a different document but connected via host is being append.
+FAIL Template content should throw exception when its ancestor in a different document but connected via host is being append. assert_equals: expected Document node with 0 children but got Document node with 2 children
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/template-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/template-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Template element content is correctly serialized
-PASS HTML fragment serialization algorithm should be applied to the template content
+FAIL HTML fragment serialization algorithm should be applied to the template content assert_equals: expected "<div xml:lang=\"en-us\" p:attr=\"v\"></div>" but got "<div xmlns=\"xx\" xml:lang=\"en-us\" p:attr=\"v\" xmlns:p=\"uri2\"/>"
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -389,9 +389,6 @@ static inline bool isChildTypeAllowed(ContainerNode& newParent, Node& child)
 
 static bool containsIncludingHostElements(const Node& possibleAncestor, const Node& node)
 {
-    if (LIKELY(!node.isInShadowTree() && !node.document().templateDocumentHost()))
-        return possibleAncestor.contains(node);
-
     const Node* currentNode = &node;
     do {
         if (currentNode == &possibleAncestor)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -255,7 +255,6 @@
 #include "StyleSheetList.h"
 #include "StyleTreeResolver.h"
 #include "SubresourceLoader.h"
-#include "TemplateContentDocumentFragment.h"
 #include "TextAutoSizing.h"
 #include "TextEvent.h"
 #include "TextManipulationController.h"
@@ -1199,11 +1198,6 @@ ExceptionOr<Ref<Node>> Document::adoptNode(Node& source)
         if (source.isShadowRoot()) {
             // ShadowRoot cannot disconnect itself from the host node.
             return Exception { HierarchyRequestError };
-        }
-        if (is<TemplateContentDocumentFragment>(source)) {
-            // TemplateContentDocumentFragment::host is never null until its destruction.
-            ASSERT(downcast<TemplateContentDocumentFragment>(source).host());
-            return Ref<Node> { source };
         }
         if (is<HTMLFrameOwnerElement>(source)) {
             auto& frameOwnerElement = downcast<HTMLFrameOwnerElement>(source);


### PR DESCRIPTION
#### dd0a5a2fd2e26b769586bbdf85fa2867036c0cfc
<pre>
document.adoptNode is a no-op when called on a template element&apos;s document fragment
<a href="https://bugs.webkit.org/show_bug.cgi?id=246899">https://bugs.webkit.org/show_bug.cgi?id=246899</a>

Reviewed by Chris Dumez.

Partially revert 252098@main as this change turned out to be not web compatible.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/adoption.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-template-element/template-element/template-content-hierarcy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/template-expected.txt:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::containsIncludingHostElements):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::adoptNode):

Canonical link: <a href="https://commits.webkit.org/261491@main">https://commits.webkit.org/261491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c25a1ee78b6652d554728b394c9bc46510fdb0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/20985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3617 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12043 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117622 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104866 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/310 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13950 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52312 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/7997 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15918 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->