### PR TITLE
[JSC] Make scratch GPR / FPR static constexpr variables in WasmBBQJIT

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -67,8 +67,6 @@ namespace JSC { namespace Wasm {
 
 class BBQJIT {
 public:
-    using RegisterID = MacroAssembler::RegisterID;
-    using FPRegisterID = MacroAssembler::FPRegisterID;
     using ErrorType = String;
     using PartialResult = Expected<void, ErrorType>;
     using Address = MacroAssembler::Address;
@@ -90,6 +88,15 @@ public:
 
     static constexpr unsigned LocalIndexBits = 21;
     static_assert(maxFunctionLocals < 1 << LocalIndexBits);
+
+    static constexpr GPRReg wasmScratchGPR = GPRInfo::nonPreservedNonArgumentGPR0; // Scratch registers to hold temporaries in operations.
+    static constexpr FPRReg wasmScratchFPR = FPRInfo::nonPreservedNonArgumentFPR0;
+
+#if CPU(X86) || CPU(X86_64)
+    static constexpr GPRReg shiftRCX = X86Registers::ecx;
+#else
+    static constexpr GPRReg shiftRCX = InvalidGPRReg;
+#endif
 
 private:
     struct Location {
@@ -127,7 +134,7 @@ private:
             return loc;
         }
 
-        static Location fromGPR(RegisterID gpr)
+        static Location fromGPR(GPRReg gpr)
         {
             Location loc;
             loc.m_kind = Gpr;
@@ -135,7 +142,7 @@ private:
             return loc;
         }
 
-        static Location fromFPR(FPRegisterID fpr)
+        static Location fromFPR(FPRReg fpr)
         {
             Location loc;
             loc.m_kind = Fpr;
@@ -256,13 +263,13 @@ private:
             }
         }
 
-        RegisterID asGPR() const
+        GPRReg asGPR() const
         {
             ASSERT(isGPR());
             return m_gpr;
         }
 
-        FPRegisterID asFPR() const
+        FPRReg asFPR() const
         {
             ASSERT(isFPR());
             return m_fpr;
@@ -331,11 +338,11 @@ private:
             };
             struct {
                 Kind m_padGpr;
-                RegisterID m_gpr;
+                GPRReg m_gpr;
             };
             struct {
                 Kind m_padFpr;
-                FPRegisterID m_fpr;
+                FPRReg m_fpr;
             };
         };
     };
@@ -1284,8 +1291,8 @@ public:
         RegisterSetBuilder callerSaveGprs = gprSetBuilder;
         RegisterSetBuilder callerSaveFprs = fprSetBuilder;
 
-        gprSetBuilder.remove(m_scratchGPR);
-        fprSetBuilder.remove(m_scratchFPR);
+        gprSetBuilder.remove(wasmScratchGPR);
+        fprSetBuilder.remove(wasmScratchFPR);
 
         m_gprSet = m_validGPRs = gprSetBuilder.buildAndValidate();
         m_fprSet = m_validFPRs = fprSetBuilder.buildAndValidate();
@@ -1645,14 +1652,14 @@ public:
             break;
         case Wasm::GlobalInformation::BindingMode::Portable:
             ASSERT(global.mutability == Wasm::Mutability::Mutable);
-            m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, offset), m_scratchGPR);
+            m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, offset), wasmScratchGPR);
             if (type.kind == TypeKind::V128) {
                 // Vectors aren't handled by the normal load-op helper, but since we know the offset is zero
                 // we don't need the song and dance of addSIMDLoad.
                 result = topValue(type.kind);
-                m_jit.loadVector(Address(m_scratchGPR), loadIfNecessary(result).asFPR());
+                m_jit.loadVector(Address(wasmScratchGPR), loadIfNecessary(result).asFPR());
             } else
-                result = emitLoadOp(loadOpForTypeKind(type.kind), Location::fromGPR(m_scratchGPR), 0);
+                result = emitLoadOp(loadOpForTypeKind(type.kind), Location::fromGPR(wasmScratchGPR), 0);
             break;
         }
 
@@ -1744,24 +1751,24 @@ public:
             emitMove(value, Location::fromGlobal(offset));
             consume(value);
             if (isRefType(type)) {
-                m_jit.load64(Address(GPRInfo::wasmContextInstancePointer, Instance::offsetOfOwner()), m_scratchGPR);
-                emitWriteBarrier(m_scratchGPR);
+                m_jit.load64(Address(GPRInfo::wasmContextInstancePointer, Instance::offsetOfOwner()), wasmScratchGPR);
+                emitWriteBarrier(wasmScratchGPR);
             }
             break;
         }
         case Wasm::GlobalInformation::BindingMode::Portable: {
             ASSERT(global.mutability == Wasm::Mutability::Mutable);
-            m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, offset), m_scratchGPR);
+            m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, offset), wasmScratchGPR);
             if (type.kind == TypeKind::V128) {
                 // Vectors aren't handled by the normal load-op helper, but since we know the offset is zero
                 // we don't need the song and dance of addSIMDStore.
-                m_jit.storeVector(loadIfNecessary(value).asFPR(), Address(m_scratchGPR));
+                m_jit.storeVector(loadIfNecessary(value).asFPR(), Address(wasmScratchGPR));
             } else
-                emitStoreOp(storeOpForTypeKind(type.kind), Location::fromGPR(m_scratchGPR), value, 0);
+                emitStoreOp(storeOpForTypeKind(type.kind), Location::fromGPR(wasmScratchGPR), value, 0);
             consume(value);
             if (isRefType(type)) {
-                m_jit.loadPtr(Address(m_scratchGPR, Wasm::Global::offsetOfOwner() - Wasm::Global::offsetOfValue()), m_scratchGPR);
-                emitWriteBarrier(m_scratchGPR);
+                m_jit.loadPtr(Address(wasmScratchGPR, Wasm::Global::offsetOfOwner() - Wasm::Global::offsetOfValue()), wasmScratchGPR);
+                emitWriteBarrier(wasmScratchGPR);
             }
             break;
         }
@@ -1789,10 +1796,10 @@ public:
         case MemoryMode::BoundsChecking: {
             // We're not using signal handling only when the memory is not shared.
             // Regardless of signaling, we must check that no memory access exceeds the current memory size.
-            m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), m_scratchGPR);
+            m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
             if (boundary)
-                m_jit.add64(TrustedImm64(boundary), m_scratchGPR);
-            throwExceptionIf(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branch64(RelationalCondition::AboveOrEqual, m_scratchGPR, GPRInfo::wasmBoundsCheckingSizeRegister));
+                m_jit.add64(TrustedImm64(boundary), wasmScratchGPR);
+            throwExceptionIf(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branch64(RelationalCondition::AboveOrEqual, wasmScratchGPR, GPRInfo::wasmBoundsCheckingSizeRegister));
             break;
         }
 
@@ -1809,24 +1816,24 @@ public:
             // any access equal to or greater than 4GiB will trap, no need to add the redzone.
             if (uoffset >= Memory::fastMappedRedzoneBytes()) {
                 uint64_t maximum = m_info.memory.maximum() ? m_info.memory.maximum().bytes() : std::numeric_limits<uint32_t>::max();
-                m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), m_scratchGPR);
+                m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
                 if (boundary)
-                    m_jit.add64(TrustedImm64(boundary), m_scratchGPR);
-                throwExceptionIf(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branch64(RelationalCondition::AboveOrEqual, m_scratchGPR, TrustedImm64(static_cast<int64_t>(maximum))));
+                    m_jit.add64(TrustedImm64(boundary), wasmScratchGPR);
+                throwExceptionIf(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branch64(RelationalCondition::AboveOrEqual, wasmScratchGPR, TrustedImm64(static_cast<int64_t>(maximum))));
             }
             break;
         }
         }
 
 #if CPU(ARM64)
-        m_jit.addZeroExtend64(GPRInfo::wasmBaseMemoryPointer, pointerLocation.asGPR(), m_scratchGPR);
+        m_jit.addZeroExtend64(GPRInfo::wasmBaseMemoryPointer, pointerLocation.asGPR(), wasmScratchGPR);
 #else
-        m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), m_scratchGPR);
-        m_jit.addPtr(GPRInfo::wasmBaseMemoryPointer, m_scratchGPR);
+        m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
+        m_jit.addPtr(GPRInfo::wasmBaseMemoryPointer, wasmScratchGPR);
 #endif
 
         consume(pointer);
-        return Location::fromGPR(m_scratchGPR);
+        return Location::fromGPR(wasmScratchGPR);
     }
 
     static inline uint32_t sizeOfLoadOp(LoadOpType op)
@@ -2097,14 +2104,14 @@ public:
     {
         result = topValue(TypeKind::I32);
         Location resultLocation = allocate(result);
-        m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, Instance::offsetOfMemory()), m_scratchGPR);
-        m_jit.loadPtr(Address(m_scratchGPR, Memory::offsetOfHandle()), m_scratchGPR);
-        m_jit.loadPtr(Address(m_scratchGPR, BufferMemoryHandle::offsetOfSize()), m_scratchGPR);
+        m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, Instance::offsetOfMemory()), wasmScratchGPR);
+        m_jit.loadPtr(Address(wasmScratchGPR, Memory::offsetOfHandle()), wasmScratchGPR);
+        m_jit.loadPtr(Address(wasmScratchGPR, BufferMemoryHandle::offsetOfSize()), wasmScratchGPR);
 
         constexpr uint32_t shiftValue = 16;
         static_assert(PageCount::pageSize == 1ull << shiftValue, "This must hold for the code below to be correct.");
-        m_jit.urshiftPtr(Imm32(shiftValue), m_scratchGPR);
-        m_jit.zeroExtend32ToWord(m_scratchGPR, resultLocation.asGPR());
+        m_jit.urshiftPtr(Imm32(shiftValue), wasmScratchGPR);
+        m_jit.zeroExtend32ToWord(wasmScratchGPR, resultLocation.asGPR());
 
         LOG_INSTRUCTION("CurrentMemory", RESULT(result));
 
@@ -3337,7 +3344,7 @@ public:
 
         Location operandLocation;
         if (operand.isConst()) {
-            operandLocation = Location::fromFPR(m_scratchFPR);
+            operandLocation = Location::fromFPR(wasmScratchFPR);
             emitMoveConst(operand, operandLocation);
         } else
             operandLocation = loadIfNecessary(operand);
@@ -3421,7 +3428,7 @@ public:
 
         Location operandLocation;
         if (operand.isConst()) {
-            operandLocation = Location::fromFPR(m_scratchFPR);
+            operandLocation = Location::fromFPR(wasmScratchFPR);
             emitMoveConst(operand, operandLocation);
         } else
             operandLocation = loadIfNecessary(operand);
@@ -3552,8 +3559,8 @@ public:
             // If the condition location and the result alias, we want to make sure the condition is
             // preserved no matter what.
             if (conditionLocation == resultLocation) {
-                m_jit.move(conditionLocation.asGPR(), m_scratchGPR);
-                conditionLocation = Location::fromGPR(m_scratchGPR);
+                m_jit.move(conditionLocation.asGPR(), wasmScratchGPR);
+                conditionLocation = Location::fromGPR(wasmScratchGPR);
             }
 
             // Kind of gross isel, but it should handle all use/def aliasing cases correctly.
@@ -3737,8 +3744,8 @@ public:
                 m_jit.addFloat(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 m_jit.addFloat(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             )
         );
@@ -3753,8 +3760,8 @@ public:
                 m_jit.addDouble(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 m_jit.addDouble(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             )
         );
@@ -3774,8 +3781,8 @@ public:
                     m_jit.move(lhsLocation.asGPR(), resultLocation.asGPR());
                     m_jit.add32(Imm32(-rhs.asI32()), resultLocation.asGPR());
                 } else {
-                    emitMoveConst(lhs, Location::fromGPR(m_scratchGPR));
-                    m_jit.sub32(m_scratchGPR, rhsLocation.asGPR(), resultLocation.asGPR());
+                    emitMoveConst(lhs, Location::fromGPR(wasmScratchGPR));
+                    m_jit.sub32(wasmScratchGPR, rhsLocation.asGPR(), resultLocation.asGPR());
                 }
             )
         );
@@ -3795,8 +3802,8 @@ public:
                     m_jit.move(lhsLocation.asGPR(), resultLocation.asGPR());
                     m_jit.add64(TrustedImm64(-rhs.asI64()), resultLocation.asGPR());
                 } else {
-                    emitMoveConst(lhs, Location::fromGPR(m_scratchGPR));
-                    m_jit.sub64(m_scratchGPR, rhsLocation.asGPR(), resultLocation.asGPR());
+                    emitMoveConst(lhs, Location::fromGPR(wasmScratchGPR));
+                    m_jit.sub64(wasmScratchGPR, rhsLocation.asGPR(), resultLocation.asGPR());
                 }
             )
         );
