### PR TITLE
DisplayListRecorder fails to record state change before multiple commands

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -531,22 +531,26 @@ void Recorder::drawControlPart(ControlPart& part, const FloatRoundedRect& border
 
 void Recorder::clip(const FloatRect& rect)
 {
+    appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
     currentState().clipBounds.intersect(currentState().ctm.mapRect(rect));
     recordClip(rect);
 }
 
 void Recorder::clipOut(const FloatRect& rect)
 {
+    appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
     recordClipOut(rect);
 }
 
 void Recorder::clipOut(const Path& path)
 {
+    appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
     recordClipOutToPath(path);
 }
 
 void Recorder::clipPath(const Path& path, WindRule windRule)
 {
+    appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
     currentState().clipBounds.intersect(currentState().ctm.mapRect(path.fastBoundingRect()));
     recordClipPath(path, windRule);
 }
@@ -563,6 +567,8 @@ IntRect Recorder::clipBounds() const
 
 void Recorder::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect)
 {
+    appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
+    currentState().clipBounds.intersect(currentState().ctm.mapRect(destRect));
     recordResourceUse(imageBuffer);
     recordClipToImageBuffer(imageBuffer, destRect);
 }
@@ -580,11 +586,13 @@ void Recorder::paintFrameForMedia(MediaPlayer& player, const FloatRect& destinat
         return;
     }
     ASSERT(player.identifier());
+    appendStateChangeItemIfNecessary();
     recordPaintFrameForMedia(player, destination);
 }
 
 void Recorder::paintVideoFrame(VideoFrame& frame, const FloatRect& destination, bool shouldDiscardAlpha)
 {
+    appendStateChangeItemIfNecessary();
     recordPaintVideoFrame(frame, destination, shouldDiscardAlpha);
 }
 #endif

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -342,7 +342,7 @@ void BorderPainter::paintSides(const Sides& sides)
 
         if (!firstVisibleSide)
             firstVisibleSide = boxSide;
-        else if (currEdge.color() != sides.edges.at(*firstVisibleSide).color())
+        else if (!equalIgnoringSemanticColor(currEdge.color(), sides.edges.at(*firstVisibleSide).color()))
             allEdgesShareColor = false;
 
         if (!currEdge.color().isOpaque())
@@ -513,7 +513,7 @@ void BorderPainter::paintTranslucentBorderSides(const RoundedRect& outerBorder, 
                 commonColor = edge.color();
                 includeEdge = true;
             } else
-                includeEdge = edge.color() == commonColor;
+                includeEdge = equalIgnoringSemanticColor(edge.color(), commonColor);
 
             if (includeEdge)
                 commonColorEdgeSet.add(edgeFlagForSide(side));


### PR DESCRIPTION
#### b9e5c9199441501375c71988e4efca5f487905f2
<pre>
DisplayListRecorder fails to record state change before multiple commands
<a href="https://bugs.webkit.org/show_bug.cgi?id=253693">https://bugs.webkit.org/show_bug.cgi?id=253693</a>
rdar://problem/106542943

Reviewed by Simon Fraser.

Problems:
1. Multiple commands that use or might use the state are missing the
   appendStateChangeItemIfNecessary() that would write the state item.
2. Recorder::clipToImageBuffer() does not maintain the state needed to
   return the correct GraphicsContext::clipBounds().

Fix 1. by applying appendStateChangeItemIfNecessary() conservatively.
This is likely not a perf problem, since all the clip commands
would anyway need some future draw command, and those would append
the state change at that point.

Fix 2. by updating the clip bounds, similar to other cases which
update the clip bounds.

The video drawing commands are not testable currently, as MediaPlayer
cannot be instantiated as a mock and VideoFrame command is not implemented.

Auxiliary problems:
The unfixed, buggy behavior of Recorder::clipToPath() would invert buggy
behavior of BorderPainter.

This would lead to passing
imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-input-button-border-block-end-color-001.html
and similar tests.

The example of the problem, test above would compare two renderings:

Reference (kind-of-widget-fallback-input-button-border-block-end-color-001-expected.html)
    &lt;input id=&quot;button-input&quot; type=&quot;button&quot; value=&quot;input-button&quot;&gt;

vs:

Test (kind-of-widget-fallback-input-button-border-block-end-color-001.html)
    &lt;input id=&quot;button-input&quot; type=&quot;button&quot; value=&quot;input-button&quot;&gt;

    const prop = &quot;border-block-end-color&quot;;
    for (const el of elements) {
        el.style.setProperty(prop, getComputedStyle(el).getPropertyValue(prop));
    }

The BorderPainter would compare the colors of each border, and run the
fast path if all the colors match.

For the reference, the fast path was taken.

For the test, because of the BorderPainter bug, the colors would not match. The
BorderPainter would take slow path that would set up complex clip path
with antialiasing.

Because the Recorder::clipToPath would incorrectly skip setting the antialiasing
state, two corner pixels of the rounded rect would be included in the rendering.
This would match the unclipped fast path rendering of the reference.

Once the clipToPath() bug was fixed, it would show two-pixel difference due
to the clipToPath being correctly cliping antialiased path vs the reference
using the fast path, unclipped.

Fix by fixing BorderPainter to compare the border colors always without
the &quot;semantic&quot; bit.

This makes the test take the same fast path as the reference, and thus the
rendering is identical.

Also in a best-effort manner, fix one other color compare case to ignore
the semantic bit. It is not consistent that one code-path would ignore
the semantic bit while others would be continue using it.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::clip):
(WebCore::DisplayList::Recorder::clipOut):
(WebCore::DisplayList::Recorder::clipPath):
(WebCore::DisplayList::Recorder::clipToImageBuffer):
(WebCore::DisplayList::Recorder::paintFrameForMedia):
(WebCore::DisplayList::Recorder::paintVideoFrame):
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:
(TestWebKitAPI::createTestPath):
(TestWebKitAPI::createTestImageBuffer):
(TestWebKitAPI::checkEqualState):
* Source/WebCore/rendering/BorderPainter.cpp:
 (WebCore::BorderPainter::paintSides):
 (WebCore::BorderPainter::paintTranslucentBorderSides):

Canonical link: <a href="https://commits.webkit.org/261618@main">https://commits.webkit.org/261618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd042adf409f52963ada3cbc217df38fd993996a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112171 "44 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4586 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105232 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45839 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/587 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14393 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52586 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8100 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16186 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->