### PR TITLE
Merge hasGetterSetterProperties() and hasCustomGetterSetterProperties() structure flags

### DIFF
--- a/Source/JavaScriptCore/runtime/ClassInfo.h
+++ b/Source/JavaScriptCore/runtime/ClassInfo.h
@@ -206,7 +206,7 @@ struct CLASS_INFO_ALIGNMENT ClassInfo {
 
     JS_EXPORT_PRIVATE void dump(PrintStream&) const;
 
-    JS_EXPORT_PRIVATE bool hasStaticPropertyWithAttributes(uint8_t attributes) const;
+    JS_EXPORT_PRIVATE bool hasStaticPropertyWithAnyOfAttributes(uint8_t attributes) const;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -350,8 +350,7 @@ ALWAYS_INLINE JSValue JSCell::fastGetOwnProperty(VM& vm, Structure& structure, P
 
 inline bool JSCell::canUseFastGetOwnProperty(const Structure& structure)
 {
-    return !structure.hasGetterSetterProperties() 
-        && !structure.hasCustomGetterSetterProperties()
+    return !structure.hasAnyKindOfGetterSetterProperties()
         && !structure.typeInfo().overridesGetOwnPropertySlot();
 }
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -855,9 +855,7 @@ static bool canPerformFastPropertyEnumerationForCopyDataProperties(Structure* st
     // https://bugs.webkit.org/show_bug.cgi?id=185358
     if (hasIndexedProperties(structure->indexingType()))
         return false;
-    if (structure->hasGetterSetterProperties())
-        return false;
-    if (structure->hasCustomGetterSetterProperties())
+    if (structure->hasAnyKindOfGetterSetterProperties())
         return false;
     if (structure->isUncacheableDictionary())
         return false;

--- a/Source/JavaScriptCore/runtime/JSLexicalEnvironment.cpp
+++ b/Source/JavaScriptCore/runtime/JSLexicalEnvironment.cpp
@@ -103,7 +103,7 @@ bool JSLexicalEnvironment::getOwnPropertySlot(JSObject* object, JSGlobalObject* 
 
     // We don't call through to JSObject because there's no way to give a 
     // lexical environment object getter properties or a prototype.
-    ASSERT(!thisObject->hasGetterSetterProperties());
+    ASSERT(!thisObject->structure()->hasAnyKindOfGetterSetterProperties());
     ASSERT(thisObject->getPrototypeDirect().isNull());
     return false;
 }
@@ -122,7 +122,7 @@ bool JSLexicalEnvironment::put(JSCell* cell, JSGlobalObject* globalObject, Prope
     // We don't call through to JSObject because __proto__ and getter/setter 
     // properties are non-standard extensions that other implementations do not
     // expose in the lexicalEnvironment object.
-    ASSERT(!thisObject->hasGetterSetterProperties());
+    ASSERT(!thisObject->structure()->hasAnyKindOfGetterSetterProperties());
     return thisObject->putOwnDataProperty(globalObject->vm(), propertyName, value, slot);
 }
 

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -880,12 +880,10 @@ void FastStringifier::recordFastPropertyEnumerationFailure(JSObject& object)
         recordFailure("overridesAnyFormOfGetOwnPropertyNames"_s);
     else if (hasIndexedProperties(structure.indexingType()))
         recordFailure("hasIndexedProperties"_s);
-    else if (structure.hasGetterSetterProperties())
+    else if (structure.hasAnyKindOfGetterSetterProperties())
         recordFailure("getter/setter: "_s + firstGetterSetterPropertyName(object));
     else if (structure.hasReadOnlyOrGetterSetterPropertiesExcludingProto())
         recordFailure("hasReadOnlyOrGetterSetterPropertiesExcludingProto"_s);
-    else if (structure.hasCustomGetterSetterProperties())
-        recordFailure("hasCustomGetterSetterProperties"_s);
     else if (structure.isUncacheableDictionary())
         recordFailure("isUncacheableDictionary"_s);
     else if (structure.hasUnderscoreProtoPropertyExcludingOriginalProto())

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -908,7 +908,7 @@ bool JSObject::definePropertyOnReceiver(JSGlobalObject* globalObject, PropertyNa
             return definePropertyOnReceiverSlow(globalObject, propertyName, value, receiver, slot.isStrictMode());
     }
 
-    if (receiver->structure()->hasCustomGetterSetterProperties()) {
+    if (receiver->structure()->hasAnyKindOfGetterSetterProperties()) {
         unsigned attributes;
         if (receiver->getDirectOffset(vm, propertyName, attributes) != invalidOffset && (attributes & PropertyAttribute::CustomValue))
             return definePropertyOnReceiverSlow(globalObject, propertyName, value, receiver, slot.isStrictMode());
@@ -2086,7 +2086,7 @@ bool JSObject::putDirectCustomAccessor(VM& vm, PropertyName propertyName, JSValu
     Structure* structure = this->structure();
     if (attributes & PropertyAttribute::ReadOnly)
         structure->setContainsReadOnlyProperties();
-    structure->setHasCustomGetterSetterPropertiesWithProtoCheck(propertyName == vm.propertyNames->underscoreProto);
+    structure->setHasAnyKindOfGetterSetterPropertiesWithProtoCheck(propertyName == vm.propertyNames->underscoreProto);
     return result;
 }
 
@@ -2103,7 +2103,7 @@ void JSObject::putDirectCustomGetterSetterWithoutTransition(VM& vm, PropertyName
 
     if (attributes & PropertyAttribute::ReadOnly)
         structure->setContainsReadOnlyProperties();
-    structure->setHasCustomGetterSetterPropertiesWithProtoCheck(propertyName == vm.propertyNames->underscoreProto);
+    structure->setHasAnyKindOfGetterSetterPropertiesWithProtoCheck(propertyName == vm.propertyNames->underscoreProto);
 }
 
 bool JSObject::putDirectNonIndexAccessor(VM& vm, PropertyName propertyName, GetterSetter* accessor, unsigned attributes)
@@ -2116,7 +2116,7 @@ bool JSObject::putDirectNonIndexAccessor(VM& vm, PropertyName propertyName, Gett
     if (attributes & PropertyAttribute::ReadOnly)
         structure->setContainsReadOnlyProperties();
 
-    structure->setHasGetterSetterPropertiesWithProtoCheck(propertyName == vm.propertyNames->underscoreProto);
+    structure->setHasAnyKindOfGetterSetterPropertiesWithProtoCheck(propertyName == vm.propertyNames->underscoreProto);
     return result;
 }
 
@@ -2130,7 +2130,7 @@ void JSObject::putDirectNonIndexAccessorWithoutTransition(VM& vm, PropertyName p
     if (attributes & PropertyAttribute::ReadOnly)
         structure->setContainsReadOnlyProperties();
 
-    structure->setHasGetterSetterPropertiesWithProtoCheck(propertyName == vm.propertyNames->underscoreProto);
+    structure->setHasAnyKindOfGetterSetterPropertiesWithProtoCheck(propertyName == vm.propertyNames->underscoreProto);
 }
 
 // https://tc39.es/ecma262/#sec-hasproperty

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -803,8 +803,6 @@ public:
     void transitionTo(VM&, Structure*);
 
     bool hasCustomProperties() { return structure()->didTransition(); }
-    bool hasGetterSetterProperties() { return structure()->hasGetterSetterProperties(); }
-    bool hasCustomGetterSetterProperties() { return structure()->hasCustomGetterSetterProperties(); }
 
     bool hasNonReifiedStaticProperties()
     {

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -614,22 +614,15 @@ public:
     
     Vector<PropertyTableEntry> getPropertiesConcurrently();
     
-    void setHasGetterSetterPropertiesWithProtoCheck(bool is__proto__)
+    void setHasAnyKindOfGetterSetterPropertiesWithProtoCheck(bool is__proto__)
     {
-        setHasGetterSetterProperties(true);
+        setHasAnyKindOfGetterSetterProperties(true);
         if (!is__proto__)
             setHasReadOnlyOrGetterSetterPropertiesExcludingProto(true);
     }
     
     void setContainsReadOnlyProperties() { setHasReadOnlyOrGetterSetterPropertiesExcludingProto(true); }
     
-    void setHasCustomGetterSetterPropertiesWithProtoCheck(bool is__proto__)
-    {
-        setHasCustomGetterSetterProperties(true);
-        if (!is__proto__)
-            setHasReadOnlyOrGetterSetterPropertiesExcludingProto(true);
-    }
-
     void setCachedPropertyNameEnumerator(VM&, JSPropertyNameEnumerator*, StructureChain*);
     JSPropertyNameEnumerator* cachedPropertyNameEnumerator() const;
     uintptr_t cachedPropertyNameEnumeratorAndFlag() const;
@@ -810,7 +803,7 @@ public:
 
     DEFINE_BITFIELD(DictionaryKind, dictionaryKind, DictionaryKind, 2, 0);
     DEFINE_BITFIELD(bool, isPinnedPropertyTable, IsPinnedPropertyTable, 1, 2);
-    DEFINE_BITFIELD(bool, hasGetterSetterProperties, HasGetterSetterProperties, 1, 3);
+    DEFINE_BITFIELD(bool, hasAnyKindOfGetterSetterProperties, HasAnyKindOfGetterSetterProperties, 1, 3);
     DEFINE_BITFIELD(bool, hasReadOnlyOrGetterSetterPropertiesExcludingProto, HasReadOnlyOrGetterSetterPropertiesExcludingProto, 1, 4);
     DEFINE_BITFIELD(bool, isQuickPropertyAccessAllowedForEnumeration, IsQuickPropertyAccessAllowedForEnumeration, 1, 5);
     DEFINE_BITFIELD(TransitionPropertyAttributes, transitionPropertyAttributes, TransitionPropertyAttributes, 8, 6);
@@ -819,7 +812,6 @@ public:
     DEFINE_BITFIELD(bool, didTransition, DidTransition, 1, 21);
     DEFINE_BITFIELD(bool, staticPropertiesReified, StaticPropertiesReified, 1, 22);
     DEFINE_BITFIELD(bool, hasBeenFlattenedBefore, HasBeenFlattenedBefore, 1, 23);
-    DEFINE_BITFIELD(bool, hasCustomGetterSetterProperties, HasCustomGetterSetterProperties, 1, 24);
     DEFINE_BITFIELD(bool, didWatchInternalProperties, DidWatchInternalProperties, 1, 25);
     DEFINE_BITFIELD(bool, transitionWatchpointIsLikelyToBeFired, TransitionWatchpointIsLikelyToBeFired, 1, 26);
     DEFINE_BITFIELD(bool, hasBeenDictionary, HasBeenDictionary, 1, 27);

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -770,11 +770,9 @@ ALWAYS_INLINE bool Structure::canPerformFastPropertyEnumeration() const
     // https://bugs.webkit.org/show_bug.cgi?id=185358
     if (hasIndexedProperties(indexingType()))
         return false;
-    if (hasGetterSetterProperties())
+    if (hasAnyKindOfGetterSetterProperties())
         return false;
     if (hasReadOnlyOrGetterSetterPropertiesExcludingProto())
-        return false;
-    if (hasCustomGetterSetterProperties())
         return false;
     if (isUncacheableDictionary())
         return false;


### PR DESCRIPTION
#### b3afaca67e101ba727d5ead5716a19a795d4ecaf
<pre>
Merge hasGetterSetterProperties() and hasCustomGetterSetterProperties() structure flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=253795">https://bugs.webkit.org/show_bug.cgi?id=253795</a>
&lt;rdar://problem/106617446&gt;

Reviewed by Yusuke Suzuki.

This change merges hasGetterSetterProperties() and hasCustomGetterSetterProperties() structure flags,
which reduces number of static hash table lookups in constructors and even fixes the regression
introduced in <a href="http://webkit.org/b/253175">http://webkit.org/b/253175</a> by making hasReadOnlyOrGetterSetterPropertiesExcludingProto()
take into account custom accessors in static hash table.

The merged flags have always being used hand in hand, except for use case in Reflect.set() / slowest
path of [[Set]], which eventually will be removed along with PropertyAttribute::CustomValue.

The merging is necessary to free up a bit for a follow-up patch, which will make the validation of
Proxy trap results conditional based structure flags of its [[ProxyTarget]].

Also, renames hasStaticPropertyWithAttributes() to better reflect on its mechanics.

* Source/JavaScriptCore/runtime/ClassInfo.h:
* Source/JavaScriptCore/runtime/JSCellInlines.h:
(JSC::JSCell::canUseFastGetOwnProperty):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::canPerformFastPropertyEnumerationForCopyDataProperties):
* Source/JavaScriptCore/runtime/JSLexicalEnvironment.cpp:
(JSC::JSLexicalEnvironment::getOwnPropertySlot):
(JSC::JSLexicalEnvironment::put):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::FastStringifier::recordFastPropertyEnumerationFailure):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::definePropertyOnReceiver):
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::hasCustomProperties):
(JSC::JSObject::hasGetterSetterProperties): Deleted.
(JSC::JSObject::hasCustomGetterSetterProperties): Deleted.
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):
(JSC::ClassInfo::hasStaticPropertyWithAnyOfAttributes const):
(JSC::Structure::canAccessPropertiesQuicklyForEnumeration const):
(JSC::ClassInfo::hasStaticPropertyWithAttributes const): Deleted.
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::setHasGetterSetterPropertiesWithProtoCheck):
(JSC::Structure::setHasCustomGetterSetterPropertiesWithProtoCheck):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::canPerformFastPropertyEnumeration const):

Canonical link: <a href="https://commits.webkit.org/261556@main">https://commits.webkit.org/261556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9a2c199f1b0bc1d519a482c72714ed627fdb0e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112110 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120767 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22590 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4194 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105168 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45792 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100523 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13654 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/532 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/11789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14333 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101860 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52531 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8055 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16123 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109902 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27151 "Passed tests") | 
<!--EWS-Status-Bubble-End-->