### PR TITLE
[WPE] Link fails due to undefined inlines with -Wl,--as-needed

### DIFF
--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -34,6 +34,7 @@
 #include "DOMAttributeGetterSetter.h"
 #include "DOMJITGetterSetter.h"
 #include "Debugger.h"
+#include "ExecutableBaseInlines.h"
 #include "FrameTracers.h"
 #include "FunctionCodeBlock.h"
 #include "GetterSetter.h"

--- a/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
+++ b/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
@@ -29,6 +29,7 @@
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/BlockDirectoryInlines.h>
 #include <JavaScriptCore/HeapInlines.h>
+#include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/MarkedBlockInlines.h>
 #include <JavaScriptCore/SlotVisitorInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>

--- a/Source/WebCore/bindings/js/JSPaintRenderingContext2DCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPaintRenderingContext2DCustom.cpp
@@ -29,6 +29,8 @@
 #if ENABLE(CSS_PAINTING_API)
 
 #include "WebCoreOpaqueRootInlines.h"
+#include <JavaScriptCore/AbstractSlotVisitorInlines.h>
+#include <JavaScriptCore/JSCJSValueInlines.h>
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/bindings/js/JSWorkerNavigatorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerNavigatorCustom.cpp
@@ -27,6 +27,7 @@
 #include "JSWorkerNavigator.h"
 
 #include "WebCoreOpaqueRootInlines.h"
+#include <JavaScriptCore/AbstractSlotVisitorInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -46,6 +46,7 @@
 #include "HTMLLegendElement.h"
 #include "HTMLParserIdioms.h"
 #include "PseudoClassChangeInvalidation.h"
+#include "RenderElement.h"
 #include "ScriptDisallowedScope.h"
 #include "ValidationMessage.h"
 #include <wtf/Ref.h>

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -57,6 +57,7 @@
 #include "MediaQueryParser.h"
 #include "NodeRenderStyle.h"
 #include "PlatformStrategies.h"
+#include "RenderElement.h"
 #include "ResourceError.h"
 #include "Settings.h"
 #include "SizesAttributeParser.h"

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
@@ -33,6 +33,7 @@
 #include "SerializedScriptValue.h"
 #include "StructuredSerializeOptions.h"
 #include <JavaScriptCore/Exception.h>
+#include <JavaScriptCore/JSCJSValueInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -32,6 +32,7 @@
 #include "WebImage.h"
 #include <WebCore/BitmapImage.h>
 #include <WebCore/Document.h>
+#include <WebCore/Element.h>
 #include <WebCore/Frame.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>


### PR DESCRIPTION
#### f735506198f5107f919ba461479fffadd32adc93
<pre>
[WPE] Link fails due to undefined inlines with -Wl,--as-needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=253798">https://bugs.webkit.org/show_bug.cgi?id=253798</a>

Unreviewed build fixes.

These issues would have been caught by Clang&apos;s -Wundefined-inline.

* Source/JavaScriptCore/tools/JSDollarVM.cpp: Add missing
  ExecutableBaseInlines.h header.
* Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp: Add mising
  JavaScriptCore/JSCellInlines.h header.
* Source/WebCore/bindings/js/JSPaintRenderingContext2DCustom.cpp: Add
  missing JavaScriptCore/AbstractSlotVisitorInlines.h and
  JavaScriptCore/JSCJSValueInlines.h header.
* Source/WebCore/bindings/js/JSWorkerNavigatorCustom.cpp: Add missing
  WebCoreOpaqueRoot.h and JavaScriptCore/AbstractSlotVisitorInlines.h
* Source/WebCore/html/ValidatedFormListedElement.cpp: Add missing
  RenderElement.h header inclusion.
* Source/WebCore/loader/LinkLoader.cpp: Ditto.
* Source/WebCore/page/WindowOrWorkerGlobalScope.cpp: Add missing
  JavaScriptCore/JSCJSValueInlines.h inclusion.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp:
  Add missing WebCore/Element.h inclusion.

Canonical link: <a href="https://commits.webkit.org/261563@main">https://commits.webkit.org/261563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a45ba239d51dfecd9577dc2b1620f19ac6fc6a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3910 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120769 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116174 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22593 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4222 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105171 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45789 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100526 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13656 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/534 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11791 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14335 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101862 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52533 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31852 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16126 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109905 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4386 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27152 "Passed tests") | 
<!--EWS-Status-Bubble-End-->