### PR TITLE
Add some swipe tests with wheel event handlers

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -890,6 +890,8 @@ webkit.org/b/168466 http/tests/security/bypassing-cors-checks-for-extension-urls
 
 # The test directly sends Cocoa events
 swipe/pushState-programmatic-back-while-swiping-crash.html [ Skip ]
+swipe/swipe-back-with-passive-wheel-listener.html [ Skip ]
+swipe/swipe-back-with-active-wheel-listener.html [ Skip ]
 
 # GTK port doesn't suport datalist in range elements
 fast/forms/datalist/input-appearance-range-with-datalist-rtl.html [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3100,6 +3100,8 @@ imported/blink/compositing/video/video-controls-layer-creation-squashing.html [ 
 
 # Test fails, but has flaky output.
 swipe/main-frame-pinning-requirement.html [ Pass Failure ]
+webkit.org/b/253850 swipe/swipe-back-with-passive-wheel-listener.html [ Skip ]
+webkit.org/b/253850 swipe/swipe-back-with-active-wheel-listener.html [ Skip ]
 
 # These tests fail unexpectedly with accelerated drawing enabled.
 # Interestingly, these versions fail worse than the more recently updated WPT versions above.

--- a/LayoutTests/swipe/resources/swipe-test.js
+++ b/LayoutTests/swipe/resources/swipe-test.js
@@ -9,14 +9,16 @@ function log(s)
     window.localStorage["swipeLogging"] += s + "<br/>";
 }
 
-function dumpLog()
+function dumpLog(logContainer)
 {
-    window.document.body.innerHTML = window.localStorage["swipeLogging"];
+    if (!logContainer)
+        logContainer = document.body;
+    logContainer.innerHTML = window.localStorage["swipeLogging"];
 }
 
-function testComplete()
+function testComplete(logContainer)
 {
-    dumpLog();
+    dumpLog(logContainer);
     window.testRunner.notifyDone();
 }
 
@@ -37,6 +39,33 @@ function measuredDurationShouldBeLessThan(key, timeInMS, message)
     var duration = Date.now() - window.localStorage[key + "swipeStartTime"];
     if (duration >= timeInMS)
         log("Failure. " + message + " (expected: " + timeInMS + ", actual: " + duration + ")");
+}
+
+async function startSlowSwipeGesture()
+{
+    if (!window.eventSender)
+        return;
+
+    // Similar to uiController.beginBackSwipe(), but with a gap between events to allow
+    // for DOM wheel event handlers to fire.
+    eventSender.mouseMoveTo(400, 300);
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(1, 0, "began", "none");
+    await UIHelper.renderingUpdate();
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(8, 0, "changed", "none");
+    await UIHelper.renderingUpdate();
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(10, 0, "changed", "none");
+    await UIHelper.renderingUpdate();
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(10, 0, "changed", "none");
+    await UIHelper.renderingUpdate();
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(10, 0, "changed", "none");
+    await UIHelper.renderingUpdate();
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(10, 0, "changed", "none");
+    await UIHelper.renderingUpdate();
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(10, 0, "changed", "none");
+    await UIHelper.renderingUpdate();
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(5, 0, "changed", "none");
+    await UIHelper.renderingUpdate();
+    eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
 }
 
 async function startSwipeGesture()

--- a/LayoutTests/swipe/swipe-back-with-active-wheel-listener-expected.txt
+++ b/LayoutTests/swipe/swipe-back-with-active-wheel-listener-expected.txt
@@ -1,0 +1,6 @@
+Swipe target
+didBeginSwipe
+completeSwipeGesture
+willEndSwipe
+didEndSwipe
+

