### PR TITLE
Avoid including Document.h in DocumentParser and JSObject.h in JSSegmentedVariableObject.h

### DIFF
--- a/Source/JavaScriptCore/runtime/JSSegmentedVariableObject.h
+++ b/Source/JavaScriptCore/runtime/JSSegmentedVariableObject.h
@@ -29,7 +29,6 @@
 #pragma once
 
 #include "ConcurrentJSLock.h"
-#include "JSObject.h"
 #include "JSSymbolTableObject.h"
 #include "SymbolTable.h"
 #include <wtf/SegmentedVector.h>

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GAMEPAD)
 
 #include "DOMWindow.h"
+#include "Document.h"
 #include "Gamepad.h"
 #include "GamepadManager.h"
 #include "GamepadProvider.h"

--- a/Source/WebCore/dom/DocumentParser.cpp
+++ b/Source/WebCore/dom/DocumentParser.cpp
@@ -27,6 +27,7 @@
 #include "DocumentParser.h"
 
 #include "Document.h"
+#include "EventTarget.h"
 #include <wtf/Assertions.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/DocumentParser.h
+++ b/Source/WebCore/dom/DocumentParser.h
@@ -23,16 +23,17 @@
 
 #pragma once
 
-#include "Document.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
+class Document;
 class DocumentWriter;
 class SegmentedString;
 class ScriptableDocumentParser;
+class WeakPtrImplWithEventTargetData;
 
 class DocumentParser : public RefCounted<DocumentParser> {
 public:

--- a/Source/WebCore/dom/RawDataDocumentParser.h
+++ b/Source/WebCore/dom/RawDataDocumentParser.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Document.h"
 #include "DocumentParser.h"
 
 namespace WebCore {

--- a/Source/WebCore/page/AbstractDOMWindow.h
+++ b/Source/WebCore/page/AbstractDOMWindow.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "Base64Utilities.h"
 #include "EventTarget.h"
 #include "GlobalWindowIdentifier.h"
 #include <wtf/HashMap.h>

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -31,7 +31,6 @@
 #include "ContextDestructionObserver.h"
 #include "ExceptionOr.h"
 #include "Frame.h"
-#include "FrameDestructionObserver.h"
 #include "ImageBitmap.h"
 #include "ReducedResolutionSeconds.h"
 #include "ScrollToOptions.h"
@@ -88,6 +87,7 @@ class VisualViewport;
 class WebCoreOpaqueRoot;
 class WebKitNamespace;
 class WebKitPoint;
+class WindowProxy;
 
 #if ENABLE(DEVICE_ORIENTATION)
 class DeviceMotionController;


### PR DESCRIPTION
#### f19ec43b36052596d3f894d7048c205606a35433
<pre>
Avoid including Document.h in DocumentParser and JSObject.h in JSSegmentedVariableObject.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=253741">https://bugs.webkit.org/show_bug.cgi?id=253741</a>
&lt;rdar://problem/106579489&gt;

Reviewed by Chris Dumez.

The Document.h and JSObject.h headers are very costly. They are included in a few places where they are not used:

1. DocumentParser.h doesn&apos;t need to include the header, and already includes it in its implementation file.
2. JSSegmentedVariableObject.h doesn&apos;t use the contents of JSObject.h at all, so pays a heavy price for no benefit.

These two changes save about 4 minutes of CPU time parsing, and about 0.75 minutes of codegen.

* Source/JavaScriptCore/runtime/JSSegmentedVariableObject.h:
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
* Source/WebCore/dom/DocumentParser.cpp:
* Source/WebCore/dom/DocumentParser.h:
* Source/WebCore/dom/RawDataDocumentParser.h:
* Source/WebCore/page/AbstractDOMWindow.h:
* Source/WebCore/page/DOMWindow.h:

Canonical link: <a href="https://commits.webkit.org/261538@main">https://commits.webkit.org/261538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e3f6b983ee7e878ed90993e5552791b0adb72a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3781 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12295 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/3530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117780 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105040 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45683 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/100446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/445 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11729 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14244 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101739 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52457 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31607 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8034 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16042 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109781 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27010 "Passed tests") | 
<!--EWS-Status-Bubble-End-->