### PR TITLE
WebGPU: Prefer member function find over std::find

### DIFF
--- a/Source/WebGPU/WebGPU/Adapter.mm
+++ b/Source/WebGPU/WebGPU/Adapter.mm
@@ -79,7 +79,7 @@ void Adapter::getProperties(WGPUAdapterProperties& properties)
 
 bool Adapter::hasFeature(WGPUFeatureName feature)
 {
-    return std::find(m_capabilities.features.begin(), m_capabilities.features.end(), feature);
+    return m_capabilities.features.find(feature);
 }
 
 void Adapter::requestDevice(const WGPUDeviceDescriptor& descriptor, CompletionHandler<void(WGPURequestDeviceStatus, Ref<Device>&&, String&&)>&& callback)

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -221,7 +221,7 @@ Queue& Device::getQueue()
 
 bool Device::hasFeature(WGPUFeatureName feature)
 {
-    return std::find(m_capabilities.features.begin(), m_capabilities.features.end(), feature);
+    return m_capabilities.features.find(feature);
 }
 
 auto Device::currentErrorScope(WGPUErrorFilter type) -> ErrorScope*


### PR DESCRIPTION
#### 87cdc612103fd30eb88d376790fc9ed254fa1e94
<pre>
WebGPU: Prefer member function find over std::find
<a href="https://bugs.webkit.org/show_bug.cgi?id=253764">https://bugs.webkit.org/show_bug.cgi?id=253764</a>

Reviewed by NOBODY (OOPS!).

This makes the code cleaner and more terse.

* Source/WebGPU/WebGPU/Adapter.mm:(hasFeature): Prefer
  member function &apos;find&apos; over std::find.

* Source/WebGPU/WebGPU/Device.mm:(hasFeature): Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87cdc612103fd30eb88d376790fc9ed254fa1e94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120831 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22661 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4598 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105241 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45844 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13722 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/597 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14401 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52596 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16194 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->