### PR TITLE
[UI-side compositing] Keyboard scroll should not start if a wheel gesture event is in progress

### DIFF
--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll-expected.txt
@@ -1,5 +1,5 @@
+PASS endY >= startY is true
 PASS successfullyParsed is true
 
 TEST COMPLETE
-Successful.
-
+fixed

--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html
@@ -1,46 +1,81 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
-
+<!DOCTYPE html> <!-- webkit-test-runner [ ScrollAnimatorEnabled=true ] -->
 <html>
+    <head>
+    <style>
+        body {
+            height: 10000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+        }
 
-<head>
+        .fixed {
+            position: fixed;
+            top: 0;
+        }
+    </style>
+    <script src="../../../resources/js-test-pre.js"></script>
     <script src="../../../resources/ui-helper.js"></script>
-    <script src="../../../resources/js-test.js"></script>
-    <meta name="viewport" content="initial-scale=1.5, user-scalable=no">
     <script>
-        if (window.testRunner) {
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
-        }
-        
-        async function runTest()
+        var jsTestIsAsync = true;
+
+        async function scrollTest()
         {
+            await UIHelper.renderingUpdate();
+
             await UIHelper.startMonitoringWheelEvents();
-            if (!window.testRunner || !testRunner.runUIScript)
-                return;
+            eventSender.mouseMoveTo(100, 100);
 
-            await UIHelper.rawKeyDown("downArrow");
-            
-            setTimeout(async () => {
-                await UIHelper.rawKeyUp("downArrow");
-                const startingPosition = window.scrollY;
+            // normal scroll
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "began", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
+            await UIHelper.renderingUpdate();
 
-                await UIHelper.mouseWheelScrollAt(0, 0, 0, 0, 0, 0);
+            // momentum scroll
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "begin");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "continue");
+            await UIHelper.renderingUpdate();
 
-                const position = window.scrollY;
-                if (Math.abs(startingPosition - position) < 20)
-                    debug("Successful.");
-                else
-                    debug("Unsuccessful. window.scrollY after wheel event == " + position + "; window.scrollY before wheel event == " + startingPosition);
+            startY = window.scrollY;
 
-                testRunner.notifyDone();
-            }, 100);
+            await UIHelper.rawKeyDown("upArrow");
+            await UIHelper.renderingUpdate();
+
+            await UIHelper.delayFor(100);
+
+            await UIHelper.rawKeyUp("upArrow");
+            await UIHelper.renderingUpdate();
+
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
+            await UIHelper.renderingUpdate();
+
+            endY = window.scrollY;
+            shouldBeTrue('endY >= startY');
+
+            finishJSTest();
         }
+
+        window.addEventListener('load', scrollTest, false);
     </script>
-</head>
-
-<body onload="runTest()">
-    <div style="height: 5000px;">
-    </div>
-</body>
-
+    </head>
+    <body>
+    <div class="fixed">fixed</div>
+    <script src="../../../resources/js-test-post.js"></script>
+    </body>
 </html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1773,7 +1773,6 @@ webkit.org/b/252866 [ Debug ] fast/text/glyph-display-lists/glyph-display-list-c
 [ BigSur+ ] streams/readable-stream-default-controller-error.html [ Pass Crash ]
 [ BigSur+ ] fast/mediastream/mediastreamtrack-video-clone.html [ Pass Failure ]
 [ BigSur+ ] fast/repaint/fixed-move-after-keyboard-scroll.html [ Pass Failure ]
