### PR TITLE
[UI-side compositing] Resizing window doesn't cause scrollbars to show/change size

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -590,6 +590,27 @@ FloatRect ScrollingTree::layoutViewport() const
     return m_rootNode ? m_rootNode->layoutViewport() : FloatRect();
 }
 
+void ScrollingTree::viewWillStartLiveResize()
+{
+    Locker locker { m_treeLock };
+    if (m_rootNode)
+        m_rootNode->viewWillStartLiveResize();
+}
+
+void ScrollingTree::viewWillEndLiveResize()
+{
+    Locker locker { m_treeLock };
+    if (m_rootNode)
+        m_rootNode->viewWillEndLiveResize();
+}
+
+void ScrollingTree::viewSizeDidChange()
+{
+    Locker locker { m_treeLock };
+    if (m_rootNode)
+        m_rootNode->viewSizeDidChange();
+}
+
 void ScrollingTree::setGestureState(std::optional<WheelScrollGestureState> gestureState)
 {
     Locker locker { m_treeStateLock };

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -237,7 +237,11 @@ public:
     WEBCORE_EXPORT float mainFrameScaleFactor() const;
     WEBCORE_EXPORT FloatSize totalContentsSize() const;
     WEBCORE_EXPORT FloatRect layoutViewport() const;
-
+    
+    WEBCORE_EXPORT void viewWillStartLiveResize();
+    WEBCORE_EXPORT void viewWillEndLiveResize();
+    WEBCORE_EXPORT void viewSizeDidChange();
+    
 protected:
     WheelEventHandlingResult handleWheelEventWithNode(const PlatformWheelEvent&, OptionSet<WheelEventProcessingSteps>, ScrollingTreeNode*, EventTargeting = EventTargeting::Propagate);
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
@@ -54,7 +54,9 @@ public:
     int headerHeight() const { return m_headerHeight; }
     int footerHeight() const { return m_footerHeight; }
     float topContentInset() const { return m_topContentInset; }
-
+    virtual void viewWillStartLiveResize() { }
+    virtual void viewWillEndLiveResize() { }
+    virtual void viewSizeDidChange() { }
 protected:
     ScrollingTreeFrameScrollingNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -50,6 +50,10 @@ public:
     virtual void handleWheelEventPhase(const PlatformWheelEventPhase) { }
     virtual bool handleMouseEventForScrollbars(const PlatformMouseEvent&) { return false; }
     
+    virtual void viewWillStartLiveResize() { }
+    virtual void viewWillEndLiveResize() { }
+    virtual void viewSizeDidChange() { }
+    
     virtual void updateScrollbarLayers() { }
     virtual void initScrollbars() { }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -77,19 +77,24 @@ public:
     void releaseReferencesToScrollerImpsOnTheMainThread();
     
     bool hasScrollerImp();
+    
+    void viewWillStartLiveResize();
+    void viewWillEndLiveResize();
+    void contentsSizeChanged();
+    bool inLiveResize() const { return m_inLiveResize; }
 
     // Only for use by WebScrollerImpPairDelegateMac. Do not use elsewhere!
     ScrollerMac& verticalScroller() { return m_verticalScroller; }
     ScrollerMac& horizontalScroller() { return m_horizontalScroller; }
 
 private:
-
     NSScrollerImp *scrollerImpHorizontal() { return horizontalScroller().scrollerImp(); }
     NSScrollerImp *scrollerImpVertical() { return verticalScroller().scrollerImp(); }
     
     NSScrollerImpPair *scrollerImpPair() { return m_scrollerImpPair.get(); }
     Lock& scrollerImpPairLock() WTF_RETURNS_LOCK(m_scrollerImpPairLock) { return m_scrollerImpPairLock; }
 
+    bool m_inLiveResize;
     WebCore::ScrollingTreeScrollingNode& m_scrollingNode;
 
     ScrollerMac m_verticalScroller;

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -73,8 +73,7 @@
 
 - (BOOL)inLiveResizeForScrollerImpPair:(NSScrollerImpPair *)scrollerImpPair
 {
-    // FIMXE: Not implemented.
-    return NO;
+    return _scrollerPair->inLiveResize();
 }
 
 - (NSPoint)mouseLocationInContentAreaForScrollerImpPair:(NSScrollerImpPair *)scrollerImpPair
@@ -167,6 +166,38 @@ void ScrollerPairMac::handleWheelEventPhase(PlatformWheelEventPhase phase)
     default:
         break;
     }
