### PR TITLE
Remove CF from Windows CMake files

### DIFF
--- a/Source/JavaScriptCore/PlatformWin.cmake
+++ b/Source/JavaScriptCore/PlatformWin.cmake
@@ -7,20 +7,6 @@ list(APPEND JavaScriptCore_PUBLIC_FRAMEWORK_HEADERS
     API/JavaScriptCore.h
 )
 
-if (USE_CF)
-    list(APPEND JavaScriptCore_SOURCES
-        API/JSStringRefCF.cpp
-    )
-
-    list(APPEND JavaScriptCore_PUBLIC_FRAMEWORK_HEADERS
-        API/JSStringRefCF.h
-    )
-
-    list(APPEND JavaScriptCore_LIBRARIES
-        Apple::CoreFoundation
-    )
-endif ()
-
 if (ENABLE_REMOTE_INSPECTOR)
     include(inspector/remote/Socket.cmake)
 else ()

--- a/Source/WTF/wtf/PlatformWin.cmake
+++ b/Source/WTF/wtf/PlatformWin.cmake
@@ -44,26 +44,3 @@ list(APPEND WTF_LIBRARIES
     shlwapi
     winmm
 )
-
-if (USE_CF)
-    list(APPEND WTF_PUBLIC_HEADERS
-        cf/CFURLExtras.h
-        cf/SpanCF.h
-        cf/TypeCastsCF.h
-        cf/VectorCF.h
-
-        text/cf/StringConcatenateCF.h
-        text/cf/TextBreakIteratorCF.h
-    )
-    list(APPEND WTF_SOURCES
-        cf/CFURLExtras.cpp
-        cf/URLCF.cpp
-
-        text/cf/AtomStringImplCF.cpp
-        text/cf/StringCF.cpp
-        text/cf/StringImplCF.cpp
-        text/cf/StringViewCF.cpp
-    )
-
-    list(APPEND WTF_LIBRARIES Apple::CoreFoundation)
-endif ()

--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -91,6 +91,7 @@ list(APPEND WebCore_SOURCES
     platform/network/win/DownloadBundleWin.cpp
     platform/network/win/NetworkStateNotifierWin.cpp
 
+    platform/text/Hyphenation.cpp
     platform/text/win/LocaleWin.cpp
 
     platform/win/BString.cpp
@@ -177,34 +178,6 @@ file(COPY ${ModernMediaControlsImageFiles}
     DESTINATION
     ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WebKit.resources/media-controls
 )
-
-if (USE_CF)
-    list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
-        "${WEBCORE_DIR}/loader/archive/cf"
-        "${WEBCORE_DIR}/platform/cf"
-    )
-
-    list(APPEND WebCore_SOURCES
-        editing/SmartReplaceCF.cpp
-
-        loader/archive/cf/LegacyWebArchive.cpp
-
-        platform/cf/SharedBufferCF.cpp
-
-        platform/text/cf/HyphenationCF.cpp
-    )
-
-    list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
-        loader/archive/cf/LegacyWebArchive.h
-    )
-
-    list(APPEND WebCore_LIBRARIES Apple::CoreFoundation)
-    list(APPEND WebCoreTestSupport_LIBRARIES Apple::CoreFoundation)
-else ()
-    list(APPEND WebCore_SOURCES
-        platform/text/Hyphenation.cpp
-    )
-endif ()
 
 if (ENABLE_VIDEO AND USE_MEDIA_FOUNDATION)
     # Define a INTERFACE library for MediaFoundation and link it

--- a/Source/cmake/FindApple.cmake
+++ b/Source/cmake/FindApple.cmake
@@ -112,7 +112,7 @@ endif ()
 if ("CoreFoundation" IN_LIST Apple_FIND_COMPONENTS)
     _FIND_APPLE_FRAMEWORK(CoreFoundation
         HEADER CoreFoundation/CoreFoundation.h
-        LIBRARY_NAMES CoreFoundation${DEBUG_SUFFIX} CFlite
+        LIBRARY_NAMES CoreFoundation${DEBUG_SUFFIX}
     )
 endif ()
 


### PR DESCRIPTION
#### 0389a04d70b274e45be999ef11f858172977a372
<pre>
Remove CF from Windows CMake files
<a href="https://bugs.webkit.org/show_bug.cgi?id=253809">https://bugs.webkit.org/show_bug.cgi?id=253809</a>
rdar://106630488

Reviewed by Fujii Hironori.

Remove CF related files from CMake definitions.

* Source/JavaScriptCore/PlatformWin.cmake:
* Source/WTF/wtf/PlatformWin.cmake:
* Source/WebCore/PlatformWin.cmake:
* Source/cmake/FindApple.cmake:

Canonical link: <a href="https://commits.webkit.org/261561@main">https://commits.webkit.org/261561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c8052f79b0abf0e51cfaa2c3ed524af5b871e9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3945 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120801 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22627 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/4373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117908 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/99987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105206 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/529 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/100560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13690 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/564 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/11814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14369 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101896 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52563 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31860 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16160 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/109940 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4385 "Built successfully and passed tests") | | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/27161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->