-[ BigSur+ ] fast/scrolling/mac/keyboard-scrolling-with-mouse-scroll.html [ Pass Failure ]
 [ BigSur+ x86_64 ] http/tests/media/hls/track-in-band-hls-metadata-cue-duration.html [ Pass Failure ]
 [ Monterey+ x86_64 ] http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers.html [ Pass Failure ]
 [ Bigsur+ x86_64 ] http/wpt/mediarecorder/pause-recording.html [ Pass Failure ]

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -635,10 +635,13 @@ void ScrollingTree::setUserScrollInProgressForNode(ScrollingNodeID nodeID, bool 
 {
     ASSERT(nodeID);
     Locker locker { m_treeStateLock };
-    if (isScrolling)
+    if (isScrolling) {
         m_treeState.nodesWithActiveUserScrolls.add(nodeID);
-    else
+        scrollingTreeNodeWillStartScroll(nodeID);
+    } else {
         m_treeState.nodesWithActiveUserScrolls.remove(nodeID);
+        scrollingTreeNodeDidEndScroll(nodeID);
+    }
 }
 
 void ScrollingTree::clearNodesWithUserScrollInProgress()

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -138,9 +138,9 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     virtual void scrollingTreeNodeWillStartPanGesture(ScrollingNodeID) { }
+#endif
     virtual void scrollingTreeNodeWillStartScroll(ScrollingNodeID) { }
     virtual void scrollingTreeNodeDidEndScroll(ScrollingNodeID) { }
-#endif
 
     WEBCORE_EXPORT TrackingType eventTrackingTypeForPoint(EventTrackingRegions::EventType, IntPoint);
 

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -202,6 +202,12 @@ bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(ScrollDirection direc
     if (!scroll)
         return false;
 
+    if (m_scrollableArea.isUserScrollInProgress()) {
+        m_scrollTriggeringKeyIsPressed = false;
+        m_scrollableArea.endKeyboardScroll(true);
+        return true;
+    }
+
     if (m_scrollTriggeringKeyIsPressed)
         return false;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -106,6 +106,18 @@ bool RemoteScrollingTree::scrollingTreeNodeRequestsKeyboardScroll(ScrollingNodeI
     return m_scrollingCoordinatorProxy->scrollingTreeNodeRequestsKeyboardScroll(nodeID, request);
 }
 
+void RemoteScrollingTree::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
+{
+    if (m_scrollingCoordinatorProxy)
+        m_scrollingCoordinatorProxy->scrollingTreeNodeWillStartScroll(nodeID);
+}
+
+void RemoteScrollingTree::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
+{
+    if (m_scrollingCoordinatorProxy)
+        m_scrollingCoordinatorProxy->scrollingTreeNodeDidEndScroll(nodeID);
+}
+
 Ref<ScrollingTreeNode> RemoteScrollingTree::createScrollingTreeNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {
     switch (nodeType) {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -58,6 +58,9 @@ public:
     bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
     bool scrollingTreeNodeRequestsKeyboardScroll(WebCore::ScrollingNodeID, const WebCore::RequestedKeyboardScrollData&) override;
 
+    void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
+    void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;
+
     void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical) override;
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea) override;
     void reportSynchronousScrollingReasonsChanged(MonotonicTime, OptionSet<WebCore::SynchronousScrollingReason>) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
@@ -52,18 +52,6 @@ void RemoteScrollingTreeIOS::scrollingTreeNodeWillStartPanGesture(ScrollingNodeI
         m_scrollingCoordinatorProxy->scrollingTreeNodeWillStartPanGesture(nodeID);
 }
 
-void RemoteScrollingTreeIOS::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
-{
-    if (m_scrollingCoordinatorProxy)
-        m_scrollingCoordinatorProxy->scrollingTreeNodeWillStartScroll(nodeID);
-}
-
-void RemoteScrollingTreeIOS::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
-{
-    if (m_scrollingCoordinatorProxy)
-        m_scrollingCoordinatorProxy->scrollingTreeNodeDidEndScroll(nodeID);
-}
-
 Ref<ScrollingTreeNode> RemoteScrollingTreeIOS::createScrollingTreeNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {
     switch (nodeType) {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h
@@ -42,8 +42,6 @@ private:
     Ref<ScrollingTreeNode> createScrollingTreeNode(ScrollingNodeType, ScrollingNodeID) final;
 
     void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) final;
-    void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) final;
-    void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) final;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -47,6 +47,9 @@ private:
     bool scrollingTreeNodeRequestsKeyboardScroll(WebCore::ScrollingNodeID, const WebCore::RequestedKeyboardScrollData&) override;
     void hasNodeWithAnimatedScrollChanged(bool) override;
 
+    void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
+    void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;
+
     void connectStateNodeLayers(WebCore::ScrollingStateTree&, const RemoteLayerTreeHost&) override;
     void establishLayerTreeScrollingRelations(const RemoteLayerTreeHost&) override;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -96,6 +96,18 @@ void RemoteScrollingCoordinatorProxyMac::hasNodeWithAnimatedScrollChanged(bool h
 #endif
 }
 
+void RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
+{
+    m_uiState.addNodeWithActiveUserScroll(nodeID);
+    sendUIStateChangedIfNecessary();
+}
+
+void RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
+{
+    m_uiState.removeNodeWithActiveUserScroll(nodeID);
+    sendUIStateChangedIfNecessary();
+}
+
 void RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers(ScrollingStateTree& stateTree, const RemoteLayerTreeHost& layerTreeHost)
 {
     using PlatformLayerID = GraphicsLayer::PlatformLayerID;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -76,6 +76,9 @@ private:
 
     void startPendingScrollAnimations() WTF_REQUIRES_LOCK(m_treeLock);
 
+    void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
+    void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;
+
     Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) override;
 
     HashMap<WebCore::ScrollingNodeID, WebCore::RequestedScrollData> m_nodesWithPendingScrollAnimations; // Guarded by m_treeLock but used via call chains that can't be annotated.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -70,6 +70,20 @@ void RemoteScrollingTreeMac::displayDidRefresh(PlatformDisplayID)
     serviceScrollAnimations(MonotonicTime::now()); // FIXME: Share timestamp with the rest of the update.
 }
 
