### PR TITLE
[iOS] Various tests in editing/selection/ios fail with out-of-process keyboard enabled

### DIFF
--- a/LayoutTests/editing/selection/ios/do-not-hide-selection-in-visible-container.html
+++ b/LayoutTests/editing/selection/ios/do-not-hide-selection-in-visible-container.html
@@ -61,9 +61,9 @@ addEventListener("load", async () => {
         await ensureCaretIsVisible(expectedVisibility);
         document.activeElement.blur();
         buttonToTap.remove();
+        await UIHelper.waitForKeyboardToHide();
     }
 
-    await UIHelper.waitForKeyboardToHide();
     finishJSTest();
 });
 </script>

--- a/LayoutTests/editing/selection/ios/do-not-show-selection-in-empty-borderless-subframe.html
+++ b/LayoutTests/editing/selection/ios/do-not-show-selection-in-empty-borderless-subframe.html
@@ -42,6 +42,8 @@
             caretRect = await UIHelper.getUICaretViewRect();
             shouldBe("caretRect.width", "0");
             shouldBe("caretRect.height", "0");
+            document.activeElement.blur();
+            await UIHelper.waitForKeyboardToHide();
             finishJSTest();
         });
     </script>

--- a/LayoutTests/editing/selection/ios/do-not-zoom-to-focused-hidden-contenteditable.html
+++ b/LayoutTests/editing/selection/ios/do-not-zoom-to-focused-hidden-contenteditable.html
@@ -81,12 +81,14 @@ async function runTest() {
 
     await UIHelper.activateAndWaitForInputSessionAt(160, 80);
     document.querySelector("#div-scale").textContent = internals.pageScaleFactor().toFixed(3);
-    UIHelper.resignFirstResponder();
+    document.activeElement.blur();
     await UIHelper.waitForKeyboardToHide();
 
     await UIHelper.activateAndWaitForInputSessionAt(160, 240);
     document.querySelector("#iframe-scale").textContent = internals.pageScaleFactor().toFixed(3);
 
+    document.activeElement.blur();
+    await UIHelper.waitForKeyboardToHide();
     testRunner.notifyDone();
 }
 </script>

--- a/LayoutTests/editing/selection/ios/hide-selection-in-hidden-contenteditable.html
+++ b/LayoutTests/editing/selection/ios/hide-selection-in-hidden-contenteditable.html
@@ -78,6 +78,9 @@ function selectionToString() {
     await UIHelper.tapAt(32, 32);
     document.querySelector("#selection-after").textContent = selectionToString();
 
+    document.activeElement.blur();
+    await UIHelper.waitForKeyboardToHide();
+
     testRunner.notifyDone();
 })();
 </script>

--- a/LayoutTests/editing/selection/ios/hide-selection-in-tiny-contenteditable.html
+++ b/LayoutTests/editing/selection/ios/hide-selection-in-tiny-contenteditable.html
@@ -80,6 +80,8 @@ async function checkCaretRect(description)
     await UIHelper.typeCharacter("g");
     await checkCaretRect("After making editor opaque again");
 
+    document.activeElement.blur();
+    await UIHelper.waitForKeyboardToHide();
     finishJSTest();
 })();
 </script>

--- a/LayoutTests/editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html
+++ b/LayoutTests/editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html
@@ -48,6 +48,11 @@
         window.getSelection().setBaseAndExtent(target, 0, target, 1);
 
         await UIHelper.activateElement(clickTarget);
+
+        document.activeElement.blur();
+        await UIHelper.waitForKeyboardToHide();
+
+        testRunner.notifyDone();
     }
     </script>
 </head>

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -466,6 +466,7 @@ typedef struct CGSVGDocument *CGSVGDocumentRef;
 - (void)addInputString:(NSString *)string withFlags:(NSUInteger)flags withInputManagerHint:(NSString *)hint;
 - (BOOL)autocorrectSpellingEnabled;
 - (BOOL)isAutoShifted;
+- (void)dismissKeyboard;
 - (void)clearShiftState;
 - (void)deleteFromInput;
 - (void)deleteFromInputWithFlags:(NSUInteger)flags;


### PR DESCRIPTION
#### 0817760f7266b906787bf6779391ff6a2fcc882c
<pre>
[iOS] Various tests in editing/selection/ios fail with out-of-process keyboard enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=253800">https://bugs.webkit.org/show_bug.cgi?id=253800</a>
rdar://106007933

Reviewed by Ryosuke Niwa.

Apply several mitigations to keep these iOS-specific tests passing, when OOP keyboard is enabled.
See below for more details.

* LayoutTests/editing/selection/ios/do-not-hide-selection-in-visible-container.html:
* LayoutTests/editing/selection/ios/do-not-show-selection-in-empty-borderless-subframe.html:
* LayoutTests/editing/selection/ios/do-not-zoom-to-focused-hidden-contenteditable.html:

Adjust various tests to wait for the keyboard to hide before either ending, or attempting to show
the keyboard again by focusing another element. While this is generally good test hygiene, when OOPK
is enabled, failure to ensure this causes the keyboard hiding/showing notifications to be batched
together when the keyboard is shown before it even starts to dismiss; this breaks any subsequent
attempt to wait for the keyboard to appear when focusing, which waits for the notification to be
posted.

* LayoutTests/editing/selection/ios/hide-selection-in-hidden-contenteditable.html:
* LayoutTests/editing/selection/ios/hide-selection-in-tiny-contenteditable.html:
* LayoutTests/editing/selection/ios/persist-selection-after-tapping-on-element-with-mousedown-handler.html:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::handleKeyboardWillHideNotification):
(WTR::TestController::platformResetStateToConsistentValues):

Additionally fix logic that dismisses the keyboard (and waits for it to finish disappearing) between
tests to work with OOPK. With OOPK enabled, this will fail because we currently expect the
notification for `WillHide` to be dispatched during the call to `-resignFirstResponder`, such that
we only wait for the `DidHide` notification afterwards. However, since `WillHide` itself is delayed,
we end up skipping waiting altogether.

To fix this, we add another phase to wait for `WillHide` before waiting for `DidHide`. Note that
this is still compatible with OOPK disabled, since the flag will already be unset underneath the
call to `-resignFirstResponder`, causing us to effectively skip waiting.

Canonical link: <a href="https://commits.webkit.org/261588@main">https://commits.webkit.org/261588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d90d3c6dd6ffecb3df11a51362e68bfb00b728fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4026 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22710 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/4791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117990 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/100053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105288 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/635 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14445 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52637 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8079 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16240 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->