### PR TITLE
[WebGPU] GPUQueue.writeBuffer does not support default value for dataOffset

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/onSubmittedWorkDone-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/onSubmittedWorkDone-expected.txt
@@ -1,1 +1,7 @@
-(Populate me when we're ready to investigate this test)
+
+PASS :without_work:
+PASS :with_work:
+PASS :many,serial:
+PASS :many,parallel:
+PASS :many,parallel_order:
+

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2342,7 +2342,7 @@ http/tests/webgpu/webgpu/api/operation/command_buffer/copyTextureToTexture.html 
 http/tests/webgpu/webgpu/api/operation/command_buffer/programmable/state_tracking.html [ Skip ]
 http/tests/webgpu/webgpu/api/operation/command_buffer/image_copy.html [ Skip ]
 http/tests/webgpu/webgpu/api/operation/command_buffer/clearBuffer.html [ Skip ]
-http/tests/webgpu/webgpu/api/operation/onSubmittedWorkDone.html [ Skip ]
+http/tests/webgpu/webgpu/api/operation/onSubmittedWorkDone.html [ Pass ]
 http/tests/webgpu/webgpu/api/operation/render_pipeline/pipeline_output_targets.html [ Skip ]
 http/tests/webgpu/webgpu/api/operation/render_pipeline/alpha_to_coverage.html [ Skip ]
 http/tests/webgpu/webgpu/api/operation/render_pipeline/primitive_topology.html [ Skip ]

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -71,10 +71,10 @@ void GPUQueue::writeBuffer(
     const GPUBuffer& buffer,
     GPUSize64 bufferOffset,
     BufferSource&& data,
-    GPUSize64 dataOffset,
+    std::optional<GPUSize64> dataOffset,
     std::optional<GPUSize64> size)
 {
-    m_backing->writeBuffer(buffer.backing(), bufferOffset, data.data(), data.length(), dataOffset, size);
+    m_backing->writeBuffer(buffer.backing(), bufferOffset, data.data(), data.length(), dataOffset.value_or(0), size);
 }
 
 void GPUQueue::writeTexture(

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.h
@@ -64,7 +64,7 @@ public:
         const GPUBuffer&,
         GPUSize64 bufferOffset,
         BufferSource&& data,
-        GPUSize64 dataOffset,
+        std::optional<GPUSize64> dataOffset,
         std::optional<GPUSize64>);
 
     void writeTexture(

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.idl
@@ -41,11 +41,12 @@ interface GPUQueue {
 
     Promise<undefined> onSubmittedWorkDone();
 
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=240219, second last parameter should have default value of 0
     undefined writeBuffer(
         GPUBuffer buffer,
         GPUSize64 bufferOffset,
         [AllowShared] (ArrayBufferView or ArrayBuffer) data,
-        optional GPUSize64 dataOffset = 0,
+        optional GPUSize64 dataOffset,
         optional GPUSize64 size);
 
     undefined writeTexture(


### PR DESCRIPTION
#### cac6801043b942fce4db277678985a293fbe2a3d
<pre>
[WebGPU] GPUQueue.writeBuffer does not support default value for dataOffset
<a href="https://bugs.webkit.org/show_bug.cgi?id=253747">https://bugs.webkit.org/show_bug.cgi?id=253747</a>
&lt;radar://106582095&gt;

Reviewed by Myles C. Maxfield.

Workaround <a href="https://bugs.webkit.org/show_bug.cgi?id=240219">https://bugs.webkit.org/show_bug.cgi?id=240219</a> by placing the default
value for an optional inside the cpp file.

onSubmittedWorkDone.html now passes, so enable it.

* LayoutTests/http/tests/webgpu/webgpu/api/operation/onSubmittedWorkDone-expected.txt:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::writeBuffer):
* Source/WebCore/Modules/WebGPU/GPUQueue.h:
* Source/WebCore/Modules/WebGPU/GPUQueue.idl:

Canonical link: <a href="https://commits.webkit.org/261551@main">https://commits.webkit.org/261551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4075731b6a2625543c09a021b1c8828ccfa8f252

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3783 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120666 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3531 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105042 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45684 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13577 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/447 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14246 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52459 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8050 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16044 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->