### PR TITLE
[LFC][IFC][shape-outside] Support overhanging shapes

### DIFF
--- a/Source/WebCore/layout/floats/FloatingState.cpp
+++ b/Source/WebCore/layout/floats/FloatingState.cpp
@@ -29,6 +29,7 @@
 #include "LayoutContainingBlockChainIterator.h"
 #include "LayoutInitialContainingBlock.h"
 #include "LayoutState.h"
+#include "Shape.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -40,14 +41,18 @@ FloatingState::FloatItem::FloatItem(const Box& layoutBox, Position position, Box
     : m_layoutBox(layoutBox)
     , m_position(position)
     , m_absoluteBoxGeometry(absoluteBoxGeometry)
+    , m_shape(layoutBox.shape())
 {
 }
 
-FloatingState::FloatItem::FloatItem(Position position, BoxGeometry absoluteBoxGeometry)
+FloatingState::FloatItem::FloatItem(Position position, BoxGeometry absoluteBoxGeometry, const Shape* shape)
     : m_position(position)
     , m_absoluteBoxGeometry(absoluteBoxGeometry)
+    , m_shape(shape)
 {
 }
+
+FloatingState::FloatItem::~FloatItem() = default;
 
 FloatingState::FloatingState(LayoutState& layoutState, const ElementBox& blockFormattingContextRoot)
     : m_layoutState(layoutState)

--- a/Source/WebCore/layout/floats/FloatingState.h
+++ b/Source/WebCore/layout/floats/FloatingState.h
@@ -54,8 +54,10 @@ public:
     public:
         // FIXME: This c'tor is only used by the render tree integation codepath.
         enum class Position { Left, Right };
-        FloatItem(Position, BoxGeometry absoluteBoxGeometry);
+        FloatItem(Position, BoxGeometry absoluteBoxGeometry, const Shape*);
         FloatItem(const Box&, Position, BoxGeometry absoluteBoxGeometry);
+
+        ~FloatItem();
 
         bool isLeftPositioned() const { return m_position == Position::Left; }
         bool isRightPositioned() const { return m_position == Position::Right; }
@@ -66,7 +68,7 @@ public:
         BoxGeometry::HorizontalMargin horizontalMargin() const { return m_absoluteBoxGeometry.horizontalMargin(); }
         PositionInContextRoot bottom() const { return { rectWithMargin().bottom() }; }
 
-        const Shape* shape() const { return m_layoutBox ? m_layoutBox->shape() : nullptr; }
+        const Shape* shape() const { return m_shape.get(); }
 
 #if ASSERT_ENABLED
         const Box* floatBox() const { return m_layoutBox.get(); }
@@ -75,6 +77,7 @@ public:
         CheckedPtr<const Box> m_layoutBox;
         Position m_position;
         BoxGeometry m_absoluteBoxGeometry;
+        RefPtr<const Shape> m_shape;
     };
     using FloatList = Vector<FloatItem>;
     const FloatList& floats() const { return m_floats; }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -408,10 +408,8 @@ void LineLayout::updateLayoutBoxDimensions(const RenderBox& replacedOrInlineBloc
         layoutBox.setBaselineForIntegration(roundToInt(baseline));
     }
 
-    if (ShapeOutsideInfo::isEnabledFor(replacedOrInlineBlock)) {
-        auto shape = makeShapeForShapeOutside(replacedOrInlineBlock);
-        layoutBox.setShape(WTFMove(shape));
-    }
+    if (auto* shapeOutsideInfo = replacedOrInlineBlock.shapeOutsideInfo())
+        layoutBox.setShape(&shapeOutsideInfo->computedShape());
 }
 
 void LineLayout::updateLineBreakBoxDimensions(const RenderLineBreak& lineBreakBox)
@@ -822,7 +820,11 @@ void LineLayout::prepareFloatingState()
         boxGeometry.setPadding({ });
         boxGeometry.setHorizontalMargin({ });
         boxGeometry.setVerticalMargin({ });