@@ -3813,11 +3820,11 @@ public:
             BLOCK(
                 if (rhs.isConst()) {
                     // Add a negative if rhs is a constant.
-                    emitMoveConst(Value::fromF32(-rhs.asF32()), Location::fromFPR(m_scratchFPR));
-                    m_jit.addFloat(lhsLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                    emitMoveConst(Value::fromF32(-rhs.asF32()), Location::fromFPR(wasmScratchFPR));
+                    m_jit.addFloat(lhsLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
                 } else {
-                    emitMoveConst(lhs, Location::fromFPR(m_scratchFPR));
-                    m_jit.subFloat(m_scratchFPR, rhsLocation.asFPR(), resultLocation.asFPR());
+                    emitMoveConst(lhs, Location::fromFPR(wasmScratchFPR));
+                    m_jit.subFloat(wasmScratchFPR, rhsLocation.asFPR(), resultLocation.asFPR());
                 }
             )
         );
@@ -3834,11 +3841,11 @@ public:
             BLOCK(
                 if (rhs.isConst()) {
                     // Add a negative if rhs is a constant.
-                    emitMoveConst(Value::fromF64(-rhs.asF64()), Location::fromFPR(m_scratchFPR));
-                    m_jit.addDouble(lhsLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                    emitMoveConst(Value::fromF64(-rhs.asF64()), Location::fromFPR(wasmScratchFPR));
+                    m_jit.addDouble(lhsLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
                 } else {
-                    emitMoveConst(lhs, Location::fromFPR(m_scratchFPR));
-                    m_jit.subDouble(m_scratchFPR, rhsLocation.asFPR(), resultLocation.asFPR());
+                    emitMoveConst(lhs, Location::fromFPR(wasmScratchFPR));
+                    m_jit.subDouble(wasmScratchFPR, rhsLocation.asFPR(), resultLocation.asFPR());
                 }
             )
         );
@@ -3871,8 +3878,8 @@ public:
                 m_jit.mul64(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR(m_scratchGPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR(m_scratchGPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR(wasmScratchGPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR(wasmScratchGPR));
                 m_jit.mul64(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
             )
         );
@@ -3887,8 +3894,8 @@ public:
                 m_jit.mulFloat(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 m_jit.mulFloat(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             )
         );
@@ -3903,8 +3910,8 @@ public:
                 m_jit.mulDouble(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 m_jit.mulDouble(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             )
         );
@@ -3966,9 +3973,9 @@ public:
 
         ASSERT(lhsLocation.isRegister() || rhsLocation.isRegister());
         if (lhs.isConst())
-            emitMoveConst(lhs, lhsLocation = Location::fromGPR(m_scratchGPR));
+            emitMoveConst(lhs, lhsLocation = Location::fromGPR(wasmScratchGPR));
         else if (rhs.isConst())
-            emitMoveConst(rhs, rhsLocation = Location::fromGPR(m_scratchGPR));
+            emitMoveConst(rhs, rhsLocation = Location::fromGPR(wasmScratchGPR));
         ASSERT(lhsLocation.isRegister() && rhsLocation.isRegister());
 
         ASSERT(resultLocation.isRegister());
@@ -4096,7 +4103,7 @@ public:
                 if constexpr (IsMod) {
                     Location originalResult = resultLocation;
                     if constexpr (isSigned)
-                        resultLocation = Location::fromGPR(m_scratchGPR);
+                        resultLocation = Location::fromGPR(wasmScratchGPR);
 
                     if constexpr (is32)
                         m_jit.and32(Imm32(static_cast<uint32_t>(divisor) - 1), lhsLocation.asGPR(), resultLocation.asGPR());
@@ -4108,11 +4115,11 @@ public:
                             ? m_jit.branch32(RelationalCondition::GreaterThanOrEqual, lhsLocation.asGPR(), TrustedImm32(0))
                             : m_jit.branch64(RelationalCondition::GreaterThanOrEqual, lhsLocation.asGPR(), TrustedImm64(0));
                         if constexpr (is32)
-                            m_jit.neg32(m_scratchGPR, m_scratchGPR);
+                            m_jit.neg32(wasmScratchGPR, wasmScratchGPR);
                         else
-                            m_jit.neg64(m_scratchGPR, m_scratchGPR);
+                            m_jit.neg64(wasmScratchGPR, wasmScratchGPR);
                         isNonNegative.link(&m_jit);
-                        m_jit.move(m_scratchGPR, originalResult.asGPR());
+                        m_jit.move(wasmScratchGPR, originalResult.asGPR());
                     }
                     return;
                 }
@@ -4136,7 +4143,7 @@ public:
             // TODO: try generating integer reciprocal instead.
             checkedForNegativeOne = true;
             checkedForZero = true;
-            rhsLocation = Location::fromGPR(m_scratchGPR);
+            rhsLocation = Location::fromGPR(wasmScratchGPR);
             emitMoveConst(rhs, rhsLocation);
             // Fall through to register/register div.
         } else if (lhs.isConst()) {
@@ -4163,7 +4170,7 @@ public:
                 checkedForNegativeOne = true;
             }
 
-            lhsLocation = Location::fromGPR(m_scratchGPR);
+            lhsLocation = Location::fromGPR(wasmScratchGPR);
             emitMoveConst(lhs, lhsLocation);
             // Fall through to register/register div.
         }
@@ -4178,21 +4185,21 @@ public:
         ScratchScope<1, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
         if (isSigned && !IsMod && !checkedForNegativeOne) {
             if constexpr (is32)
-                m_jit.compare32(RelationalCondition::Equal, rhsLocation.asGPR(), TrustedImm32(-1), m_scratchGPR);
+                m_jit.compare32(RelationalCondition::Equal, rhsLocation.asGPR(), TrustedImm32(-1), wasmScratchGPR);
             else
-                m_jit.compare64(RelationalCondition::Equal, rhsLocation.asGPR(), TrustedImm32(-1), m_scratchGPR);
+                m_jit.compare64(RelationalCondition::Equal, rhsLocation.asGPR(), TrustedImm32(-1), wasmScratchGPR);
             if constexpr (is32)
                 m_jit.compare32(RelationalCondition::Equal, lhsLocation.asGPR(), TrustedImm32(std::numeric_limits<int32_t>::min()), scratches.gpr(0));
             else {
                 m_jit.move(TrustedImm64(std::numeric_limits<int64_t>::min()), scratches.gpr(0));
                 m_jit.compare64(RelationalCondition::Equal, lhsLocation.asGPR(), scratches.gpr(0), scratches.gpr(0));
             }
-            m_jit.and64(m_scratchGPR, scratches.gpr(0), m_scratchGPR);
-            Jump isNegativeOne = m_jit.branchTest64(ResultCondition::NonZero, m_scratchGPR);
+            m_jit.and64(wasmScratchGPR, scratches.gpr(0), wasmScratchGPR);
+            Jump isNegativeOne = m_jit.branchTest64(ResultCondition::NonZero, wasmScratchGPR);
             throwExceptionIf(ExceptionType::IntegerOverflow, isNegativeOne);
         }
 
-        RegisterID divResult = IsMod ? scratches.gpr(0) : resultLocation.asGPR();
+        GPRReg divResult = IsMod ? scratches.gpr(0) : resultLocation.asGPR();
         if (is32 && isSigned)
             m_jit.div32(lhsLocation.asGPR(), rhsLocation.asGPR(), divResult);
         else if (is32)
@@ -4373,8 +4380,8 @@ public:
                 m_jit.divFloat(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 m_jit.divFloat(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             )
         );
@@ -4389,8 +4396,8 @@ public:
                 m_jit.divDouble(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 m_jit.divDouble(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             )
         );
@@ -4399,7 +4406,7 @@ public:
     enum class MinOrMax { Min, Max };
 
     template<typename FloatType, MinOrMax IsMinOrMax>
-    void emitFloatingPointMinOrMax(FPRegisterID left, FPRegisterID right, FPRegisterID result)
+    void emitFloatingPointMinOrMax(FPRReg left, FPRReg right, FPRReg result)
     {
         constexpr bool is32 = sizeof(FloatType) == 4;
 
@@ -4475,8 +4482,8 @@ public:
                 emitFloatingPointMinOrMax<float, MinOrMax::Min>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 emitFloatingPointMinOrMax<float, MinOrMax::Min>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             )
         );
@@ -4491,8 +4498,8 @@ public:
                 emitFloatingPointMinOrMax<double, MinOrMax::Min>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 emitFloatingPointMinOrMax<double, MinOrMax::Min>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             )
         );
@@ -4507,8 +4514,8 @@ public:
                 emitFloatingPointMinOrMax<float, MinOrMax::Max>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 emitFloatingPointMinOrMax<float, MinOrMax::Max>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             )
         );
@@ -4523,8 +4530,8 @@ public:
                 emitFloatingPointMinOrMax<double, MinOrMax::Max>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 emitFloatingPointMinOrMax<double, MinOrMax::Max>(lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asFPR());
             )
         );
@@ -4643,9 +4650,9 @@ public:
 #if CPU(X86_64)
 #define PREPARE_FOR_SHIFT \
     do { \
-        clobber(m_shiftRCX); \
+        clobber(shiftRCX); \
     } while (false); \
-    ScratchScope<0, 0> scratches(*this, Location::fromGPR(m_shiftRCX))
+    ScratchScope<0, 0> scratches(*this, Location::fromGPR(shiftRCX))
 #else
 #define PREPARE_FOR_SHIFT
 #endif
@@ -4653,8 +4660,8 @@ public:
     void moveShiftAmountIfNecessary(Location& rhsLocation)
     {
         if constexpr (isX86()) {
-            m_jit.move(rhsLocation.asGPR(), m_shiftRCX);
-            rhsLocation = Location::fromGPR(m_shiftRCX);
+            m_jit.move(rhsLocation.asGPR(), shiftRCX);
+            rhsLocation = Location::fromGPR(shiftRCX);
         }
     }
 
@@ -4673,7 +4680,7 @@ public:
                     m_jit.lshift32(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(rhs.asI32())), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
-                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(m_scratchGPR));
+                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(wasmScratchGPR));
                     m_jit.lshift32(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
                 }
             )
@@ -4695,7 +4702,7 @@ public:
                     m_jit.lshift64(lhsLocation.asGPR(), TrustedImm32(rhs.asI64()), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
-                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(m_scratchGPR));
+                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(wasmScratchGPR));
                     m_jit.lshift64(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
                 }
             )
@@ -4717,7 +4724,7 @@ public:
                     m_jit.rshift32(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(rhs.asI32())), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
-                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(m_scratchGPR));
+                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(wasmScratchGPR));
                     m_jit.rshift32(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
                 }
             )
@@ -4739,7 +4746,7 @@ public:
                     m_jit.rshift64(lhsLocation.asGPR(), TrustedImm32(rhs.asI64()), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
-                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(m_scratchGPR));
+                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(wasmScratchGPR));
                     m_jit.rshift64(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
                 }
             )
@@ -4761,7 +4768,7 @@ public:
                     m_jit.urshift32(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(rhs.asI32())), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
-                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(m_scratchGPR));
+                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(wasmScratchGPR));
                     m_jit.urshift32(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
                 }
             )
@@ -4783,7 +4790,7 @@ public:
                     m_jit.urshift64(lhsLocation.asGPR(), TrustedImm32(rhs.asI64()), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
-                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(m_scratchGPR));
+                    emitMoveConst(lhs, lhsLocation = Location::fromGPR(wasmScratchGPR));
                     m_jit.urshift64(lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
                 }
             )
@@ -4813,17 +4820,17 @@ public:
 #else
             BLOCK(
                 moveShiftAmountIfNecessary(rhsLocation);
-                m_jit.neg32(rhsLocation.asGPR(), m_scratchGPR);
-                m_jit.rotateRight32(lhsLocation.asGPR(), m_scratchGPR, resultLocation.asGPR());
+                m_jit.neg32(rhsLocation.asGPR(), wasmScratchGPR);
+                m_jit.rotateRight32(lhsLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
             ),
             BLOCK(
                 if (rhs.isConst())
                     m_jit.rotateRight32(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(-rhs.asI32())), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
-                    m_jit.neg32(rhsLocation.asGPR(), m_scratchGPR);
+                    m_jit.neg32(rhsLocation.asGPR(), wasmScratchGPR);
                     emitMoveConst(lhs, resultLocation);
-                    m_jit.rotateRight32(resultLocation.asGPR(), m_scratchGPR, resultLocation.asGPR());
+                    m_jit.rotateRight32(resultLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
                 }
             )
 #endif
@@ -4853,17 +4860,17 @@ public:
 #else
             BLOCK(
                 moveShiftAmountIfNecessary(rhsLocation);
-                m_jit.neg64(rhsLocation.asGPR(), m_scratchGPR);
-                m_jit.rotateRight64(lhsLocation.asGPR(), m_scratchGPR, resultLocation.asGPR());
+                m_jit.neg64(rhsLocation.asGPR(), wasmScratchGPR);
+                m_jit.rotateRight64(lhsLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
             ),
             BLOCK(
                 if (rhs.isConst())
                     m_jit.rotateRight64(lhsLocation.asGPR(), TrustedImm32(-rhs.asI64()), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
-                    m_jit.neg64(rhsLocation.asGPR(), m_scratchGPR);
+                    m_jit.neg64(rhsLocation.asGPR(), wasmScratchGPR);
                     emitMoveConst(lhs, resultLocation);
-                    m_jit.rotateRight64(resultLocation.asGPR(), m_scratchGPR, resultLocation.asGPR());
+                    m_jit.rotateRight64(resultLocation.asGPR(), wasmScratchGPR, resultLocation.asGPR());
                 }
             )
 #endif
@@ -4885,8 +4892,8 @@ public:
                     m_jit.rotateRight32(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(rhs.asI32())), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
-                    emitMoveConst(lhs, Location::fromGPR(m_scratchGPR));
-                    m_jit.rotateRight32(m_scratchGPR, rhsLocation.asGPR(), resultLocation.asGPR());
+                    emitMoveConst(lhs, Location::fromGPR(wasmScratchGPR));
+                    m_jit.rotateRight32(wasmScratchGPR, rhsLocation.asGPR(), resultLocation.asGPR());
                 }
             )
         );
@@ -4907,8 +4914,8 @@ public:
                     m_jit.rotateRight64(lhsLocation.asGPR(), TrustedImm32(rhs.asI64()), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
-                    emitMoveConst(lhs, Location::fromGPR(m_scratchGPR));
-                    m_jit.rotateRight64(m_scratchGPR, rhsLocation.asGPR(), resultLocation.asGPR());
+                    emitMoveConst(lhs, Location::fromGPR(wasmScratchGPR));
+                    m_jit.rotateRight64(wasmScratchGPR, rhsLocation.asGPR(), resultLocation.asGPR());
                 }
             )
         );
@@ -4984,8 +4991,8 @@ public:
                 m_jit.compare64(condition, lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR(m_scratchGPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR(m_scratchGPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR(wasmScratchGPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR(wasmScratchGPR));
                 m_jit.compare64(condition, lhsLocation.asGPR(), rhsLocation.asGPR(), resultLocation.asGPR());
             )
         )
@@ -5103,8 +5110,8 @@ public:
                 m_jit.compareFloat(condition, lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asGPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 m_jit.compareFloat(condition, lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asGPR());
             )
         )
@@ -5119,8 +5126,8 @@ public:
                 m_jit.compareDouble(condition, lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asGPR());
             ),
             BLOCK(
-                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(m_scratchFPR);
-                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(m_scratchFPR));
+                ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromFPR(wasmScratchFPR);
+                emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromFPR(wasmScratchFPR));
                 m_jit.compareDouble(condition, lhsLocation.asFPR(), rhsLocation.asFPR(), resultLocation.asGPR());
             )
         )
@@ -5418,11 +5425,11 @@ public:
             BLOCK(
 #if CPU(X86_64)
                 ScratchScope<1, 0> scratches(*this);
-                m_jit.zeroExtend32ToWord(operandLocation.asGPR(), m_scratchGPR);
-                m_jit.convertUInt64ToFloat(m_scratchGPR, resultLocation.asFPR(), scratches.gpr(0));
+                m_jit.zeroExtend32ToWord(operandLocation.asGPR(), wasmScratchGPR);
+                m_jit.convertUInt64ToFloat(wasmScratchGPR, resultLocation.asFPR(), scratches.gpr(0));
 #else
-                m_jit.zeroExtend32ToWord(operandLocation.asGPR(), m_scratchGPR);
-                m_jit.convertUInt64ToFloat(m_scratchGPR, resultLocation.asFPR());
+                m_jit.zeroExtend32ToWord(operandLocation.asGPR(), wasmScratchGPR);
+                m_jit.convertUInt64ToFloat(wasmScratchGPR, resultLocation.asFPR());
 #endif
             )
         )
@@ -5446,7 +5453,7 @@ public:
             BLOCK(Value::fromF32(static_cast<uint64_t>(operand.asI64()))),
             BLOCK(
 #if CPU(X86_64)
-                m_jit.convertUInt64ToFloat(operandLocation.asGPR(), resultLocation.asFPR(), m_scratchGPR);
+                m_jit.convertUInt64ToFloat(operandLocation.asGPR(), resultLocation.asFPR(), wasmScratchGPR);
 #else
                 m_jit.convertUInt64ToFloat(operandLocation.asGPR(), resultLocation.asFPR());
 #endif
@@ -5473,11 +5480,11 @@ public:
             BLOCK(
 #if CPU(X86_64)
                 ScratchScope<1, 0> scratches(*this);
-                m_jit.zeroExtend32ToWord(operandLocation.asGPR(), m_scratchGPR);
-                m_jit.convertUInt64ToDouble(m_scratchGPR, resultLocation.asFPR(), scratches.gpr(0));
+                m_jit.zeroExtend32ToWord(operandLocation.asGPR(), wasmScratchGPR);
+                m_jit.convertUInt64ToDouble(wasmScratchGPR, resultLocation.asFPR(), scratches.gpr(0));
 #else
-                m_jit.zeroExtend32ToWord(operandLocation.asGPR(), m_scratchGPR);
-                m_jit.convertUInt64ToDouble(m_scratchGPR, resultLocation.asFPR());
+                m_jit.zeroExtend32ToWord(operandLocation.asGPR(), wasmScratchGPR);
+                m_jit.convertUInt64ToDouble(wasmScratchGPR, resultLocation.asFPR());
 #endif
             )
         )
