### PR TITLE
Avoid doing too much iteration in WebExtensionContext::removeExpired.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -364,7 +364,7 @@ bool WebExtensionContext::hasInjectedContentForURL(NSURL *url)
 
 const WebExtensionContext::PermissionsMap& WebExtensionContext::grantedPermissions()
 {
-    return removeExpired(m_grantedPermissions, _WKWebExtensionContextGrantedPermissionsWereRemovedNotification);
+    return removeExpired(m_grantedPermissions, m_nextGrantedPermissionsExpirationDate, _WKWebExtensionContextGrantedPermissionsWereRemovedNotification);
 }
 
 void WebExtensionContext::setGrantedPermissions(PermissionsMap&& grantedPermissions)
@@ -373,7 +373,8 @@ void WebExtensionContext::setGrantedPermissions(PermissionsMap&& grantedPermissi
     for (auto& entry : m_grantedPermissions)
         removedPermissions.add(entry.key);
 
-    m_grantedPermissions = removeExpired(grantedPermissions);
+    m_nextGrantedPermissionsExpirationDate = WallTime::nan();
+    m_grantedPermissions = removeExpired(grantedPermissions, m_nextGrantedPermissionsExpirationDate);
 
     PermissionsSet addedPermissions;
     for (auto& entry : m_grantedPermissions) {
@@ -396,7 +397,7 @@ void WebExtensionContext::setGrantedPermissions(PermissionsMap&& grantedPermissi
 
 const WebExtensionContext::PermissionsMap& WebExtensionContext::deniedPermissions()
 {
-    return removeExpired(m_deniedPermissions, _WKWebExtensionContextDeniedPermissionsWereRemovedNotification);
+    return removeExpired(m_deniedPermissions, m_nextDeniedPermissionsExpirationDate, _WKWebExtensionContextDeniedPermissionsWereRemovedNotification);
 }
 
 void WebExtensionContext::setDeniedPermissions(PermissionsMap&& deniedPermissions)
@@ -405,7 +406,8 @@ void WebExtensionContext::setDeniedPermissions(PermissionsMap&& deniedPermission
     for (auto& entry : m_deniedPermissions)
         removedPermissions.add(entry.key);
 
-    m_deniedPermissions = removeExpired(deniedPermissions);
+    m_nextDeniedPermissionsExpirationDate = WallTime::nan();
+    m_deniedPermissions = removeExpired(deniedPermissions, m_nextDeniedPermissionsExpirationDate);
 
     PermissionsSet addedPermissions;
     for (auto& entry : m_deniedPermissions) {
@@ -428,7 +430,7 @@ void WebExtensionContext::setDeniedPermissions(PermissionsMap&& deniedPermission
 
 const WebExtensionContext::PermissionMatchPatternsMap& WebExtensionContext::grantedPermissionMatchPatterns()
 {
-    return removeExpired(m_grantedPermissionMatchPatterns, _WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification);
+    return removeExpired(m_grantedPermissionMatchPatterns, m_nextGrantedPermissionMatchPatternsExpirationDate, _WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification);
 }
 
 void WebExtensionContext::setGrantedPermissionMatchPatterns(PermissionMatchPatternsMap&& grantedPermissionMatchPatterns)
@@ -437,7 +439,8 @@ void WebExtensionContext::setGrantedPermissionMatchPatterns(PermissionMatchPatte
     for (auto& entry : m_grantedPermissionMatchPatterns)
         removedMatchPatterns.add(entry.key);
 
-    m_grantedPermissionMatchPatterns = removeExpired(grantedPermissionMatchPatterns);
+    m_nextGrantedPermissionMatchPatternsExpirationDate = WallTime::nan();
+    m_grantedPermissionMatchPatterns = removeExpired(grantedPermissionMatchPatterns, m_nextGrantedPermissionsExpirationDate);
 
     MatchPatternSet addedMatchPatterns;
     for (auto& entry : m_grantedPermissionMatchPatterns) {
@@ -461,7 +464,7 @@ void WebExtensionContext::setGrantedPermissionMatchPatterns(PermissionMatchPatte
 
 const WebExtensionContext::PermissionMatchPatternsMap& WebExtensionContext::deniedPermissionMatchPatterns()
 {
-    return removeExpired(m_deniedPermissionMatchPatterns, _WKWebExtensionContextDeniedPermissionMatchPatternsWereRemovedNotification);
+    return removeExpired(m_deniedPermissionMatchPatterns, m_nextDeniedPermissionMatchPatternsExpirationDate, _WKWebExtensionContextDeniedPermissionMatchPatternsWereRemovedNotification);
 }
 
 void WebExtensionContext::setDeniedPermissionMatchPatterns(PermissionMatchPatternsMap&& deniedPermissionMatchPatterns)
@@ -470,7 +473,8 @@ void WebExtensionContext::setDeniedPermissionMatchPatterns(PermissionMatchPatter
     for (auto& entry : m_deniedPermissionMatchPatterns)
         removedMatchPatterns.add(entry.key);
 
-    m_deniedPermissionMatchPatterns = removeExpired(deniedPermissionMatchPatterns);
+    m_nextDeniedPermissionMatchPatternsExpirationDate = WallTime::nan();
+    m_deniedPermissionMatchPatterns = removeExpired(deniedPermissionMatchPatterns, m_nextDeniedPermissionMatchPatternsExpirationDate);
 
     MatchPatternSet addedMatchPatterns;
     for (auto& entry : m_deniedPermissionMatchPatterns) {
@@ -527,6 +531,9 @@ void WebExtensionContext::grantPermissions(PermissionsSet&& permissions, WallTim
     if (permissions.isEmpty())
         return;
 
+    if (m_nextGrantedPermissionsExpirationDate > expirationDate)
+        m_nextGrantedPermissionsExpirationDate = expirationDate;
+
     for (auto& permission : permissions)
         m_grantedPermissions.add(permission, expirationDate);
 
@@ -540,6 +547,9 @@ void WebExtensionContext::denyPermissions(PermissionsSet&& permissions, WallTime
     if (permissions.isEmpty())
         return;
 
+    if (m_nextDeniedPermissionsExpirationDate > expirationDate)
+        m_nextDeniedPermissionsExpirationDate = expirationDate;
+
     for (auto& permission : permissions)
         m_deniedPermissions.add(permission, expirationDate);
 
@@ -552,6 +562,9 @@ void WebExtensionContext::grantPermissionMatchPatterns(MatchPatternSet&& permiss
 {
     if (permissionMatchPatterns.isEmpty())
         return;
+
+    if (m_nextGrantedPermissionMatchPatternsExpirationDate > expirationDate)
+        m_nextGrantedPermissionMatchPatternsExpirationDate = expirationDate;
 
     for (auto& pattern : permissionMatchPatterns)
         m_grantedPermissionMatchPatterns.add(pattern, expirationDate);
@@ -569,6 +582,9 @@ void WebExtensionContext::denyPermissionMatchPatterns(MatchPatternSet&& permissi
     if (permissionMatchPatterns.isEmpty())
         return;
 
+    if (m_nextDeniedPermissionMatchPatternsExpirationDate > expirationDate)
+        m_nextDeniedPermissionMatchPatternsExpirationDate = expirationDate;
+
     for (auto& pattern : permissionMatchPatterns)
         m_deniedPermissionMatchPatterns.add(pattern, expirationDate);
 
@@ -582,32 +598,34 @@ void WebExtensionContext::denyPermissionMatchPatterns(MatchPatternSet&& permissi
 
 void WebExtensionContext::removeGrantedPermissions(PermissionsSet& permissionsToRemove)
 {
-    removePermissions(m_grantedPermissions, permissionsToRemove, _WKWebExtensionContextGrantedPermissionsWereRemovedNotification);
+    removePermissions(m_grantedPermissions, permissionsToRemove, m_nextGrantedPermissionsExpirationDate, _WKWebExtensionContextGrantedPermissionsWereRemovedNotification);
 }
 
 void WebExtensionContext::removeGrantedPermissionMatchPatterns(MatchPatternSet& matchPatternsToRemove, EqualityOnly equalityOnly)
 {
-    removePermissionMatchPatterns(m_grantedPermissionMatchPatterns, matchPatternsToRemove, equalityOnly, _WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification);
+    removePermissionMatchPatterns(m_grantedPermissionMatchPatterns, matchPatternsToRemove, equalityOnly, m_nextGrantedPermissionMatchPatternsExpirationDate, _WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification);
 
     removeInjectedContent(matchPatternsToRemove);
 }
 
 void WebExtensionContext::removeDeniedPermissions(PermissionsSet& permissionsToRemove)
 {
-    removePermissions(m_deniedPermissions, permissionsToRemove, _WKWebExtensionContextDeniedPermissionsWereRemovedNotification);
+    removePermissions(m_deniedPermissions, permissionsToRemove, m_nextDeniedPermissionsExpirationDate, _WKWebExtensionContextDeniedPermissionsWereRemovedNotification);
 }
 
 void WebExtensionContext::removeDeniedPermissionMatchPatterns(MatchPatternSet& matchPatternsToRemove, EqualityOnly equalityOnly)
 {
-    removePermissionMatchPatterns(m_deniedPermissionMatchPatterns, matchPatternsToRemove, equalityOnly, _WKWebExtensionContextDeniedPermissionsWereRemovedNotification);
+    removePermissionMatchPatterns(m_deniedPermissionMatchPatterns, matchPatternsToRemove, equalityOnly, m_nextDeniedPermissionMatchPatternsExpirationDate, _WKWebExtensionContextDeniedPermissionsWereRemovedNotification);
 
     updateInjectedContent();
 }
 
-void WebExtensionContext::removePermissions(PermissionsMap& permissionMap, PermissionsSet& permissionsToRemove, NSNotificationName notificationName)
+void WebExtensionContext::removePermissions(PermissionsMap& permissionMap, PermissionsSet& permissionsToRemove, WallTime& nextExpirationDate, NSNotificationName notificationName)
 {
     if (permissionsToRemove.isEmpty())
         return;
+
+    nextExpirationDate = WallTime::infinity();
 
     PermissionsSet removedPermissions;
     permissionMap.removeIf([&](auto& entry) {
@@ -615,6 +633,9 @@ void WebExtensionContext::removePermissions(PermissionsMap& permissionMap, Permi
             removedPermissions.add(entry.key);
             return true;
         }
+
+        if (entry.value < nextExpirationDate)
+            nextExpirationDate = entry.value;
 
         return false;
     });
@@ -625,10 +646,12 @@ void WebExtensionContext::removePermissions(PermissionsMap& permissionMap, Permi
     postAsyncNotification(notificationName, removedPermissions);
 }
 
-void WebExtensionContext::removePermissionMatchPatterns(PermissionMatchPatternsMap& matchPatternMap, MatchPatternSet& matchPatternsToRemove, EqualityOnly equalityOnly, NSNotificationName notificationName)
+void WebExtensionContext::removePermissionMatchPatterns(PermissionMatchPatternsMap& matchPatternMap, MatchPatternSet& matchPatternsToRemove, EqualityOnly equalityOnly, WallTime& nextExpirationDate, NSNotificationName notificationName)
 {
     if (matchPatternsToRemove.isEmpty())
         return;
+
+    nextExpirationDate = WallTime::infinity();
 
     MatchPatternSet removedMatchPatterns;
     matchPatternMap.removeIf([&](auto& entry) {
@@ -637,8 +660,12 @@ void WebExtensionContext::removePermissionMatchPatterns(PermissionMatchPatternsM
             return true;
         }
 
-        if (equalityOnly == EqualityOnly::Yes)
+        if (equalityOnly == EqualityOnly::Yes) {
+            if (entry.value < nextExpirationDate)
+                nextExpirationDate = entry.value;
+
             return false;
+        }
 
         for (auto& patternToRemove : matchPatternsToRemove) {
             if (patternToRemove->matchesPattern(entry.key, WebExtensionMatchPattern::Options::IgnorePaths)) {
@@ -646,6 +673,9 @@ void WebExtensionContext::removePermissionMatchPatterns(PermissionMatchPatternsM
                 return true;
             }
         }
+
+        if (entry.value < nextExpirationDate)
+            nextExpirationDate = entry.value;
 
         return false;
     });
@@ -658,9 +688,15 @@ void WebExtensionContext::removePermissionMatchPatterns(PermissionMatchPatternsM
     postAsyncNotification(notificationName, removedMatchPatterns);
 }
 
-WebExtensionContext::PermissionsMap& WebExtensionContext::removeExpired(PermissionsMap& permissionMap, NSNotificationName notificationName)
+WebExtensionContext::PermissionsMap& WebExtensionContext::removeExpired(PermissionsMap& permissionMap, WallTime& nextExpirationDate, NSNotificationName notificationName)
 {
     WallTime currentTime = WallTime::now();
+
+    // If the next expiration date hasn't passed yet, there is nothing to remove.
+    if (nextExpirationDate != WallTime::nan() && nextExpirationDate > currentTime)
+        return permissionMap;
+
+    nextExpirationDate = WallTime::infinity();
 
     PermissionsSet removedPermissions;
     permissionMap.removeIf([&](auto& entry) {
@@ -668,6 +704,9 @@ WebExtensionContext::PermissionsMap& WebExtensionContext::removeExpired(Permissi
             removedPermissions.add(entry.key);
             return true;
         }
+
+        if (entry.value < nextExpirationDate)
+            nextExpirationDate = entry.value;
 
         return false;
     });
@@ -680,9 +719,15 @@ WebExtensionContext::PermissionsMap& WebExtensionContext::removeExpired(Permissi
     return permissionMap;
 }
 
-WebExtensionContext::PermissionMatchPatternsMap& WebExtensionContext::removeExpired(PermissionMatchPatternsMap& matchPatternMap, NSNotificationName notificationName)
+WebExtensionContext::PermissionMatchPatternsMap& WebExtensionContext::removeExpired(PermissionMatchPatternsMap& matchPatternMap, WallTime& nextExpirationDate, NSNotificationName notificationName)
 {
     WallTime currentTime = WallTime::now();
+
+    // If the next expiration date hasn't passed yet, there is nothing to remove.
+    if (nextExpirationDate != WallTime::nan() && nextExpirationDate > currentTime)
+        return matchPatternMap;
+
+    nextExpirationDate = WallTime::infinity();
 
     MatchPatternSet removedMatchPatterns;
     matchPatternMap.removeIf([&](auto& entry) {
@@ -690,6 +735,9 @@ WebExtensionContext::PermissionMatchPatternsMap& WebExtensionContext::removeExpi
             removedMatchPatterns.add(entry.key);
             return true;
         }
+
+        if (entry.value < nextExpirationDate)
+            nextExpirationDate = entry.value;
 
         return false;
     });

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -249,11 +249,11 @@ private:
     void postAsyncNotification(NSString *notificationName, PermissionsSet&);
     void postAsyncNotification(NSString *notificationName, MatchPatternSet&);
 
-    void removePermissions(PermissionsMap&, PermissionsSet&, NSString *notificationName);
-    void removePermissionMatchPatterns(PermissionMatchPatternsMap&, MatchPatternSet&, EqualityOnly, NSString *notificationName);
+    void removePermissions(PermissionsMap&, PermissionsSet&, WallTime& nextExpirationDate, NSString *notificationName);
+    void removePermissionMatchPatterns(PermissionMatchPatternsMap&, MatchPatternSet&, EqualityOnly, WallTime& nextExpirationDate, NSString *notificationName);
 
-    PermissionsMap& removeExpired(PermissionsMap&, NSString *notificationName = nil);
-    PermissionMatchPatternsMap& removeExpired(PermissionMatchPatternsMap&, NSString *notificationName = nil);
+    PermissionsMap& removeExpired(PermissionsMap&, WallTime& nextExpirationDate, NSString *notificationName = nil);
+    PermissionMatchPatternsMap& removeExpired(PermissionMatchPatternsMap&, WallTime& nextExpirationDate, NSString *notificationName = nil);
 
     WKWebViewConfiguration *webViewConfiguration();
 
@@ -323,8 +323,14 @@ private:
     PermissionsMap m_grantedPermissions;
     PermissionsMap m_deniedPermissions;
 
+    WallTime m_nextGrantedPermissionsExpirationDate { WallTime::nan() };
+    WallTime m_nextDeniedPermissionsExpirationDate { WallTime::nan() };
+
     PermissionMatchPatternsMap m_grantedPermissionMatchPatterns;
     PermissionMatchPatternsMap m_deniedPermissionMatchPatterns;
+
+    WallTime m_nextGrantedPermissionMatchPatternsExpirationDate { WallTime::nan() };
+    WallTime m_nextDeniedPermissionMatchPatternsExpirationDate { WallTime::nan() };
 
     ListHashSet<URL> m_cachedPermissionURLs;
     HashMap<URL, PermissionState> m_cachedPermissionStates;


### PR DESCRIPTION
#### d09ca7493d1e615d85381165fbebc38753c3c1be
<pre>
Avoid doing too much iteration in WebExtensionContext::removeExpired.
<a href="https://webkit.org/b/253766">https://webkit.org/b/253766</a>

Reviewed by Brian Weinstein.

Store the next expiration date so we don&apos;t need to iterate the HashMaps if nothing has expired.
Passes existing WKWebExtensionContext tests that exercise expiration dates.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::grantedPermissions):
(WebKit::WebExtensionContext::setGrantedPermissions):
(WebKit::WebExtensionContext::deniedPermissions):
(WebKit::WebExtensionContext::setDeniedPermissions):
(WebKit::WebExtensionContext::grantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::setGrantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::deniedPermissionMatchPatterns):
(WebKit::WebExtensionContext::setDeniedPermissionMatchPatterns):
(WebKit::WebExtensionContext::grantPermissions):
(WebKit::WebExtensionContext::denyPermissions):
(WebKit::WebExtensionContext::grantPermissionMatchPatterns):
(WebKit::WebExtensionContext::denyPermissionMatchPatterns):
(WebKit::WebExtensionContext::removeGrantedPermissions):
(WebKit::WebExtensionContext::removeGrantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::removeDeniedPermissions):
(WebKit::WebExtensionContext::removeDeniedPermissionMatchPatterns):
(WebKit::WebExtensionContext::removePermissions):
(WebKit::WebExtensionContext::removePermissionMatchPatterns):
(WebKit::WebExtensionContext::removeExpired):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/261706@main">https://commits.webkit.org/261706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c32593f7b47171fccc8fa3fb7d8675e6fd2b7ee9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4465 "Built successfully and passed tests") | | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->