### PR TITLE
Add <functional> to precompiled header set

### DIFF
--- a/Source/WebCore/WebCorePrefix.h
+++ b/Source/WebCore/WebCorePrefix.h
@@ -67,6 +67,7 @@
 #ifdef __cplusplus
 #include <algorithm>
 #include <cstddef>
+#include <functional>
 #include <new>
 #endif
 

--- a/Source/WebKit/WebKit2Prefix.h
+++ b/Source/WebKit/WebKit2Prefix.h
@@ -58,6 +58,7 @@
 
 #ifdef __cplusplus
 #include <algorithm> // needed for exception_defines.h
+#include <functional>
 #endif
 
 #ifdef __OBJC__


### PR DESCRIPTION
#### 1f6f5b1e5d879b8c2c3e41f76bf51325d7586847
<pre>
Add &lt;functional&gt; to precompiled header set
<a href="https://bugs.webkit.org/show_bug.cgi?id=253725">https://bugs.webkit.org/show_bug.cgi?id=253725</a>
&lt;rdar://problem/106562509&gt;

Reviewed by Tim Horton.

One of the most costly headers across the build is boyer_moore_searcher.h, which is
used inside &lt;functional&gt;. The file is included 2499 times, and only changes (sometimes)
when the SDK is updated.

We should precompile it!

Before the proposed change (M1 Pro):
Compilation (10226 times):
  Parsing (frontend):         9479.2 s
  Codegen &amp; opts (backend):   3429.0 s

With the change:
Compilation (10196 times):
  Parsing (frontend):         9312.7 s
  Codegen &amp; opts (backend):   3316.7 s

* Source/WebCore/WebCorePrefix.h:
* Source/WebKit/WebKit2Prefix.h:

Canonical link: <a href="https://commits.webkit.org/261531@main">https://commits.webkit.org/261531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58f9c173b41f62d32279fbdb1610dc5559bf6229

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3712 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3456 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117710 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104969 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45636 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13516 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/389 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9796 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52391 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8028 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/15997 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->