--- a/LayoutTests/swipe/swipe-back-with-active-wheel-listener.html
+++ b/LayoutTests/swipe/swipe-back-with-active-wheel-listener.html
@@ -1,0 +1,79 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<head>
+<style>
+    body, html {
+        height: 100%;
+    }
+    #swipeTarget {
+        position: absolute;
+        inset: 100px;
+        border: 1px solid black;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<script src="resources/swipe-test.js"></script>
+<script>
+    var logElement;
+    function didBeginSwipeCallback()
+    {
+        log("didBeginSwipe");
+
+        completeSwipeGesture();
+    }
+
+    function willEndSwipeCallback()
+    {
+        log("willEndSwipe");
+
+        shouldBe(false, isFirstPage(), "The swipe should not yet have navigated away from the second page.");
+    }
+
+    function didEndSwipeCallback()
+    {
+        log("didEndSwipe");
+
+        testComplete(logElement);
+    }
+
+    function isFirstPage()
+    {
+        return window.location.href.indexOf("second") == -1;
+    }
+
+    window.onload = async function () {
+        logElement = document.getElementById('console');
+        logElement.innerHTML = isFirstPage() ? "first" : "second";
+
+        if (isFirstPage()) {
+            setTimeout(function () { 
+                window.location.href = window.location.href + "?second";
+            }, 0);
+
+            if (!window.eventSender || !window.testRunner)
+                return;
+
+            initializeSwipeTest();
+        
+            testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+            testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+            testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+
+            return;
+        }
+
+        const swipeTarget = document.getElementById('swipeTarget');
+        swipeTarget.addEventListener('wheel', () => { }, { passive: false });
+
+        await startSlowSwipeGesture();
+    };
+</script>
+</head>
+<body>
+    <div id="swipeTarget">
+        Swipe target
+    </div>
+    <div id="console">This test must be run in WebKitTestRunner.</div>
+</body>

--- a/LayoutTests/swipe/swipe-back-with-passive-wheel-listener-expected.txt
+++ b/LayoutTests/swipe/swipe-back-with-passive-wheel-listener-expected.txt
@@ -1,0 +1,7 @@
+Swipe target
+startSwipeGesture
+didBeginSwipe
+completeSwipeGesture
+willEndSwipe
+didEndSwipe
+

--- a/LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html
+++ b/LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html
@@ -1,0 +1,78 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<head>
+<style>
+    body, html {
+        height: 100%;
+    }
+    #swipeTarget {
+        position: absolute;
+        inset: 100px;
+        border: 1px solid black;
+    }
+</style>
+<script src="resources/swipe-test.js"></script>
+<script>
+    var logElement;
+    function didBeginSwipeCallback()
+    {
+        log("didBeginSwipe");
+
+        completeSwipeGesture();
+    }
+
+    function willEndSwipeCallback()
+    {
+        log("willEndSwipe");
+
+        shouldBe(false, isFirstPage(), "The swipe should not yet have navigated away from the second page.");
+    }
+
+    function didEndSwipeCallback()
+    {
+        log("didEndSwipe");
+
+        testComplete(logElement);
+    }
+
+    function isFirstPage()
+    {
+        return window.location.href.indexOf("second") == -1;
+    }
+
+    window.onload = async function () {
+        logElement = document.getElementById('console');
+        logElement.innerHTML = isFirstPage() ? "first" : "second";
+
+        if (isFirstPage()) {
+            setTimeout(function () { 
+                window.location.href = window.location.href + "?second";
+            }, 0);
+
+            if (!window.eventSender || !window.testRunner)
+                return;
+
+            initializeSwipeTest();
+        
+            testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+            testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+            testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+
+            return;
+        }
+
+        const swipeTarget = document.getElementById('swipeTarget');
+        swipeTarget.addEventListener('wheel', () => { }, { passive: true });
+
+        await startSwipeGesture();
+    };
+</script>
+</head>
+<body>
+    <div id="swipeTarget">
+        Swipe target
+    </div>
+    <div id="console">This test must be run in WebKitTestRunner.</div>
+</body>

--- a/LayoutTests/swipe/wheel-prevent-default-prevents-swipe-back-expected.txt
+++ b/LayoutTests/swipe/wheel-prevent-default-prevents-swipe-back-expected.txt
@@ -1,0 +1,3 @@
+Swipe target
+completeSwipeGesture
+

