### PR TITLE
VideoPreset does not need to be RefCounted

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
@@ -54,21 +54,21 @@ public:
 
     void ensureIntrinsicSizeMaintainsAspectRatio();
 
-    const VideoPreset* currentPreset() const { return m_currentPreset.get(); }
+    const std::optional<VideoPreset> currentPreset() const { return m_currentPreset; }
 
 protected:
     RealtimeVideoCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, PageIdentifier);
 
     void setSizeFrameRateAndZoom(std::optional<int> width, std::optional<int> height, std::optional<double>, std::optional<double>) override;
 
-    virtual bool prefersPreset(VideoPreset&) { return true; }
-    virtual void setFrameRateAndZoomWithPreset(double, double, RefPtr<VideoPreset>) { };
+    virtual bool prefersPreset(const VideoPreset&) { return true; }
+    virtual void setFrameRateAndZoomWithPreset(double, double, std::optional<VideoPreset>&&) { };
     virtual bool canResizeVideoFrames() const { return false; }
-    bool shouldUsePreset(VideoPreset& current, VideoPreset& candidate);
+    bool shouldUsePreset(const VideoPreset& current, const VideoPreset& candidate);
 
-    void setSupportedPresets(const Vector<Ref<VideoPreset>>&);
+    void setSupportedPresets(Vector<VideoPreset>&&);
     void setSupportedPresets(Vector<VideoPresetData>&&);
-    const Vector<Ref<VideoPreset>>& presets();
+    const Vector<VideoPreset>& presets();
 
     bool frameRateRangeIncludesRate(const FrameRateRange&, double);
 
@@ -80,7 +80,7 @@ protected:
 
 private:
     struct CaptureSizeFrameRateAndZoom {
-        RefPtr<VideoPreset> encodingPreset;
+        std::optional<VideoPreset> encodingPreset;
         IntSize requestedSize;
         double requestedFrameRate { 0 };
         double requestedZoom { 0 };
@@ -94,8 +94,8 @@ private:
     const char* logClassName() const override { return "RealtimeVideoCaptureSource"; }
 #endif
 
-    RefPtr<VideoPreset> m_currentPreset;
-    Vector<Ref<VideoPreset>> m_presets;
+    std::optional<VideoPreset> m_currentPreset;
+    Vector<VideoPreset> m_presets;
     Deque<double> m_observedFrameTimeStamps;
     double m_observedFrameRate { 0 };
 };

--- a/Source/WebCore/platform/mediastream/RealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoSource.cpp
@@ -105,8 +105,8 @@ void RealtimeVideoSource::setSizeFrameRateAndZoom(std::optional<int> width, std:
     ASSERT(sourceSize.height());
     ASSERT(sourceSize.width());
 
-    auto* currentPreset = m_source->currentPreset();
-    auto intrinsicSize = currentPreset ? currentPreset->size : sourceSize;
+    auto currentPreset = m_source->currentPreset();
+    auto intrinsicSize = currentPreset ? currentPreset->size() : sourceSize;
 
     if (!width)
         width = intrinsicSize.width() * height.value() / intrinsicSize.height();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -46,19 +46,6 @@ static void initializeDebugCategory()
     });
 }
 
-class GStreamerVideoPreset : public VideoPreset {
-public:
-    static Ref<GStreamerVideoPreset> create(IntSize size, Vector<FrameRateRange>&& framerates)
-    {
-        return adoptRef(*new GStreamerVideoPreset(size, WTFMove(framerates)));
-    }
-
-    GStreamerVideoPreset(IntSize size, Vector<FrameRateRange>&& frameRateRanges)
-        : VideoPreset(size, WTFMove(frameRateRanges), GStreamer, { }, { })
-    {
-    }
-};
-
 class GStreamerVideoCaptureSourceFactory final : public VideoCaptureFactory {
 public:
     CaptureSourceOrError createVideoCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, PageIdentifier) final
