### PR TITLE
SIMD test gardening

### DIFF
--- a/JSTests/wasm/stress/big-try-simd.js
+++ b/JSTests/wasm/stress/big-try-simd.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/big-try.js
+++ b/JSTests/wasm/stress/big-try.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/big-tuple-args.js
+++ b/JSTests/wasm/stress/big-tuple-args.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/big-tuple.js
+++ b/JSTests/wasm/stress/big-tuple.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-big-tuple.js
+++ b/JSTests/wasm/stress/simd-big-tuple.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const-spill.js
+++ b/JSTests/wasm/stress/simd-const-spill.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-const.js
+++ b/JSTests/wasm/stress/simd-const.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-exception-throwing-v128-clobbers-fp.js
+++ b/JSTests/wasm/stress/simd-exception-throwing-v128-clobbers-fp.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 var wasm_code = read('./simd-exception-throwing-v128-clobbers-fp.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);
 var wasm_instance = new WebAssembly.Instance(wasm_module);

--- a/JSTests/wasm/stress/simd-exception.js
+++ b/JSTests/wasm/stress/simd-exception.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-global-get.js
+++ b/JSTests/wasm/stress/simd-global-get.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-global-set.js
+++ b/JSTests/wasm/stress/simd-global-set.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-import-global-2.js
+++ b/JSTests/wasm/stress/simd-import-global-2.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-kitchen-sink.js
+++ b/JSTests/wasm/stress/simd-kitchen-sink.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-load.js
+++ b/JSTests/wasm/stress/simd-load.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 
@@ -19,7 +19,7 @@ let wat = `
 
         (v128.load (i32.const 0))
         (i8x16.extract_lane_u 1)
-        
+
         (return)
     )
 
@@ -27,7 +27,7 @@ let wat = `
         (v128.store (i32.const 0) (v128.const i64x2 0xABCD 0xEFBD))
 
         (i64.load (i32.const 8))
-        
+
         (return)
     )
 )

--- a/JSTests/wasm/stress/simd-osr-many-vectors.js
+++ b/JSTests/wasm/stress/simd-osr-many-vectors.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1", "--useConcurrentJIT=0")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-osr.js
+++ b/JSTests/wasm/stress/simd-osr.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1", "--useConcurrentJIT=0")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-register-allocation.js
+++ b/JSTests/wasm/stress/simd-register-allocation.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-regress.js
+++ b/JSTests/wasm/stress/simd-regress.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-return-value-alignment.js
+++ b/JSTests/wasm/stress/simd-return-value-alignment.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 
 /*
 (module

--- a/JSTests/wasm/stress/simd-shuffle.js
+++ b/JSTests/wasm/stress/simd-shuffle.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-tail-calls-throw.js
+++ b/JSTests/wasm/stress/simd-tail-calls-throw.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1","--useWebAssemblyTailCalls=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-tiny-loop.js
+++ b/JSTests/wasm/stress/simd-tiny-loop.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1", "--watchdog=1000", "--watchdog-exception-ok")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 //@ skip
 //FIXME: this test is currently broken.
 import { instantiate } from "../wabt-wrapper.js"

--- a/JSTests/wasm/stress/simd-unreachable.js
+++ b/JSTests/wasm/stress/simd-unreachable.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--webAssemblyBBQAirModeThreshold=0", "--wasmBBQUsesAir=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tag-return.js
+++ b/JSTests/wasm/stress/tag-return.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1")
-//@ skip if $architecture != "arm64" && $architecture != "x86_64"
+//@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/throw-from-wasm-catch-in-baseline-JIT.js
+++ b/JSTests/wasm/stress/throw-from-wasm-catch-in-baseline-JIT.js
@@ -1,3 +1,4 @@
+//@ skip if !$isWasmPlatform
 //@ runNoisyTestDefault("--traceBaselineJITExecution=1", "--jitPolicyScale=0")
 
 let x = readFile('throw-from-wasm-catch-in-baseline-JIT-payload.bin', 'binary');


### PR DESCRIPTION
#### 3d9ae3d7ebd2448980e09d9ab8b497a16d0613c4
<pre>
SIMD test gardening
<a href="https://bugs.webkit.org/show_bug.cgi?id=253737">https://bugs.webkit.org/show_bug.cgi?id=253737</a>
rdar://106576973

Unreviewed test gardening.

* JSTests/wasm/stress/big-try-simd.js:
* JSTests/wasm/stress/big-try.js:
* JSTests/wasm/stress/big-tuple-args.js:
* JSTests/wasm/stress/big-tuple.js:
* JSTests/wasm/stress/simd-big-tuple.js:
* JSTests/wasm/stress/simd-const-spill.js:
* JSTests/wasm/stress/simd-const.js:
* JSTests/wasm/stress/simd-exception-throwing-v128-clobbers-fp.js:
* JSTests/wasm/stress/simd-exception.js:
* JSTests/wasm/stress/simd-global-get.js:
* JSTests/wasm/stress/simd-global-set.js:
* JSTests/wasm/stress/simd-import-global-2.js:
* JSTests/wasm/stress/simd-kitchen-sink.js:
* JSTests/wasm/stress/simd-load.js:
* JSTests/wasm/stress/simd-osr-many-vectors.js:
* JSTests/wasm/stress/simd-osr.js:
* JSTests/wasm/stress/simd-register-allocation.js:
* JSTests/wasm/stress/simd-regress.js:
* JSTests/wasm/stress/simd-return-value-alignment.js:
* JSTests/wasm/stress/simd-shuffle.js:
* JSTests/wasm/stress/simd-tail-calls-throw.js:
* JSTests/wasm/stress/simd-tiny-loop.js:
* JSTests/wasm/stress/simd-unreachable.js:
* JSTests/wasm/stress/tag-return.js:
* JSTests/wasm/stress/throw-from-wasm-catch-in-baseline-JIT.js:

Canonical link: <a href="https://commits.webkit.org/261554@main">https://commits.webkit.org/261554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac7a89188498b8ba4f0c9b9e37813114746da6cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3880 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120743 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22563 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3925 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105141 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45771 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100502 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13630 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/513 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/11772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14308 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101835 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52512 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31842 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8053 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16099 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109877 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27141 "Passed tests") | 
<!--EWS-Status-Bubble-End-->