### PR TITLE
Fix Internal Server Error issue on bugs.webkit.org

### DIFF
--- a/Websites/bugs.webkit.org/Bugzilla/BugMail.pm
+++ b/Websites/bugs.webkit.org/Bugzilla/BugMail.pm
@@ -467,9 +467,9 @@ sub _generate_bugmail {
     }
 
     my $email = Bugzilla::MIME->new($msg_header);
-    if (scalar(@parts) == 1) {
-        $email->content_type_set($parts[0]->content_type);
-    } else {
+    # WEBKIT_CHANGES: Back ported changes from 5.0.6
+    # https://bugs.webkit.org/show_bug.cgi?id=253790
+    if (scalar(@parts) > 1) {
         $email->content_type_set('multipart/alternative');
         # Some mail clients need same encoding for each part, even empty ones.
         $email->charset_set('UTF-8') if $use_utf8;


### PR DESCRIPTION
#### 70407aacf250ad220e43c1797d6f51395f88d8a4
<pre>
Fix Internal Server Error issue on bugs.webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=253790">https://bugs.webkit.org/show_bug.cgi?id=253790</a>
&lt;rdar://problem/106610536&gt;

Reviewed by Chris Dumez and Alexey Proskuryakov.

* Websites/bugs.webkit.org/Bugzilla/BugMail.pm:
(_generate_bugmail):

Canonical link: <a href="https://commits.webkit.org/261562@main">https://commits.webkit.org/261562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b440b56eefa8d0e611a4c84405c5eb5c101b08dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120794 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22620 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4348 "61 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117901 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105199 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45809 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13683 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/558 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14362 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52557 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/8116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16153 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->