--- a/LayoutTests/swipe/wheel-prevent-default-prevents-swipe-back.html
+++ b/LayoutTests/swipe/wheel-prevent-default-prevents-swipe-back.html
@@ -1,0 +1,78 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<head>
+<style>
+    body, html {
+        height: 100%;
+    }
+    #swipeTarget {
+        position: absolute;
+        inset: 100px;
+        border: 1px solid black;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<script src="resources/swipe-test.js"></script>
+<script>
+    var logElement;
+    function didBeginSwipeCallback()
+    {
+        log("didBeginSwipe");
+    }
+
+    function willEndSwipeCallback()
+    {
+        log("willEndSwipe");
+    }
+
+    function didEndSwipeCallback()
+    {
+        log("didEndSwipe");
+    }
+
+    function isFirstPage()
+    {
+        return window.location.href.indexOf("second") == -1;
+    }
+    
+    window.onload = async function () {
+        logElement = document.getElementById('console');
+        logElement.innerHTML = isFirstPage() ? "first" : "second";
+
+        if (isFirstPage()) {
+            setTimeout(function () { 
+                window.location.href = window.location.href + "?second";
+            }, 0);
+
+            if (!window.eventSender || !window.testRunner)
+                return;
+
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+
+            initializeSwipeTest();
+        
+            testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+            testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+            testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+
+            return;
+        }
+        
+        const swipeTarget = document.getElementById('swipeTarget');
+        swipeTarget.addEventListener('wheel', (event) => {
+            event.preventDefault();
+        }, { passive: false });
+
+        await startSlowSwipeGesture();
+        await completeSwipeGesture();
+
+        testComplete(logElement);
+    };
+</script>
+</head>
+<body>
+    <div id="swipeTarget">
+        Swipe target
+    </div>
+    <div id="console">This test must be run in WebKitTestRunner.</div>
+</body>