@@ -5501,7 +5508,7 @@ public:
             BLOCK(Value::fromF64(static_cast<uint64_t>(operand.asI64()))),
             BLOCK(
 #if CPU(X86_64)
-                m_jit.convertUInt64ToDouble(operandLocation.asGPR(), resultLocation.asFPR(), m_scratchGPR);
+                m_jit.convertUInt64ToDouble(operandLocation.asGPR(), resultLocation.asFPR(), wasmScratchGPR);
 #else
                 m_jit.convertUInt64ToDouble(operandLocation.asGPR(), resultLocation.asFPR());
 #endif
@@ -5519,38 +5526,38 @@ public:
                 // there's some vector instruction we can use to do this much quicker.
 
 #if CPU(X86_64)
-                m_jit.moveFloatTo32(lhsLocation.asFPR(), m_scratchGPR);
-                m_jit.and32(TrustedImm32(0x7fffffff), m_scratchGPR);
-                m_jit.move32ToFloat(m_scratchGPR, m_scratchFPR);
-                m_jit.moveFloatTo32(rhsLocation.asFPR(), m_scratchGPR);
-                m_jit.and32(TrustedImm32(static_cast<int32_t>(0x80000000u)), m_scratchGPR, m_scratchGPR);
-                m_jit.move32ToFloat(m_scratchGPR, resultLocation.asFPR());
-                m_jit.orFloat(resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.moveFloatTo32(lhsLocation.asFPR(), wasmScratchGPR);
+                m_jit.and32(TrustedImm32(0x7fffffff), wasmScratchGPR);
+                m_jit.move32ToFloat(wasmScratchGPR, wasmScratchFPR);
+                m_jit.moveFloatTo32(rhsLocation.asFPR(), wasmScratchGPR);
+                m_jit.and32(TrustedImm32(static_cast<int32_t>(0x80000000u)), wasmScratchGPR, wasmScratchGPR);
+                m_jit.move32ToFloat(wasmScratchGPR, resultLocation.asFPR());
+                m_jit.orFloat(resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #else
-                m_jit.moveFloatTo32(rhsLocation.asFPR(), m_scratchGPR);
-                m_jit.and32(TrustedImm32(static_cast<int32_t>(0x80000000u)), m_scratchGPR, m_scratchGPR);
-                m_jit.move32ToFloat(m_scratchGPR, m_scratchFPR);
+                m_jit.moveFloatTo32(rhsLocation.asFPR(), wasmScratchGPR);
+                m_jit.and32(TrustedImm32(static_cast<int32_t>(0x80000000u)), wasmScratchGPR, wasmScratchGPR);
+                m_jit.move32ToFloat(wasmScratchGPR, wasmScratchFPR);
                 m_jit.absFloat(lhsLocation.asFPR(), lhsLocation.asFPR());
-                m_jit.orFloat(lhsLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.orFloat(lhsLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #endif
             ),
             BLOCK(
                 if (lhs.isConst()) {
-                    m_jit.moveFloatTo32(rhsLocation.asFPR(), m_scratchGPR);
-                    m_jit.and32(TrustedImm32(static_cast<int32_t>(0x80000000u)), m_scratchGPR, m_scratchGPR);
-                    m_jit.move32ToFloat(m_scratchGPR, m_scratchFPR);
+                    m_jit.moveFloatTo32(rhsLocation.asFPR(), wasmScratchGPR);
+                    m_jit.and32(TrustedImm32(static_cast<int32_t>(0x80000000u)), wasmScratchGPR, wasmScratchGPR);
+                    m_jit.move32ToFloat(wasmScratchGPR, wasmScratchFPR);
 
                     emitMoveConst(Value::fromF32(std::fabs(lhs.asF32())), resultLocation);
-                    m_jit.orFloat(resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                    m_jit.orFloat(resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
                 } else {
                     bool signBit = bitwise_cast<uint32_t>(rhs.asF32()) & 0x80000000u;
 #if CPU(X86_64)
                     m_jit.moveDouble(lhsLocation.asFPR(), resultLocation.asFPR());
-                    m_jit.move32ToFloat(TrustedImm32(0x7fffffff), m_scratchFPR);
-                    m_jit.andFloat(m_scratchFPR, resultLocation.asFPR());
+                    m_jit.move32ToFloat(TrustedImm32(0x7fffffff), wasmScratchFPR);
+                    m_jit.andFloat(wasmScratchFPR, resultLocation.asFPR());
                     if (signBit) {
-                        m_jit.xorFloat(m_scratchFPR, m_scratchFPR);
-                        m_jit.subFloat(m_scratchFPR, resultLocation.asFPR(), resultLocation.asFPR());
+                        m_jit.xorFloat(wasmScratchFPR, wasmScratchFPR);
+                        m_jit.subFloat(wasmScratchFPR, resultLocation.asFPR(), resultLocation.asFPR());
                     }
 #else
                     m_jit.absFloat(lhsLocation.asFPR(), resultLocation.asFPR());
@@ -5565,7 +5572,7 @@ public:
     PartialResult WARN_UNUSED_RETURN addF64Copysign(Value lhs, Value rhs, Value& result)
     {
         if constexpr (isX86())
-            clobber(m_shiftRCX);
+            clobber(shiftRCX);
 
         EMIT_BINARY(
             "F64Copysign", TypeKind::F64,
@@ -5575,46 +5582,46 @@ public:
                 // there's some vector instruction we can use to do this much quicker.
 
 #if CPU(X86_64)
-                m_jit.moveDoubleTo64(lhsLocation.asFPR(), m_scratchGPR);
-                m_jit.and64(TrustedImm64(0x7fffffffffffffffll), m_scratchGPR);
-                m_jit.move64ToDouble(m_scratchGPR, m_scratchFPR);
-                m_jit.moveDoubleTo64(rhsLocation.asFPR(), m_scratchGPR);
-                m_jit.urshift64(m_scratchGPR, TrustedImm32(63), m_scratchGPR);
-                m_jit.lshift64(m_scratchGPR, TrustedImm32(63), m_scratchGPR);
-                m_jit.move64ToDouble(m_scratchGPR, resultLocation.asFPR());
-                m_jit.orDouble(resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.moveDoubleTo64(lhsLocation.asFPR(), wasmScratchGPR);
+                m_jit.and64(TrustedImm64(0x7fffffffffffffffll), wasmScratchGPR);
+                m_jit.move64ToDouble(wasmScratchGPR, wasmScratchFPR);
+                m_jit.moveDoubleTo64(rhsLocation.asFPR(), wasmScratchGPR);
+                m_jit.urshift64(wasmScratchGPR, TrustedImm32(63), wasmScratchGPR);
+                m_jit.lshift64(wasmScratchGPR, TrustedImm32(63), wasmScratchGPR);
+                m_jit.move64ToDouble(wasmScratchGPR, resultLocation.asFPR());
+                m_jit.orDouble(resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #else
-                m_jit.moveDoubleTo64(rhsLocation.asFPR(), m_scratchGPR);
+                m_jit.moveDoubleTo64(rhsLocation.asFPR(), wasmScratchGPR);
 
                 // Probably saves us a bit of space compared to reserving another register and
                 // materializing a 64-bit constant.
-                m_jit.urshift64(m_scratchGPR, TrustedImm32(63), m_scratchGPR);
-                m_jit.lshift64(m_scratchGPR, TrustedImm32(63), m_scratchGPR);
-                m_jit.move64ToDouble(m_scratchGPR, m_scratchFPR);
+                m_jit.urshift64(wasmScratchGPR, TrustedImm32(63), wasmScratchGPR);
+                m_jit.lshift64(wasmScratchGPR, TrustedImm32(63), wasmScratchGPR);
+                m_jit.move64ToDouble(wasmScratchGPR, wasmScratchFPR);
 
                 m_jit.absDouble(lhsLocation.asFPR(), lhsLocation.asFPR());
-                m_jit.orDouble(lhsLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.orDouble(lhsLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #endif
             ),
             BLOCK(
                 if (lhs.isConst()) {
-                    m_jit.moveDoubleTo64(rhsLocation.asFPR(), m_scratchGPR);
-                    m_jit.urshift64(m_scratchGPR, TrustedImm32(63), m_scratchGPR);
-                    m_jit.lshift64(m_scratchGPR, TrustedImm32(63), m_scratchGPR);
-                    m_jit.move64ToDouble(m_scratchGPR, m_scratchFPR);
+                    m_jit.moveDoubleTo64(rhsLocation.asFPR(), wasmScratchGPR);
+                    m_jit.urshift64(wasmScratchGPR, TrustedImm32(63), wasmScratchGPR);
+                    m_jit.lshift64(wasmScratchGPR, TrustedImm32(63), wasmScratchGPR);
+                    m_jit.move64ToDouble(wasmScratchGPR, wasmScratchFPR);
 
-                    // Moving this constant clobbers m_scratchGPR, but not m_scratchFPR
+                    // Moving this constant clobbers wasmScratchGPR, but not wasmScratchFPR
                     emitMoveConst(Value::fromF64(std::fabs(lhs.asF64())), resultLocation);
-                    m_jit.orDouble(resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                    m_jit.orDouble(resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
                 } else {
                     bool signBit = bitwise_cast<uint64_t>(rhs.asF64()) & 0x8000000000000000ull;
 #if CPU(X86_64)
                     m_jit.moveDouble(lhsLocation.asFPR(), resultLocation.asFPR());
-                    m_jit.move64ToDouble(TrustedImm64(0x7fffffffffffffffll), m_scratchFPR);
-                    m_jit.andDouble(m_scratchFPR, resultLocation.asFPR());
+                    m_jit.move64ToDouble(TrustedImm64(0x7fffffffffffffffll), wasmScratchFPR);
+                    m_jit.andDouble(wasmScratchFPR, resultLocation.asFPR());
                     if (signBit) {
-                        m_jit.xorDouble(m_scratchFPR, m_scratchFPR);
-                        m_jit.subDouble(m_scratchFPR, resultLocation.asFPR(), resultLocation.asFPR());
+                        m_jit.xorDouble(wasmScratchFPR, wasmScratchFPR);
+                        m_jit.subDouble(wasmScratchFPR, resultLocation.asFPR(), resultLocation.asFPR());
                     }
 #else
                     m_jit.absDouble(lhsLocation.asFPR(), resultLocation.asFPR());
@@ -5677,8 +5684,8 @@ public:
             BLOCK(Value::fromF32(std::abs(operand.asF32()))),
             BLOCK(
 #if CPU(X86_64)
-                m_jit.move32ToFloat(TrustedImm32(0x7fffffffll), m_scratchFPR);
-                m_jit.andFloat(operandLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.move32ToFloat(TrustedImm32(0x7fffffffll), wasmScratchFPR);
+                m_jit.andFloat(operandLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #else
                 m_jit.absFloat(operandLocation.asFPR(), resultLocation.asFPR());
 #endif
@@ -5693,8 +5700,8 @@ public:
             BLOCK(Value::fromF64(std::abs(operand.asF64()))),
             BLOCK(
 #if CPU(X86_64)
-                m_jit.move64ToDouble(TrustedImm64(0x7fffffffffffffffll), m_scratchFPR);
-                m_jit.andDouble(operandLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.move64ToDouble(TrustedImm64(0x7fffffffffffffffll), wasmScratchFPR);
+                m_jit.andDouble(operandLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #else
                 m_jit.absDouble(operandLocation.asFPR(), resultLocation.asFPR());
 #endif
@@ -5731,9 +5738,9 @@ public:
             BLOCK(Value::fromF32(-operand.asF32())),
             BLOCK(
 #if CPU(X86_64)
-                m_jit.moveFloatTo32(operandLocation.asFPR(), m_scratchGPR);
-                m_jit.xor32(TrustedImm32(bitwise_cast<uint32_t>(static_cast<float>(-0.0))), m_scratchGPR);
-                m_jit.move32ToFloat(m_scratchGPR, resultLocation.asFPR());
+                m_jit.moveFloatTo32(operandLocation.asFPR(), wasmScratchGPR);
+                m_jit.xor32(TrustedImm32(bitwise_cast<uint32_t>(static_cast<float>(-0.0))), wasmScratchGPR);
+                m_jit.move32ToFloat(wasmScratchGPR, resultLocation.asFPR());
 #else
                 m_jit.negateFloat(operandLocation.asFPR(), resultLocation.asFPR());
 #endif
@@ -5748,9 +5755,9 @@ public:
             BLOCK(Value::fromF64(-operand.asF64())),
             BLOCK(
 #if CPU(X86_64)
-                m_jit.moveDoubleTo64(operandLocation.asFPR(), m_scratchGPR);
-                m_jit.xor64(TrustedImm64(bitwise_cast<uint64_t>(static_cast<double>(-0.0))), m_scratchGPR);
-                m_jit.move64ToDouble(m_scratchGPR, resultLocation.asFPR());
+                m_jit.moveDoubleTo64(operandLocation.asFPR(), wasmScratchGPR);
+                m_jit.xor64(TrustedImm64(bitwise_cast<uint64_t>(static_cast<double>(-0.0))), wasmScratchGPR);
+                m_jit.move64ToDouble(wasmScratchGPR, resultLocation.asFPR());
 #else
                 m_jit.negateDouble(operandLocation.asFPR(), resultLocation.asFPR());
 #endif
@@ -5861,7 +5868,7 @@ public:
     {
         Location valueLocation;
         if (value.isConst()) {
-            valueLocation = Location::fromGPR(m_scratchGPR);
+            valueLocation = Location::fromGPR(wasmScratchGPR);
             emitMoveConst(value, valueLocation);
         } else
             valueLocation = loadIfNecessary(value);
@@ -5903,8 +5910,8 @@ public:
         clobber(GPRInfo::argumentGPR0);
         clobber(GPRInfo::argumentGPR1);
 
-        m_jit.move(TrustedImmPtr(bitwise_cast<uintptr_t>(&m_tierUp->m_counter)), m_scratchGPR);
-        Jump tierUp = m_jit.branchAdd32(CCallHelpers::PositiveOrZero, TrustedImm32(TierUpCount::functionEntryIncrement()), Address(m_scratchGPR));
+        m_jit.move(TrustedImmPtr(bitwise_cast<uintptr_t>(&m_tierUp->m_counter)), wasmScratchGPR);
+        Jump tierUp = m_jit.branchAdd32(CCallHelpers::PositiveOrZero, TrustedImm32(TierUpCount::functionEntryIncrement()), Address(wasmScratchGPR));
         MacroAssembler::Label tierUpResume = m_jit.label();
         auto functionIndex = m_functionIndex;
         addLatePath([tierUp, tierUpResume, functionIndex](BBQJIT& generator, CCallHelpers& jit) {
@@ -5939,38 +5946,38 @@ public:
         m_jit.emitFunctionPrologue();
         m_topLevel = ControlData(*this, BlockType::TopLevel, signature, 0);
 
-        m_jit.move(CCallHelpers::TrustedImmPtr(CalleeBits::boxWasm(&m_callee)), m_scratchGPR);
+        m_jit.move(CCallHelpers::TrustedImmPtr(CalleeBits::boxWasm(&m_callee)), wasmScratchGPR);
         static_assert(CallFrameSlot::codeBlock + 1 == CallFrameSlot::callee);
         if constexpr (is32Bit()) {
             CCallHelpers::Address calleeSlot { GPRInfo::callFrameRegister, CallFrameSlot::callee * sizeof(Register) };
-            m_jit.storePtr(m_scratchGPR, calleeSlot.withOffset(PayloadOffset));
+            m_jit.storePtr(wasmScratchGPR, calleeSlot.withOffset(PayloadOffset));
             m_jit.store32(CCallHelpers::TrustedImm32(JSValue::WasmTag), calleeSlot.withOffset(TagOffset));
             m_jit.storePtr(GPRInfo::wasmContextInstancePointer, CCallHelpers::addressFor(CallFrameSlot::codeBlock));
         } else
-            m_jit.storePairPtr(GPRInfo::wasmContextInstancePointer, m_scratchGPR, GPRInfo::callFrameRegister, CCallHelpers::TrustedImm32(CallFrameSlot::codeBlock * sizeof(Register)));
+            m_jit.storePairPtr(GPRInfo::wasmContextInstancePointer, wasmScratchGPR, GPRInfo::callFrameRegister, CCallHelpers::TrustedImm32(CallFrameSlot::codeBlock * sizeof(Register)));
 
-        m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), m_scratchGPR));
+        m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), wasmScratchGPR));
 
         bool mayHaveExceptionHandlers = !m_hasExceptionHandlers || m_hasExceptionHandlers.value();
         if (mayHaveExceptionHandlers)
             m_jit.store32(CCallHelpers::TrustedImm32(PatchpointExceptionHandle::s_invalidCallSiteIndex), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
 
         // Because we compile in a single pass, we always need to pessimistically check for stack underflow/overflow.
-        ASSERT(m_scratchGPR == GPRInfo::nonPreservedNonArgumentGPR0);
-        m_jit.subPtr(GPRInfo::callFrameRegister, m_scratchGPR, m_scratchGPR);
+        static_assert(wasmScratchGPR == GPRInfo::nonPreservedNonArgumentGPR0);
+        m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, wasmScratchGPR);
         MacroAssembler::JumpList underflow;
-        underflow.append(m_jit.branchPtr(CCallHelpers::Above, m_scratchGPR, GPRInfo::callFrameRegister));
+        underflow.append(m_jit.branchPtr(CCallHelpers::Above, wasmScratchGPR, GPRInfo::callFrameRegister));
         m_jit.addLinkTask([underflow] (LinkBuffer& linkBuffer) {
             linkBuffer.link(underflow, CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(throwStackOverflowFromWasmThunkGenerator).code()));
         });
 
         MacroAssembler::JumpList overflow;
         m_jit.loadPtr(CCallHelpers::Address(GPRInfo::wasmContextInstancePointer, Instance::offsetOfVM()), GPRInfo::nonPreservedNonArgumentGPR1);
-        overflow.append(m_jit.branchPtr(CCallHelpers::Below, m_scratchGPR, CCallHelpers::Address(GPRInfo::nonPreservedNonArgumentGPR1, VM::offsetOfSoftStackLimit())));
+        overflow.append(m_jit.branchPtr(CCallHelpers::Below, wasmScratchGPR, CCallHelpers::Address(GPRInfo::nonPreservedNonArgumentGPR1, VM::offsetOfSoftStackLimit())));
         m_jit.addLinkTask([overflow] (LinkBuffer& linkBuffer) {
             linkBuffer.link(overflow, CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(throwStackOverflowFromWasmThunkGenerator).code()));
         });
-        m_jit.move(m_scratchGPR, MacroAssembler::stackPointerRegister);
+        m_jit.move(wasmScratchGPR, MacroAssembler::stackPointerRegister);
 
         LocalOrTempIndex i = 0;
         for (; i < m_arguments.size(); ++i)
@@ -6099,15 +6106,15 @@ public:
         auto label = m_jit.label();
         m_jit.emitFunctionPrologue();
 
-        m_jit.move(CCallHelpers::TrustedImmPtr(CalleeBits::boxWasm(&m_callee)), m_scratchGPR);
+        m_jit.move(CCallHelpers::TrustedImmPtr(CalleeBits::boxWasm(&m_callee)), wasmScratchGPR);
         static_assert(CallFrameSlot::codeBlock + 1 == CallFrameSlot::callee);
         if constexpr (is32Bit()) {
             CCallHelpers::Address calleeSlot { GPRInfo::callFrameRegister, CallFrameSlot::callee * sizeof(Register) };
-            m_jit.storePtr(m_scratchGPR, calleeSlot.withOffset(PayloadOffset));
+            m_jit.storePtr(wasmScratchGPR, calleeSlot.withOffset(PayloadOffset));
             m_jit.store32(CCallHelpers::TrustedImm32(JSValue::WasmTag), calleeSlot.withOffset(TagOffset));
             m_jit.storePtr(GPRInfo::wasmContextInstancePointer, CCallHelpers::addressFor(CallFrameSlot::codeBlock));
         } else
-            m_jit.storePairPtr(GPRInfo::wasmContextInstancePointer, m_scratchGPR, GPRInfo::callFrameRegister, CCallHelpers::TrustedImm32(CallFrameSlot::codeBlock * sizeof(Register)));
+            m_jit.storePairPtr(GPRInfo::wasmContextInstancePointer, wasmScratchGPR, GPRInfo::callFrameRegister, CCallHelpers::TrustedImm32(CallFrameSlot::codeBlock * sizeof(Register)));
 
         int frameSize = m_frameSize + m_maxCalleeStackSize;
         int roundedFrameSize = WTF::roundUpToMultipleOf(stackAlignmentBytes(), frameSize);
@@ -6127,13 +6134,13 @@ public:
         });
 
         // This operation shuffles around values on the stack, until everything is in the right place. Then,
-        // it returns the address of the loop we're jumping to in m_scratchGPR (so we don't interfere with
+        // it returns the address of the loop we're jumping to in wasmScratchGPR (so we don't interfere with
         // anything we just loaded from the scratch buffer into a register)
         m_jit.probe(tagCFunction<JITProbePtrTag>(operationWasmLoopOSREnterBBQJIT), m_tierUp, m_usesSIMD ? SavedFPWidth::SaveVectors : SavedFPWidth::DontSaveVectors);
 
         // We expect the loop address to be populated by the probe operation.
-        ASSERT(m_scratchGPR == GPRInfo::nonPreservedNonArgumentGPR0);
-        m_jit.farJump(m_scratchGPR, WasmEntryPtrTag);
+        static_assert(wasmScratchGPR == GPRInfo::nonPreservedNonArgumentGPR0);
+        m_jit.farJump(wasmScratchGPR, WasmEntryPtrTag);
         return label;
     }
 
@@ -6232,14 +6239,14 @@ public:
         clobber(GPRInfo::argumentGPR0);
         clobber(GPRInfo::argumentGPR1);
 
-        m_jit.move(TrustedImm64(bitwise_cast<uintptr_t>(&m_tierUp->m_counter)), m_scratchGPR);
+        m_jit.move(TrustedImm64(bitwise_cast<uintptr_t>(&m_tierUp->m_counter)), wasmScratchGPR);
 
         TierUpCount::TriggerReason* forceEntryTrigger = &(m_tierUp->osrEntryTriggers().last());
         static_assert(!static_cast<uint8_t>(TierUpCount::TriggerReason::DontTrigger), "the JIT code assumes non-zero means 'enter'");
         static_assert(sizeof(TierUpCount::TriggerReason) == 1, "branchTest8 assumes this size");
 
         Jump forceOSREntry = m_jit.branchTest8(ResultCondition::NonZero, CCallHelpers::AbsoluteAddress(forceEntryTrigger));
-        Jump tierUp = m_jit.branchAdd32(ResultCondition::PositiveOrZero, TrustedImm32(TierUpCount::loopIncrement()), CCallHelpers::Address(m_scratchGPR));
+        Jump tierUp = m_jit.branchAdd32(ResultCondition::PositiveOrZero, TrustedImm32(TierUpCount::loopIncrement()), CCallHelpers::Address(wasmScratchGPR));
         MacroAssembler::Label tierUpResume = m_jit.label();
 
         OSREntryData& osrEntryData = m_tierUp->addOSREntryData(m_functionIndex, loopIndex, makeStackMap(data, enclosingStack));
@@ -6276,7 +6283,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addIf(Value condition, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
     {
-        Location conditionLocation = Location::fromGPR(m_scratchGPR);
+        Location conditionLocation = Location::fromGPR(wasmScratchGPR);
         if (!condition.isConst())
             emitMove(condition, conditionLocation);
         consume(condition);
@@ -6294,7 +6301,7 @@ public:
         if (condition.isConst() && !condition.asI32())
             result.setIfBranch(m_jit.jump()); // Emit direct branch if we know the condition is false.
         else if (!condition.isConst()) // Otherwise, we only emit a branch at all if we don't know the condition statically.
-            result.setIfBranch(m_jit.branchTest32(ResultCondition::Zero, m_scratchGPR, m_scratchGPR));
+            result.setIfBranch(m_jit.branchTest32(ResultCondition::Zero, wasmScratchGPR, wasmScratchGPR));
         return { };
     }
 
@@ -6369,7 +6376,7 @@ public:
         m_jit.subPtr(GPRInfo::callFrameRegister, GPRInfo::nonPreservedNonArgumentGPR0, MacroAssembler::stackPointerRegister);
         if (!!m_info.memory) {
             m_jit.loadPairPtr(GPRInfo::wasmContextInstancePointer, TrustedImm32(Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister);
-            m_jit.cageConditionallyAndUntag(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, m_scratchGPR, /* validateAuth */ true, /* mayBeNull */ false);
+            m_jit.cageConditionallyAndUntag(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, wasmScratchGPR, /* validateAuth */ true, /* mayBeNull */ false);
         }
         static_assert(noOverlap(GPRInfo::nonPreservedNonArgumentGPR0, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR2));
     }
@@ -6401,8 +6408,8 @@ public:
                 Location slot = canonicalSlot(result);
                 switch (type.kind) {
                 case TypeKind::I32:
-                    m_jit.load32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), m_scratchGPR);
-                    m_jit.store32(m_scratchGPR, slot.asAddress());
+                    m_jit.load32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), wasmScratchGPR);
+                    m_jit.store32(wasmScratchGPR, slot.asAddress());
                     break;
                 case TypeKind::I31ref:
                 case TypeKind::I64:
@@ -6417,21 +6424,21 @@ public:
                 case TypeKind::Array:
                 case TypeKind::Struct:
                 case TypeKind::Func: {
-                    m_jit.load64(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), m_scratchGPR);
-                    m_jit.store64(m_scratchGPR, slot.asAddress());
+                    m_jit.load64(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), wasmScratchGPR);
+                    m_jit.store64(wasmScratchGPR, slot.asAddress());
                     break;
                 }
                 case TypeKind::F32:
-                    m_jit.loadFloat(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), m_scratchFPR);
-                    m_jit.storeFloat(m_scratchFPR, slot.asAddress());
+                    m_jit.loadFloat(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), wasmScratchFPR);
+                    m_jit.storeFloat(wasmScratchFPR, slot.asAddress());
                     break;
                 case TypeKind::F64:
-                    m_jit.loadDouble(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), m_scratchFPR);
-                    m_jit.storeDouble(m_scratchFPR, slot.asAddress());
+                    m_jit.loadDouble(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), wasmScratchFPR);
+                    m_jit.storeDouble(wasmScratchFPR, slot.asAddress());
                     break;
                 case TypeKind::V128:
-                    materializeVectorConstant(v128_t { }, Location::fromFPR(m_scratchFPR));
-                    m_jit.storeVector(m_scratchFPR, slot.asAddress());
+                    materializeVectorConstant(v128_t { }, Location::fromFPR(wasmScratchFPR));
+                    m_jit.storeVector(wasmScratchFPR, slot.asAddress());
                     break;
                 case TypeKind::Void:
                     RELEASE_ASSERT_NOT_REACHED();
@@ -6646,7 +6653,7 @@ public:
         if (condition.isConst() && !condition.asI32()) // If condition is known to be false, this is a no-op.
             return { };
 
-        Location conditionLocation = Location::fromGPR(m_scratchGPR);
+        Location conditionLocation = Location::fromGPR(wasmScratchGPR);
         if (!condition.isNone() && !condition.isConst())
             emitMove(condition, conditionLocation);
         consume(condition);
@@ -6661,7 +6668,7 @@ public:
             target.addBranch(m_jit.jump()); // We know condition is true, since if it was false we would have returned early.
         } else {
             currentControlData().flushAtBlockBoundary(*this, 0, results, condition.isNone());
-            Jump ifNotTaken = m_jit.branchTest32(ResultCondition::Zero, m_scratchGPR);
+            Jump ifNotTaken = m_jit.branchTest32(ResultCondition::Zero, wasmScratchGPR);
             currentControlData().addExit(*this, target.targetLocations(), results);
             target.addBranch(m_jit.jump());
             ifNotTaken.link(&m_jit);
@@ -6678,7 +6685,7 @@ public:
         LOG_INSTRUCTION("BrTable", condition);
 
         if (!condition.isConst())
-            emitMove(condition, Location::fromGPR(m_scratchGPR));
+            emitMove(condition, Location::fromGPR(wasmScratchGPR));
         consume(condition);
 
         if (condition.isConst()) {
@@ -6702,11 +6709,11 @@ public:
             Vector<Box<CCallHelpers::Label>> labels;
             labels.reserveInitialCapacity(targets.size());
             auto* jumpTable = m_callee.addJumpTable(targets.size());
-            auto fallThrough = m_jit.branch32(RelationalCondition::AboveOrEqual, m_scratchGPR, TrustedImm32(targets.size()));
-            m_jit.zeroExtend32ToWord(m_scratchGPR, m_scratchGPR);
-            m_jit.lshiftPtr(TrustedImm32(3), m_scratchGPR);
-            m_jit.addPtr(TrustedImmPtr(jumpTable->data()), m_scratchGPR);
-            m_jit.farJump(Address(m_scratchGPR), JSSwitchPtrTag);
+            auto fallThrough = m_jit.branch32(RelationalCondition::AboveOrEqual, wasmScratchGPR, TrustedImm32(targets.size()));
+            m_jit.zeroExtend32ToWord(wasmScratchGPR, wasmScratchGPR);
+            m_jit.lshiftPtr(TrustedImm32(3), wasmScratchGPR);
+            m_jit.addPtr(TrustedImmPtr(jumpTable->data()), wasmScratchGPR);
+            m_jit.farJump(Address(wasmScratchGPR), JSSwitchPtrTag);
 
             for (unsigned index = 0; index < targets.size(); ++index) {
                 Box<CCallHelpers::Label> label = Box<CCallHelpers::Label>::create(m_jit.label());
@@ -6734,7 +6741,7 @@ public:
             for (size_t i = 0; i < targets.size(); ++i)
                 cases.uncheckedAppend(i);
 
-            BinarySwitch binarySwitch(m_scratchGPR, cases, BinarySwitch::Int32);
+            BinarySwitch binarySwitch(wasmScratchGPR, cases, BinarySwitch::Int32);
             while (binarySwitch.advance(m_jit)) {
                 unsigned value = binarySwitch.caseValue();
                 unsigned index = binarySwitch.caseIndex();
@@ -6877,7 +6884,7 @@ public:
         // FIXME: We should just store these registers on stack and load them.
         if (!!m_info.memory) {
             m_jit.loadPairPtr(GPRInfo::wasmContextInstancePointer, TrustedImm32(Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister);
-            m_jit.cageConditionallyAndUntag(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, m_scratchGPR, /* validateAuth */ true, /* mayBeNull */ false);
+            m_jit.cageConditionallyAndUntag(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, wasmScratchGPR, /* validateAuth */ true, /* mayBeNull */ false);
         }
     }
 
@@ -7002,8 +7009,8 @@ public:
 
         // Materialize address of native function and call register
         void* taggedFunctionPtr = tagCFunctionPtr<void*, OperationPtrTag>(function);
-        m_jit.move(TrustedImmPtr(bitwise_cast<uintptr_t>(taggedFunctionPtr)), m_scratchGPR);
-        m_jit.call(m_scratchGPR, OperationPtrTag);
+        m_jit.move(TrustedImmPtr(bitwise_cast<uintptr_t>(taggedFunctionPtr)), wasmScratchGPR);
+        m_jit.call(wasmScratchGPR, OperationPtrTag);
     }
 
     template<typename Func, size_t N>
@@ -7031,8 +7038,8 @@ public:
 
         // Materialize address of native function and call register
         void* taggedFunctionPtr = tagCFunctionPtr<void*, OperationPtrTag>(function);
-        m_jit.move(TrustedImmPtr(bitwise_cast<uintptr_t>(taggedFunctionPtr)), m_scratchGPR);
-        m_jit.call(m_scratchGPR, OperationPtrTag);
+        m_jit.move(TrustedImmPtr(bitwise_cast<uintptr_t>(taggedFunctionPtr)), wasmScratchGPR);
+        m_jit.call(wasmScratchGPR, OperationPtrTag);
 
         // FIXME: Probably we should make CCall more lower level, and we should bind the result to Value separately.
         result = Value::fromTemp(returnType, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + m_parser->expressionStack().size());
@@ -7094,11 +7101,11 @@ public:
         passParametersToCall(arguments, callInfo);
 
         if (m_info.isImportedFunctionFromFunctionIndexSpace(functionIndex)) {
-            m_jit.move(TrustedImmPtr(Instance::offsetOfImportFunctionStub(functionIndex)), m_scratchGPR);
-            m_jit.addPtr(GPRInfo::wasmContextInstancePointer, m_scratchGPR);
-            m_jit.loadPtr(Address(m_scratchGPR), m_scratchGPR);
+            m_jit.move(TrustedImmPtr(Instance::offsetOfImportFunctionStub(functionIndex)), wasmScratchGPR);
+            m_jit.addPtr(GPRInfo::wasmContextInstancePointer, wasmScratchGPR);
+            m_jit.loadPtr(Address(wasmScratchGPR), wasmScratchGPR);
 
-            m_jit.call(m_scratchGPR, WasmEntryPtrTag);
+            m_jit.call(wasmScratchGPR, WasmEntryPtrTag);
         } else {
             // Emit the call.
             Vector<UnlinkedWasmToWasmCall>* unlinkedWasmToWasmCalls = &m_unlinkedWasmToWasmCalls;
@@ -7119,7 +7126,7 @@ public:
         return { };
     }
 
-    void emitIndirectCall(const char* opcode, const Value& calleeIndex, RegisterID calleeInstance, RegisterID calleeCode, RegisterID jsCalleeAnchor, const TypeDefinition& signature, Vector<Value>& arguments, ResultList& results, CallType callType = CallType::Call)
+    void emitIndirectCall(const char* opcode, const Value& calleeIndex, GPRReg calleeInstance, GPRReg calleeCode, GPRReg jsCalleeAnchor, const TypeDefinition& signature, Vector<Value>& arguments, ResultList& results, CallType callType = CallType::Call)
     {
         // TODO: Support tail calls
         UNUSED_PARAM(jsCalleeAnchor);
@@ -7134,18 +7141,18 @@ public:
         Jump isSameInstance = m_jit.branchPtr(RelationalCondition::Equal, calleeInstance, GPRInfo::wasmContextInstancePointer);
         m_jit.move(calleeInstance, GPRInfo::wasmContextInstancePointer);
         m_jit.loadPairPtr(GPRInfo::wasmContextInstancePointer, TrustedImm32(Instance::offsetOfCachedMemory()), GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister);
-        m_jit.cageConditionallyAndUntag(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, m_scratchGPR, /* validateAuth */ true, /* mayBeNull */ false);
+        m_jit.cageConditionallyAndUntag(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, wasmScratchGPR, /* validateAuth */ true, /* mayBeNull */ false);
         isSameInstance.link(&m_jit);
 
         // Since this can switch instance, we need to keep JSWebAssemblyInstance anchored in the stack.
         m_jit.storePtr(jsCalleeAnchor, Location::fromArgumentLocation(wasmCalleeInfo.thisArgument).asAddress());
 
         // Safe to use across saveValues/passParameters since neither clobber the scratch GPR.
-        m_jit.loadPtr(Address(calleeCode), m_scratchGPR);
+        m_jit.loadPtr(Address(calleeCode), wasmScratchGPR);
         prepareForExceptions();
         saveValuesAcrossCall(wasmCalleeInfo);
         passParametersToCall(arguments, wasmCalleeInfo);
-        m_jit.call(m_scratchGPR, WasmEntryPtrTag);
+        m_jit.call(wasmScratchGPR, WasmEntryPtrTag);
         returnValuesFromCall(results, *signature.as<FunctionSignature>(), wasmCalleeInfo);
 
         // The call could have been to another WebAssembly instance, and / or could have modified our Memory.
@@ -7163,7 +7170,7 @@ public:
         ASSERT(m_info.tables[tableIndex].type() == TableElementType::Funcref);
 
         Location calleeIndexLocation;
-        RegisterID calleeInstance, calleeCode, jsCalleeAnchor;
+        GPRReg calleeInstance, calleeCode, jsCalleeAnchor;
 
         {
             ScratchScope<3, 0> scratches(*this);
@@ -7173,8 +7180,8 @@ public:
             else
                 calleeIndexLocation = loadIfNecessary(calleeIndex);
 
-            RegisterID callableFunctionBufferLength = scratches.gpr(0);
-            RegisterID callableFunctionBuffer = scratches.gpr(1);
+            GPRReg callableFunctionBufferLength = scratches.gpr(0);
+            GPRReg callableFunctionBuffer = scratches.gpr(1);
 
             ASSERT(tableIndex < m_info.tableCount());
 
@@ -7206,7 +7213,7 @@ public:
             jsCalleeAnchor = scratches.gpr(2);
 
             static_assert(sizeof(TypeIndex) == sizeof(void*));
-            RegisterID calleeSignatureIndex = m_scratchGPR;
+            GPRReg calleeSignatureIndex = wasmScratchGPR;
 
             // Compute the offset in the table index space we are looking for.
             m_jit.move(TrustedImmPtr(sizeof(FuncRefTable::Function)), calleeSignatureIndex);
@@ -7343,21 +7350,21 @@ public:
 
             // Store each byte (w/ index - 16 >= 0) of `b` to result2
             // and zero clear each byte (w/ index - 16 < 0) in result2.
-            materializeVectorConstant(rightImm, Location::fromFPR(m_scratchFPR));
-            m_jit.vectorSwizzle(bLocation.asFPR(), m_scratchFPR, m_scratchFPR);
-            m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, scratches.fpr(0), m_scratchFPR, resultLocation.asFPR());
+            materializeVectorConstant(rightImm, Location::fromFPR(wasmScratchFPR));
+            m_jit.vectorSwizzle(bLocation.asFPR(), wasmScratchFPR, wasmScratchFPR);
+            m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, scratches.fpr(0), wasmScratchFPR, resultLocation.asFPR());
             return { };
         }
 
 #if CPU(ARM64)
-        materializeVectorConstant(imm, Location::fromFPR(m_scratchFPR));
+        materializeVectorConstant(imm, Location::fromFPR(wasmScratchFPR));
         if (unsigned(aLocation.asFPR()) + 1 != unsigned(bLocation.asFPR())) {
             m_jit.moveVector(aLocation.asFPR(), ARM64Registers::q28);
             m_jit.moveVector(bLocation.asFPR(), ARM64Registers::q29);
             aLocation = Location::fromFPR(ARM64Registers::q28);
             bLocation = Location::fromFPR(ARM64Registers::q29);
         }
-        m_jit.vectorSwizzle2(aLocation.asFPR(), bLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+        m_jit.vectorSwizzle2(aLocation.asFPR(), bLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #else
         UNREACHABLE_FOR_PLATFORM();
 #endif
@@ -7369,13 +7376,13 @@ public:
     {
 #if CPU(X86_64)
         // Clobber and preserve RCX on x86, since we need it to do shifts.
-        clobber(m_shiftRCX);
-        ScratchScope<2, 2> scratches(*this, Location::fromGPR(m_shiftRCX));
+        clobber(shiftRCX);
+        ScratchScope<2, 2> scratches(*this, Location::fromGPR(shiftRCX));
 #endif
         Location srcLocation = loadIfNecessary(src);
         Location shiftLocation;
         if (shift.isConst()) {
-            shiftLocation = Location::fromGPR(m_scratchGPR);
+            shiftLocation = Location::fromGPR(wasmScratchGPR);
             emitMoveConst(shift, shiftLocation);
         } else
             shiftLocation = loadIfNecessary(shift);
@@ -7390,29 +7397,29 @@ public:
         LOG_INSTRUCTION("Vector", op, src, srcLocation, shift, shiftLocation, RESULT(result));
 
 #if CPU(ARM64)
-        m_jit.and32(Imm32(mask), shiftLocation.asGPR(), m_scratchGPR);
+        m_jit.and32(Imm32(mask), shiftLocation.asGPR(), wasmScratchGPR);
         if (op == SIMDLaneOperation::Shr) {
             // ARM64 doesn't have a version of this instruction for right shift. Instead, if the input to
             // left shift is negative, it's a right shift by the absolute value of that amount.
-            m_jit.neg32(m_scratchGPR);
+            m_jit.neg32(wasmScratchGPR);
         }
-        m_jit.vectorSplatInt8(m_scratchGPR, m_scratchFPR);
+        m_jit.vectorSplatInt8(wasmScratchGPR, wasmScratchFPR);
         if (info.signMode == SIMDSignMode::Signed)
-            m_jit.vectorSshl(info, srcLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+            m_jit.vectorSshl(info, srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
         else
-            m_jit.vectorUshl(info, srcLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+            m_jit.vectorUshl(info, srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #else
         ASSERT(isX86());
-        m_jit.move(shiftLocation.asGPR(), m_scratchGPR);
-        m_jit.and32(Imm32(mask), m_scratchGPR);
+        m_jit.move(shiftLocation.asGPR(), wasmScratchGPR);
+        m_jit.and32(Imm32(mask), wasmScratchGPR);
 
         if (op == SIMDLaneOperation::Shr && info.signMode == SIMDSignMode::Signed && info.lane == SIMDLane::i64x2) {
             // x86 has no SIMD 64-bit signed right shift instruction, so we scalarize it here.
-            m_jit.move(m_scratchGPR, m_shiftRCX);
+            m_jit.move(wasmScratchGPR, shiftRCX);
             m_jit.vectorExtractLaneInt64(TrustedImm32(0), srcLocation.asFPR(), scratches.gpr(0));
             m_jit.vectorExtractLaneInt64(TrustedImm32(1), srcLocation.asFPR(), scratches.gpr(1));
-            m_jit.rshift64(m_shiftRCX, scratches.gpr(0));
-            m_jit.rshift64(m_shiftRCX, scratches.gpr(1));
+            m_jit.rshift64(shiftRCX, scratches.gpr(0));
+            m_jit.rshift64(shiftRCX, scratches.gpr(1));
             m_jit.vectorReplaceLaneInt64(TrustedImm32(0), scratches.gpr(0), resultLocation.asFPR());
             m_jit.vectorReplaceLaneInt64(TrustedImm32(1), scratches.gpr(1), resultLocation.asFPR());
             return { };
@@ -7420,27 +7427,27 @@ public:
 
         // Unlike ARM, x86 expects the shift provided as a *scalar*, stored in the lower 64 bits of a vector register.
         // So, we don't need to splat the shift amount like we do on ARM.
-        m_jit.move64ToDouble(m_scratchGPR, m_scratchFPR);
+        m_jit.move64ToDouble(wasmScratchGPR, wasmScratchFPR);
 
         // 8-bit shifts are pretty involved to implement on Intel, so they get their own instruction type with extra temps.
         if (op == SIMDLaneOperation::Shl && info.lane == SIMDLane::i8x16) {
-            m_jit.vectorUshl8(srcLocation.asFPR(), m_scratchFPR, resultLocation.asFPR(), scratches.fpr(0), scratches.fpr(1));
+            m_jit.vectorUshl8(srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR(), scratches.fpr(0), scratches.fpr(1));
             return { };
         }
         if (op == SIMDLaneOperation::Shr && info.lane == SIMDLane::i8x16) {
             if (info.signMode == SIMDSignMode::Signed)
-                m_jit.vectorSshr8(srcLocation.asFPR(), m_scratchFPR, resultLocation.asFPR(), scratches.fpr(0), scratches.fpr(1));
+                m_jit.vectorSshr8(srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR(), scratches.fpr(0), scratches.fpr(1));
             else
-                m_jit.vectorUshr8(srcLocation.asFPR(), m_scratchFPR, resultLocation.asFPR(), scratches.fpr(0), scratches.fpr(1));
+                m_jit.vectorUshr8(srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR(), scratches.fpr(0), scratches.fpr(1));
             return { };
         }
 
         if (op == SIMDLaneOperation::Shl)
-            m_jit.vectorUshl(info, srcLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+            m_jit.vectorUshl(info, srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
         else if (info.signMode == SIMDSignMode::Signed)
-            m_jit.vectorSshr(info, srcLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+            m_jit.vectorSshr(info, srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
         else
-            m_jit.vectorUshr(info, srcLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+            m_jit.vectorUshr(info, srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #endif
         return { };
     }
@@ -7460,14 +7467,14 @@ public:
         LOG_INSTRUCTION("Vector", op, left, leftLocation, right, rightLocation, RESULT(result));
 
         if (op == SIMDLaneOperation::ExtmulLow) {
-            m_jit.vectorExtendLow(info, leftLocation.asFPR(), m_scratchFPR);
+            m_jit.vectorExtendLow(info, leftLocation.asFPR(), wasmScratchFPR);
             m_jit.vectorExtendLow(info, rightLocation.asFPR(), resultLocation.asFPR());
         } else {
             ASSERT(op == SIMDLaneOperation::ExtmulHigh);
-            m_jit.vectorExtendHigh(info, leftLocation.asFPR(), m_scratchFPR);
+            m_jit.vectorExtendHigh(info, leftLocation.asFPR(), wasmScratchFPR);
             m_jit.vectorExtendHigh(info, rightLocation.asFPR(), resultLocation.asFPR());
         }
-        emitVectorMul(info, Location::fromFPR(m_scratchFPR), resultLocation, resultLocation);
+        emitVectorMul(info, Location::fromFPR(wasmScratchFPR), resultLocation, resultLocation);
 
         return { };
     }
@@ -7485,7 +7492,7 @@ public:
         switch (op) {
 #if CPU(X86_64)
         case SIMDLaneOperation::LoadSplat8:
-            m_jit.vectorLoad8Splat(address, resultLocation.asFPR(), m_scratchFPR);
+            m_jit.vectorLoad8Splat(address, resultLocation.asFPR(), wasmScratchFPR);
             break;
 #else
         case SIMDLaneOperation::LoadSplat8:
@@ -7646,7 +7653,7 @@ public:
             m_jit.moveZeroToVector(result.asFPR());
         else if (value.u64x2[0] == 0xffffffffffffffffull && value.u64x2[1] == 0xffffffffffffffffull)
 #if CPU(X86_64)
-            m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::Unsigned }, result.asFPR(), result.asFPR(), result.asFPR(), m_scratchFPR);
+            m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::Unsigned }, result.asFPR(), result.asFPR(), result.asFPR(), wasmScratchFPR);
 #else
             m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::Unsigned }, result.asFPR(), result.asFPR(), result.asFPR());
 #endif
@@ -7688,7 +7695,7 @@ public:
         Location vectorLocation = loadIfNecessary(vector);
         Location scalarLocation;
         if (scalar.isConst()) {
-            scalarLocation = scalar.isFloat() ? Location::fromFPR(m_scratchFPR) : Location::fromGPR(m_scratchGPR);
+            scalarLocation = scalar.isFloat() ? Location::fromFPR(wasmScratchFPR) : Location::fromGPR(wasmScratchGPR);
             emitMoveConst(scalar, scalarLocation);
         } else
             scalarLocation = loadIfNecessary(scalar);
@@ -7699,8 +7706,8 @@ public:
         Location resultLocation = allocate(result);
 
         if (scalarLocation == resultLocation) {
-            m_jit.moveVector(scalarLocation.asFPR(), m_scratchFPR);
-            scalarLocation = Location::fromFPR(m_scratchFPR);
+            m_jit.moveVector(scalarLocation.asFPR(), wasmScratchFPR);
+            scalarLocation = Location::fromFPR(wasmScratchFPR);
         }
 
         LOG_INSTRUCTION("VectorReplaceLane", info.lane, lane, vector, vectorLocation, scalar, scalarLocation, RESULT(result));
@@ -7728,11 +7735,11 @@ public:
 #if CPU(ARM64)
             if (info.lane == SIMDLane::i64x2) {
                 // This might look bad, but remember: every bit of information we destroy contributes to the heat death of the universe.
-                m_jit.vectorSshr8(SIMDInfo { SIMDLane::i64x2, SIMDSignMode::None }, valueLocation.asFPR(), TrustedImm32(63), m_scratchFPR);
-                m_jit.vectorUnzipEven(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, m_scratchFPR, m_scratchFPR, m_scratchFPR);
-                m_jit.moveDoubleTo64(m_scratchFPR, m_scratchGPR);
-                m_jit.rshift64(m_scratchGPR, TrustedImm32(31), m_scratchGPR);
-                m_jit.and32(Imm32(0b11), m_scratchGPR, resultLocation.asGPR());
+                m_jit.vectorSshr8(SIMDInfo { SIMDLane::i64x2, SIMDSignMode::None }, valueLocation.asFPR(), TrustedImm32(63), wasmScratchFPR);
+                m_jit.vectorUnzipEven(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, wasmScratchFPR, wasmScratchFPR, wasmScratchFPR);
+                m_jit.moveDoubleTo64(wasmScratchFPR, wasmScratchGPR);
+                m_jit.rshift64(wasmScratchGPR, TrustedImm32(31), wasmScratchGPR);
+                m_jit.and32(Imm32(0b11), wasmScratchGPR, resultLocation.asGPR());
                 return { };
             }
 
@@ -7758,18 +7765,18 @@ public:
                 }
 
                 // FIXME: this is bad, we should load
-                materializeVectorConstant(towerOfPower, Location::fromFPR(m_scratchFPR));
+                materializeVectorConstant(towerOfPower, Location::fromFPR(wasmScratchFPR));
             }
 
             {
                 ScratchScope<0, 1> scratches(*this, valueLocation, resultLocation);
 
                 m_jit.vectorSshr8(info, valueLocation.asFPR(), TrustedImm32(elementByteSize(info.lane) * 8 - 1), scratches.fpr(0));
-                m_jit.vectorAnd(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, scratches.fpr(0), m_scratchFPR, scratches.fpr(0));
+                m_jit.vectorAnd(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, scratches.fpr(0), wasmScratchFPR, scratches.fpr(0));
 
                 if (info.lane == SIMDLane::i8x16) {
-                    m_jit.vectorExtractPair(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, TrustedImm32(8), scratches.fpr(0), scratches.fpr(0), m_scratchFPR);
-                    m_jit.vectorZipUpper(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, scratches.fpr(0), m_scratchFPR, scratches.fpr(0));
+                    m_jit.vectorExtractPair(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, TrustedImm32(8), scratches.fpr(0), scratches.fpr(0), wasmScratchFPR);
+                    m_jit.vectorZipUpper(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, scratches.fpr(0), wasmScratchFPR, scratches.fpr(0));
                     info.lane = SIMDLane::i16x8;
                 }
 
@@ -7778,13 +7785,13 @@ public:
             }
 #else
             ASSERT(isX86());
-            m_jit.vectorBitmask(info, valueLocation.asFPR(), resultLocation.asGPR(), m_scratchFPR);
+            m_jit.vectorBitmask(info, valueLocation.asFPR(), resultLocation.asGPR(), wasmScratchFPR);
 #endif
             return { };
         case JSC::SIMDLaneOperation::AnyTrue:
 #if CPU(ARM64)
-            m_jit.vectorUnsignedMax(SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, valueLocation.asFPR(), m_scratchFPR);
-            m_jit.moveFloatTo32(m_scratchFPR, resultLocation.asGPR());
+            m_jit.vectorUnsignedMax(SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, valueLocation.asFPR(), wasmScratchFPR);
+            m_jit.moveFloatTo32(wasmScratchFPR, resultLocation.asGPR());
             m_jit.test32(ResultCondition::NonZero, resultLocation.asGPR(), resultLocation.asGPR(), resultLocation.asGPR());
 #else
             m_jit.vectorAnyTrue(valueLocation.asFPR(), resultLocation.asGPR());
@@ -7795,23 +7802,23 @@ public:
             ASSERT(scalarTypeIsIntegral(info.lane));
             switch (info.lane) {
             case SIMDLane::i64x2:
-                m_jit.compareIntegerVectorWithZero(RelationalCondition::NotEqual, info, valueLocation.asFPR(), m_scratchFPR);
-                m_jit.vectorUnsignedMin(SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, m_scratchFPR, m_scratchFPR);
+                m_jit.compareIntegerVectorWithZero(RelationalCondition::NotEqual, info, valueLocation.asFPR(), wasmScratchFPR);
+                m_jit.vectorUnsignedMin(SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, wasmScratchFPR, wasmScratchFPR);
                 break;
             case SIMDLane::i32x4:
             case SIMDLane::i16x8:
             case SIMDLane::i8x16:
-                m_jit.vectorUnsignedMin(info, valueLocation.asFPR(), m_scratchFPR);
+                m_jit.vectorUnsignedMin(info, valueLocation.asFPR(), wasmScratchFPR);
                 break;
             default:
                 RELEASE_ASSERT_NOT_REACHED();
             }
 
-            m_jit.moveFloatTo32(m_scratchFPR, m_scratchGPR);
-            m_jit.test32(ResultCondition::NonZero, m_scratchGPR, m_scratchGPR, resultLocation.asGPR());
+            m_jit.moveFloatTo32(wasmScratchFPR, wasmScratchGPR);
+            m_jit.test32(ResultCondition::NonZero, wasmScratchGPR, wasmScratchGPR, resultLocation.asGPR());
 #else
             ASSERT(isX86());
-            m_jit.vectorAllTrue(info, valueLocation.asFPR(), resultLocation.asGPR(), m_scratchFPR);
+            m_jit.vectorAllTrue(info, valueLocation.asFPR(), resultLocation.asGPR(), wasmScratchFPR);
 #endif
             return { };
         default:
@@ -7840,18 +7847,18 @@ public:
         case JSC::SIMDLaneOperation::Abs:
 #if CPU(X86_64)
             if (info.lane == SIMDLane::i64x2) {
-                m_jit.vectorAbsInt64(valueLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
+                m_jit.vectorAbsInt64(valueLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
                 return { };
             }
             if (scalarTypeIsFloatingPoint(info.lane)) {
                 if (info.lane == SIMDLane::f32x4) {
-                    m_jit.move32ToFloat(TrustedImm32(0x7fffffff), m_scratchFPR);
-                    m_jit.vectorSplatFloat32(m_scratchFPR, m_scratchFPR);
+                    m_jit.move32ToFloat(TrustedImm32(0x7fffffff), wasmScratchFPR);
+                    m_jit.vectorSplatFloat32(wasmScratchFPR, wasmScratchFPR);
                 } else {
-                    m_jit.move64ToDouble(TrustedImm64(0x7fffffffffffffffll), m_scratchFPR);
-                    m_jit.vectorSplatFloat64(m_scratchFPR, m_scratchFPR);
+                    m_jit.move64ToDouble(TrustedImm64(0x7fffffffffffffffll), wasmScratchFPR);
+                    m_jit.vectorSplatFloat64(wasmScratchFPR, wasmScratchFPR);
                 }
-                m_jit.vectorAnd(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, valueLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.vectorAnd(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, valueLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
                 return { };
             }
 #endif
@@ -7874,14 +7881,14 @@ public:
                 popcntConst.u64x2[1] = 0x0403030203020201;
 
                 materializeVectorConstant(bottomNibbleConst, Location::fromFPR(scratches.fpr(0)));
-                m_jit.vectorAndnot(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, valueLocation.asFPR(), scratches.fpr(0), m_scratchFPR);
+                m_jit.vectorAndnot(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, valueLocation.asFPR(), scratches.fpr(0), wasmScratchFPR);
                 m_jit.vectorAnd(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, valueLocation.asFPR(), scratches.fpr(0), resultLocation.asFPR());
-                m_jit.vectorUshr8(SIMDInfo { SIMDLane::i16x8, SIMDSignMode::None }, m_scratchFPR, TrustedImm32(4), m_scratchFPR);
+                m_jit.vectorUshr8(SIMDInfo { SIMDLane::i16x8, SIMDSignMode::None }, wasmScratchFPR, TrustedImm32(4), wasmScratchFPR);
 
                 materializeVectorConstant(popcntConst, Location::fromFPR(scratches.fpr(0)));
                 m_jit.vectorSwizzle(scratches.fpr(0), resultLocation.asFPR(), resultLocation.asFPR());
-                m_jit.vectorSwizzle(scratches.fpr(0), m_scratchFPR, m_scratchFPR);
-                m_jit.vectorAdd(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.vectorSwizzle(scratches.fpr(0), wasmScratchFPR, wasmScratchFPR);
+                m_jit.vectorAdd(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
             }
 #else
             m_jit.vectorPopcnt(info, valueLocation.asFPR(), resultLocation.asFPR());
@@ -7905,10 +7912,10 @@ public:
         case JSC::SIMDLaneOperation::ExtaddPairwise:
 #if CPU(X86_64)
             if (info.lane == SIMDLane::i16x8 && info.signMode == SIMDSignMode::Unsigned) {
-                m_jit.vectorExtaddPairwiseUnsignedInt16(valueLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
+                m_jit.vectorExtaddPairwiseUnsignedInt16(valueLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
                 return { };
             }
-            m_jit.vectorExtaddPairwise(info, valueLocation.asFPR(), resultLocation.asFPR(), m_scratchGPR, m_scratchFPR);
+            m_jit.vectorExtaddPairwise(info, valueLocation.asFPR(), resultLocation.asFPR(), wasmScratchGPR, wasmScratchFPR);
 #else
             m_jit.vectorExtaddPairwise(info, valueLocation.asFPR(), resultLocation.asFPR());
 #endif
@@ -7916,7 +7923,7 @@ public:
         case JSC::SIMDLaneOperation::Convert:
 #if CPU(X86_64)
             if (info.signMode == SIMDSignMode::Unsigned) {
-                m_jit.vectorConvertUnsigned(valueLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
+                m_jit.vectorConvertUnsigned(valueLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
                 return { };
             }
 #endif
@@ -7927,7 +7934,7 @@ public:
             if (info.signMode == SIMDSignMode::Signed)
                 m_jit.vectorConvertLowSignedInt32(valueLocation.asFPR(), resultLocation.asFPR());
             else
-                m_jit.vectorConvertLowUnsignedInt32(valueLocation.asFPR(), resultLocation.asFPR(), m_scratchGPR, m_scratchFPR);
+                m_jit.vectorConvertLowUnsignedInt32(valueLocation.asFPR(), resultLocation.asFPR(), wasmScratchGPR, wasmScratchFPR);
 #else
             m_jit.vectorConvertLow(info, valueLocation.asFPR(), resultLocation.asFPR());
 #endif
@@ -7943,16 +7950,16 @@ public:
             switch (info.lane) {
             case SIMDLane::f64x2:
                 if (info.signMode == SIMDSignMode::Signed)
-                    m_jit.vectorTruncSatSignedFloat64(valueLocation.asFPR(), resultLocation.asFPR(), m_scratchGPR, m_scratchFPR);
+                    m_jit.vectorTruncSatSignedFloat64(valueLocation.asFPR(), resultLocation.asFPR(), wasmScratchGPR, wasmScratchFPR);
                 else
-                    m_jit.vectorTruncSatUnsignedFloat64(valueLocation.asFPR(), resultLocation.asFPR(), m_scratchGPR, m_scratchFPR);
+                    m_jit.vectorTruncSatUnsignedFloat64(valueLocation.asFPR(), resultLocation.asFPR(), wasmScratchGPR, wasmScratchFPR);
                 break;
             case SIMDLane::f32x4: {
                 ScratchScope<0, 1> scratches(*this, valueLocation, resultLocation);
                 if (info.signMode == SIMDSignMode::Signed)
-                    m_jit.vectorTruncSat(info, valueLocation.asFPR(), resultLocation.asFPR(), m_scratchGPR, m_scratchFPR, scratches.fpr(0));
+                    m_jit.vectorTruncSat(info, valueLocation.asFPR(), resultLocation.asFPR(), wasmScratchGPR, wasmScratchFPR, scratches.fpr(0));
                 else
-                    m_jit.vectorTruncSatUnsignedFloat32(valueLocation.asFPR(), resultLocation.asFPR(), m_scratchGPR, m_scratchFPR, scratches.fpr(0));
+                    m_jit.vectorTruncSatUnsignedFloat32(valueLocation.asFPR(), resultLocation.asFPR(), wasmScratchGPR, wasmScratchFPR, scratches.fpr(0));
                 break;
             }
             default:
@@ -7965,8 +7972,8 @@ public:
         case JSC::SIMDLaneOperation::Not: {
 #if CPU(X86_64)
             ScratchScope<0, 1> scratches(*this, valueLocation, resultLocation);
-            m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, m_scratchFPR, m_scratchFPR, m_scratchFPR, scratches.fpr(0));
-            m_jit.vectorXor(info, valueLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+            m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, wasmScratchFPR, wasmScratchFPR, wasmScratchFPR, scratches.fpr(0));
+            m_jit.vectorXor(info, valueLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #else
             m_jit.vectorNot(info, valueLocation.asFPR(), resultLocation.asFPR());
 #endif
@@ -7980,19 +7987,19 @@ public:
             case SIMDLane::i32x4:
             case SIMDLane::i64x2:
                 // For integers, we can negate by subtracting our input from zero.
-                m_jit.moveZeroToVector(m_scratchFPR);
-                m_jit.vectorSub(info, m_scratchFPR, valueLocation.asFPR(), resultLocation.asFPR());
+                m_jit.moveZeroToVector(wasmScratchFPR);
+                m_jit.vectorSub(info, wasmScratchFPR, valueLocation.asFPR(), resultLocation.asFPR());
                 break;
             case SIMDLane::f32x4:
                 // For floats, we unfortunately have to flip the sign bit using XOR.
-                m_jit.move32ToFloat(TrustedImm32(-0x80000000), m_scratchFPR);
-                m_jit.vectorSplatFloat32(m_scratchFPR, m_scratchFPR);
-                m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, valueLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.move32ToFloat(TrustedImm32(-0x80000000), wasmScratchFPR);
+                m_jit.vectorSplatFloat32(wasmScratchFPR, wasmScratchFPR);
+                m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, valueLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
                 break;
             case SIMDLane::f64x2:
-                m_jit.move64ToDouble(TrustedImm64(-0x8000000000000000ll), m_scratchFPR);
-                m_jit.vectorSplatFloat64(m_scratchFPR, m_scratchFPR);
-                m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, valueLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.move64ToDouble(TrustedImm64(-0x8000000000000000ll), wasmScratchFPR);
+                m_jit.vectorSplatFloat64(wasmScratchFPR, wasmScratchFPR);
+                m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, valueLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
                 break;
             default:
                 RELEASE_ASSERT_NOT_REACHED();
@@ -8022,13 +8029,13 @@ public:
         LOG_INSTRUCTION("VectorBitwiseSelect", left, leftLocation, right, rightLocation, selector, selectorLocation, RESULT(result));
 
 #if CPU(X86_64)
-        m_jit.vectorAnd(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, leftLocation.asFPR(), selectorLocation.asFPR(), m_scratchFPR);
+        m_jit.vectorAnd(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, leftLocation.asFPR(), selectorLocation.asFPR(), wasmScratchFPR);
         m_jit.vectorAndnot(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, rightLocation.asFPR(), selectorLocation.asFPR(), resultLocation.asFPR());
-        m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+        m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #else
-        m_jit.moveVector(selectorLocation.asFPR(), m_scratchFPR);
-        m_jit.vectorBitwiseSelect(leftLocation.asFPR(), rightLocation.asFPR(), m_scratchFPR);
-        m_jit.moveVector(m_scratchFPR, resultLocation.asFPR());
+        m_jit.moveVector(selectorLocation.asFPR(), wasmScratchFPR);
+        m_jit.vectorBitwiseSelect(leftLocation.asFPR(), rightLocation.asFPR(), wasmScratchFPR);
+        m_jit.moveVector(wasmScratchFPR, resultLocation.asFPR());
 #endif
         return { };
     }
@@ -8058,23 +8065,23 @@ public:
         switch (relOp.asRelationalCondition()) {
         case MacroAssembler::NotEqual: {
             ScratchScope<0, 1> scratches(*this, leftLocation, rightLocation, resultLocation);
-            m_jit.compareIntegerVector(RelationalCondition::Equal, info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
-            m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, m_scratchFPR, m_scratchFPR, m_scratchFPR, scratches.fpr(0));
-            m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+            m_jit.compareIntegerVector(RelationalCondition::Equal, info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
+            m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, wasmScratchFPR, wasmScratchFPR, wasmScratchFPR, scratches.fpr(0));
+            m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
             break;
         }
         case MacroAssembler::Above: {
             ScratchScope<0, 1> scratches(*this, leftLocation, rightLocation, resultLocation);
-            m_jit.compareIntegerVector(RelationalCondition::BelowOrEqual, info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
-            m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, m_scratchFPR, m_scratchFPR, m_scratchFPR, scratches.fpr(0));
-            m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+            m_jit.compareIntegerVector(RelationalCondition::BelowOrEqual, info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
+            m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, wasmScratchFPR, wasmScratchFPR, wasmScratchFPR, scratches.fpr(0));
+            m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
             break;
         }
         case MacroAssembler::Below: {
             ScratchScope<0, 1> scratches(*this, leftLocation, rightLocation, resultLocation);
-            m_jit.compareIntegerVector(RelationalCondition::AboveOrEqual, info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
-            m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, m_scratchFPR, m_scratchFPR, m_scratchFPR, scratches.fpr(0));
-            m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+            m_jit.compareIntegerVector(RelationalCondition::AboveOrEqual, info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
+            m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, wasmScratchFPR, wasmScratchFPR, wasmScratchFPR, scratches.fpr(0));
+            m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
             break;
         }
         case MacroAssembler::GreaterThanOrEqual:
@@ -8082,23 +8089,23 @@ public:
                 // Note: rhs and lhs are reversed here, we are semantically negating LessThan. GreaterThan is
                 // just better supported on AVX.
                 ScratchScope<0, 1> scratches(*this, leftLocation, rightLocation, resultLocation);
-                m_jit.compareIntegerVector(RelationalCondition::GreaterThan, info, rightLocation.asFPR(), leftLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
-                m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, m_scratchFPR, m_scratchFPR, m_scratchFPR, scratches.fpr(0));
-                m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.compareIntegerVector(RelationalCondition::GreaterThan, info, rightLocation.asFPR(), leftLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
+                m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, wasmScratchFPR, wasmScratchFPR, wasmScratchFPR, scratches.fpr(0));
+                m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
             } else
-                m_jit.compareIntegerVector(relOp.asRelationalCondition(), info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
+                m_jit.compareIntegerVector(relOp.asRelationalCondition(), info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
             break;
         case MacroAssembler::LessThanOrEqual:
             if (info.lane == SIMDLane::i64x2) {
                 ScratchScope<0, 1> scratches(*this, leftLocation, rightLocation, resultLocation);
-                m_jit.compareIntegerVector(RelationalCondition::GreaterThan, info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
-                m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, m_scratchFPR, m_scratchFPR, m_scratchFPR, scratches.fpr(0));
-                m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.compareIntegerVector(RelationalCondition::GreaterThan, info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
+                m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::None }, wasmScratchFPR, wasmScratchFPR, wasmScratchFPR, scratches.fpr(0));
+                m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
             } else
-                m_jit.compareIntegerVector(relOp.asRelationalCondition(), info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
+                m_jit.compareIntegerVector(relOp.asRelationalCondition(), info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
             break;
         default:
-            m_jit.compareIntegerVector(relOp.asRelationalCondition(), info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
+            m_jit.compareIntegerVector(relOp.asRelationalCondition(), info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
         }
 #else
         m_jit.compareIntegerVector(relOp.asRelationalCondition(), info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
@@ -8113,15 +8120,15 @@ public:
             // so we scalarize it instead.
             ScratchScope<1, 0> scratches(*this);
             GPRReg dataScratchGPR = scratches.gpr(0);
-            m_jit.vectorExtractLaneInt64(TrustedImm32(0), left.asFPR(), m_scratchGPR);
+            m_jit.vectorExtractLaneInt64(TrustedImm32(0), left.asFPR(), wasmScratchGPR);
             m_jit.vectorExtractLaneInt64(TrustedImm32(0), right.asFPR(), dataScratchGPR);
-            m_jit.mul64(m_scratchGPR, dataScratchGPR, m_scratchGPR);
-            m_jit.vectorReplaceLane(SIMDLane::i64x2, TrustedImm32(0), m_scratchGPR, m_scratchFPR);
-            m_jit.vectorExtractLaneInt64(TrustedImm32(1), left.asFPR(), m_scratchGPR);
+            m_jit.mul64(wasmScratchGPR, dataScratchGPR, wasmScratchGPR);
+            m_jit.vectorReplaceLane(SIMDLane::i64x2, TrustedImm32(0), wasmScratchGPR, wasmScratchFPR);
+            m_jit.vectorExtractLaneInt64(TrustedImm32(1), left.asFPR(), wasmScratchGPR);
             m_jit.vectorExtractLaneInt64(TrustedImm32(1), right.asFPR(), dataScratchGPR);
-            m_jit.mul64(m_scratchGPR, dataScratchGPR, m_scratchGPR);
-            m_jit.vectorReplaceLane(SIMDLane::i64x2, TrustedImm32(1), m_scratchGPR, m_scratchFPR);
-            m_jit.moveVector(m_scratchFPR, result.asFPR());
+            m_jit.mul64(wasmScratchGPR, dataScratchGPR, wasmScratchGPR);
+            m_jit.vectorReplaceLane(SIMDLane::i64x2, TrustedImm32(1), wasmScratchGPR, wasmScratchFPR);
+            m_jit.moveVector(wasmScratchFPR, result.asFPR());
         } else
             m_jit.vectorMul(info, left.asFPR(), right.asFPR(), result.asFPR());
     }
@@ -8136,9 +8143,9 @@ public:
         v128_t mask;
         mask.u64x2[0] = 0x7070707070707070;
         mask.u64x2[1] = 0x7070707070707070;
-        materializeVectorConstant(mask, Location::fromFPR(m_scratchFPR));
-        m_jit.vectorAddSat(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::Unsigned }, m_scratchFPR, b.asFPR(), m_scratchFPR);
-        m_jit.vectorSwizzle(a.asFPR(), m_scratchFPR, result.asFPR());
+        materializeVectorConstant(mask, Location::fromFPR(wasmScratchFPR));
+        m_jit.vectorAddSat(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::Unsigned }, wasmScratchFPR, b.asFPR(), wasmScratchFPR);
+        m_jit.vectorSwizzle(a.asFPR(), wasmScratchFPR, result.asFPR());
         return { };
     }
 
@@ -8166,7 +8173,7 @@ public:
             return { };
         case SIMDLaneOperation::DotProduct:
 #if CPU(ARM64)
-            m_jit.vectorDotProduct(leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
+            m_jit.vectorDotProduct(leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
 #else
             m_jit.vectorDotProduct(leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
 #endif
@@ -8179,7 +8186,7 @@ public:
             return { };
         case SIMDLaneOperation::MulSat:
 #if CPU(X86_64)
-            m_jit.vectorMulSat(leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchGPR, m_scratchFPR);
+            m_jit.vectorMulSat(leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchGPR, wasmScratchFPR);
 #else
             m_jit.vectorMulSat(leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
 #endif
@@ -8192,14 +8199,14 @@ public:
             return { };
         case SIMDLaneOperation::Pmax:
 #if CPU(ARM64)
-            m_jit.vectorPmax(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
+            m_jit.vectorPmax(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
 #else
             m_jit.vectorPmax(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
 #endif
             return { };
         case SIMDLaneOperation::Pmin:
 #if CPU(ARM64)
-            m_jit.vectorPmin(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
+            m_jit.vectorPmin(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
 #else
             m_jit.vectorPmin(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
 #endif
@@ -8216,7 +8223,7 @@ public:
             m_jit.vectorXor(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
             return { };
         case SIMDLaneOperation::Narrow:
-            m_jit.vectorNarrow(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), m_scratchFPR);
+            m_jit.vectorNarrow(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR(), wasmScratchFPR);
             return { };
         case SIMDLaneOperation::AddSat:
             m_jit.vectorAddSat(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
@@ -8234,22 +8241,22 @@ public:
                 // the necessary edge cases.
 
                 // Compute result in both directions.
-                m_jit.vectorPmax(info, rightLocation.asFPR(), leftLocation.asFPR(), m_scratchFPR);
+                m_jit.vectorPmax(info, rightLocation.asFPR(), leftLocation.asFPR(), wasmScratchFPR);
                 m_jit.vectorPmax(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
 
                 // Check for discrepancies by XORing the two results together.
-                m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, m_scratchFPR, resultLocation.asFPR(), resultLocation.asFPR());
+                m_jit.vectorXor(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, wasmScratchFPR, resultLocation.asFPR(), resultLocation.asFPR());
 
                 // OR results, propagating the sign bit for negative zeroes, and NaNs.
-                m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, m_scratchFPR, resultLocation.asFPR(), m_scratchFPR);
+                m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, wasmScratchFPR, resultLocation.asFPR(), wasmScratchFPR);
 
                 // Propagate discrepancies in the sign bit.
-                m_jit.vectorSub(info, m_scratchFPR, resultLocation.asFPR(), m_scratchFPR);
+                m_jit.vectorSub(info, wasmScratchFPR, resultLocation.asFPR(), wasmScratchFPR);
 
                 // Canonicalize NaNs by checking for unordered values and clearing payload if necessary.
-                m_jit.compareFloatingPointVectorUnordered(info, resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
+                m_jit.compareFloatingPointVectorUnordered(info, resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
                 m_jit.vectorUshr8(SIMDInfo { info.lane == SIMDLane::f32x4 ? SIMDLane::i32x4 : SIMDLane::i64x2, SIMDSignMode::None }, resultLocation.asFPR(), TrustedImm32(info.lane == SIMDLane::f32x4 ? 10 : 13), resultLocation.asFPR());
-                m_jit.vectorAndnot(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, m_scratchFPR, resultLocation.asFPR(), resultLocation.asFPR());
+                m_jit.vectorAndnot(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, wasmScratchFPR, resultLocation.asFPR(), resultLocation.asFPR());
             } else
                 m_jit.vectorMax(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
 #else
@@ -8266,17 +8273,17 @@ public:
                 // the necessary edge cases.
 
                 // Compute result in both directions.
-                m_jit.vectorPmin(info, rightLocation.asFPR(), leftLocation.asFPR(), m_scratchFPR);
+                m_jit.vectorPmin(info, rightLocation.asFPR(), leftLocation.asFPR(), wasmScratchFPR);
                 m_jit.vectorPmin(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
 
                 // OR results, propagating the sign bit for negative zeroes, and NaNs.
-                m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, m_scratchFPR, resultLocation.asFPR(), m_scratchFPR);
+                m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, wasmScratchFPR, resultLocation.asFPR(), wasmScratchFPR);
 
                 // Canonicalize NaNs by checking for unordered values and clearing payload if necessary.
-                m_jit.compareFloatingPointVectorUnordered(info, resultLocation.asFPR(), m_scratchFPR, resultLocation.asFPR());
-                m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, m_scratchFPR, resultLocation.asFPR(), m_scratchFPR);
+                m_jit.compareFloatingPointVectorUnordered(info, resultLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
+                m_jit.vectorOr(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, wasmScratchFPR, resultLocation.asFPR(), wasmScratchFPR);
                 m_jit.vectorUshr8(SIMDInfo { info.lane == SIMDLane::f32x4 ? SIMDLane::i32x4 : SIMDLane::i64x2, SIMDSignMode::None }, resultLocation.asFPR(), TrustedImm32(info.lane == SIMDLane::f32x4 ? 10 : 13), resultLocation.asFPR());
-                m_jit.vectorAndnot(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, m_scratchFPR, resultLocation.asFPR(), resultLocation.asFPR());
+                m_jit.vectorAndnot(SIMDInfo { SIMDLane::v128, SIMDSignMode::None }, wasmScratchFPR, resultLocation.asFPR(), resultLocation.asFPR());
             } else
                 m_jit.vectorMin(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
 #else
@@ -8306,9 +8313,9 @@ public:
     }
 
 private:
-    bool isScratch(Location loc)
+    static bool isScratch(Location loc)
     {
-        return (loc.isGPR() && loc.asGPR() == m_scratchGPR) || (loc.isFPR() && loc.asFPR() == m_scratchFPR);
+        return (loc.isGPR() && loc.asGPR() == wasmScratchGPR) || (loc.isFPR() && loc.asFPR() == wasmScratchFPR);
     }
 
     void emitStoreConst(Value constant, Location loc)
@@ -8443,8 +8450,8 @@ private:
             m_jit.transfer64(src.asAddress(), dst.asAddress());
             break;
         case TypeKind::F64:
-            m_jit.loadDouble(src.asAddress(), m_scratchFPR);
-            m_jit.storeDouble(m_scratchFPR, dst.asAddress());
+            m_jit.loadDouble(src.asAddress(), wasmScratchFPR);
+            m_jit.storeDouble(wasmScratchFPR, dst.asAddress());
             break;
         case TypeKind::Externref:
         case TypeKind::Ref:
@@ -8457,8 +8464,8 @@ private:
         case TypeKind::V128: {
             Address srcAddress = src.asAddress();
             Address dstAddress = dst.asAddress();
-            m_jit.loadVector(srcAddress, m_scratchFPR);
-            m_jit.storeVector(m_scratchFPR, dstAddress);
+            m_jit.loadVector(srcAddress, wasmScratchFPR);
+            m_jit.storeVector(wasmScratchFPR, dstAddress);
             break;
         }
         default:
@@ -8842,10 +8849,10 @@ private:
     static Register fromJSCReg(Reg reg)
     {
         // This pattern avoids an explicit template specialization in class scope, which GCC does not support.
-        if constexpr (std::is_same_v<Register, RegisterID>) {
+        if constexpr (std::is_same_v<Register, GPRReg>) {
             ASSERT(reg.isGPR());
             return reg.gpr();
-        } else if constexpr (std::is_same_v<Register, FPRegisterID>) {
+        } else if constexpr (std::is_same_v<Register, FPRReg>) {
             ASSERT(reg.isFPR());
             return reg.fpr();
         }
@@ -8906,25 +8913,25 @@ private:
         RegisterSet m_locked;
     };
 
-    RegisterID nextGPR()
+    GPRReg nextGPR()
     {
         auto next = m_gprSet.begin();
         ASSERT(next != m_gprSet.end());
-        RegisterID reg = (*next).gpr();
+        GPRReg reg = (*next).gpr();
         ASSERT(m_gprBindings[reg].m_kind == RegisterBinding::None);
         return reg;
     }
 
-    FPRegisterID nextFPR()
+    FPRReg nextFPR()
     {
         auto next = m_fprSet.begin();
         ASSERT(next != m_fprSet.end());
-        FPRegisterID reg = (*next).fpr();
+        FPRReg reg = (*next).fpr();
         ASSERT(m_fprBindings[reg].m_kind == RegisterBinding::None);
         return reg;
     }
 
-    RegisterID evictGPR()
+    GPRReg evictGPR()
     {
         auto lruGPR = m_gprLRU.findMin();
         auto lruBinding = m_gprBindings[lruGPR];
@@ -8938,7 +8945,7 @@ private:
         return lruGPR;
     }
 
-    FPRegisterID evictFPR()
+    FPRReg evictFPR()
     {
         auto lruFPR = m_fprLRU.findMin();
         auto lruBinding = m_fprBindings[lruFPR];
@@ -8954,7 +8961,7 @@ private:
 
     // We use this to free up specific registers that might get clobbered by an instruction.
 
-    void clobber(RegisterID gpr)
+    void clobber(GPRReg gpr)
     {
         if (m_validGPRs.contains(gpr, IgnoreVectors) && !m_gprSet.contains(gpr, IgnoreVectors)) {
             RegisterBinding& binding = m_gprBindings[gpr];
@@ -8965,7 +8972,7 @@ private:
         }
     }
 
-    void clobber(FPRegisterID fpr)
+    void clobber(FPRReg fpr)
     {
         if (m_validFPRs.contains(fpr, Width::Width128) && !m_fprSet.contains(fpr, Width::Width128)) {
             RegisterBinding& binding = m_fprBindings[fpr];
@@ -9015,14 +9022,14 @@ private:
             unbind();
         }
 
-        inline RegisterID gpr(unsigned i) const
+        inline GPRReg gpr(unsigned i) const
         {
             ASSERT(i < GPRs);
             ASSERT(!m_endedEarly);
             return m_tempGPRs[i];
         }
 
-        inline FPRegisterID fpr(unsigned i) const
+        inline FPRReg fpr(unsigned i) const
         {
             ASSERT(i < FPRs);
             ASSERT(!m_endedEarly);
@@ -9030,7 +9037,7 @@ private:
         }
 
     private:
-        RegisterID bindGPRToScratch(RegisterID reg)
+        GPRReg bindGPRToScratch(GPRReg reg)
         {
             if (!m_generator.m_validGPRs.contains(reg, IgnoreVectors))
                 return reg;
@@ -9049,7 +9056,7 @@ private:
             return reg;
         }
 
-        FPRegisterID bindFPRToScratch(FPRegisterID reg)
+        FPRReg bindFPRToScratch(FPRReg reg)
         {
             if (!m_generator.m_validFPRs.contains(reg, Width::Width128))
                 return reg;
@@ -9068,7 +9075,7 @@ private:
             return reg;
         }
 
-        void unbindGPRFromScratch(RegisterID reg)
+        void unbindGPRFromScratch(GPRReg reg)
         {
             if (!m_generator.m_validGPRs.contains(reg, IgnoreVectors))
                 return;
@@ -9083,7 +9090,7 @@ private:
             m_generator.m_gprLRU.unlock(reg);
         }
 
-        void unbindFPRFromScratch(FPRegisterID reg)
+        void unbindFPRFromScratch(FPRReg reg)
         {
             if (!m_generator.m_validFPRs.contains(reg, Width::Width128))
                 return;
@@ -9139,8 +9146,8 @@ private:
         }
 
         BBQJIT& m_generator;
-        RegisterID m_tempGPRs[GPRs];
-        FPRegisterID m_tempFPRs[FPRs];
+        GPRReg m_tempGPRs[GPRs];
+        FPRReg m_tempFPRs[FPRs];
         RegisterSet m_preserved;
         bool m_endedEarly;
     };
@@ -9196,8 +9203,8 @@ private:
     Vector<Location, 8> m_temps;
     Vector<Location, 8> m_localSlots; // Persistent stack slots for local variables.
     Vector<TypeKind, 8> m_localTypes; // Types of all non-argument locals in this function.
-    LRU<RegisterID> m_gprLRU; // LRU cache tracking when general-purpose registers were last used.
-    LRU<FPRegisterID> m_fprLRU; // LRU cache tracking when floating-point registers were last used.
+    LRU<GPRReg> m_gprLRU; // LRU cache tracking when general-purpose registers were last used.
+    LRU<FPRReg> m_fprLRU; // LRU cache tracking when floating-point registers were last used.
     uint32_t m_lastUseTimestamp; // Monotonically increasing integer incrementing with each register use.
     Vector<RefPtr<SharedTask<void(BBQJIT&, CCallHelpers&)>>, 8> m_latePaths; // Late paths to emit after the rest of the function body.
 
@@ -9209,15 +9216,6 @@ private:
     bool m_usesExceptions { false };
     Checked<unsigned> m_tryCatchDepth { 0 };
     Checked<unsigned> m_callSiteIndex { 0 };
-
-    RegisterID m_scratchGPR { GPRInfo::nonPreservedNonArgumentGPR0 }; // Scratch registers to hold temporaries in operations.
-    FPRegisterID m_scratchFPR { FPRInfo::nonPreservedNonArgumentFPR0 };
-
-#if CPU(X86) || CPU(X86_64)
-    RegisterID m_shiftRCX { X86Registers::ecx };
-#else
-    RegisterID m_shiftRCX { RegisterID::InvalidGPRReg };
-#endif
 
     RegisterSet m_callerSaveGPRs;
     RegisterSet m_callerSaveFPRs;


### PR DESCRIPTION
#### 8de1c7b4175a6d6aaa01ef2899e7b9536c004761
<pre>
[JSC] Make scratch GPR / FPR static constexpr variables in WasmBBQJIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=253754">https://bugs.webkit.org/show_bug.cgi?id=253754</a>
rdar://106586236

Reviewed by Mark Lam.

This patch adds wasmScratchGPR and wasmScratchFPR static constexpr variables in WasmBBQJIT.
And remove m_scratchGPR / m_scratchFPR. So we can statically define and use these scratch registers.

We also
1. change m_shiftRCX to shiftRCX.
2. use FPRReg / GPRReg instead of RegisterID / FPRegisterID consistently.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJIT::getGlobal):
(JSC::Wasm::BBQJIT::setGlobal):
(JSC::Wasm::BBQJIT::emitCheckAndPreparePointer):
(JSC::Wasm::BBQJIT::addCurrentMemory):
(JSC::Wasm::BBQJIT::truncTrapping):
(JSC::Wasm::BBQJIT::truncSaturated):
(JSC::Wasm::BBQJIT::addSelect):
(JSC::Wasm::BBQJIT::addF32Add):
(JSC::Wasm::BBQJIT::addF64Add):
(JSC::Wasm::BBQJIT::addI32Sub):
(JSC::Wasm::BBQJIT::addI64Sub):
(JSC::Wasm::BBQJIT::addF32Sub):
(JSC::Wasm::BBQJIT::addF64Sub):
(JSC::Wasm::BBQJIT::addI64Mul):
(JSC::Wasm::BBQJIT::addF32Mul):
(JSC::Wasm::BBQJIT::addF64Mul):
(JSC::Wasm::BBQJIT::emitModOrDiv):
(JSC::Wasm::BBQJIT::addF32Div):
(JSC::Wasm::BBQJIT::addF64Div):
(JSC::Wasm::BBQJIT::addF32Min):
(JSC::Wasm::BBQJIT::addF64Min):
(JSC::Wasm::BBQJIT::addF32Max):
(JSC::Wasm::BBQJIT::addF64Max):
(JSC::Wasm::BBQJIT::addI32Shl):
(JSC::Wasm::BBQJIT::addI64Shl):
(JSC::Wasm::BBQJIT::addI32ShrS):
(JSC::Wasm::BBQJIT::addI64ShrS):
(JSC::Wasm::BBQJIT::addI32ShrU):
(JSC::Wasm::BBQJIT::addI64ShrU):
(JSC::Wasm::BBQJIT::addI32Rotl):
(JSC::Wasm::BBQJIT::addI64Rotl):
(JSC::Wasm::BBQJIT::addI32Rotr):
(JSC::Wasm::BBQJIT::addI64Rotr):
(JSC::Wasm::BBQJIT::emitCompareI64):
(JSC::Wasm::BBQJIT::emitCompareF32):
(JSC::Wasm::BBQJIT::emitCompareF64):
(JSC::Wasm::BBQJIT::addF32ConvertUI32):
(JSC::Wasm::BBQJIT::addF32ConvertUI64):
(JSC::Wasm::BBQJIT::addF64ConvertUI32):
(JSC::Wasm::BBQJIT::addF64ConvertUI64):
(JSC::Wasm::BBQJIT::addF32Copysign):
(JSC::Wasm::BBQJIT::addF64Copysign):
(JSC::Wasm::BBQJIT::addF32Abs):
(JSC::Wasm::BBQJIT::addF64Abs):
(JSC::Wasm::BBQJIT::addF32Neg):
(JSC::Wasm::BBQJIT::addF64Neg):
(JSC::Wasm::BBQJIT::addRefAsNonNull):
(JSC::Wasm::BBQJIT::emitEntryTierUpCheck):
(JSC::Wasm::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJIT::addLoopOSREntrypoint):
(JSC::Wasm::BBQJIT::emitLoopTierUpCheck):
(JSC::Wasm::BBQJIT::addIf):
(JSC::Wasm::BBQJIT::emitCatchPrologue):
(JSC::Wasm::BBQJIT::emitCatchImpl):
(JSC::Wasm::BBQJIT::addBranch):
(JSC::Wasm::BBQJIT::addSwitch):
(JSC::Wasm::BBQJIT::restoreWebAssemblyGlobalState):
(JSC::Wasm::BBQJIT::emitCCall):
(JSC::Wasm::BBQJIT::addCall):
(JSC::Wasm::BBQJIT::emitIndirectCall):
(JSC::Wasm::BBQJIT::addCallIndirect):
(JSC::Wasm::BBQJIT::addSIMDShuffle):
(JSC::Wasm::BBQJIT::addSIMDShift):
(JSC::Wasm::BBQJIT::addSIMDExtmul):
(JSC::Wasm::BBQJIT::addSIMDLoadSplat):
(JSC::Wasm::BBQJIT::materializeVectorConstant):
(JSC::Wasm::BBQJIT::addReplaceLane):
(JSC::Wasm::BBQJIT::addSIMDI_V):
(JSC::Wasm::BBQJIT::addSIMDV_V):
(JSC::Wasm::BBQJIT::addSIMDBitwiseSelect):
(JSC::Wasm::BBQJIT::addSIMDRelOp):
(JSC::Wasm::BBQJIT::emitVectorMul):
(JSC::Wasm::BBQJIT::fixupOutOfBoundsIndicesForSwizzle):
(JSC::Wasm::BBQJIT::addSIMDV_VV):
(JSC::Wasm::BBQJIT::isScratch):
(JSC::Wasm::BBQJIT::emitMoveMemory):

Canonical link: <a href="https://commits.webkit.org/261546@main">https://commits.webkit.org/261546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68985b3b118d06d599125ce02136c9eec3b3fb53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3803 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120677 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3544 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117799 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105062 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45695 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/100462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13587 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/466 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/11748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14263 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101761 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19635 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52465 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31633 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16055 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109803 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4380 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27027 "Passed tests") | 
<!--EWS-Status-Bubble-End-->