### PR TITLE
[JSC] Add signExtend8To64 / signExtend16To64

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -1862,6 +1862,16 @@ public:
         m_assembler.sxth<32>(dest, src);
     }
 
+    void zeroExtend16To64(RegisterID src, RegisterID dest)
+    {
+        m_assembler.uxth<64>(dest, src);
+    }
+
+    void signExtend16To64(RegisterID src, RegisterID dest)
+    {
+        m_assembler.sxth<64>(dest, src);
+    }
+
     void load8(Address address, RegisterID dest)
     {
         if (tryLoadWithOffset<8>(dest, address.base, address.offset))
@@ -1937,6 +1947,16 @@ public:
     void signExtend8To32(RegisterID src, RegisterID dest)
     {
         m_assembler.sxtb<32>(dest, src);
+    }
+
+    void zeroExtend8To64(RegisterID src, RegisterID dest)
+    {
+        m_assembler.uxtb<64>(dest, src);
+    }
+
+    void signExtend8To64(RegisterID src, RegisterID dest)
+    {
+        m_assembler.sxtb<64>(dest, src);
     }
 
     void store64(RegisterID src, Address address)
@@ -3193,14 +3213,24 @@ public:
         moveDouble(fpTempRegister, reg2);
     }
 
-    void signExtend32ToPtr(TrustedImm32 imm, RegisterID dest)
+    void signExtend32To64(TrustedImm32 imm, RegisterID dest)
     {
         move(TrustedImm64(imm.m_value), dest);
     }
 
-    void signExtend32ToPtr(RegisterID src, RegisterID dest)
+    void signExtend32To64(RegisterID src, RegisterID dest)
     {
         m_assembler.sxtw(dest, src);
+    }
+
+    void signExtend32ToPtr(TrustedImm32 imm, RegisterID dest)
+    {
+        signExtend32To64(imm, dest);
+    }
+
+    void signExtend32ToPtr(RegisterID src, RegisterID dest)
+    {
+        signExtend32To64(src, dest);
     }
 
     void zeroExtend32ToWord(RegisterID src, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -1279,12 +1279,44 @@ public:
         m_assembler.srliInsn<32>(dest, dest);
     }
 
+    void zeroExtend8To64(RegisterID src, RegisterID dest)
+    {
+        zeroExtend8To32(src, dest);
+    }
+
+    void zeroExtend16To64(RegisterID src, RegisterID dest)
+    {
+        zeroExtend16To32(src, dest);
+    }
+
+    void signExtend8To64(RegisterID src, RegisterID dest)
+    {
+        signExtend8To32(src, dest);
+        signExtend32To64(dest, dest);
+    }
+
+    void signExtend16To64(RegisterID src, RegisterID dest)
+    {
+        signExtend16To32(src, dest);
+        signExtend32To64(dest, dest);
+    }
+
     void signExtend32ToPtr(RegisterID src, RegisterID dest)
+    {
+        signExtend32To64(src, dest);
+    }
+
+    void signExtend32ToPtr(TrustedImm32 imm, RegisterID dest)
+    {
+        signExtend32To64(imm, dest);
+    }
+
+    void signExtend32To64(RegisterID src, RegisterID dest)
     {
         m_assembler.addiwInsn(dest, src, Imm::I<0>());
     }
 
-    void signExtend32ToPtr(TrustedImm32 imm, RegisterID dest)
+    void signExtend32To64(TrustedImm32 imm, RegisterID dest)
     {
         loadImmediate(imm, dest);
     }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -2573,7 +2573,7 @@ public:
         moveDouble(FPRegisterID::xmm7, reg2);
     }
 
-    void signExtend32ToPtr(TrustedImm32 imm, RegisterID dest)
+    void signExtend32To64(TrustedImm32 imm, RegisterID dest)
     {
         if (!imm.m_value)
             m_assembler.xorq_rr(dest, dest);
@@ -2581,9 +2581,19 @@ public:
             m_assembler.mov_i32r(imm.m_value, dest);
     }
 
-    void signExtend32ToPtr(RegisterID src, RegisterID dest)
+    void signExtend32To64(RegisterID src, RegisterID dest)
     {
         m_assembler.movsxd_rr(src, dest);
+    }
+
+    void signExtend32ToPtr(RegisterID src, RegisterID dest)
+    {
+        signExtend32To64(src, dest);
+    }
+
+    void signExtend32ToPtr(TrustedImm32 imm, RegisterID dest)
+    {
+        signExtend32To64(imm, dest);
     }
 
     void zeroExtend32ToWord(RegisterID src, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -1062,6 +1062,26 @@ public:
         m_assembler.notq_m(dest.offset, dest.base, dest.index, dest.scale);
     }
 