--- a/Tools/TestRunnerShared/EventSerialization/mac/SharedEventStreamsMac.mm
+++ b/Tools/TestRunnerShared/EventSerialization/mac/SharedEventStreamsMac.mm
@@ -34,178 +34,178 @@ NSString *beginSwipeBackEventStream()
 {
     return QUOTE([
         {
-            "relativeTimeMS" : 0,
-            "kCGEventScrollGestureFlagBits" : 1,
             "kCGEventGestureHIDType" : 6,
-            "kCGSEventTypeField" : 29,
             "kCGEventGesturePhase" : 128,
+            "kCGEventScrollGestureFlagBits" : 1,
+            "kCGSEventTypeField" : 29,
+            "relativeTimeMS" : 0,
             "windowLocation" : "{400, 300}"
         },
         {
-            "relativeTimeMS" : 8,
             "kCGEventGestureHIDType" : 61,
-            "kCGSEventTypeField" : 29,
             "kCGEventGestureStartEndSeriesType" : 6,
+            "kCGSEventTypeField" : 29,
+            "relativeTimeMS" : 8,
             "windowLocation" : "{400, 300}"
         },
         {
             "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 8,
-            "windowLocation" : "{400, 300}",
             "kCGEventGesturePhase" : 1,
+            "kCGEventGestureScrollX" : 2,
             "kCGEventScrollGestureFlagBits" : 1,
             "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 2
+            "relativeTimeMS" : 8,
+            "windowLocation" : "{400, 300}"
         },
         {
-            "relativeTimeMS" : 8,
-            "windowLocation" : "{400, 300}",
-            "kCGScrollWheelEventScrollPhase" : 1,
             "kCGScrollWheelEventIsContinuous" : 1,
             "kCGScrollWheelEventPointDeltaAxis2" : 1,
-            "kCGSEventTypeField" : 22
+            "kCGScrollWheelEventScrollPhase" : 1,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 8,
+            "windowLocation" : "{400, 300}"
         },
         {
             "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 17,
-            "windowLocation" : "{400, 300}",
+            "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 12,
             "kCGEventGestureScrollY" : 1,
-            "kCGEventGesturePhase" : 2,
             "kCGEventScrollGestureFlagBits" : 1,
             "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 12
+            "relativeTimeMS" : 17,
+            "windowLocation" : "{400, 300}"
         },
         {
-            "kCGScrollWheelEventPointDeltaAxis1" : 1,
-            "relativeTimeMS" : 17,
-            "kCGScrollWheelEventScrollPhase" : 2,
             "kCGScrollWheelEventIsContinuous" : 1,
+            "kCGScrollWheelEventPointDeltaAxis1" : 1,
             "kCGScrollWheelEventPointDeltaAxis2" : 4,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
+            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 17,
+            "windowLocation" : "{400, 300}"
         },
         {
             "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 25,
-            "windowLocation" : "{400, 300}",
-            "kCGEventGestureScrollY" : 2,
             "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 23,
+            "kCGEventGestureScrollY" : 2,
             "kCGEventScrollGestureFlagBits" : 1,
             "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 23
+            "relativeTimeMS" : 25,
+            "windowLocation" : "{400, 300}"
         },
         {
             "kCGScrollWheelEventDeltaAxis2" : 1,
-            "kCGScrollWheelEventPointDeltaAxis1" : 1,
-            "relativeTimeMS" : 25,
             "kCGScrollWheelEventIsContinuous" : 1,
-            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGScrollWheelEventPointDeltaAxis1" : 1,
             "kCGScrollWheelEventPointDeltaAxis2" : 11,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
+            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 25,
+            "windowLocation" : "{400, 300}"
         },
         {
             "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 33,
-            "windowLocation" : "{400, 300}",
+            "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 28,
             "kCGEventGestureScrollY" : 2,
-            "kCGEventGesturePhase" : 2,
             "kCGEventScrollGestureFlagBits" : 1,
             "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 28
-        },
-        {
-            "kCGScrollWheelEventDeltaAxis2" : 2,
-            "kCGScrollWheelEventPointDeltaAxis1" : 1,
             "relativeTimeMS" : 33,
-            "kCGScrollWheelEventIsContinuous" : 1,
-            "kCGScrollWheelEventScrollPhase" : 2,
-            "kCGScrollWheelEventPointDeltaAxis2" : 16,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
-        },
-        {
-            "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 41,
-            "windowLocation" : "{400, 300}",
-            "kCGEventGestureScrollY" : 1,
-            "kCGEventGesturePhase" : 2,
-            "kCGEventScrollGestureFlagBits" : 1,
-            "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 35
+            "windowLocation" : "{400, 300}"
         },
         {
             "kCGScrollWheelEventDeltaAxis2" : 2,
+            "kCGScrollWheelEventIsContinuous" : 1,
             "kCGScrollWheelEventPointDeltaAxis1" : 1,
+            "kCGScrollWheelEventPointDeltaAxis2" : 16,
+            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 33,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGEventGestureHIDType" : 6,
+            "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 35,
+            "kCGEventGestureScrollY" : 1,
+            "kCGEventScrollGestureFlagBits" : 1,
+            "kCGSEventTypeField" : 29,
             "relativeTimeMS" : 41,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGScrollWheelEventDeltaAxis2" : 2,
             "kCGScrollWheelEventIsContinuous" : 1,
-            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGScrollWheelEventPointDeltaAxis1" : 1,
             "kCGScrollWheelEventPointDeltaAxis2" : 24,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
+            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 41,
+            "windowLocation" : "{400, 300}"
         },
         {
             "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 49,
-            "windowLocation" : "{400, 300}",
+            "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 45,
             "kCGEventGestureScrollY" : -1,
-            "kCGEventGesturePhase" : 2,
             "kCGEventScrollGestureFlagBits" : 1,
             "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 45
-        },
-        {
-            "kCGScrollWheelEventScrollCount" : 1,
-            "kCGScrollWheelEventDeltaAxis2" : 4,
-            "kCGScrollWheelEventPointDeltaAxis1" : -1,
             "relativeTimeMS" : 49,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGScrollWheelEventDeltaAxis2" : 4,
             "kCGScrollWheelEventIsContinuous" : 1,
-            "kCGScrollWheelEventScrollPhase" : 2,
-            "kCGScrollWheelEventPointDeltaAxis2" : 37,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
-        },
-        {
-            "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 57,
-            "windowLocation" : "{400, 300}",
-            "kCGEventGestureScrollY" : -3,
-            "kCGEventGesturePhase" : 2,
-            "kCGEventScrollGestureFlagBits" : 1,
-            "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 57
-        },
-        {
-            "kCGScrollWheelEventScrollCount" : 1,
-            "kCGScrollWheelEventDeltaAxis2" : 5,
             "kCGScrollWheelEventPointDeltaAxis1" : -1,
-            "relativeTimeMS" : 57,
-            "kCGScrollWheelEventIsContinuous" : 1,
+            "kCGScrollWheelEventPointDeltaAxis2" : 37,
+            "kCGScrollWheelEventScrollCount" : 1,
             "kCGScrollWheelEventScrollPhase" : 2,
-            "kCGScrollWheelEventPointDeltaAxis2" : 54,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 49,
+            "windowLocation" : "{400, 300}"
         },
         {
             "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 65,
-            "windowLocation" : "{400, 300}",
-            "kCGEventGestureScrollY" : -5,
             "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 57,
+            "kCGEventGestureScrollY" : -3,
             "kCGEventScrollGestureFlagBits" : 1,
             "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 81
+            "relativeTimeMS" : 57,
+            "windowLocation" : "{400, 300}"
         },
         {
-            "kCGScrollWheelEventScrollCount" : 1,
-            "kCGScrollWheelEventDeltaAxis2" : 9,
-            "kCGScrollWheelEventPointDeltaAxis1" : -2,
-            "relativeTimeMS" : 65,
+            "kCGScrollWheelEventDeltaAxis2" : 5,
             "kCGScrollWheelEventIsContinuous" : 1,
+            "kCGScrollWheelEventPointDeltaAxis1" : -1,
+            "kCGScrollWheelEventPointDeltaAxis2" : 54,
+            "kCGScrollWheelEventScrollCount" : 1,
             "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 57,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGEventGestureHIDType" : 6,
+            "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 81,
+            "kCGEventGestureScrollY" : -5,
+            "kCGEventScrollGestureFlagBits" : 1,
+            "kCGSEventTypeField" : 29,
+            "relativeTimeMS" : 65,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGScrollWheelEventDeltaAxis2" : 9,
+            "kCGScrollWheelEventIsContinuous" : 1,
+            "kCGScrollWheelEventPointDeltaAxis1" : -2,
             "kCGScrollWheelEventPointDeltaAxis2" : 92,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
+            "kCGScrollWheelEventScrollCount" : 1,
+            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 65,
+            "windowLocation" : "{400, 300}"
         },
     ]);
 }
