### PR TITLE
CSS Nesting: support top-level & selector

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6218,9 +6218,7 @@ imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noop
 imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?_parent [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?_top [ Skip ]
 
-# CSS nesting unsupported yet
 imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html [ ImageOnlyFailure ]
 
 # Needs non-zero line gap in 'Arial'
 fast/text/text-edge-no-half-leading-simple.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-004-expected.txt
@@ -1,4 +1,4 @@
 Test passes if color is green.
 
-FAIL CSS Selectors nested invalidation through @media by selectorText undefined is not an object (evaluating 'document.styleSheets[0].rules[1].selectorText = '.a'')
+FAIL CSS Selectors nested invalidation through @media by selectorText assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule-expected.html
@@ -19,4 +19,5 @@
   <div class="test"></div>
   <div class="test"></div>
   <div class="test"></div>
+  <div class="test"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule-ref.html
@@ -19,4 +19,5 @@
   <div class="test"></div>
   <div class="test"></div>
   <div class="test"></div>
+  <div class="test"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule.html
@@ -33,6 +33,12 @@
     }
   }
 
+  @supports(selector(&)) {
+    .test-4 {
+      background-color: green;
+    }
+  }
+
   body * + * {
     margin-top: 8px;
   }
@@ -42,4 +48,5 @@
   <div class="test test-1"></div>
   <div class="test"><div class="test-2"></div></div>
   <div class="test test-3"></div>
+  <div class="test test-4"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL & as direct ancestor The string did not match the expected pattern.
-FAIL & matches scoped element only, not everything The string did not match the expected pattern.
+PASS & as direct ancestor
+PASS & matches scoped element only, not everything
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -1033,18 +1033,12 @@ void CSSSelector::resolveNestingParentSelectors(const CSSSelectorList& parent)
     visitAllSimpleSelectors(replaceParentSelector);
 }
 