+}
+
+void ScrollerPairMac::viewWillStartLiveResize()
+{
+    if (m_inLiveResize)
+        return;
+    
+    m_inLiveResize = true;
+    if ([m_scrollerImpPair overlayScrollerStateIsLocked])
+        return;
+
+    [m_scrollerImpPair startLiveResize];
+}
+
+void ScrollerPairMac::viewWillEndLiveResize()
+{
+    if (!m_inLiveResize)
+        return;
+    
+    m_inLiveResize = false;
+    if ([m_scrollerImpPair overlayScrollerStateIsLocked])
+        return;
+
+    [m_scrollerImpPair endLiveResize];
+}
+
+void ScrollerPairMac::contentsSizeChanged()
+{
+    if ([m_scrollerImpPair overlayScrollerStateIsLocked])
+        return;
+
+    [m_scrollerImpPair contentAreaDidResize];
 }
 
 bool ScrollerPairMac::handleMouseEvent(const WebCore::PlatformMouseEvent& event)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -62,7 +62,9 @@ public:
     
     void handleWheelEventPhase(const PlatformWheelEventPhase) final;
     bool handleMouseEventForScrollbars(const PlatformMouseEvent&) final;
-    
+    void viewWillStartLiveResize() final;
+    void viewWillEndLiveResize() final;
+    void viewSizeDidChange() final;
     void initScrollbars() final;
 
 private:

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -314,11 +314,26 @@ void ScrollingTreeScrollingNodeDelegateMac::handleWheelEventPhase(const Platform
 {
     m_scrollerPair.handleWheelEventPhase(wheelEventPhase);
 }
+
 bool ScrollingTreeScrollingNodeDelegateMac::handleMouseEventForScrollbars(const PlatformMouseEvent& mouseEvent)
 {
     return m_scrollerPair.handleMouseEvent(mouseEvent);
 }
 
+void ScrollingTreeScrollingNodeDelegateMac::viewWillStartLiveResize()
+{
+    return m_scrollerPair.viewWillStartLiveResize();
+}
+
+void ScrollingTreeScrollingNodeDelegateMac::viewWillEndLiveResize()
+{
+    return m_scrollerPair.viewWillEndLiveResize();
+}
+
+void ScrollingTreeScrollingNodeDelegateMac::viewSizeDidChange()
+{
+    return m_scrollerPair.contentsSizeChanged();
+}
 } // namespace WebCore
 
 #endif // PLATFORM(MAC) && ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -130,6 +130,8 @@ public:
     virtual bool shouldSendWheelEventsToEventDispatcher() const { return false; }
 
     WebPageProxy& page() const { return m_webPageProxy; }
+    virtual void viewWillStartLiveResize() { };
+    virtual void viewWillEndLiveResize() { };
 
 protected:
     DrawingAreaProxy(DrawingAreaType, WebPageProxy&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -68,6 +68,9 @@ public:
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     void updateOverlayRegionIDs(const HashSet<WebCore::PlatformLayerIdentifier> &overlayRegionIDs) { m_remoteLayerTreeHost->updateOverlayRegionIDs(overlayRegionIDs); }
 #endif
+    
+    void viewWillStartLiveResize() final;
+    void viewWillEndLiveResize() final;
 
     // For testing.
     unsigned countOfTransactionsWithNonEmptyLayerChanges() const { return m_countOfTransactionsWithNonEmptyLayerChanges; }
@@ -78,6 +81,7 @@ protected:
     bool shouldCoalesceVisualEditorStateUpdates() const override { return true; }
 
 private:
+
     void sizeDidChange() final;
     void deviceScaleFactorDidChange() final;
     void windowKindDidChange() final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -92,11 +92,21 @@ void RemoteLayerTreeDrawingAreaProxy::sizeDidChange()
 {
     if (!m_webPageProxy.hasRunningProcess())
         return;
+    m_webPageProxy.scrollingCoordinatorProxy()->viewSizeDidChange();
 
     if (m_isWaitingForDidUpdateGeometry)
         return;
-
     sendUpdateGeometry();
+}
+
+void RemoteLayerTreeDrawingAreaProxy::viewWillStartLiveResize()
+{
+    m_webPageProxy.scrollingCoordinatorProxy()->viewWillStartLiveResize();
+}
+
+void RemoteLayerTreeDrawingAreaProxy::viewWillEndLiveResize()
+{
+    m_webPageProxy.scrollingCoordinatorProxy()->viewWillEndLiveResize();
 }
 
 void RemoteLayerTreeDrawingAreaProxy::deviceScaleFactorDidChange()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -380,6 +380,21 @@ void RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForR
     m_webPageProxy.send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(nodeID, reason));
 }
 