-        floatingState.append({ logicalPosition(), boxGeometry });
+
+        auto shapeOutsideInfo = floatingObject->renderer().shapeOutsideInfo();
+        auto* shape = shapeOutsideInfo ? &shapeOutsideInfo->computedShape() : nullptr;
+
+        floatingState.append({ logicalPosition(), boxGeometry, shape });
     }
 }
 

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -450,7 +450,7 @@ const Shape* Box::shape() const
     return rareData().shape.get();
 }
 
-void Box::setShape(std::unique_ptr<Shape> shape)
+void Box::setShape(RefPtr<const Shape> shape)
 {
     ensureRareData().shape = WTFMove(shape);
 }

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -179,7 +179,7 @@ public:
     void setIsFirstChildForIntegration(bool value) { m_isFirstChildForIntegration = value; }
 
     const Shape* shape() const;
-    void setShape(std::unique_ptr<Shape>);
+    void setShape(RefPtr<const Shape>);
 
     bool canCacheForLayoutState(const LayoutState&) const;
     BoxGeometry* cachedGeometryForLayoutState(const LayoutState&) const;
@@ -204,7 +204,7 @@ private:
         CellSpan tableCellSpan;
         std::optional<LayoutUnit> columnWidth;
         std::unique_ptr<RenderStyle> firstLineStyle;
-        std::unique_ptr<Shape> shape;
+        RefPtr<const Shape> shape;
     };
 
     bool hasRareData() const { return m_hasRareData; }

