### PR TITLE
`screen.width` and `screen.height` in headless mode should not change when page scale factor is changed

### DIFF
--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -1073,7 +1073,10 @@ FloatSize LocalFrame::screenSize() const
         if (!window)
             return std::nullopt;
 
-        return { { window->innerWidth(), window->innerHeight() } };
+        IntSize size { window->innerWidth(), window->innerHeight() };
+        if (auto* page = this->page())
+            size.scale(page->pageScaleFactor());
+        return size;
     }();
 
     if (sizeForHeadlessMode)


### PR DESCRIPTION
#### a3d25bb21b9b3283e50679df4c4af4ce3e4286d9
<pre>
`screen.width` and `screen.height` in headless mode should not change when page scale factor is changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=253762">https://bugs.webkit.org/show_bug.cgi?id=253762</a>
rdar://106482703

Reviewed by Tim Horton.

Account for page scale factor when computing the screen size in headless mode, such that the
adjusted dimensions remain stable as the page is zoomed on both macOS and iOS.

* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::screenSize const):

Canonical link: <a href="https://commits.webkit.org/261574@main">https://commits.webkit.org/261574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3ccf16b301f99f7113f0ec9863a6db0c587849d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3626 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105082 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45714 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13595 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/478 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14271 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19643 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52477 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8069 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16064 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->