@@ -267,7 +254,7 @@ const RealtimeMediaSourceSettings& GStreamerVideoCaptureSource::settings()
 
 void GStreamerVideoCaptureSource::generatePresets()
 {
-    Vector<Ref<VideoPreset>> presets;
+    Vector<VideoPreset> presets;
     GRefPtr<GstCaps> caps = adoptGRef(m_capturer->caps());
     for (unsigned i = 0; i < gst_caps_get_size(caps.get()); i++) {
         GstStructure* str = gst_caps_get_structure(caps.get(), i);
@@ -307,7 +294,7 @@ void GStreamerVideoCaptureSource::generatePresets()
             }
         }
 
-        presets.append(GStreamerVideoPreset::create(size, WTFMove(frameRates)));
+        presets.append(VideoPreset { { size, WTFMove(frameRates) } });
     }
 
     if (presets.isEmpty()) {
@@ -317,7 +304,7 @@ void GStreamerVideoCaptureSource::generatePresets()
             Vector<FrameRateRange> frameRates;
 
             frameRates.append({ 0, G_MAXDOUBLE});
-            presets.append(GStreamerVideoPreset::create(size, WTFMove(frameRates)));
+            presets.append(VideoPreset { { size, WTFMove(frameRates) } });
         }
     }
 

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -49,7 +49,6 @@ OBJC_CLASS WebCoreAVVideoCaptureSourceObserver;
 
 namespace WebCore {
 
-class AVVideoPreset;
 class ImageTransferSessionVT;
 
 enum class VideoFrameRotation : uint16_t;
@@ -95,8 +94,8 @@ private:
     bool interrupted() const final;
 
     VideoFrameRotation videoFrameRotation() const final { return m_videoFrameRotation; }
-    void setFrameRateAndZoomWithPreset(double, double, RefPtr<VideoPreset>) final;
-    bool prefersPreset(VideoPreset&) final;
+    void setFrameRateAndZoomWithPreset(double, double, std::optional<VideoPreset>&&) final;
+    bool prefersPreset(const VideoPreset&) final;
     void generatePresets() final;
     bool canResizeVideoFrames() const final { return true; }
 
@@ -135,8 +134,8 @@ private:
     RetainPtr<AVCaptureSession> m_session;
     RetainPtr<AVCaptureDevice> m_device;
 
-    RefPtr<AVVideoPreset> m_currentPreset;
-    RefPtr<AVVideoPreset> m_appliedPreset;
+    std::optional<VideoPreset> m_currentPreset;
+    std::optional<VideoPreset> m_appliedPreset;
     RetainPtr<AVFrameRateRange> m_appliedFrameRateRange;
     double m_appliedZoom { 1 };
 
@@ -154,9 +153,5 @@ private:
 };
 
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AVVideoPreset)
-    static bool isType(const WebCore::VideoPreset& preset) { return preset.type == WebCore::VideoPreset::VideoPresetType::AVCapture; }
-SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -169,10 +169,10 @@ const RealtimeMediaSourceCapabilities& MockRealtimeVideoSource::capabilities()
     return m_capabilities.value();
 }
 
-static bool isZoomSupported(const Vector<Ref<VideoPreset>>& presets)
+static bool isZoomSupported(const Vector<VideoPreset>& presets)
 {
     return anyOf(presets, [](auto& preset) {
-        return preset->isZoomSupported();
+        return preset.isZoomSupported();
     });
 }
 
@@ -224,19 +224,19 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
     return m_currentSettings.value();
 }
 
-void MockRealtimeVideoSource::setFrameRateAndZoomWithPreset(double frameRate, double zoom, RefPtr<VideoPreset> preset)
+void MockRealtimeVideoSource::setFrameRateAndZoomWithPreset(double frameRate, double zoom, std::optional<VideoPreset>&& preset)
 {
     UNUSED_PARAM(zoom);
     m_preset = WTFMove(preset);
     if (m_preset)
-        setIntrinsicSize(m_preset->size);
+        setIntrinsicSize(m_preset->size());
     if (isProducingData())
         m_emitFrameTimer.startRepeating(1_s / frameRate);
 }
 
 IntSize MockRealtimeVideoSource::captureSize() const
 {
-    return m_preset ? m_preset->size : this->size();
+    return m_preset ? m_preset->size() : this->size();
 }
 
 void MockRealtimeVideoSource::settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag> settings)

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -79,7 +79,7 @@ private:
     CaptureDevice::DeviceType deviceType() const final { return mockCamera() ? CaptureDevice::DeviceType::Camera : CaptureDevice::DeviceType::Screen; }
     bool supportsSizeFrameRateAndZoom(std::optional<int> width, std::optional<int> height, std::optional<double>, std::optional<double>) final;
     void setSizeFrameRateAndZoom(std::optional<int> width, std::optional<int> height, std::optional<double>, std::optional<double>) final;
