### PR TITLE
[CMake][GTK] Add Development Debug preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,6 +7,42 @@
     },
     "configurePresets": [
         {
+            "name": "release",
+            "hidden": true,
+            "binaryDir": "WebKitBuild/Release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": {
+                    "type": "STRING",
+                    "value": "Release"
+                }
+            }
+        },
+        {
+            "name": "debug",
+            "hidden": true,
+            "binaryDir": "WebKitBuild/Debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": {
+                    "type": "STRING",
+                    "value": "Debug"
+                }
+            }
+        },
+        {
+            "name": "dev",
+            "hidden": true,
+            "cacheVariables": {
+                "DEVELOPER_MODE": {
+                    "type": "BOOL",
+                    "value": "ON"
+                },
+                "ENABLE_EXPERIMENTAL_FEATURES": {
+                    "type": "BOOL",
+                    "value": "ON"
+                }
+            }
+        },
+        {
             "name": "gtk",
             "hidden": true,
             "generator": "Ninja",
@@ -20,41 +56,22 @@
         {
             "name": "gtk-release",
             "displayName": "GTK Release",
-            "inherits": "gtk",
-            "binaryDir": "WebKitBuild/Release",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": {
-                    "type": "STRING",
-                    "value": "Release"
-                }
-            }
+            "inherits": ["gtk", "release"]
         },
         {
             "name": "gtk-debug",
             "displayName": "GTK Debug",
-            "inherits": "gtk",
-            "binaryDir": "WebKitBuild/Debug",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": {
-                    "type": "STRING",
-                    "value": "Debug"
-                }
-            }
+            "inherits": ["gtk", "debug"]
         },
         {
-            "name": "gtk-dev",
-            "displayName": "GTK Development",
-            "inherits": "gtk-release",
-            "cacheVariables": {
-                "DEVELOPER_MODE": {
-                    "type": "BOOL",
-                    "value": "ON"
-                },
-                "ENABLE_EXPERIMENTAL_FEATURES": {
-                    "type": "BOOL",
-                    "value": "ON"
-                }
-            }
+            "name": "gtk-dev-release",
+            "displayName": "GTK Development Release",
+            "inherits": ["gtk", "dev", "release"]
+        },
+        {
+            "name": "gtk-dev-debug",
+            "displayName": "GTK Development Debug",
+            "inherits": ["gtk", "dev", "debug"]
         }
     ],
     "buildPresets": [
@@ -69,9 +86,14 @@
             "configurePreset": "gtk-debug"
         },
         {
-            "name": "gtk-dev",
-            "displayName": "GTK Development",
-            "configurePreset": "gtk-dev"
+            "name": "gtk-dev-relese",
+            "displayName": "GTK Dev Release",
+            "configurePreset": "gtk-dev-release"
+        },
+        {
+            "name": "gtk-dev-debug",
+            "displayName": "GTK Dev Debug",
+            "configurePreset": "gtk-dev-debug"
         }
     ]
 }


### PR DESCRIPTION
#### 8dd4ab1e87d5a2c6a6d1c86601553fac39cb0f83
<pre>
[CMake][GTK] Add Development Debug preset
<a href="https://bugs.webkit.org/show_bug.cgi?id=253707">https://bugs.webkit.org/show_bug.cgi?id=253707</a>

Reviewed by Carlos Garcia Campos.

It can be useful to have a preset with debug build type and developer mode on.

* CMakePresets.json:

Canonical link: <a href="https://commits.webkit.org/261787@main">https://commits.webkit.org/261787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b39f7c40919739fcecd13eb424d3a59a23a975da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3671 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120593 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3417 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45599 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13484 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/362 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/92791 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9770 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52364 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15965 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4510 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->