--- a/Source/WebCore/rendering/shapes/Shape.cpp
+++ b/Source/WebCore/rendering/shapes/Shape.cpp
@@ -44,27 +44,27 @@
 
 namespace WebCore {
 
-static std::unique_ptr<Shape> createInsetShape(const FloatRoundedRect& bounds)
+static Ref<Shape> createInsetShape(const FloatRoundedRect& bounds)
 {
     ASSERT(bounds.rect().width() >= 0 && bounds.rect().height() >= 0);
-    return makeUnique<BoxShape>(bounds);
+    return adoptRef(*new BoxShape(bounds));
 }
 
-static std::unique_ptr<Shape> createCircleShape(const FloatPoint& center, float radius)
+static Ref<Shape> createCircleShape(const FloatPoint& center, float radius)
 {
     ASSERT(radius >= 0);
-    return makeUnique<RectangleShape>(FloatRect(center.x() - radius, center.y() - radius, radius*2, radius*2), FloatSize(radius, radius));
+    return adoptRef(*new RectangleShape(FloatRect(center.x() - radius, center.y() - radius, radius*2, radius*2), FloatSize(radius, radius)));
 }
 
-static std::unique_ptr<Shape> createEllipseShape(const FloatPoint& center, const FloatSize& radii)
+static Ref<Shape> createEllipseShape(const FloatPoint& center, const FloatSize& radii)
 {
     ASSERT(radii.width() >= 0 && radii.height() >= 0);
-    return makeUnique<RectangleShape>(FloatRect(center.x() - radii.width(), center.y() - radii.height(), radii.width()*2, radii.height()*2), radii);
+    return adoptRef(*new RectangleShape(FloatRect(center.x() - radii.width(), center.y() - radii.height(), radii.width()*2, radii.height()*2), radii));
 }
 
-static std::unique_ptr<Shape> createPolygonShape(Vector<FloatPoint>&& vertices, WindRule fillRule)
+static Ref<Shape> createPolygonShape(Vector<FloatPoint>&& vertices, WindRule fillRule)
 {
-    return makeUnique<PolygonShape>(WTFMove(vertices), fillRule);
+    return adoptRef(*new PolygonShape(WTFMove(vertices), fillRule));
 }
 
 static inline FloatRect physicalRectToLogical(const FloatRect& rect, float logicalBoxHeight, WritingMode writingMode)
@@ -92,12 +92,12 @@ static inline FloatSize physicalSizeToLogical(const FloatSize& size, WritingMode
     return size.transposedSize();
 }
 
-std::unique_ptr<Shape> Shape::createShape(const BasicShape& basicShape, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode writingMode, float margin)
+Ref<const Shape> Shape::createShape(const BasicShape& basicShape, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode writingMode, float margin)
 {
     bool horizontalWritingMode = isHorizontalWritingMode(writingMode);
     float boxWidth = horizontalWritingMode ? logicalBoxSize.width() : logicalBoxSize.height();
     float boxHeight = horizontalWritingMode ? logicalBoxSize.height() : logicalBoxSize.width();
-    std::unique_ptr<Shape> shape;
+    RefPtr<Shape> shape;
 
     switch (basicShape.type()) {
 
@@ -174,10 +174,10 @@ std::unique_ptr<Shape> Shape::createShape(const BasicShape& basicShape, const La
     shape->m_writingMode = writingMode;
     shape->m_margin = margin;
 
-    return shape;
+    return shape.releaseNonNull();
 }
 
-std::unique_ptr<Shape> Shape::createRasterShape(Image* image, float threshold, const LayoutRect& imageR, const LayoutRect& marginR, WritingMode writingMode, float margin)
+Ref<const Shape> Shape::createRasterShape(Image* image, float threshold, const LayoutRect& imageR, const LayoutRect& marginR, WritingMode writingMode, float margin)
 {
     ASSERT(marginR.height() >= 0);
 
@@ -188,7 +188,7 @@ std::unique_ptr<Shape> Shape::createRasterShape(Image* image, float threshold, c
     auto imageBuffer = ImageBuffer::create(imageRect.size(), RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
 
     auto createShape = [&]() {
-        auto rasterShape = makeUnique<RasterShape>(WTFMove(intervals), marginRect.size());
+        auto rasterShape = adoptRef(*new RasterShape(WTFMove(intervals), marginRect.size()));
         rasterShape->m_writingMode = writingMode;
         rasterShape->m_margin = margin;
         return rasterShape;
@@ -239,12 +239,12 @@ std::unique_ptr<Shape> Shape::createRasterShape(Image* image, float threshold, c
     return createShape();
 }
 
-std::unique_ptr<Shape> Shape::createBoxShape(const RoundedRect& roundedRect, WritingMode writingMode, float margin)
+Ref<const Shape> Shape::createBoxShape(const RoundedRect& roundedRect, WritingMode writingMode, float margin)
 {
     ASSERT(roundedRect.rect().width() >= 0 && roundedRect.rect().height() >= 0);
 
     FloatRoundedRect bounds { roundedRect };
-    auto shape = makeUnique<BoxShape>(bounds);
+    auto shape = adoptRef(*new BoxShape(bounds));
     shape->m_writingMode = writingMode;
     shape->m_margin = margin;
 

--- a/Source/WebCore/rendering/shapes/Shape.h
+++ b/Source/WebCore/rendering/shapes/Shape.h
@@ -32,6 +32,7 @@
 #include "LayoutRect.h"
 #include "Path.h"
 #include "WritingMode.h"
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 
@@ -64,17 +65,16 @@ class RoundedRect;
 // computed segments are returned as pairs of logical X coordinates. The BasicShape itself is defined in
 // physical coordinates.
 
-class Shape {
-    WTF_MAKE_FAST_ALLOCATED;
+class Shape : public RefCounted<Shape> {
 public:
     struct DisplayPaths {
         Path shape;
         Path marginShape;
     };
 
-    static std::unique_ptr<Shape> createShape(const BasicShape&, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode, float margin);
-    static std::unique_ptr<Shape> createRasterShape(Image*, float threshold, const LayoutRect& imageRect, const LayoutRect& marginRect, WritingMode, float margin);
-    static std::unique_ptr<Shape> createBoxShape(const RoundedRect&, WritingMode, float margin);
+    static Ref<const Shape> createShape(const BasicShape&, const LayoutPoint& borderBoxOffset, const LayoutSize& logicalBoxSize, WritingMode, float margin);
+    static Ref<const Shape> createRasterShape(Image*, float threshold, const LayoutRect& imageRect, const LayoutRect& marginRect, WritingMode, float margin);
+    static Ref<const Shape> createBoxShape(const RoundedRect&, WritingMode, float margin);
 
     virtual ~Shape() = default;
 

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -119,7 +119,7 @@ static LayoutRect getShapeImageMarginRect(const RenderBox& renderBox, const Layo
     return LayoutRect(marginBoxOrigin, marginRectSize);
 }
 
-std::unique_ptr<Shape> makeShapeForShapeOutside(const RenderBox& renderer)
+Ref<const Shape> makeShapeForShapeOutside(const RenderBox& renderer)
 {
     auto& style = renderer.style();
     auto& containingBlock = *renderer.containingBlock();
@@ -163,7 +163,7 @@ std::unique_ptr<Shape> makeShapeForShapeOutside(const RenderBox& renderer)
     }
     }
     ASSERT_NOT_REACHED();
-    return nullptr;
+    return Shape::createBoxShape(RoundedRect { { } }, writingMode, 0);
 }
 
 static inline bool checkShapeImageOrigin(Document& document, const StyleImage& styleImage)

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
@@ -41,7 +41,7 @@ class RenderBox;
 class StyleImage;
 class FloatingObject;
 
-std::unique_ptr<Shape> makeShapeForShapeOutside(const RenderBox&);
+Ref<const Shape> makeShapeForShapeOutside(const RenderBox&);
 
 class ShapeOutsideDeltas final {
 public:
@@ -128,7 +128,7 @@ private:
 
     const RenderBox& m_renderer;
 
-    mutable std::unique_ptr<Shape> m_shape;
+    mutable RefPtr<const Shape> m_shape;
     LayoutSize m_cachedShapeLogicalSize;
 
     ShapeOutsideDeltas m_shapeOutsideDeltas;


### PR DESCRIPTION
#### 14c862ab6338a88885dee7297abe779edab4afc2
<pre>
[LFC][IFC][shape-outside] Support overhanging shapes
<a href="https://bugs.webkit.org/show_bug.cgi?id=253702">https://bugs.webkit.org/show_bug.cgi?id=253702</a>
rdar://106548869

Reviewed by Alan Baradlay.

* Source/WebCore/layout/floats/FloatingState.cpp:
(WebCore::Layout::FloatingState::FloatItem::FloatItem):
* Source/WebCore/layout/floats/FloatingState.h:
(WebCore::Layout::FloatingState::FloatItem::shape const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateLayoutBoxDimensions):
(WebCore::LayoutIntegration::LineLayout::prepareFloatingState):

Set the shape when synhesizing a FloatItem from overhang.

* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::setShape):
* Source/WebCore/layout/layouttree/LayoutBox.h:
* Source/WebCore/rendering/shapes/Shape.cpp:
(WebCore::createInsetShape):
(WebCore::createCircleShape):
(WebCore::createEllipseShape):
(WebCore::createPolygonShape):
(WebCore::Shape::createShape):
(WebCore::Shape::createRasterShape):
(WebCore::Shape::createBoxShape):
* Source/WebCore/rendering/shapes/Shape.h:

Make Shapes refcounted (simpler than making them copyable).

* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::makeShapeForShapeOutside):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.h:

Canonical link: <a href="https://commits.webkit.org/261499@main">https://commits.webkit.org/261499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d53b81711ca97e6da006efa09b91ec38aed78a1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/115964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12084 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117662 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104918 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13473 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/352 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/13993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9764 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52354 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8004 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15956 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->