+void RemoteScrollingTreeMac::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
+{
+    RunLoop::main().dispatch([this, nodeID] {
+        RemoteScrollingTree::scrollingTreeNodeWillStartScroll(nodeID);
+    });
+}
+
+void RemoteScrollingTreeMac::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
+{
+    RunLoop::main().dispatch([this, nodeID] {
+        RemoteScrollingTree::scrollingTreeNodeDidEndScroll(nodeID);
+    });
+}
+
 Ref<ScrollingTreeNode> RemoteScrollingTreeMac::createScrollingTreeNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {
     switch (nodeType) {


### PR DESCRIPTION
#### f72d588a05aa866762a1cf414496ad92a57f1237
<pre>
[UI-side compositing] Keyboard scroll should not start if a wheel gesture event is in progress
<a href="https://bugs.webkit.org/show_bug.cgi?id=253726">https://bugs.webkit.org/show_bug.cgi?id=253726</a>
rdar://106563114

Reviewed by Simon Fraser.

Wheel event scrolls should always take precedence over keyboard scrolls. Without UI Side Compositing,
this currently works by stopping any keyboard scrolls whenever any wheel event is received. For
keyboard scrolling with UI Side Compositing enabled, this is not an ideal mechanism. Instead, a
keyboard scroll should never begin in the first place if a wheel event gesture scroll is in progress.

There already exists ways to know if a wheel event gesture scroll is in progress on iOS, so this PR
just brings the same logic to macOS. Then, when a keyboard scroll is about to begin, it bails out
if there is a wheel event gesture scroll in progress.

This PR also improves and fixes the flakyness of the existing layout test which tests this
functionality, and makes it work when UI-side compositing is enabled or disabled.

* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::beginKeyboardScrollGesture):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeWillStartScroll):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidEndScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeWillStartScroll): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidEndScroll): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::scrollingTreeNodeWillStartScroll):
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidEndScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillStartScroll): Deleted.
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeDidEndScroll): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp:
(WebKit::RemoteScrollingTreeIOS::scrollingTreeNodeWillStartScroll): Deleted.
(WebKit::RemoteScrollingTreeIOS::scrollingTreeNodeDidEndScroll): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::handleWheelEventPhase):

Canonical link: <a href="https://commits.webkit.org/261581@main">https://commits.webkit.org/261581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f0ec39b035851c6ff06223bfb8c2750a00b8d53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3830 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120704 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3638 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45723 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13598 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/476 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14274 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52475 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8074 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16067 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->