-void CSSSelector::replaceNestingParentByNotAll()
+void CSSSelector::replaceNestingParentByPseudoClassScope()
 {
     auto replaceParentSelector = [] (CSSSelector& selector) {
         if (selector.match() == CSSSelector::PseudoClass && selector.pseudoClassType() == CSSSelector::PseudoClassNestingParent) {
-            // We replace by :not(*)
-            auto allSelector = makeUnique<CSSParserSelector>(CSSSelector(anyQName()));
-            Vector<std::unique_ptr<CSSParserSelector>> vector;
-            vector.append(WTFMove(allSelector));
-            auto selectorList = makeUnique<CSSSelectorList>(WTFMove(vector));
-            selector.setMatch(Match::PseudoClass);
-            selector.setPseudoClassType(PseudoClassType::PseudoClassNot);
-            selector.setSelectorList(WTFMove(selectorList));
+            // Replace by :scope
+            selector.setPseudoClassType(PseudoClassType::PseudoClassScope);
         }
     };
 

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -67,7 +67,7 @@ struct PossiblyQuotedIdentifier {
 
         bool hasExplicitNestingParent() const;
         void resolveNestingParentSelectors(const CSSSelectorList& parent);
-        void replaceNestingParentByNotAll();
+        void replaceNestingParentByPseudoClassScope();
 
         // How the attribute value has to match. Default is Exact.
         enum Match {

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -113,6 +113,10 @@ void CSSStyleRule::setSelectorText(const String& selectorText)
     if (!selectorList)
         return;
 
+    // FIXME: We don't support setting nesting parent selector by CSSOM
+    if (selectorList->hasExplicitNestingParent())
+        return;
+
     // NOTE: The selector list has to fit into RuleData. <http://webkit.org/b/118369>
     if (selectorList->componentCount() > Style::RuleData::maximumSelectorComponentCount)
         return;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -519,7 +519,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeSimpleSelector(CSSP
         selector = consumeId(range);
     else if (token.type() == DelimiterToken && token.delimiter() == '.')
         selector = consumeClass(range);
-    else if (token.type() == DelimiterToken && token.delimiter() == '&' && m_context.cssNestingEnabled && m_isNestedContext == CSSParserEnum::IsNestedContext::Yes) // FIXME: handle top-level nesting selector
+    else if (token.type() == DelimiterToken && token.delimiter() == '&' && m_context.cssNestingEnabled)
         selector = consumeNesting(range);
     else if (token.type() == LeftBracketToken)
         selector = consumeAttribute(range);
@@ -1185,8 +1185,8 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
                 // FIXME: We should build a new CSSParserSelector from this selector and resolve it
                 const_cast<CSSSelector*>(selector)->resolveNestingParentSelectors(*parentResolvedSelectorList);
             } else {
-                // It's top-level, the nesting parent selector should be replace by not(*)
-                const_cast<CSSSelector*>(selector)->replaceNestingParentByNotAll();
+                // It's top-level, the nesting parent selector should be replace by :scope
+                const_cast<CSSSelector*>(selector)->replaceNestingParentByPseudoClassScope();
             }
             auto parserSelector = makeUnique<CSSParserSelector>(*selector);
             result.append(WTFMove(parserSelector));

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -595,11 +595,12 @@ ExceptionOr<SelectorQuery&> SelectorQueryCache::add(const String& selectors, Doc
     if (selectorList->selectorsNeedNamespaceResolution())
         return Exception { SyntaxError };
 
+    auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(*selectorList, nullptr);
     constexpr int maximumSelectorQueryCacheSize = 256;
     if (m_entries.size() == maximumSelectorQueryCacheSize)
         m_entries.remove(m_entries.random());
 
-    return *m_entries.add(selectors, makeUnique<SelectorQuery>(WTFMove(*selectorList))).iterator->value;
+    return *m_entries.add(selectors, makeUnique<SelectorQuery>(WTFMove(resolvedSelectorList))).iterator->value;
 }
 
 }

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -217,12 +217,10 @@ void RuleSetBuilder::addRulesFromSheetContents(const StyleSheetContents& sheet)
 
 void RuleSetBuilder::populateStyleRuleResolvedSelectorList(const StyleRuleWithNesting& rule)
 {
-    auto resolvedSelectorList = rule.selectorList();
-
-    // FIXME: handle top-level nesting selector
+    const CSSSelectorList* parentResolvedSelectorList = nullptr;
     if (m_styleRuleStack.size()) 
-        resolvedSelectorList = CSSSelectorParser::resolveNestingParent(rule.selectorList(), m_styleRuleStack.last());
-
+        parentResolvedSelectorList =  m_styleRuleStack.last();
+    auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(rule.selectorList(), parentResolvedSelectorList);
     rule.setResolvedSelectorList(WTFMove(resolvedSelectorList));    
 }
 


### PR DESCRIPTION
#### 20329b62061b40d5a423a1d75b67779945b84729
<pre>
CSS Nesting: support top-level &amp; selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=250379">https://bugs.webkit.org/show_bug.cgi?id=250379</a>
rdar://104073866

Reviewed by Antti Koivisto.

Replaces any top-level &amp; selector by the :scope pseudo class.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/supports-rule.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-is-scope-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::replaceNestingParentByPseudoClassScope):
(WebCore::CSSSelector::replaceNestingParentByNotAll): Deleted.
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::setSelectorText):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeSimpleSelector):
(WebCore::CSSSelectorParser::resolveNestingParent):
* Source/WebCore/dom/SelectorQuery.cpp:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::populateStyleRuleResolvedSelectorList):

Canonical link: <a href="https://commits.webkit.org/261739@main">https://commits.webkit.org/261739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66d6b83478f68c4cdc642e82540d6ab23bc62968

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4323 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121105 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5464 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118316 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17116 "5 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105625 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46132 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100853 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14037 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/900 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/95238 "13 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12138 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14719 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10277 "2 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102329 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52905 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31965 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/8148 "The change is no longer eligible for processing.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16555 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110368 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4489 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27265 "Passed tests") | 
<!--EWS-Status-Bubble-End-->