### PR TITLE
Rebaseline editing/mac/attributed-string/ tests following 260447@main

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2402,13 +2402,6 @@ webkit.org/b/245902 [ Debug ] contentfiltering/allow-media-document.html [ Skip 
 
 webkit.org/b/246653 [ Debug ] media/modern-media-controls/media-documents/click-on-video-should-not-pause.html [ Skip ]
 
-# webkit.org/b/252582 5 x editing/mac/attributed-string tests are constant failures
-editing/mac/attributed-string/attributed-string-across-shadow-boundaries-1.html [ Failure ]
-editing/mac/attributed-string/attributed-string-across-shadow-boundaries-2.html [ Failure ]
-editing/mac/attributed-string/attributed-string-across-shadow-boundaries-3.html [ Failure ]
-editing/mac/attributed-string/attributed-string-across-shadow-boundaries-4.html [ Failure ]
-editing/mac/attributed-string/attributed-string-across-shadow-boundaries-5.html [ Failure ]
-
 # CONSOLE MESSAGE output is nondeterministic and varies from run-to-run
 http/tests/security/basic-auth-subresource.html [ Failure Pass ]
 http/tests/security/contentSecurityPolicy/image-with-https-url-allowed-by-csp-img-src-star.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-1-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-1-expected.txt
@@ -24,7 +24,17 @@ Alignment 4
     TighteningForTruncation: YES
     HeaderLevel: 0 LineBreakStrategy 0 PresentationIntents (
 ) ListIntentOrdinal 0 CodeBlockIntentLanguageHint ''
-[hello world WebKit rocks]
+[hello ]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[world]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[ WebKit rocks]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)

--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-2-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-2-expected.txt
@@ -24,7 +24,12 @@ Alignment 4
     TighteningForTruncation: YES
     HeaderLevel: 0 LineBreakStrategy 0 PresentationIntents (
 ) ListIntentOrdinal 0 CodeBlockIntentLanguageHint ''
-[world WebKit rocks]
+[world]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[ WebKit rocks]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)

--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-3-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-3-expected.txt
@@ -24,7 +24,12 @@ Alignment 4
     TighteningForTruncation: YES
     HeaderLevel: 0 LineBreakStrategy 0 PresentationIntents (
 ) ListIntentOrdinal 0 CodeBlockIntentLanguageHint ''
-[world WebKit rocks]
+[world WebKit]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[ rocks]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)

--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-4-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-4-expected.txt
@@ -24,7 +24,12 @@ Alignment 4
     TighteningForTruncation: YES
     HeaderLevel: 0 LineBreakStrategy 0 PresentationIntents (
 ) ListIntentOrdinal 0 CodeBlockIntentLanguageHint ''
-[hello world Web]
+[hello ]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[world Web]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)

--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-5-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-5-expected.txt
@@ -24,7 +24,17 @@ Alignment 4
     TighteningForTruncation: YES
     HeaderLevel: 0 LineBreakStrategy 0 PresentationIntents (
 ) ListIntentOrdinal 0 CodeBlockIntentLanguageHint ''
-[hello world WebKit]
+[hello ]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[world]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[ WebKit]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)

--- a/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/font-weight-expected.txt
+++ b/LayoutTests/platform/mac-wk1/editing/mac/attributed-string/font-weight-expected.txt
@@ -38,7 +38,47 @@ Alignment 4
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)
     NSStrokeWidth: 0
-[ font weight 100 font weight 200 font weight 300 font weight 400 font weight 500 ]
+[ ]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[font weight 100]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[ ]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[font weight 200]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[ ]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[font weight 300]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[ font weight 400 ]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[font weight 500]
+    NSFont: Times-Roman 16.00 pt.
+    NSKern: 0pt
+    NSStrokeColor: #000000 (sRGB)
+    NSStrokeWidth: 0
+[ ]
     NSFont: Times-Roman 16.00 pt.
     NSKern: 0pt
     NSStrokeColor: #000000 (sRGB)


### PR DESCRIPTION
#### ca69c6046133da0f5ce909337c0ccc26c3bd2c4a
<pre>
Rebaseline editing/mac/attributed-string/ tests following 260447@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=252582">https://bugs.webkit.org/show_bug.cgi?id=252582</a>
rdar://105686568

Unreviewed test gardening.

Following 260447@main, `NSAttributedString`s created from web content can
contain additional ranges with unique attributes, due to minor differences in
the used font&apos;s `NSFontVariationAttribute` dictionary. These differences do
not affect rendering.

This is similar to the change made in 260826@main.

* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-1-expected.txt:
* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-2-expected.txt:
* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-3-expected.txt:
* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-4-expected.txt:
* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/attributed-string-across-shadow-boundaries-5-expected.txt:
* LayoutTests/platform/mac-wk1/editing/mac/attributed-string/font-weight-expected.txt:

Canonical link: <a href="https://commits.webkit.org/261521@main">https://commits.webkit.org/261521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30668afea9c54167da68bb93e9b5f3d76cfc6bb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3719 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12232 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117717 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/99820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/104976 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/92892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/52401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/16002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4369 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->