+    void zeroExtend8To64(RegisterID src, RegisterID dest)
+    {
+        zeroExtend8To32(src, dest);
+    }
+
+    void signExtend8To64(RegisterID src, RegisterID dest)
+    {
+        m_assembler.movsbq_rr(src, dest);
+    }
+
+    void zeroExtend16To64(RegisterID src, RegisterID dest)
+    {
+        zeroExtend16To32(src, dest);
+    }
+
+    void signExtend16To64(RegisterID src, RegisterID dest)
+    {
+        m_assembler.movswq_rr(src, dest);
+    }
+
     void load64(Address address, RegisterID dest)
     {
         m_assembler.movq_mr(address.offset, address.base, dest);

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -3359,6 +3359,11 @@ public:
         m_formatter.twoByteOp8(OP2_MOVSX_GvEb, dst, src);
     }
 
+    void movsbq_rr(RegisterID src, RegisterID dst)
+    {
+        m_formatter.twoByteOp64(OP2_MOVSX_GvEb, dst, src);
+    }
+
     void movzwl_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.twoByteOp8(OP2_MOVZX_GvEw, dst, src);
@@ -3367,6 +3372,11 @@ public:
     void movswl_rr(RegisterID src, RegisterID dst)
     {
         m_formatter.twoByteOp8(OP2_MOVSX_GvEw, dst, src);
+    }
+
+    void movswq_rr(RegisterID src, RegisterID dst)
+    {
+        m_formatter.twoByteOp64(OP2_MOVSX_GvEw, dst, src);
     }
 
     void cmovl_rr(Condition cond, RegisterID src, RegisterID dst)

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4232,16 +4232,23 @@ private:
             return;
         }
 
+        case SExt8To64: {
+            appendUnOp<SignExtend8To64, Air::Oops>(m_value->child(0));
+            return;
+        }
+
+        case SExt16To64: {
+            appendUnOp<SignExtend16To64, Air::Oops>(m_value->child(0));
+            return;
+        }
+
         case ZExt32: {
             appendUnOp<Move32, Air::Oops>(m_value->child(0));
             return;
         }
 
         case SExt32: {
-            // FIXME: We should have support for movsbq/movswq
-            // https://bugs.webkit.org/show_bug.cgi?id=152232
-            
-            appendUnOp<SignExtend32ToPtr, Air::Oops>(m_value->child(0));
+            appendUnOp<SignExtend32To64, Air::Oops>(m_value->child(0));
             return;
         }
 

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -219,6 +219,12 @@ void printInternal(PrintStream& out, Opcode opcode)
     case SExt16:
         out.print("SExt16");
         return;