@@ -215,153 +215,153 @@ NSString *completeSwipeBackEventStream()
     return QUOTE([
         {
             "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 73,
-            "windowLocation" : "{400, 300}",
-            "kCGEventGestureScrollY" : -3,
             "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 75,
+            "kCGEventGestureScrollY" : -3,
             "kCGEventScrollGestureFlagBits" : 1,
             "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 75
+            "relativeTimeMS" : 73,
+            "windowLocation" : "{400, 300}"
         },
         {
-            "kCGScrollWheelEventScrollCount" : 1,
             "kCGScrollWheelEventDeltaAxis2" : 11,
-            "kCGScrollWheelEventPointDeltaAxis1" : -1,
-            "relativeTimeMS" : 73,
             "kCGScrollWheelEventIsContinuous" : 1,
-            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGScrollWheelEventPointDeltaAxis1" : -1,
             "kCGScrollWheelEventPointDeltaAxis2" : 106,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
+            "kCGScrollWheelEventScrollCount" : 1,
+            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 73,
+            "windowLocation" : "{400, 300}"
         },
         {
             "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 81,
-            "windowLocation" : "{400, 300}",
+            "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 85,
             "kCGEventGestureScrollY" : -3,
-            "kCGEventGesturePhase" : 2,
             "kCGEventScrollGestureFlagBits" : 1,
             "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 85
-        },
-        {
-            "kCGScrollWheelEventScrollCount" : 1,
-            "kCGScrollWheelEventDeltaAxis2" : 13,
-            "kCGScrollWheelEventPointDeltaAxis1" : -1,
             "relativeTimeMS" : 81,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGScrollWheelEventDeltaAxis2" : 13,
             "kCGScrollWheelEventIsContinuous" : 1,
-            "kCGScrollWheelEventScrollPhase" : 2,
-            "kCGScrollWheelEventPointDeltaAxis2" : 127,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
-        },
-        {
-            "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 89,
-            "windowLocation" : "{400, 300}",
-            "kCGEventGestureScrollY" : -1,
-            "kCGEventGesturePhase" : 2,
-            "kCGEventScrollGestureFlagBits" : 1,
-            "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 91
-        },
-        {
-            "kCGScrollWheelEventScrollCount" : 1,
-            "kCGScrollWheelEventDeltaAxis2" : 14,
             "kCGScrollWheelEventPointDeltaAxis1" : -1,
+            "kCGScrollWheelEventPointDeltaAxis2" : 127,
+            "kCGScrollWheelEventScrollCount" : 1,
+            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 81,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGEventGestureHIDType" : 6,
+            "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 91,
+            "kCGEventGestureScrollY" : -1,
+            "kCGEventScrollGestureFlagBits" : 1,
+            "kCGSEventTypeField" : 29,
             "relativeTimeMS" : 89,
-            "kCGScrollWheelEventIsContinuous" : 1,
-            "kCGScrollWheelEventScrollPhase" : 2,
-            "kCGScrollWheelEventPointDeltaAxis2" : 139,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
+            "windowLocation" : "{400, 300}"
         },
         {
-            "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 97,
-            "windowLocation" : "{400, 300}",
-            "kCGEventGestureScrollY" : 2,
-            "kCGEventGesturePhase" : 2,
-            "kCGEventScrollGestureFlagBits" : 1,
-            "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 136
-        },
-        {
-            "kCGScrollWheelEventScrollCount" : 1,
-            "kCGScrollWheelEventDeltaAxis2" : 20,
-            "kCGScrollWheelEventPointDeltaAxis1" : 1,
-            "relativeTimeMS" : 97,
-            "kCGScrollWheelEventIsContinuous" : 1,
-            "kCGScrollWheelEventScrollPhase" : 2,
-            "kCGScrollWheelEventPointDeltaAxis2" : 204,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
-        },
-        {
-            "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 105,
-            "windowLocation" : "{400, 300}",
-            "kCGEventGestureScrollY" : 5,
-            "kCGEventGesturePhase" : 2,
-            "kCGEventScrollGestureFlagBits" : 1,
-            "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 92
-        },
-        {
-            "kCGScrollWheelEventScrollCount" : 1,
             "kCGScrollWheelEventDeltaAxis2" : 14,
-            "kCGScrollWheelEventPointDeltaAxis1" : 2,
-            "relativeTimeMS" : 105,
             "kCGScrollWheelEventIsContinuous" : 1,
+            "kCGScrollWheelEventPointDeltaAxis1" : -1,
+            "kCGScrollWheelEventPointDeltaAxis2" : 139,
+            "kCGScrollWheelEventScrollCount" : 1,
             "kCGScrollWheelEventScrollPhase" : 2,
-            "kCGScrollWheelEventPointDeltaAxis2" : 136,
-            "windowLocation" : "{400, 300}",
-            "kCGSEventTypeField" : 22
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 89,
+            "windowLocation" : "{400, 300}"
         },
         {
             "kCGEventGestureHIDType" : 6,
-            "relativeTimeMS" : 113,
-            "windowLocation" : "{400, 300}",
-            "kCGEventGestureScrollY" : 14,
             "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 136,
+            "kCGEventGestureScrollY" : 2,
             "kCGEventScrollGestureFlagBits" : 1,
             "kCGSEventTypeField" : 29,
-            "kCGEventGestureScrollX" : 133
+            "relativeTimeMS" : 97,
+            "windowLocation" : "{400, 300}"
         },
         {
-            "kCGScrollWheelEventScrollPhase" : 2,
-            "kCGScrollWheelEventPointDeltaAxis2" : 192,
-            "kCGSEventTypeField" : 22,
-            "kCGScrollWheelEventDeltaAxis1" : 1,
+            "kCGScrollWheelEventDeltaAxis2" : 20,
             "kCGScrollWheelEventIsContinuous" : 1,
-            "relativeTimeMS" : 113,
+            "kCGScrollWheelEventPointDeltaAxis1" : 1,
+            "kCGScrollWheelEventPointDeltaAxis2" : 204,
             "kCGScrollWheelEventScrollCount" : 1,
-            "kCGScrollWheelEventDeltaAxis2" : 19,
-            "windowLocation" : "{400, 300}",
-            "kCGScrollWheelEventPointDeltaAxis1" : 7
-        },
-        {
-            "relativeTimeMS" : 121,
-            "kCGEventScrollGestureFlagBits" : 1,
-            "kCGEventGestureHIDType" : 6,
-            "kCGSEventTypeField" : 29,
-            "kCGEventGesturePhase" : 4,
-            "windowLocation" : "{400, 300}"
-        },
-        {
-            "relativeTimeMS" : 121,
-            "kCGEventGestureHIDType" : 62,
-            "kCGSEventTypeField" : 29,
-            "kCGEventGestureStartEndSeriesType" : 6,
-            "windowLocation" : "{400, 300}"
-        },
-        {
-            "kCGScrollWheelEventScrollCount" : 1,
-            "relativeTimeMS" : 139,
-            "windowLocation" : "{400, 300}",
+            "kCGScrollWheelEventScrollPhase" : 2,
             "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 97,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGEventGestureHIDType" : 6,
+            "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 92,
+            "kCGEventGestureScrollY" : 5,
+            "kCGEventScrollGestureFlagBits" : 1,
+            "kCGSEventTypeField" : 29,
+            "relativeTimeMS" : 105,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGScrollWheelEventDeltaAxis2" : 14,
+            "kCGScrollWheelEventIsContinuous" : 1,
+            "kCGScrollWheelEventPointDeltaAxis1" : 2,
+            "kCGScrollWheelEventPointDeltaAxis2" : 136,
+            "kCGScrollWheelEventScrollCount" : 1,
+            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 105,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGEventGestureHIDType" : 6,
+            "kCGEventGesturePhase" : 2,
+            "kCGEventGestureScrollX" : 133,
+            "kCGEventGestureScrollY" : 14,
+            "kCGEventScrollGestureFlagBits" : 1,
+            "kCGSEventTypeField" : 29,
+            "relativeTimeMS" : 113,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGScrollWheelEventDeltaAxis1" : 1,
+            "kCGScrollWheelEventDeltaAxis2" : 19,
+            "kCGScrollWheelEventIsContinuous" : 1,
+            "kCGScrollWheelEventPointDeltaAxis1" : 7,
+            "kCGScrollWheelEventPointDeltaAxis2" : 192,
+            "kCGScrollWheelEventScrollCount" : 1,
+            "kCGScrollWheelEventScrollPhase" : 2,
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 113,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGEventGestureHIDType" : 6,
+            "kCGEventGesturePhase" : 4,
+            "kCGEventScrollGestureFlagBits" : 1,
+            "kCGSEventTypeField" : 29,
+            "relativeTimeMS" : 121,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGEventGestureHIDType" : 62,
+            "kCGEventGestureStartEndSeriesType" : 6,
+            "kCGSEventTypeField" : 29,
+            "relativeTimeMS" : 121,
+            "windowLocation" : "{400, 300}"
+        },
+        {
+            "kCGScrollWheelEventIsContinuous" : 1,
+            "kCGScrollWheelEventScrollCount" : 1,
             "kCGScrollWheelEventScrollPhase" : 4,
-            "kCGScrollWheelEventIsContinuous" : 1
+            "kCGSEventTypeField" : 22,
+            "relativeTimeMS" : 139,
+            "windowLocation" : "{400, 300}"
         }
     ]);
 }


### PR DESCRIPTION
#### a35669fc381359abd48ba7ca725fce9eedcf94e0
<pre>
Add some swipe tests with wheel event handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=253768">https://bugs.webkit.org/show_bug.cgi?id=253768</a>
rdar://106604885

Reviewed by Tim Horton.

Add new tests to test the interaction between swipe gestures and wheel event
handlers. Two of these tests fail when using the built-in swipe gesture because
the events are fired so fast that the UI process queues them up in
WebWheelEventCoalescer::shouldDispatchEvent() and the swipe fails, so add
startSlowSwipeGesture() which waits for a rendering update between each event.

Clean up SharedEventStreamsMac.mm by sorting each dictionary (with no data changes).

Canonical link: <a href="https://commits.webkit.org/261666@main">https://commits.webkit.org/261666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68183847dfaea59c387c4b552349b0aba8e15b2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4200 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121018 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5255 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105475 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46024 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13922 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/794 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14621 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10140 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52796 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8129 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16430 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->