### PR TITLE
Fix undefined behavior in valueFromPool(Span<LazyNeverDestroyed<CSSPrimitiveValue>>, double)

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -450,7 +450,9 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(CSSPropertyID propertyID)
 
 static CSSPrimitiveValue* valueFromPool(Span<LazyNeverDestroyed<CSSPrimitiveValue>> pool, double value)
 {
-    unsigned poolIndex = value;
+    // Casting to a signed integer first since casting a negative floating point value to an unsigned
+    // integer is undefined behavior.
+    unsigned poolIndex = static_cast<unsigned>(static_cast<int>(value));
     double roundTripValue = poolIndex;
     if (!memcmp(&value, &roundTripValue, sizeof(double)) && poolIndex < pool.size())
         return &pool[poolIndex].get();

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -203,9 +203,7 @@ bool StyledElement::setInlineStyleProperty(CSSPropertyID propertyID, CSSProperty
 
 bool StyledElement::setInlineStyleProperty(CSSPropertyID propertyID, double value, CSSUnitType unit, bool important)
 {
-    auto cssValue = CSSPrimitiveValue::create(value, unit);
-    auto& style = ensureMutableInlineStyle();
-    style.setProperty(propertyID, WTFMove(cssValue), important);
+    ensureMutableInlineStyle().setProperty(propertyID, CSSPrimitiveValue::create(value, unit), important);
     inlineStyleChanged();
     return true;
 }


### PR DESCRIPTION
#### fa8dddf7984e4d3f5035805df6dfb6e075287267
<pre>
Fix undefined behavior in valueFromPool(Span&lt;LazyNeverDestroyed&lt;CSSPrimitiveValue&gt;&gt;, double)
<a href="https://bugs.webkit.org/show_bug.cgi?id=253720">https://bugs.webkit.org/show_bug.cgi?id=253720</a>
rdar://106522324

Reviewed by Darin Adler.

Fix undefined behavior in valueFromPool(). This appeared to be the cause of
the crashes we started seeing on production builds yesterday. Alexey P. found
the issue with a UBSan build.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::valueFromPool):
Fix undefined behavior by casting the double to a signed integer because
casting it to an unsigned one. Casting a negative double to an unsigned
integer is UB.

* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::setInlineStyleProperty):
Revert temporary workaround I had landed in 261490@main.

Canonical link: <a href="https://commits.webkit.org/261527@main">https://commits.webkit.org/261527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39b884cf562fb8fd79a24af6eafb1b961b566991

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3701 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120616 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3446 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117699 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104958 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45624 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13509 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/379 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9789 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52381 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8025 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15990 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->