### PR TITLE
Inline Document's svgExtensions() & cssTarget()

### DIFF
--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -35,6 +35,7 @@
 #include "DOMJITHelpers.h"
 #include "Element.h"
 #include "ElementData.h"
+#include "ElementInlines.h"
 #include "ElementRareData.h"
 #include "FunctionCall.h"
 #include "HTMLDocument.h"

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5040,11 +5040,6 @@ void Document::setCSSTarget(Element* newTarget)
     m_cssTarget = newTarget;
 }
 
-Element* Document::cssTarget() const
-{
-    return m_cssTarget.get();
-}
-
 void Document::registerNodeListForInvalidation(LiveNodeList& list)
 {
     m_nodeListAndCollectionCounts[list.invalidationType()]++;
@@ -6303,11 +6298,6 @@ ExceptionOr<Ref<Attr>> Document::createAttributeNS(const AtomString& namespaceUR
     if (!shouldIgnoreNamespaceChecks && !hasValidNamespaceForAttributes(parsedName))
         return Exception { NamespaceError };
     return Attr::create(*this, parsedName, emptyAtom());
-}
-
-const SVGDocumentExtensions* Document::svgExtensions()
-{
-    return m_svgExtensions.get();
 }
 
 SVGDocumentExtensions& Document::accessSVGExtensions()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -871,7 +871,7 @@ public:
 
     // Updates for :target (CSS3 selector).
     void setCSSTarget(Element*);
-    Element* cssTarget() const;
+    inline Element* cssTarget() const; // Defined in ElementInlines.h.
 
     WEBCORE_EXPORT void scheduleFullStyleRebuild();
     void scheduleStyleRecalc();
@@ -1236,7 +1236,7 @@ public:
 
     void removeAllEventListeners() final;
 
-    WEBCORE_EXPORT const SVGDocumentExtensions* svgExtensions();
+    const SVGDocumentExtensions* svgExtensions() { return m_svgExtensions.get(); }
     WEBCORE_EXPORT SVGDocumentExtensions& accessSVGExtensions();
 
     void initSecurityContext();

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -220,4 +220,9 @@ inline void Element::hideNonce()
     hideNonceSlow();
 }
 
+inline Element* Document::cssTarget() const
+{
+    return m_cssTarget.get();
+}
+
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3648,6 +3648,8 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
             return;
         }
 
+        PageClientProtector pageClientProtector(pageClient());
+
         bool shouldProcessSwap = processForNavigation.ptr() != sourceProcess.ptr();
         if (shouldProcessSwap) {
             policyAction = PolicyAction::StopAllLoads;


### PR DESCRIPTION
#### fc587437089f6046c8ac7eff7ba6cca4c73b6243
<pre>
Inline Document&apos;s svgExtensions() &amp; cssTarget()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253772">https://bugs.webkit.org/show_bug.cgi?id=253772</a>

Reviewed by NOBODY (OOPS!).

Inline Document&apos;s svgExtensions() &amp; cssTarget() as they are trivial getters
than are frequently called.

* Source/WebCore/cssjit/SelectorCompiler.cpp:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::cssTarget const): Deleted.
(WebCore::Document::svgExtensions): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::svgExtensions):
* Source/WebCore/dom/ElementInlines.h:
(WebCore::Document::cssTarget const):
</pre>
----------------------------------------------------------------------
#### f45dd959c9b005e1d583d2665ccedd46f0c3d015
<pre>
Crash under ProvisionalPageProxy::initializeWebPage()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253767">https://bugs.webkit.org/show_bug.cgi?id=253767</a>
rdar://106597341

Reviewed by NOBODY (OOPS!).

receivedNavigationPolicyDecision() calls continueNavigationInNewProcess(), which
creates a new ProvisionalPageProxy. The ProvisionalPageProxy constructor calls
ProvisionalPageProxy::initializeWebPage() which accessing m_page.pageClient()
and crashes with a null dereference.

receivedNavigationPolicyDecision() early returns if Page::isClosed() is true,
which should indicate that the pageClient couldn&apos;t have been null initially.
This means the pageClient must have been nulled out in between the isClosed()
check and the ProvisionalPageProxy::initializeWebPage() call. To protect
against this, I am adding a PageClientProtector to this code path, right after
the isClosed() check.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationPolicyDecision):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc587437089f6046c8ac7eff7ba6cca4c73b6243

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120717 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22537 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12335 "Failed to checkout and rebase branch from PR 11412") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3715 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105115 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45744 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13604 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/486 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14282 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/12335 "Failed to checkout and rebase branch from PR 11412") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52485 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16073 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->