+void RemoteScrollingCoordinatorProxy::viewWillStartLiveResize()
+{
+    m_scrollingTree->viewWillStartLiveResize();
+}
+
+void RemoteScrollingCoordinatorProxy::viewWillEndLiveResize()
+{
+    m_scrollingTree->viewWillEndLiveResize();
+}
+
+void RemoteScrollingCoordinatorProxy::viewSizeDidChange()
+{
+    m_scrollingTree->viewSizeDidChange();
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -147,6 +147,10 @@ public:
     int footerHeight() const;
     float mainFrameScaleFactor() const;
     WebCore::FloatSize totalContentsSize() const;
+    
+    void viewWillStartLiveResize();
+    void viewWillEndLiveResize();
+    void viewSizeDidChange();
 
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -71,6 +71,21 @@ bool ScrollingTreeFrameScrollingNodeRemoteMac::handleMouseEvent(const PlatformMo
     return m_delegate->handleMouseEventForScrollbars(mouseEvent);
 }
 
+void ScrollingTreeFrameScrollingNodeRemoteMac::viewWillStartLiveResize()
+{
+    m_delegate->viewWillStartLiveResize();
+}
+
+void ScrollingTreeFrameScrollingNodeRemoteMac::viewWillEndLiveResize()
+{
+    m_delegate->viewWillEndLiveResize();
+}
+
+void ScrollingTreeFrameScrollingNodeRemoteMac::viewSizeDidChange()
+{
+    m_delegate->viewSizeDidChange();
+}
+
 }
 
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
@@ -47,6 +47,11 @@ private:
     void handleWheelEventPhase(const PlatformWheelEventPhase) override;
 
     void repositionRelatedLayers() override;
+    
+    void viewWillStartLiveResize() override;
+    void viewWillEndLiveResize() override;
+    void viewSizeDidChange() override;
+
 };
 
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2132,6 +2132,9 @@ void WebPageProxy::viewWillStartLiveResize()
         return;
 
     closeOverlayedViews();
+    
+    m_drawingArea->viewWillStartLiveResize();
+    
     send(Messages::WebPage::ViewWillStartLiveResize());
 }
 
@@ -2139,6 +2142,9 @@ void WebPageProxy::viewWillEndLiveResize()
 {
     if (!hasRunningProcess())
         return;
+
+    m_drawingArea->viewWillEndLiveResize();
+
     send(Messages::WebPage::ViewWillEndLiveResize());
 }
 


### PR DESCRIPTION
#### 9389cc84fa302b8971ba56ab28396eb79eb33202
<pre>
[UI-side compositing] Resizing window doesn&apos;t cause scrollbars to show/change size
<a href="https://bugs.webkit.org/show_bug.cgi?id=253739">https://bugs.webkit.org/show_bug.cgi?id=253739</a>
rdar://106385267

Reviewed by Simon Fraser.

Hook up ScrollerMac to UI-process resize events so that scrollbars
dynamically resize when resizing window. We should also consider subclassing
ScrollerMac under ScrollbarsControllerMac so we dont duplicate this
NScrollerImp interaction code.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::viewWillStartLiveResize):
(WebCore::ScrollingTree::viewWillEndLiveResize):
(WebCore::ScrollingTree::contentsSizeChanged):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::viewWillStartLiveResize):
(WebCore::ScrollingTreeScrollingNodeDelegate::viewWillEndLiveResize):
(WebCore::ScrollingTreeScrollingNodeDelegate::contentsSizeChanged):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::viewWillStartLiveResize):
(WebCore::ScrollerPairMac::viewWillEndLiveResize):
(WebCore::ScrollerPairMac::contentsSizeChanged):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::ScrollingTreeScrollingNodeDelegateMac):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::scrollPositionIsNotRubberbandingEdge const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::allowsHorizontalStretching const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::allowsVerticalStretching const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::stretchAmount const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::isPinnedOnSide const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateScrollbarPainters):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::viewWillStartLiveResize):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::viewWillEndLiveResize):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::contentsSizeChanged):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::sizeDidChange):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::viewWillStartLiveResize):
(WebKit::RemoteScrollingCoordinatorProxy::viewWillEndLiveResize):
(WebKit::RemoteScrollingCoordinatorProxy::contentsSizeChanged):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::viewWillStartLiveResize):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::viewWillEndLiveResize):
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::contentsSizeChanged):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::viewWillStartLiveResize):
(WebKit::WebPageProxy::viewWillEndLiveResize):
(WebKit::WebPageProxy::contentsSizeChanged):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/261977@main">https://commits.webkit.org/261977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52fb1eacec97151a7b5d9a7a0768b4ea5a69f1b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/31 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/29 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/28 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/27 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29 "3 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/23 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/26 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/26 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/26 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->