### PR TITLE
De-virtualize AbstractFrame::frameType()

### DIFF
--- a/Source/WebCore/page/AbstractFrame.cpp
+++ b/Source/WebCore/page/AbstractFrame.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement, AbstractFrame* parent)
+AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrameOwnerElement* ownerElement, AbstractFrame* parent)
     : m_page(page)
     , m_frameID(frameID)
     , m_treeNode(*this, parent)
@@ -42,6 +42,7 @@ AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, HTMLFrameOwner
     , m_ownerElement(ownerElement)
     , m_mainFrame(parent ? page.mainFrame() : *this)
     , m_settings(page.settings())
+    , m_frameType(frameType)
 {
     if (parent)
         parent->tree().appendChild(*this);

--- a/Source/WebCore/page/AbstractFrame.h
+++ b/Source/WebCore/page/AbstractFrame.h
@@ -47,7 +47,7 @@ public:
     virtual ~AbstractFrame();
 
     enum class FrameType : bool { Local, Remote };
-    virtual FrameType frameType() const = 0;
+    FrameType frameType() const { return m_frameType; }
 
     WindowProxy& windowProxy() { return m_windowProxy; }
     const WindowProxy& windowProxy() const { return m_windowProxy; }
@@ -67,7 +67,7 @@ public:
     virtual bool preventsParentFromBeingComplete() const = 0;
 
 protected:
-    AbstractFrame(Page&, FrameIdentifier, HTMLFrameOwnerElement*, AbstractFrame* parent);
+    AbstractFrame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, AbstractFrame* parent);
     void resetWindowProxy();
 
 private:
@@ -81,6 +81,7 @@ private:
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
     AbstractFrame& m_mainFrame;
     const Ref<Settings> m_settings;
+    FrameType m_frameType;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -150,7 +150,7 @@ static inline float parentTextZoomFactor(Frame* frame)
 }
 
 Frame::Frame(Page& page, UniqueRef<FrameLoaderClient>&& frameLoaderClient, FrameIdentifier identifier, HTMLFrameOwnerElement* ownerElement, AbstractFrame* parent)
-    : AbstractFrame(page, identifier, ownerElement, parent)
+    : AbstractFrame(page, identifier, FrameType::Local, ownerElement, parent)
     , m_loader(makeUniqueRef<FrameLoader>(*this, WTFMove(frameLoaderClient)))
     , m_navigationScheduler(makeUniqueRef<NavigationScheduler>(*this))
     , m_script(makeUniqueRef<ScriptController>(*this))

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -298,7 +298,6 @@ private:
 
     void dropChildren();
 
-    FrameType frameType() const final { return FrameType::Local; }
     void frameDetached() final;
     bool preventsParentFromBeingComplete() const final;
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -51,7 +51,7 @@ Ref<RemoteFrame> RemoteFrame::createSubframeWithContentsInAnotherProcess(Page& p
 }
 
 RemoteFrame::RemoteFrame(Page& page, UniqueRef<RemoteFrameClient>&& client, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement, AbstractFrame* parent, Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier)
-    : AbstractFrame(page, frameID, ownerElement, parent)
+    : AbstractFrame(page, frameID, FrameType::Remote, ownerElement, parent)
     , m_window(RemoteDOMWindow::create(*this, GlobalWindowIdentifier { Process::identifier(), WindowIdentifier::generate() }))
     , m_client(WTFMove(client))
     , m_layerHostingContextIdentifier(layerHostingContextIdentifier)

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -63,7 +63,6 @@ public:
 private:
     WEBCORE_EXPORT explicit RemoteFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, HTMLFrameOwnerElement*, AbstractFrame*, Markable<LayerHostingContextIdentifier>);
 
-    FrameType frameType() const final { return FrameType::Remote; }
     void frameDetached() final;
     bool preventsParentFromBeingComplete() const final;
 


### PR DESCRIPTION
#### 01c8713099e3ddae839c26b750d1e542edac2bdc
<pre>
De-virtualize AbstractFrame::frameType()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253779">https://bugs.webkit.org/show_bug.cgi?id=253779</a>

Reviewed by Darin Adler.

De-virtualize AbstractFrame::frameType(). It shows on profiles and it is
getting called more and more as we move towards site isolation.

* Source/WebCore/page/AbstractFrame.cpp:
(WebCore::AbstractFrame::AbstractFrame):
* Source/WebCore/page/AbstractFrame.h:
(WebCore::AbstractFrame::frameType const):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::RemoteFrame):
* Source/WebCore/page/RemoteFrame.h:

Canonical link: <a href="https://commits.webkit.org/261550@main">https://commits.webkit.org/261550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b7277d0bf360b18ce229dcbe054e7a6c43aa1e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120722 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22542 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/3761 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105120 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45749 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13609 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/491 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14287 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8049 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16078 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->