### PR TITLE
MediaPlayerPrivateMediaStreamAVFObjC needs to stop double-hosting layers

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3743,6 +3743,7 @@ webkit.org/b/242840 fast/text/international/system-language/han-text-style.html 
 webkit.org/b/242905 compositing/tiling/tiled-mask-inwindow.html [ Pass Failure ]
 
 webkit.org/b/243547 fast/mediastream/getUserMedia-to-canvas-1.html [ Pass Timeout ]
+webkit.org/b/253959 fast/mediastream/getUserMedia-to-canvas-2.html [ Pass Timeout ]
 
 # These tests have a similar assert_equals issue, causing failures. See webkit.org/b/243688
 imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/websocket.https.html [ Pass Failure ]

--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
@@ -27,6 +27,7 @@
 
 #include "PlatformLayer.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/MachSendRight.h>
 #include <wtf/WeakPtr.h>
 
 namespace WTF {
@@ -38,6 +39,8 @@ class IntSize;
 class VideoFrame;
 
 enum class VideoFrameRotation : uint16_t;
+
+using LayerHostingContextID = uint32_t;
 
 class SampleBufferDisplayLayer {
 public:
@@ -62,7 +65,7 @@ public:
     virtual void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer) = 0;
 
     virtual void updateAffineTransform(CGAffineTransform) = 0;
-    virtual void updateBoundsAndPosition(CGRect, VideoFrameRotation) = 0;
+    virtual void updateBoundsAndPosition(CGRect, VideoFrameRotation, std::optional<WTF::MachSendRight>&& = std::nullopt) = 0;
 
     virtual void flush() = 0;
     virtual void flushAndRemoveImage() = 0;
@@ -77,6 +80,8 @@ public:
 
     enum class RenderPolicy { TimingInfo, Immediately };
     virtual void setRenderPolicy(RenderPolicy) { };
+
+    virtual LayerHostingContextID hostingContextID() const { return 0; }
 
 protected:
     explicit SampleBufferDisplayLayer(Client&);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -78,7 +78,7 @@ public:
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer) final;
 
     void updateAffineTransform(CGAffineTransform)  final;
-    void updateBoundsAndPosition(CGRect, VideoFrameRotation) final;
+    void updateBoundsAndPosition(CGRect, VideoFrameRotation, std::optional<WTF::MachSendRight>&&) final;
 
     void flush() final;
     void flushAndRemoveImage() final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -283,7 +283,7 @@ void LocalSampleBufferDisplayLayer::updateAffineTransform(CGAffineTransform tran
     });
 }
 
-void LocalSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, VideoFrame::Rotation rotation)
+void LocalSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, VideoFrame::Rotation rotation, std::optional<WTF::MachSendRight>&&)
 {
     updateRootLayerBoundsAndPosition(bounds, rotation, ShouldUpdateRootLayer::No);
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -231,6 +231,9 @@ private:
 
     MediaStreamTrackPrivate* activeVideoTrack() const;
 
+    LayerHostingContextID hostingContextID() const final;
+    void setVideoInlineSizeFenced(const FloatSize&, const WTF::MachSendRight&) final;
+
     MediaPlayer* m_player { nullptr };
     RefPtr<MediaStreamPrivate> m_mediaStreamPrivate;
     RefPtr<VideoTrackPrivateMediaStream> m_activeVideoTrack;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -1157,6 +1157,20 @@ std::optional<VideoFrameMetadata> MediaPlayerPrivateMediaStreamAVFObjC::videoFra
     return metadata;
 }
 
+LayerHostingContextID MediaPlayerPrivateMediaStreamAVFObjC::hostingContextID() const
+{
+    return m_sampleBufferDisplayLayer ? m_sampleBufferDisplayLayer->hostingContextID() : 0;
+}
+
+void MediaPlayerPrivateMediaStreamAVFObjC::setVideoInlineSizeFenced(const FloatSize& size, const WTF::MachSendRight& fence)
+{
+    if (!m_sampleBufferDisplayLayer)
+        return;
+    CGRect bounds = m_sampleBufferDisplayLayer->rootLayer().bounds;
+    bounds.size = size;
+    m_sampleBufferDisplayLayer->updateBoundsAndPosition(bounds, m_videoRotation, fence);
+}
+
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
@@ -92,8 +92,11 @@ void RemoteSampleBufferDisplayLayer::updateAffineTransform(CGAffineTransform tra
     m_sampleBufferDisplayLayer->updateRootLayerAffineTransform(transform);
 }
 
-void RemoteSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, WebCore::VideoFrame::Rotation rotation)
+void RemoteSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, WebCore::VideoFrame::Rotation rotation, std::optional<WTF::MachSendRight>&& fence)
 {
+    if (fence && fence->sendRight())
+        m_layerHostingContext->setFencePort(fence->sendRight());
+
     m_sampleBufferDisplayLayer->updateRootLayerBoundsAndPosition(bounds, rotation, LocalSampleBufferDisplayLayer::ShouldUpdateRootLayer::Yes);
 }
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -72,7 +72,7 @@ private:
 #endif
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer);
     void updateAffineTransform(CGAffineTransform);
