### PR TITLE
[UI-side compositing] Lock CALayer tree for scrolling thread hit-testing

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -121,6 +121,9 @@ public:
     virtual void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) { }
     virtual void hasNodeWithAnimatedScrollChanged(bool) { }
     virtual void setRootNodeIsInUserScroll(bool) { }
+    
+    virtual void willCommitLayerAndScrollingTrees() { }
+    virtual void didCommitLayerAndScrollingTrees() { }
 
     String scrollingTreeAsText() const;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -75,6 +75,23 @@ protected:
     WeakPtr<RemoteScrollingCoordinatorProxy> m_scrollingCoordinatorProxy;
 };
 
+class RemoteLayerTreeHitTestLocker {
+public:
+    RemoteLayerTreeHitTestLocker(RemoteScrollingTree& scrollingTree)
+        : m_scrollingTree(scrollingTree)
+    {
+        m_scrollingTree->lockLayersForHitTesting();
+    }
+    
+    ~RemoteLayerTreeHitTestLocker()
+    {
+        m_scrollingTree->unlockLayersForHitTesting();
+    }
+
+private:
+    Ref<RemoteScrollingTree> m_scrollingTree;
+};
+
 } // namespace WebKit
 
 SPECIALIZE_TYPE_TRAITS_SCROLLING_TREE(WebKit::RemoteScrollingTree, isRemoteScrollingTree());

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -199,6 +199,8 @@ OptionSet<WheelEventProcessingSteps> RemoteLayerTreeEventDispatcher::determineWh
     if (!scrollingTree)
         return { };
 
+    auto locker = RemoteLayerTreeHitTestLocker { *scrollingTree };
+
     // Replicate the hack in EventDispatcher::internalWheelEvent(). We could pass rubberBandableEdges all the way through the
     // WebProcess and back via the ScrollingTree, but we only ever need to consult it here.
     if (wheelEvent.phase() == PlatformWheelEventPhase::Began)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -53,6 +53,9 @@ private:
     void displayDidRefresh(WebCore::PlatformDisplayID) override;
     void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) override;
 
+    void willCommitLayerAndScrollingTrees() override;
+    void didCommitLayerAndScrollingTrees() override;
+
 #if ENABLE(SCROLLING_THREAD)
     RefPtr<RemoteLayerTreeEventDispatcher> m_wheelEventDispatcher;
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -184,6 +184,16 @@ void RemoteScrollingCoordinatorProxyMac::windowScreenDidChange(PlatformDisplayID
 #endif
 }
 
+void RemoteScrollingCoordinatorProxyMac::willCommitLayerAndScrollingTrees()
+{
+    scrollingTree()->lockLayersForHitTesting();
+}
+
+void RemoteScrollingCoordinatorProxyMac::didCommitLayerAndScrollingTrees()
+{
+    scrollingTree()->unlockLayersForHitTesting();
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -70,13 +70,18 @@ private:
 
     void hasNodeWithAnimatedScrollChanged(bool) override;
     void displayDidRefresh(WebCore::PlatformDisplayID) override;
-    
+
+    void lockLayersForHitTesting() final WTF_ACQUIRES_LOCK(m_layerHitTestMutex);
+    void unlockLayersForHitTesting() final WTF_RELEASES_LOCK(m_layerHitTestMutex);
+
     void startPendingScrollAnimations() WTF_REQUIRES_LOCK(m_treeLock);
 
     Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) override;
 
     HashMap<WebCore::ScrollingNodeID, WebCore::RequestedScrollData> m_nodesWithPendingScrollAnimations; // Guarded by m_treeLock but used via call chains that can't be annotated.
     HashMap<WebCore::ScrollingNodeID, WebCore::RequestedKeyboardScrollData> m_nodesWithPendingKeyboardScrollAnimations; // Guarded by m_treeLock but used via call chains that can't be annotated.
+
+    mutable Lock m_layerHitTestMutex;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -250,6 +250,16 @@ void RemoteScrollingTreeMac::removeWheelEventTestCompletionDeferralForReason(Scr
     });
 }
 
+void RemoteScrollingTreeMac::lockLayersForHitTesting()
+{
+    m_layerHitTestMutex.lock();
+}
+
+void RemoteScrollingTreeMac::unlockLayersForHitTesting()
+{
+    m_layerHitTestMutex.unlock();
+}
+
 static ScrollingNodeID scrollingNodeIDForLayer(CALayer *layer)
 {
     auto* layerTreeNode = RemoteLayerTreeNode::forCALayer(layer);
@@ -309,6 +319,8 @@ RefPtr<ScrollingTreeNode> RemoteScrollingTreeMac::scrollingNodeForPoint(FloatPoi
     if (!rootScrollingNode)
         return nullptr;
 
+    ASSERT(m_layerHitTestMutex.isLocked());
+
     RetainPtr scrolledContentsLayer { static_cast<CALayer*>(rootScrollingNode->scrolledContentsLayer()) };
 
     auto rootContentsLayerPosition = FrameView::positionForRootContentLayer(rootScrollingNode->currentScrollPosition(), rootScrollingNode->scrollOrigin(), rootScrollingNode->topContentInset(), rootScrollingNode->headerHeight());
@@ -350,6 +362,8 @@ OptionSet<EventListenerRegionType> RemoteScrollingTreeMac::eventListenerRegionTy
     auto* rootScrollingNode = rootNode();
     if (!rootScrollingNode)
         return { };
+
+    ASSERT(m_layerHitTestMutex.isLocked());
 
     auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeMac*>(rootScrollingNode)->rootContentsLayer();
 


### PR DESCRIPTION
#### 373d0328adcf7b2d3cdde3e8af721be38f8341e7
<pre>
[UI-side compositing] Lock CALayer tree for scrolling thread hit-testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=253011">https://bugs.webkit.org/show_bug.cgi?id=253011</a>
rdar://105987016

Reviewed by Tim Horton.

Off-main-thread scrolling in the UI process on macOS traverses the layer tree
to find scrolling tree nodes, and consult event regions. If this tree is being
mutated on the main thread at the same time, we can crash.

So lock around the layer tree commit on the main thread in RemoteLayerTreeDrawingAreaProxy::commitLayerTree(),
and in RemoteLayerTreeEventDispatcher::determineWheelEventProcessing() on the scrolling thread, using
a lock owned by RemoteScrollingTreeMac.

This is similar to what ThreadedScrollingTree does with web process scrolling.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::willCommitLayerAndScrollingTrees):
(WebKit::RemoteScrollingCoordinatorProxy::didCommitLayerAndScrollingTrees):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
(WebKit::RemoteLayerTreeHitTestLocker::RemoteLayerTreeHitTestLocker):
(WebKit::RemoteLayerTreeHitTestLocker::~RemoteLayerTreeHitTestLocker):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::determineWheelEventProcessing):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::willCommitLayerAndScrollingTrees):
(WebKit::RemoteScrollingCoordinatorProxyMac::didCommitLayerAndScrollingTrees):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::lockLayersForHitTesting):
(WebKit::RemoteScrollingTreeMac::unlockLayersForHitTesting):
(WebKit::RemoteScrollingTreeMac::scrollingNodeForPoint):
(WebKit::RemoteScrollingTreeMac::eventListenerRegionTypesForPoint const):

Canonical link: <a href="https://commits.webkit.org/261543@main">https://commits.webkit.org/261543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efaf0cf524a298e9fc8b99fb23c77a7c1a95e3ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/111999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120651 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3510 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105017 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45670 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13547 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/425 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/9832 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52436 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8043 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16029 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->