### PR TITLE
Speedup WebExtensionMatchPattern::matchesAllHosts() to avoid makeString().

### DIFF
--- a/Source/WebCore/page/UserContentURLPattern.cpp
+++ b/Source/WebCore/page/UserContentURLPattern.cpp
@@ -151,7 +151,7 @@ UserContentURLPattern::Error UserContentURLPattern::parse(StringView pattern)
 
 String UserContentURLPattern::originalHost() const
 {
-    if (m_matchSubdomains && m_host.isEmpty())
+    if (matchAllHosts())
         return "*"_s;
 
     if (m_matchSubdomains)

--- a/Source/WebCore/page/UserContentURLPattern.h
+++ b/Source/WebCore/page/UserContentURLPattern.h
@@ -66,6 +66,7 @@ public:
     const String& host() const { return m_host; }
     const String& path() const { return m_path; }
 
+    bool matchAllHosts() const { return m_matchSubdomains && m_host.isEmpty(); }
     bool matchSubdomains() const { return m_matchSubdomains; }
 
     // The host with the '*' wildcard, if matchSubdomains is true, otherwise same as host().

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
@@ -300,7 +300,7 @@ NSArray *WebExtensionMatchPattern::expandedStrings() const
 
 bool WebExtensionMatchPattern::matchesAllHosts() const
 {
-    return isValid() && (m_matchesAllURLs || host() == "*"_s);
+    return isValid() && (m_matchesAllURLs || pattern().matchAllHosts());
 }
 
 bool WebExtensionMatchPattern::isValidScheme(String scheme)


### PR DESCRIPTION
#### f112de95435d52c2c4997cb796247c6691ba2c2b
<pre>
Speedup WebExtensionMatchPattern::matchesAllHosts() to avoid makeString().
<a href="https://webkit.org/b/253722">https://webkit.org/b/253722</a>
rdar://106052464

Reviewed by Brian Weinstein.

* Source/WebCore/page/UserContentURLPattern.cpp:
(WebCore::UserContentURLPattern::originalHost const): Use matchAllHosts().
* Source/WebCore/page/UserContentURLPattern.h:
(WebCore::UserContentURLPattern::matchAllHosts const): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm:
(WebKit::WebExtensionMatchPattern::matchesAllHosts const): Use matchAllHosts() instead of host().

Canonical link: <a href="https://commits.webkit.org/261510@main">https://commits.webkit.org/261510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/066d4949cf3023b223420c4da8ca41c64bcf3f1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111941 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/21068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3703 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116003 "Failed to checkout and rebase branch from PR 11370") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22417 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117701 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104961 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/15991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4367 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->