-    void updateBoundsAndPosition(CGRect, WebCore::VideoFrameRotation);
+    void updateBoundsAndPosition(CGRect, WebCore::VideoFrameRotation, std::optional<WTF::MachSendRight>&&);
     void flush();
     void flushAndRemoveImage();
     void play();

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
@@ -29,7 +29,7 @@ messages -> RemoteSampleBufferDisplayLayer NotRefCounted {
 #endif
     UpdateDisplayMode(bool hideDisplayLayer, bool hideRootLayer)
     UpdateAffineTransform(CGAffineTransform transform)
-    UpdateBoundsAndPosition(CGRect bounds, WebCore::VideoFrame::Rotation rotation)
+    UpdateBoundsAndPosition(CGRect bounds, WebCore::VideoFrame::Rotation rotation, std::optional<MachSendRight> fence)
     Flush()
     FlushAndRemoveImage()
     EnqueueVideoFrame(struct WebKit::SharedVideoFrame frame)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
@@ -62,8 +62,10 @@ void SampleBufferDisplayLayer::initialize(bool hideRootLayer, IntSize size, Comp
     m_connection->sendWithAsyncReply(Messages::RemoteSampleBufferDisplayLayerManager::CreateLayer { m_identifier, hideRootLayer, size }, [this, weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto contextId) mutable {
         if (!weakThis)
             return callback(false);
-        if (contextId)
+        if (contextId) {
+            m_hostingContextID = *contextId;
             m_videoLayer = LayerHostingContext::createPlatformLayerForHostingContext(*contextId);
+        }
         callback(!!m_videoLayer);
     });
 }
@@ -99,9 +101,9 @@ void SampleBufferDisplayLayer::updateAffineTransform(CGAffineTransform transform
     m_connection->send(Messages::RemoteSampleBufferDisplayLayer::UpdateAffineTransform { transform }, m_identifier);
 }
 
-void SampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, VideoFrame::Rotation rotation)
+void SampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, VideoFrame::Rotation rotation, std::optional<WTF::MachSendRight>&& fence)
 {
-    m_connection->send(Messages::RemoteSampleBufferDisplayLayer::UpdateBoundsAndPosition { bounds, rotation }, m_identifier);
+    m_connection->send(Messages::RemoteSampleBufferDisplayLayer::UpdateBoundsAndPosition { bounds, rotation, fence }, m_identifier);
 }
 
 void SampleBufferDisplayLayer::flush()

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -51,6 +51,8 @@ public:
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
+    LayerHostingContextID hostingContextID() const final { return m_hostingContextID; }
+
     using GPUProcessConnection::Client::weakPtrFactory;
     using GPUProcessConnection::Client::WeakValueType;
     using GPUProcessConnection::Client::WeakPtrImplType;
@@ -67,7 +69,7 @@ private:
     bool didFail() const final;
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer) final;
     void updateAffineTransform(CGAffineTransform) final;
-    void updateBoundsAndPosition(CGRect, WebCore::VideoFrameRotation) final;
+    void updateBoundsAndPosition(CGRect, WebCore::VideoFrameRotation, std::optional<WTF::MachSendRight>&&) final;
     void flush() final;
     void flushAndRemoveImage() final;
     void play() final;
@@ -91,6 +93,7 @@ private:
     bool m_paused { false };
 
     SharedVideoFrameWriter m_sharedVideoFrameWriter;
+    LayerHostingContextID m_hostingContextID { 0 };
 };
 
 }


### PR DESCRIPTION
#### ec2913e079230d38595455a183367ed339e14592
<pre>
MediaPlayerPrivateMediaStreamAVFObjC needs to stop double-hosting layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=253761">https://bugs.webkit.org/show_bug.cgi?id=253761</a>
rdar://106576224

Reviewed by Youenn Fablet and Brent Fulgham.

MediaPlayerPrivateMediaStreamAVFObjC needs to stop double-hosting layers to allow for CARenderServer blocking.
This patch overrides layerHostingContextID() for MediaPlayerPrivateMediaStreamAVFObjC, which will use the
hosting context ID from SampleBufferDisplayLayer. SampleBufferDisplayLayer receives this context ID from the
GPU process. Additionally, setVideoInlineSizeFenced() is overridden to set the size of the
SampleBufferDisplayLayer. When EWS was processing this patch, I saw timeouts of the test
fast/mediastream/getUserMedia-to-canvas-2.html on iOS simulator. I have not been able to reproduce this
locally. I marked the test as flaky, and filed <a href="https://bugs.webkit.org/show_bug.cgi?id=253959">https://bugs.webkit.org/show_bug.cgi?id=253959</a> to investigate
this further.

LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h:
(WebCore::SampleBufferDisplayLayer::hostingContextID const):
* Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::updateBoundsAndPosition):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::hostingContextID const):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setVideoInlineSizeFenced):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp:
(WebKit::RemoteSampleBufferDisplayLayer::updateBoundsAndPosition):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp:
(WebKit::SampleBufferDisplayLayer::updateBoundsAndPosition):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h:

Canonical link: <a href="https://commits.webkit.org/261709@main">https://commits.webkit.org/261709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc59f21aa0ba5ae0f4b5031069c27c261022cc0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4394 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12936 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118385 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105690 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14104 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/973 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14782 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52968 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8166 "'git push ...'") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16624 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->