### PR TITLE
[WGSL] Add API to revert AST modifications

### DIFF
--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -192,7 +192,7 @@ void NameManglerVisitor::visit(AST::NamedTypeName& type)
 void NameManglerVisitor::introduceVariable(AST::Identifier& name, MangledName::Kind kind)
 {
     const auto& mangledName = ContextProvider::introduceVariable(name, makeMangledName(name, kind));
-    name = AST::Identifier::makeWithSpan(name.span(), mangledName.toString());
+    m_callGraph.ast().replace(&name, AST::Identifier::makeWithSpan(name.span(), mangledName.toString()));
 }
 
 MangledName NameManglerVisitor::makeMangledName(const String& name, MangledName::Kind kind)
@@ -208,7 +208,7 @@ void NameManglerVisitor::readVariable(AST::Identifier& name) const
 {
     // FIXME: this should be unconditional
     if (const auto* mangledName = ContextProvider::readVariable(name))
-        name = AST::Identifier::makeWithSpan(name.span(), mangledName->toString());
+        m_callGraph.ast().replace(&name, AST::Identifier::makeWithSpan(name.span(), mangledName->toString()));
 }
 
 void mangleNames(CallGraph& callGraph, PrepareResult& result)

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -116,6 +116,7 @@ inline PrepareResult prepareImpl(ShaderModule& ast, const HashMap<String, Pipeli
 
     logPhaseTimes(phaseTimes);
 
+    ast.revertReplacements();
     return result;
 }
 


### PR DESCRIPTION
#### 9d82f930b0a0f102551e47b3d13876fae3ce9929
<pre>
[WGSL] Add API to revert AST modifications
<a href="https://bugs.webkit.org/show_bug.cgi?id=253699">https://bugs.webkit.org/show_bug.cgi?id=253699</a>
rdar://106548133

Reviewed by Myles C. Maxfield.

Since we might use the same AST for compiling multiple times (and potentially with
different layouts), we can&apos;t leave our modifications to the AST to be visible by
the next compilation. Instead of directly modifying the AST this patch adds an API
for replacing nodes which records all the nodes that have been replaced so we can
undo it once we are done compiling.

* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::introduceVariable):
(WGSL::NameManglerVisitor::readVariable const):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::replace):
(WGSL::ShaderModule::revertReplacements):

Canonical link: <a href="https://commits.webkit.org/261692@main">https://commits.webkit.org/261692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/496454e0a689fc7c90684e335aca3fb159fcb1f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120806 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4457 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105212 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45821 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13695 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/570 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/93667 "265 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10166 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52569 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8155 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16166 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->