+    case SExt8To64:
+        out.print("SExt8To64");
+        return;
+    case SExt16To64:
+        out.print("SExt16To64");
+        return;
     case SExt32:
         out.print("SExt32");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -122,6 +122,8 @@ enum Opcode : uint8_t {
     SExt8,
     SExt16,
     // Takes Int32 and returns Int64:
+    SExt8To64,
+    SExt16To64,
     SExt32,
     ZExt32,
     // Does a bitwise truncation of Int64->Int32 and Double->Float:

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -277,6 +277,8 @@ public:
                 VALIDATE(value->child(0)->type() == Int32, ("At ", *value));
                 VALIDATE(value->type() == Int32, ("At ", *value));
                 break;
+            case SExt8To64:
+            case SExt16To64:
             case SExt32:
             case ZExt32:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -638,6 +638,8 @@ Effects Value::effects() const
     case BitwiseCast:
     case SExt8:
     case SExt16:
+    case SExt8To64:
+    case SExt16To64:
     case SExt32:
     case ZExt32:
     case Trunc:
@@ -839,6 +841,8 @@ ValueKey Value::key() const
     case Sqrt:
     case SExt8:
     case SExt16:
+    case SExt8To64:
+    case SExt16To64:
     case SExt32:
     case ZExt32:
     case Clz:
@@ -1070,6 +1074,8 @@ Type Value::typeFor(Kind kind, Value* firstChild, Value* secondChild)
         return Int32;
     case Trunc:
         return firstChild->type() == Int64 ? Int32 : Float;
+    case SExt8To64:
+    case SExt16To64:
     case SExt32:
     case ZExt32:
         return Int64;

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -424,6 +424,8 @@ protected:
         case SExt8:
         case SExt16:
         case Trunc:
+        case SExt8To64:
+        case SExt16To64:
         case SExt32:
         case ZExt32:
         case FloatToDouble:
@@ -657,6 +659,8 @@ private:
         case SExt8:
         case SExt16:
         case Trunc:
+        case SExt8To64:
+        case SExt16To64:
         case SExt32:
         case ZExt32:
         case FloatToDouble:

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -75,6 +75,8 @@ namespace JSC { namespace B3 {
     case SExt8: \
     case SExt16: \
     case Trunc: \
+    case SExt8To64: \
+    case SExt16To64: \
     case SExt32: \
     case ZExt32: \
     case FloatToDouble: \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -72,6 +72,8 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case Depend:
     case SExt8:
     case SExt16:
+    case SExt8To64:
+    case SExt16To64:
     case SExt32:
     case ZExt32:
     case Clz:

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -723,7 +723,13 @@ arm64: Store64 U:G:64, D:G:64
     ZeroReg, Addr
     ZeroReg, Index
 
-SignExtend32ToPtr U:G:32, D:G:Ptr
+64: SignExtend8To64 U:G:8, D:G:64
+    Tmp, Tmp
+
+64: SignExtend16To64 U:G:16, D:G:64
+    Tmp, Tmp
+
+64: SignExtend32To64 U:G:32, D:G:64
     Tmp, Tmp
 
 ZeroExtend8To32 U:G:8, ZD:G:32

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -581,6 +581,11 @@ public:
     PartialResult WARN_UNUSED_RETURN addI64Eqz(ExpressionType arg0, ExpressionType& result);
     PartialResult WARN_UNUSED_RETURN addI64Or(ExpressionType arg0, ExpressionType arg1, ExpressionType& result);
 
+    PartialResult WARN_UNUSED_RETURN addI64ExtendSI32(ExpressionType, ExpressionType&);
+    PartialResult WARN_UNUSED_RETURN addI64Extend8S(ExpressionType, ExpressionType&);
+    PartialResult WARN_UNUSED_RETURN addI64Extend16S(ExpressionType, ExpressionType&);
+    PartialResult WARN_UNUSED_RETURN addI64Extend32S(ExpressionType, ExpressionType&);
+
     Tmp emitCatchImpl(CatchKind, ControlType&, unsigned exceptionIndex = 0);
     template <size_t inlineCapacity>
     Box<PatchpointExceptionHandle> preparePatchpointForExceptions(B3::PatchpointValue*, Vector<ConstrainedTmp, inlineCapacity>& args);
@@ -1073,7 +1078,7 @@ inline TypedTmp AirIRGenerator64::emitLoadOp(LoadOpType op, ExpressionType point
     case LoadOpType::I64Load8S: {
         result = g64();
         appendEffectful(Load8SignedExtendTo32, addrArg, result);
-        append(SignExtend32ToPtr, result, result);
+        append(SignExtend32To64, result, result);
         break;
     }
 
@@ -1098,7 +1103,7 @@ inline TypedTmp AirIRGenerator64::emitLoadOp(LoadOpType op, ExpressionType point
     case LoadOpType::I64Load16S: {
         result = g64();
         appendEffectful(Load16SignedExtendTo32, addrArg, result);
-        append(SignExtend32ToPtr, result, result);
+        append(SignExtend32To64, result, result);
         break;
     }
 
@@ -1128,7 +1133,7 @@ inline TypedTmp AirIRGenerator64::emitLoadOp(LoadOpType op, ExpressionType point
     case LoadOpType::I64Load32S: {
         result = g64();
         appendEffectful(Move32, addrArg, result);
-        append(SignExtend32ToPtr, result, result);
+        append(SignExtend32To64, result, result);
         break;
     }
 
@@ -2626,6 +2631,34 @@ auto AirIRGenerator64::addI64Or(ExpressionType arg0, ExpressionType arg1, Expres
 {
     result = g64();
     append(Or64, arg0, arg1, result);
+    return { };
+}
+
+auto AirIRGenerator64::addI64ExtendSI32(ExpressionType arg0, ExpressionType& result) -> PartialResult
+{
+    result = g64();
+    append(SignExtend32To64, arg0, result);
+    return { };
+}
+
+auto AirIRGenerator64::addI64Extend8S(ExpressionType arg0, ExpressionType& result) -> PartialResult
+{
+    result = g64();
+    append(SignExtend8To64, arg0, result);
+    return { };
+}
+
+auto AirIRGenerator64::addI64Extend16S(ExpressionType arg0, ExpressionType& result) -> PartialResult
+{
+    result = g64();
+    append(SignExtend16To64, arg0, result);
+    return { };
+}
+
+auto AirIRGenerator64::addI64Extend32S(ExpressionType arg0, ExpressionType& result) -> PartialResult
+{
+    result = g64();
+    append(SignExtend32To64, arg0, result);
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -4789,14 +4789,6 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addI32GtU(ExpressionType arg0,
 }
 
 template<typename Derived, typename ExpressionType>
-auto AirIRGeneratorBase<Derived, ExpressionType>::addI64ExtendSI32(ExpressionType arg0, ExpressionType& result) -> PartialResult
-{
-    result = self().g64();
-    append(SignExtend32ToPtr, arg0, result);
-    return { };
-}
-
-template<typename Derived, typename ExpressionType>
 auto AirIRGeneratorBase<Derived, ExpressionType>::addI32Extend8S(ExpressionType arg0, ExpressionType& result) -> PartialResult
 {
     result = self().g32();
@@ -4809,38 +4801,6 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addI32Extend16S(ExpressionType
 {
     result = self().g32();
     append(SignExtend16To32, arg0, result);
-    return { };
-}
-
-template<typename Derived, typename ExpressionType>
-auto AirIRGeneratorBase<Derived, ExpressionType>::addI64Extend8S(ExpressionType arg0, ExpressionType& result) -> PartialResult
-{
-    result = self().g64();
-    auto temp = self().g32();
-    append(Move32, arg0, temp);
-    append(SignExtend8To32, temp, temp);
-    append(SignExtend32ToPtr, temp, result);
-    return { };
-}
-
-template<typename Derived, typename ExpressionType>
-auto AirIRGeneratorBase<Derived, ExpressionType>::addI64Extend16S(ExpressionType arg0, ExpressionType& result) -> PartialResult
-{
-    result = self().g64();
-    auto temp = self().g32();
-    append(Move32, arg0, temp);
-    append(SignExtend16To32, temp, temp);
-    append(SignExtend32ToPtr, temp, result);
-    return { };
-}
-
-template<typename Derived, typename ExpressionType>
-auto AirIRGeneratorBase<Derived, ExpressionType>::addI64Extend32S(ExpressionType arg0, ExpressionType& result) -> PartialResult
-{
-    result = self().g64();
-    auto temp = self().g32();
-    append(Move32, arg0, temp);
-    append(SignExtend32ToPtr, temp, result);
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -2033,7 +2033,7 @@ public:
                     break;
                 case LoadOpType::I64Load8S:
                     m_jit.load8SignedExtendTo32(location, resultLocation.asGPR());
-                    m_jit.signExtend32ToPtr(resultLocation.asGPR(), resultLocation.asGPR());
+                    m_jit.signExtend32To64(resultLocation.asGPR(), resultLocation.asGPR());
                     break;
                 case LoadOpType::I32Load8U:
                     m_jit.load8(location, resultLocation.asGPR());
@@ -2046,7 +2046,7 @@ public:
                     break;
                 case LoadOpType::I64Load16S:
                     m_jit.load16SignedExtendTo32(location, resultLocation.asGPR());
-                    m_jit.signExtend32ToPtr(resultLocation.asGPR(), resultLocation.asGPR());
+                    m_jit.signExtend32To64(resultLocation.asGPR(), resultLocation.asGPR());
                     break;
                 case LoadOpType::I32Load16U:
                     m_jit.load16(location, resultLocation.asGPR());
@@ -2062,7 +2062,7 @@ public:
                     break;
                 case LoadOpType::I64Load32S:
                     m_jit.load32(location, resultLocation.asGPR());
-                    m_jit.signExtend32ToPtr(resultLocation.asGPR(), resultLocation.asGPR());
+                    m_jit.signExtend32To64(resultLocation.asGPR(), resultLocation.asGPR());
                     break;
                 case LoadOpType::I64Load:
                     m_jit.load64(location, resultLocation.asGPR());
@@ -5313,8 +5313,7 @@ public:
             "I64Extend8S", TypeKind::I64,
             BLOCK(Value::fromI64(static_cast<int64_t>(static_cast<int8_t>(operand.asI64())))),
             BLOCK(
-                m_jit.signExtend8To32(operandLocation.asGPR(), resultLocation.asGPR());
-                m_jit.signExtend32ToPtr(resultLocation.asGPR(), resultLocation.asGPR());
+                m_jit.signExtend8To64(operandLocation.asGPR(), resultLocation.asGPR());
             )
         )
     }
@@ -5325,8 +5324,7 @@ public:
             "I64Extend16S", TypeKind::I64,
             BLOCK(Value::fromI64(static_cast<int64_t>(static_cast<int16_t>(operand.asI64())))),
             BLOCK(
-                m_jit.signExtend16To32(operandLocation.asGPR(), resultLocation.asGPR());
-                m_jit.signExtend32ToPtr(resultLocation.asGPR(), resultLocation.asGPR());
+                m_jit.signExtend16To64(operandLocation.asGPR(), resultLocation.asGPR());
             )
         )
     }
@@ -5337,7 +5335,7 @@ public:
             "I64Extend32S", TypeKind::I64,
             BLOCK(Value::fromI64(static_cast<int64_t>(static_cast<int32_t>(operand.asI64())))),
             BLOCK(
-                m_jit.signExtend32ToPtr(operandLocation.asGPR(), resultLocation.asGPR());
+                m_jit.signExtend32To64(operandLocation.asGPR(), resultLocation.asGPR());
             )
         )
     }
@@ -5348,7 +5346,7 @@ public:
             "I64ExtendSI32", TypeKind::I64,
             BLOCK(Value::fromI64(static_cast<int64_t>(operand.asI32()))),
             BLOCK(
-                m_jit.signExtend32ToPtr(operandLocation.asGPR(), resultLocation.asGPR());
+                m_jit.signExtend32To64(operandLocation.asGPR(), resultLocation.asGPR());
             )
         )
     }


### PR DESCRIPTION
#### 1fac7761b9cd74db4ab8e3592ebe3ef068b0d351
<pre>
[JSC] Add signExtend8To64 / signExtend16To64
<a href="https://bugs.webkit.org/show_bug.cgi?id=152232">https://bugs.webkit.org/show_bug.cgi?id=152232</a>
rdar://106574794

Reviewed by Mark Lam.

This patch adds signExtend8To64 and signExtend16To64. We add corresponding handling in
B3 / Air so that we can use it for wasm operations. Previously we are using two instructions
signExtend8To32 and signExtend32To64. But now we can do it in one instruction.
We also use signExtend32To64 instead of signExtend32ToPtr when necessary to make it explicit
that this is 64bit extension.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::zeroExtend16To64):
(JSC::MacroAssemblerARM64::signExtend16To64):
(JSC::MacroAssemblerARM64::zeroExtend8To64):
(JSC::MacroAssemblerARM64::signExtend8To64):
(JSC::MacroAssemblerARM64::signExtend32To64):
(JSC::MacroAssemblerARM64::signExtend32ToPtr):
* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h:
(JSC::MacroAssemblerRISCV64::zeroExtend8To64):
(JSC::MacroAssemblerRISCV64::zeroExtend16To64):
(JSC::MacroAssemblerRISCV64::signExtend8To64):
(JSC::MacroAssemblerRISCV64::signExtend16To64):
(JSC::MacroAssemblerRISCV64::signExtend32ToPtr):
(JSC::MacroAssemblerRISCV64::signExtend32To64):
* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::signExtend32To64):
(JSC::MacroAssemblerX86Common::signExtend32ToPtr):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::zeroExtend8To64):
(JSC::MacroAssemblerX86_64::signExtend8To64):
(JSC::MacroAssemblerX86_64::zeroExtend16To64):
(JSC::MacroAssemblerX86_64::signExtend16To64):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::movsbq_rr):
(JSC::X86Assembler::movswq_rr):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
(JSC::B3::Value::typeFor):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::emitLoadOp):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::addI64ExtendSI32):
(JSC::Wasm::ExpressionType&gt;::addI64Extend8S):
(JSC::Wasm::ExpressionType&gt;::addI64Extend16S):
(JSC::Wasm::ExpressionType&gt;::addI64Extend32S):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitLoadOp):
(JSC::Wasm::BBQJIT::addI64Extend8S):
(JSC::Wasm::BBQJIT::addI64Extend16S):
(JSC::Wasm::BBQJIT::addI64Extend32S):
(JSC::Wasm::BBQJIT::addI64ExtendSI32):

Canonical link: <a href="https://commits.webkit.org/261660@main">https://commits.webkit.org/261660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/090a4824f866c78171cffa33daaf6ad2308a2401

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4250 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12773 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118238 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105527 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/100797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13968 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12071 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102248 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52835 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31939 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16481 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110287 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4447 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27242 "Passed tests") | 
<!--EWS-Status-Bubble-End-->