-    void setFrameRateAndZoomWithPreset(double, double, RefPtr<VideoPreset>) final;
+    void setFrameRateAndZoomWithPreset(double, double, std::optional<VideoPreset>&&) final;
 
 
     bool isMockSource() const final { return true; }
@@ -124,7 +124,7 @@ private:
     Color m_fillColor { Color::black };
     Color m_fillColorWithZoom { Color::red };
     MockMediaDevice m_device;
-    RefPtr<VideoPreset> m_preset;
+    std::optional<VideoPreset> m_preset;
     VideoFrameRotation m_deviceOrientation { };
 };
 


### PR DESCRIPTION
#### 9f776d1a36d9774af20be33092a6568765c3a74f
<pre>
VideoPreset does not need to be RefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=253817">https://bugs.webkit.org/show_bug.cgi?id=253817</a>
rdar://problem/106638837

Reviewed by Eric Carlson.

Inline AVVideoPreset field in VideoPreset.
Remove AVVideoPreset and make VideoPreset no longer RefCounted, as this is better for memory.
RefPtr&lt;VideoPreset&gt; is replaced by std::optional&lt;VideoPreset&gt;.

Covered by existing tests.

* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::presets):
(WebCore::RealtimeVideoCaptureSource::presetsData):
(WebCore::RealtimeVideoCaptureSource::setSupportedPresets):
(WebCore::RealtimeVideoCaptureSource::updateCapabilities):
(WebCore::RealtimeVideoCaptureSource::presetSupportsFrameRate):
(WebCore::RealtimeVideoCaptureSource::shouldUsePreset):
(WebCore::RealtimeVideoCaptureSource::bestSupportedSizeAndFrameRate):
(WebCore::RealtimeVideoCaptureSource::setSizeAndFrameRate):
(WebCore::RealtimeVideoCaptureSource::clientUpdatedSizeAndFrameRate):
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/RealtimeVideoSource.cpp:
(WebCore::RealtimeVideoSource::setSizeAndFrameRate):
* Source/WebCore/platform/mediastream/VideoPreset.h:
(WebCore::VideoPreset::VideoPreset):
(WebCore::VideoPreset::size const):
(WebCore::VideoPreset::frameRateRanges const):
(WebCore::VideoPreset::setFormat):
(WebCore::VideoPreset::format const):
(WebCore::VideoPreset::log const):
(WebCore::VideoPreset::minFrameRate const):
(WebCore::VideoPreset::maxFrameRate const):
(WebCore::VideoPreset::sortFrameRateRanges):
(WebCore::VideoPreset::create): Deleted.
(): Deleted.
(isType): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
(isType): Deleted.
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::prefersPreset):
(WebCore::AVVideoCaptureSource::setFrameRateWithPreset):
(WebCore::AVVideoCaptureSource::setSessionSizeAndFrameRate):
(WebCore::AVVideoCaptureSource::generatePresets):
(WebCore::AVVideoPreset::create): Deleted.
(WebCore::AVVideoPreset::AVVideoPreset): Deleted.
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::setFrameRateWithPreset):
(WebCore::MockRealtimeVideoSource::captureSize const):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:

Canonical link: <a href="https://commits.webkit.org/261737@main">https://commits.webkit.org/261737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55ea49c4c641602ea9af96262fd0778388e69bc4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112619 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4396 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5550 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118387 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17168 "5 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105695 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46186 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14106 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/975 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14784 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52970 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8189 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16626 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->