### PR TITLE
Drawing SystemImages have multiple context state handling errors

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePayLogoSystemImage.mm
+++ b/Source/WebCore/Modules/applepay/ApplePayLogoSystemImage.mm
@@ -98,17 +98,20 @@ void ApplePayLogoSystemImage::draw(GraphicsContext& context, const FloatRect& de
     auto page = applePayLogoForStyle(m_applePayLogoStyle);
     if (!page)
         return;
-
+    CGContextRef cgContext = context.platformContext();
+    CGContextSaveGState(cgContext);
     CGSize pdfSize = CGPDFPageGetBoxRect(page.get(), kCGPDFMediaBox).size;
 
     auto largestRect = largestRectWithAspectRatioInsideRect(pdfSize.width / pdfSize.height, destinationRect);
-    context.translate(largestRect.x(), largestRect.y());
-    context.scale(largestRect.width() / pdfSize.width);
+    CGContextTranslateCTM(cgContext, largestRect.x(), largestRect.y());
+    auto scale = largestRect.width() / pdfSize.width;
+    CGContextScaleCTM(cgContext, scale, scale);
 
-    context.translate(0, pdfSize.height);
-    context.scale(FloatSize(1, -1));
+    CGContextTranslateCTM(cgContext, 0, pdfSize.height);
+    CGContextScaleCTM(cgContext, 1, -1);
 
-    CGContextDrawPDFPage(context.platformContext(), page.get());
+    CGContextDrawPDFPage(cgContext, page.get());
+    CGContextRestoreGState(cgContext);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -237,6 +237,7 @@ void Recorder::drawNativeImageInternal(NativeImage& image, const FloatSize& imag
 
 void Recorder::drawSystemImage(SystemImage& systemImage, const FloatRect& destinationRect)
 {
+    appendStateChangeItemIfNecessary();
 #if USE(SYSTEM_PREVIEW)
     if (is<ARKitBadgeSystemImage>(systemImage)) {
         if (auto image = downcast<ARKitBadgeSystemImage>(systemImage).image()) {

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -37,6 +37,14 @@
 #include <WebCore/GraphicsContextCG.h>
 #endif
 
+#if ENABLE(APPLE_PAY)
+#include <WebCore/ApplePayLogoSystemImage.h>
+#endif
+
+#if ENABLE(VIDEO)
+#include <WebCore/VideoFrame.h>
+#endif
+
 namespace TestWebKitAPI {
 
 constexpr unsigned testContextWidth = 77;
@@ -151,7 +159,7 @@ struct ChangeAntialias {
         return R"DL(
 (set-state
   (change-flags [should-antialias])
-  (should-antialias 0)))DL"_s;            
+  (should-antialias 0)))DL"_s;
     }
 };
 
@@ -222,7 +230,32 @@ struct ChangeAntialiasInEmptySaveRestore {
     }
 };
 
-using AllOperations = testing::Types<NoCommands, ChangeAntialias, ChangeAntialiasBeforeSave, ChangeAntialiasBeforeAndAfterSave, ChangeAntialiasInEmptySaveRestore>;
+struct DrawSystemImage {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+#if ENABLE(APPLE_PAY)
+        auto image = WebCore::ApplePayLogoSystemImage::create(WebCore::ApplePayLogoStyle::White);
+        c.setShouldAntialias(false);
+        c.drawSystemImage(image.get(), {0, 0, 5, 5}); // This is being tested. The previous antialias == false should be used.
+#endif
+    }
+
+    static String description()
+    {
+#if ENABLE(APPLE_PAY)
+        return R"DL(
+(set-state
+  (change-flags [should-antialias])
+  (should-antialias 0))
+(draw-system-image
+  (destination at (0,0) size 5x5)))DL"_s;
+#else
+        return ""_s;
+#endif
+    }
+};
+
+using AllOperations = testing::Types<NoCommands, ChangeAntialias, ChangeAntialiasBeforeSave, ChangeAntialiasBeforeAndAfterSave, ChangeAntialiasInEmptySaveRestore, DrawSystemImage>;
 
 }
 


### PR DESCRIPTION
#### b51c7a93f9151e1d799a6a399274e0d84def4144
<pre>
Drawing SystemImages have multiple context state handling errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=253640">https://bugs.webkit.org/show_bug.cgi?id=253640</a>
rdar://106502760

Reviewed by Simon Fraser.

Problems :
1. Drawing system images through display list recorder would not apply
   the pending graphics context state. This could, for example, leave
   out antialias setting when it would be intended.
2. Drawing ApplePay system image would change the graphics context
   transform but not reset it.
3. The drawing implementation of the ApplePay image is custom, it might
   further mutate the CGContext without WebKit knowing it. It would
   mutate at least the clip state of the underlying CGContext.
   This could cause rendering problems until the state stack would
   reset the clip.

Fix 1. by making DisplayListRecorder apply the pending state before
recording the draw item.

Fix 2., 3. by adding CGContextSaveGState() and corresponding restore.
Also use the CGContext methods instead of GraphicsContext methods,
for consistency. Future commits might add mechanisms to ensure bugs
like this are harder to do.

* Source/WebCore/Modules/applepay/ApplePayLogoSystemImage.mm:
(WebCore::ApplePayLogoSystemImage::draw const):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawSystemImage):
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:

Canonical link: <a href="https://commits.webkit.org/261549@main">https://commits.webkit.org/261549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e34d2b748f3a2691c26ed7c77f09d470ea38c21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111880 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3388 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104894 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98553 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/323 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45576 "3 flakes 135 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13456 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/332 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9751 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52334 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8048 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15939 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->