### PR TITLE
attr() can no longer be used to return selectedIndex after updating jQuery from 1.4.x to 3.6.x .

### DIFF
--- a/Websites/bugs.webkit.org/code-review.js
+++ b/Websites/bugs.webkit.org/code-review.js
@@ -531,7 +531,7 @@ var CODE_REVIEW_UNITTEST;
         requestee = ' (' + requestee + ')';
       }
       var control = findControlForFlag(this)
-      control.attr('selectedIndex', $(this).attr('selectedIndex'));
+      control[0].selectedIndex = $(this)[0].selectedIndex;
       control.parent().prepend(requestee);
     });
   }
@@ -2071,7 +2071,7 @@ var CODE_REVIEW_UNITTEST;
       var control = findControlForFlag(this);
       if (!control.length)
         return;
-      $(this).attr('selectedIndex', control.attr('selectedIndex'));
+      $(this)[0].selectedIndex = control[0].selectedIndex;
     });
   }
 


### PR DESCRIPTION
#### ca7595dbf7298f87260b6b45b197e58fe08926e3
<pre>
attr() can no longer be used to return selectedIndex after updating jQuery from 1.4.x to 3.6.x .
<a href="https://bugs.webkit.org/show_bug.cgi?id=253806">https://bugs.webkit.org/show_bug.cgi?id=253806</a>
&lt;rdar://problem/106626419&gt;

Reviewed by Alexey Proskuryakov.

* Websites/bugs.webkit.org/code-review.js:
(addFlagsForAttachment):

Canonical link: <a href="https://commits.webkit.org/261560@main">https://commits.webkit.org/261560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c704fa02297f45928ec6164b47c8d876b2fd0db5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3932 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120789 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22614 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4327 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99978 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105193 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45805 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13677 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/555 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14356 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52554 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8059 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16147 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->