### PR TITLE
WebCore::IOSurface should not store a reference to a CGContext

### DIFF
--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
@@ -200,7 +200,8 @@ void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRe
     std::unique_ptr<IOSurface> badgeSurface = IOSurface::create(&IOSurfacePool::sharedPool(), { surfaceDimension, surfaceDimension }, DestinationColorSpace::SRGB());
     IOSurfaceRef surface = badgeSurface->surface();
     [ciContext render:translatedImage toIOSurface:surface bounds:badgeRect colorSpace:sRGBColorSpaceRef()];
-    cgImage = useSmallBadge ? badgeSurface->createImage() : badgeSurface->createImage();
+    auto surfaceContext = badgeSurface->createPlatformContext();
+    cgImage = badgeSurface->createImage(surfaceContext.get());
 #else
     cgImage = adoptCF([ciContext createCGImage:sourceOverFilter.outputImage fromRect:flippedInsetBadgeRect]);
 #endif

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -29,6 +29,7 @@
 
 #include "ImageBufferAllocator.h"
 #include "ImageBufferBackend.h"
+#include "ProcessIdentity.h"
 #include "RenderingMode.h"
 #include "RenderingResourceIdentifier.h"
 #include <wtf/OptionSet.h>
@@ -63,6 +64,7 @@ struct ImageBufferCreationContext {
     enum class UseCGDisplayListImageCache : bool { No, Yes };
     UseCGDisplayListImageCache useCGDisplayListImageCache;
 #endif
+    WebCore::ProcessIdentity resourceOwner;
 
     ImageBufferCreationContext(GraphicsClient* client = nullptr
 #if HAVE(IOSURFACE)
@@ -72,6 +74,7 @@ struct ImageBufferCreationContext {
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
         , UseCGDisplayListImageCache useCGDisplayListImageCache = UseCGDisplayListImageCache::No
 #endif
+        , WebCore::ProcessIdentity resourceOwner = { }
     )
         : graphicsClient(client)
 #if HAVE(IOSURFACE)
@@ -81,6 +84,7 @@ struct ImageBufferCreationContext {
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
         , useCGDisplayListImageCache(useCGDisplayListImageCache)
 #endif
+        , resourceOwner(resourceOwner)
     { }
 };
 

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -89,8 +89,6 @@ void IOSurfacePool::willAddSurface(IOSurface& surface, bool inUse)
     CachedSurfaceDetails& details = m_surfaceDetails.add(&surface, CachedSurfaceDetails()).iterator->value;
     details.resetLastUseTime();
 
-    surface.releasePlatformContext();
-
     size_t surfaceBytes = surface.totalBytes();
 
     evict(surfaceBytes);

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -85,18 +85,19 @@ std::unique_ptr<ImageBufferIOSurfaceBackend> ImageBufferIOSurfaceBackend::create
         return nullptr;
 
     auto displayID = creationContext.graphicsClient ? creationContext.graphicsClient->displayID() : 0;
-    RetainPtr<CGContextRef> cgContext = surface->ensurePlatformContext(displayID);
+    RetainPtr<CGContextRef> cgContext = surface->createPlatformContext(displayID);
     if (!cgContext)
         return nullptr;
 
     CGContextClearRect(cgContext.get(), FloatRect(FloatPoint::zero(), backendSize));
 
-    return makeUnique<ImageBufferIOSurfaceBackend>(parameters, WTFMove(surface), displayID, creationContext.surfacePool);
+    return makeUnique<ImageBufferIOSurfaceBackend>(parameters, WTFMove(surface), WTFMove(cgContext), displayID, creationContext.surfacePool);
 }
 
-ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend(const Parameters& parameters, std::unique_ptr<IOSurface>&& surface, PlatformDisplayID displayID, IOSurfacePool* ioSurfacePool)
+ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend(const Parameters& parameters, std::unique_ptr<IOSurface> surface, RetainPtr<CGContextRef> platformContext, PlatformDisplayID displayID, IOSurfacePool* ioSurfacePool)
     : ImageBufferCGBackend(parameters)
     , m_surface(WTFMove(surface))
+    , m_platformContext(WTFMove(platformContext))
     , m_displayID(displayID)
     , m_ioSurfacePool(ioSurfacePool)
 {
@@ -107,13 +108,15 @@ ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend(const Parameters& param
 ImageBufferIOSurfaceBackend::~ImageBufferIOSurfaceBackend()
 {
     ensureNativeImagesHaveCopiedBackingStore();
+    releaseGraphicsContext();
     IOSurface::moveToPool(WTFMove(m_surface), m_ioSurfacePool.get());
 }
+
 
 GraphicsContext& ImageBufferIOSurfaceBackend::context()
 {
     if (!m_context) {
-        m_context = makeUnique<GraphicsContextCG>(m_surface->ensurePlatformContext(m_displayID));
+        m_context = makeUnique<GraphicsContextCG>(ensurePlatformContext());
         applyBaseTransform(*m_context);
     }
     return *m_context;
@@ -122,6 +125,15 @@ GraphicsContext& ImageBufferIOSurfaceBackend::context()
 void ImageBufferIOSurfaceBackend::flushContext()
 {
     CGContextFlush(context().platformContext());
+}
+
+CGContextRef ImageBufferIOSurfaceBackend::ensurePlatformContext()
+{
+    if (!m_platformContext) {
+        m_platformContext = m_surface->createPlatformContext(m_displayID);
+        RELEASE_ASSERT(m_platformContext);
+    }
+    return m_platformContext.get();
 }
 
 IntSize ImageBufferIOSurfaceBackend::backendSize() const
@@ -153,7 +165,7 @@ void ImageBufferIOSurfaceBackend::invalidateCachedNativeImage()
 RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImage(BackingStoreCopy)
 {
     m_mayHaveOutstandingBackingStoreReferences = true;
-    return NativeImage::create(m_surface->createImage());
+    return NativeImage::create(m_surface->createImage(ensurePlatformContext()));
 }
 
 RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImageForDrawing(GraphicsContext& destination)
@@ -163,7 +175,7 @@ RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImageForDrawing(Graph
         // The destination backend needs to read the actual pixels. Returning non-refence will
         // copy the pixels and but still cache the image to the context. This means we must
         // return the reference or cleanup later if we return the non-reference.
-        if (auto image = adoptCF(CGIOSurfaceContextCreateImageReference(m_surface->ensurePlatformContext()))) {
+        if (auto image = adoptCF(CGIOSurfaceContextCreateImageReference(ensurePlatformContext()))) {
             // CG has internal caches for some operations related to software bitmap draw. 
             // One of these caches are per-image color matching cache. Since these will not get any hits
             // from an image that is recreated every time, mark the image transient to skip these caches.
@@ -179,7 +191,8 @@ RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImageForDrawing(Graph
 
 RefPtr<NativeImage> ImageBufferIOSurfaceBackend::sinkIntoNativeImage()
 {
-    return NativeImage::create(IOSurface::sinkIntoImage(WTFMove(m_surface)));
+    ensurePlatformContext();
+    return NativeImage::create(IOSurface::sinkIntoImage(WTFMove(m_surface), WTFMove(m_platformContext)));
 }
 
 RefPtr<PixelBuffer> ImageBufferIOSurfaceBackend::getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect& srcRect, const ImageBufferAllocator& allocator)
@@ -210,7 +223,7 @@ bool ImageBufferIOSurfaceBackend::isInUse() const
 void ImageBufferIOSurfaceBackend::releaseGraphicsContext()
 {
     m_context = nullptr;
-    m_surface->releasePlatformContext();
+    m_platformContext = nullptr;
 }
 
 bool ImageBufferIOSurfaceBackend::setVolatile()

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -46,7 +46,7 @@ public:
 
     static std::unique_ptr<ImageBufferIOSurfaceBackend> create(const Parameters&, const ImageBufferCreationContext&);
 
-    ImageBufferIOSurfaceBackend(const Parameters&, std::unique_ptr<IOSurface>&&, PlatformDisplayID, IOSurfacePool*);
+    ImageBufferIOSurfaceBackend(const Parameters&, std::unique_ptr<IOSurface>, RetainPtr<CGContextRef> platformContext, PlatformDisplayID, IOSurfacePool*);
     ~ImageBufferIOSurfaceBackend();
     
     static constexpr RenderingMode renderingMode = RenderingMode::Accelerated;
@@ -56,6 +56,7 @@ public:
     void flushContext() override;
 
 protected:
+    CGContextRef ensurePlatformContext();
     IntSize backendSize() const override;
     
     RefPtr<NativeImage> copyNativeImage(BackingStoreCopy = CopyBackingStore) override;
@@ -84,6 +85,7 @@ protected:
     void prepareForExternalWrite();
 
     std::unique_ptr<IOSurface> m_surface;
+    RetainPtr<CGContextRef> m_platformContext;
     bool m_mayHaveOutstandingBackingStoreReferences { false };
     VolatilityState m_volatilityState { VolatilityState::NonVolatile };
     const PlatformDisplayID m_displayID;

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -121,9 +121,11 @@ public:
     WEBCORE_EXPORT WTF::MachSendRight createSendRight() const;
 
     // Any images created from a surface need to be released before releasing
-    // the surface, or an expensive GPU readback can result.
-    WEBCORE_EXPORT RetainPtr<CGImageRef> createImage();
-    WEBCORE_EXPORT static RetainPtr<CGImageRef> sinkIntoImage(std::unique_ptr<IOSurface>);
+    // the context, or an expensive GPU readback can result.
+    // Passed in context is the context through which the contents was drawn.
+    WEBCORE_EXPORT RetainPtr<CGImageRef> createImage(CGContextRef);
+    // Passed in context is the context through which the contents was drawn.
+    WEBCORE_EXPORT static RetainPtr<CGImageRef> sinkIntoImage(std::unique_ptr<IOSurface>, RetainPtr<CGContextRef>);
 
 #ifdef __OBJC__
     id asLayerContents() const { return (__bridge id)m_surface.get(); }
@@ -131,10 +133,8 @@ public:
     WEBCORE_EXPORT RetainPtr<id> asCAIOSurfaceLayerContents() const;
 
     IOSurfaceRef surface() const { return m_surface.get(); }
-    WEBCORE_EXPORT CGContextRef ensurePlatformContext(PlatformDisplayID = 0);
-    // The graphics context cached on the surface counts as a "user", so to get
-    // an accurate result from isInUse(), it needs to be released.
-    WEBCORE_EXPORT void releasePlatformContext();
+
+    WEBCORE_EXPORT RetainPtr<CGContextRef> createPlatformContext(PlatformDisplayID = 0);
 
     // Querying volatility can be expensive, so in cases where the surface is
     // going to be used immediately, use the return value of setVolatile to
@@ -187,7 +187,6 @@ private:
     size_t m_totalBytes;
 
     ProcessIdentity m_resourceOwner;
-    RetainPtr<CGContextRef> m_cgContext;
 
     RetainPtr<IOSurfaceRef> m_surface;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -55,12 +55,6 @@ RemoteImageBuffer::~RemoteImageBuffer()
         context().restore();
 }
 
-void RemoteImageBuffer::setOwnershipIdentity(const ProcessIdentity& resourceOwner)
-{
-    if (m_backend)
-        m_backend->setOwnershipIdentity(resourceOwner);
-}
-
 RefPtr<RemoteImageBuffer> RemoteImageBuffer::createTransfer(std::unique_ptr<ImageBufferBackend>&& backend, const ImageBufferBackend::Info& backendInfo, RemoteRenderingBackend& remoteRenderingBackend, QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
 {
     auto context = WebCore::ImageBufferCreationContext { nullptr

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -41,14 +41,8 @@ class RemoteRenderingBackend;
 class RemoteImageBuffer : public WebCore::ImageBuffer {
 public:
     template<typename BackendType>
-    static RefPtr<RemoteImageBuffer> create(const WebCore::FloatSize& size, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::PixelFormat pixelFormat, WebCore::RenderingPurpose purpose, RemoteRenderingBackend& remoteRenderingBackend, QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+    static RefPtr<RemoteImageBuffer> create(const WebCore::FloatSize& size, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::PixelFormat pixelFormat, WebCore::RenderingPurpose purpose, RemoteRenderingBackend& remoteRenderingBackend, QualifiedRenderingResourceIdentifier renderingResourceIdentifier, WebCore::ImageBufferCreationContext context)
     {
-        auto context = WebCore::ImageBufferCreationContext { nullptr
-#if HAVE(IOSURFACE)
-            , &remoteRenderingBackend.ioSurfacePool()
-#endif
-        };
-
         auto imageBuffer = ImageBuffer::create<BackendType, RemoteImageBuffer>(size, resolutionScale, colorSpace, pixelFormat, purpose, context, remoteRenderingBackend, renderingResourceIdentifier);
         if (!imageBuffer)
             return nullptr;
@@ -64,8 +58,6 @@ public:
 
     RemoteImageBuffer(const WebCore::ImageBufferBackend::Parameters&, const WebCore::ImageBufferBackend::Info&, std::unique_ptr<WebCore::ImageBufferBackend>&&, RemoteRenderingBackend&, QualifiedRenderingResourceIdentifier);
     ~RemoteImageBuffer();
-
-    void setOwnershipIdentity(const WebCore::ProcessIdentity& resourceOwner);
 
 private:
     QualifiedRenderingResourceIdentifier m_renderingResourceIdentifier;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -205,17 +205,18 @@ void RemoteRenderingBackend::createImageBufferWithQualifiedIdentifier(const Floa
 
     RefPtr<RemoteImageBuffer> imageBuffer;
 
+    WebCore::ImageBufferCreationContext creationContext { nullptr };
+#if HAVE(IOSURFACE)
+    creationContext.surfacePool = &ioSurfacePool();
+#endif
+    creationContext.resourceOwner = m_resourceOwner;
+
     if (renderingMode == RenderingMode::Accelerated) {
-        if (auto acceleratedImageBuffer = RemoteImageBuffer::create<AcceleratedImageBufferShareableMappedBackend>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, *this, imageBufferResourceIdentifier)) {
-            // Mark the IOSurface as being owned by the WebProcess even though it was constructed by the GPUProcess so that Jetsam knows which process to kill.
-            if (m_resourceOwner)
-                acceleratedImageBuffer->setOwnershipIdentity(m_resourceOwner);
-            imageBuffer = WTFMove(acceleratedImageBuffer);
-        }
+        imageBuffer = RemoteImageBuffer::create<AcceleratedImageBufferShareableMappedBackend>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, *this, imageBufferResourceIdentifier, creationContext);
     }
 
     if (!imageBuffer)
-        imageBuffer = RemoteImageBuffer::create<UnacceleratedImageBufferShareableBackend>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, *this, imageBufferResourceIdentifier);
+        imageBuffer = RemoteImageBuffer::create<UnacceleratedImageBufferShareableBackend>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, *this, imageBufferResourceIdentifier, creationContext);
 
     if (!imageBuffer) {
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3796,7 +3796,8 @@ static bool isLockdownModeWarningNeeded()
         CATransform3D transform = CATransform3DMakeScale(imageScaleInViewCoordinates, imageScaleInViewCoordinates, 1);
         transform = CATransform3DTranslate(transform, -rectInViewCoordinates.origin.x, -rectInViewCoordinates.origin.y, 0);
         CARenderServerRenderDisplayLayerWithTransformAndTimeOffset(MACH_PORT_NULL, (CFStringRef)displayName, self.layer.context.contextId, reinterpret_cast<uint64_t>(self.layer), surface->surface(), 0, 0, &transform, 0);
-        completionHandler(WebCore::IOSurface::sinkIntoImage(WTFMove(surface)).get());
+        auto context = surface->createPlatformContext();
+        completionHandler(WebCore::IOSurface::sinkIntoImage(WTFMove(surface), WTFMove(context)).get());
         return;
     }
 #endif

--- a/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
+++ b/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
@@ -70,8 +70,8 @@ std::optional<String> WebAutomationSession::platformGetBase64EncodedPNGData(cons
     auto* snapshotSurface = snapshot.surface();
     if (!snapshotSurface)
         return std::nullopt;
-
-    return getBase64EncodedPNGData(snapshotSurface->createImage());
+    auto context = snapshotSurface->createPlatformContext();
+    return getBase64EncodedPNGData(snapshotSurface->createImage(context.get()));
 }
 
 std::optional<String> WebAutomationSession::platformGenerateLocalFilePathForRemoteFile(const String& remoteFilePath, const String& base64EncodedFileContents)

--- a/Source/WebKit/UIProcess/mac/ViewSnapshotStoreMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewSnapshotStoreMac.mm
@@ -82,7 +82,6 @@ WebCore::SetNonVolatileResult ViewSnapshot::setVolatile(bool becomeVolatile)
 
     if (!m_surface)
         return WebCore::SetNonVolatileResult::Empty;
-
     return m_surface->setVolatile(becomeVolatile);
 }
 
@@ -105,7 +104,10 @@ RetainPtr<CGImageRef> ViewSnapshot::asImageForTesting()
         return nullptr;
 
     ASSERT(ViewSnapshotStore::singleton().disableSnapshotVolatilityForTesting());
-    return m_surface->createImage();
+    // Note: here we will destroy the context immediately, which will read back
+    // the image to CPU. This should be fine for testing.
+    auto context = m_surface->createPlatformContext();
+    return m_surface->createImage(context.get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
@@ -67,8 +67,6 @@ public:
     RefPtr<WebCore::PixelBuffer> getPixelBuffer(const WebCore::PixelBufferFormat& outputFormat, const WebCore::IntRect&, const WebCore::ImageBufferAllocator&) final;
     void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat) final;
 
-    void setOwnershipIdentity(const WebCore::ProcessIdentity&) { }
-
 private:
     unsigned bytesPerRow() const final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
@@ -46,8 +46,6 @@ public:
 
     using WebCore::ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend;
 
-    void setOwnershipIdentity(const WebCore::ProcessIdentity&);
-
     ImageBufferBackendHandle createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const final;
 
 private:

--- a/Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm
+++ b/Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm
@@ -73,7 +73,9 @@ RefPtr<BitmapContext> createBitmapContextFromWebView(bool onscreen, bool increme
     WebCore::IOSurface::Format snapshotFormat = WebCore::IOSurface::Format::BGRA;
 #endif
     auto surface = WebCore::IOSurface::create(nullptr, WebCore::expandedIntSize(snapshotSize), WebCore::DestinationColorSpace::SRGB(), snapshotFormat);
-    RetainPtr<CGImageRef> cgImage = surface->createImage();
+    // FIXME: Something is missing here, nothing draws to surface.
+    auto context = surface->createPlatformContext();
+    RetainPtr<CGImageRef> cgImage = surface->createImage(context.get());
 
     size_t bitmapRowBytes = 0;
     auto bitmapContext = createBitmapContext(bufferWidth, bufferHeight, bitmapRowBytes);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 		7B9FC5D628A5326A007570E7 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F4FFAA01ED3D0DE00F7111F /* ImageIO.framework */; };
 		7BA3936C271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */; };
 		7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */; };
+		7BB62ABE29BB4BAA00228CD6 /* IOSurfaceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BB62AB629BB4BAA00228CD6 /* IOSurfaceTests.mm */; };
 		7BB8BDE428F0781A00129836 /* CompletionHandlerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB8BDDC28F0781A00129836 /* CompletionHandlerTests.cpp */; };
 		7BC8628F29B8B33500217CB5 /* DisplayListRecorderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BC8628729B8B33500217CB5 /* DisplayListRecorderTests.cpp */; };
 		7BE876032919457B00B15289 /* AudioStreamDescriptionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BE875FB2919457B00B15289 /* AudioStreamDescriptionCocoa.mm */; };
@@ -2776,6 +2777,7 @@
 		7B9FC5CC28A52DC0007570E7 /* libWebKitPlatform.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libWebKitPlatform.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TestGraphicsContextGLCocoa.mm; sourceTree = "<group>"; };
 		7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionTests.cpp; sourceTree = "<group>"; };
+		7BB62AB629BB4BAA00228CD6 /* IOSurfaceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IOSurfaceTests.mm; sourceTree = "<group>"; };
 		7BB754AF274E39A100D00EC1 /* WebCoreTestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCoreTestUtilities.h; sourceTree = "<group>"; };
 		7BB754B0274E39A100D00EC1 /* WebCoreTestUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebCoreTestUtilities.cpp; sourceTree = "<group>"; };
 		7BB8BDDC28F0781A00129836 /* CompletionHandlerTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompletionHandlerTests.cpp; sourceTree = "<group>"; };
@@ -5582,6 +5584,7 @@
 				510A667A27D2FC7A00D22629 /* CoreMediaUtilities.mm */,
 				751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */,
 				41EBA9F128ABA06500953013 /* ImageRotationSessionVT.cpp */,
+				7BB62AB629BB4BAA00228CD6 /* IOSurfaceTests.mm */,
 				57F1C91025DDD51900E8F6EA /* PrivateClickMeasurementCocoa.mm */,
 				5769C50A1D9B0001000847FB /* SerializedCryptoKeyWrap.mm */,
 				A17991861E1C994E00A505ED /* SharedBuffer.mm */,
@@ -6371,6 +6374,7 @@
 				7A909A811D877480007E10F8 /* IntPointTests.cpp in Sources */,
 				7A909A821D877480007E10F8 /* IntRectTests.cpp in Sources */,
 				7A909A831D877480007E10F8 /* IntSizeTests.cpp in Sources */,
+				7BB62ABE29BB4BAA00228CD6 /* IOSurfaceTests.mm in Sources */,
 				F4B8A5C128F8B54F00E3F54F /* IPAddressTests.cpp in Sources */,
 				5C0BF8931DD599BD00B00328 /* IsNavigationActionTrusted.mm in Sources */,
 				CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "Test.h"
+#import <WebCore/IOSurface.h>
+#import <wtf/MachSendRight.h>
+
+namespace TestWebKitAPI {
+
+TEST(IOSurfaceTest, IsInUse)
+{
+    auto s1 = WebCore::IOSurface::create(nullptr, { 5, 5 }, WebCore::DestinationColorSpace::SRGB()); 
+    EXPECT_FALSE(s1->isInUse());
+    auto sendRight1 = s1->createSendRight();
+    EXPECT_TRUE(s1->isInUse());
+    auto sendRight2 = s1->createSendRight();
+    sendRight1 = { };
+    EXPECT_TRUE(s1->isInUse());
+    sendRight2 = { };
+    EXPECT_FALSE(s1->isInUse());
+}
+
+TEST(IOSurfaceTest, CreatePlatformContext)
+{
+    auto s1 = WebCore::IOSurface::create(nullptr, { 5, 5 }, WebCore::DestinationColorSpace::SRGB()); 
+    EXPECT_FALSE(s1->isInUse());
+    auto c1 = s1->createPlatformContext();
+    auto c2 = s1->createPlatformContext();
+    EXPECT_NE(c1, c2);
+    EXPECT_FALSE(s1->isInUse());
+    c1 = nullptr;
+    EXPECT_FALSE(s1->isInUse());
+    c2 = nullptr;
+    EXPECT_FALSE(s1->isInUse());
+}
+
+}


### PR DESCRIPTION
#### 902a49a99629ceb2bf363ee4c96b0f3fdd34afc3
<pre>
WebCore::IOSurface should not store a reference to a CGContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=253698">https://bugs.webkit.org/show_bug.cgi?id=253698</a>
rdar://106547690

Reviewed by Matt Woodrow.

An IOSurface might be written to and read from by multiple CGContexts
or even other contexts such as Metal (via WebGL / ANGLE).

An arbitrary context that has been used is not useful anymore in the
future, as the caller will not know the context state.

Due to these points, does not make sense to store a CGContext as a member in
WebCore::IOSurface.

The only real CG draw to an IOSurface happens via ImageBufferIOSurfaceBackend.
Store the context there, as that is the place to use the context.

Caching the context behind the interface creates source of bugs, as in
here fixed WebAutomationSession / ViewSnapshot where the callers
would inadvertedly create the contexts and leave them stored.

Remove invalid comment about CGIOSurfaceContextCreate affecting the
use count. The added test proves otherwise.

* Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp:
(WebCore::IOSurfacePool::willAddSurface):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::create):
(WebCore::ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend):
(WebCore::ImageBufferIOSurfaceBackend::~ImageBufferIOSurfaceBackend):
(WebCore::ImageBufferIOSurfaceBackend::context):
(WebCore::ImageBufferIOSurfaceBackend::ensurePlatformContext):
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImage):
(WebCore::ImageBufferIOSurfaceBackend::copyNativeImageForDrawing):
(WebCore::ImageBufferIOSurfaceBackend::sinkIntoNativeImage):
(WebCore::ImageBufferIOSurfaceBackend::releaseGraphicsContext):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::create):
(WebCore::IOSurface::createFromImage):
(WebCore::IOSurface::createImage):
(WebCore::IOSurface::sinkIntoImage):
(WebCore::IOSurface::createPlatformContext):
(WebCore::IOSurface::setOwnershipIdentity):
(WebCore::IOSurface::ensurePlatformContext): Deleted.
(WebCore::IOSurface::releasePlatformContext): Deleted.
* Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm:
(WebKit::WebAutomationSession::platformGetBase64EncodedPNGData):
* Source/WebKit/UIProcess/mac/ViewSnapshotStoreMac.mm:
(WebKit::ViewSnapshot::setVolatile):
(WebKit::ViewSnapshot::asImageForTesting):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBackend::create):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/261699@main">https://commits.webkit.org/261699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fed313871a94b69f805bb8ad074b0c73d040d851

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121119 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5494 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118336 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105657 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/883 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14056 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/919 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14739 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52924 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8158 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16575 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->