### PR TITLE
Hooks: Fix typo in pre-push script

### DIFF
--- a/Tools/Scripts/hooks/pre-push
+++ b/Tools/Scripts/hooks/pre-push
@@ -244,7 +244,7 @@ def main(name, remote):
         elif target_security_level == 0:
             print_tty('Pushing to {}, which is classified as a public remote'.format(name or remote))
         else:
-            print_tty('Pushing to {}, which has not classification. Treating it as a public remote'.format(name or remote))
+            print_tty('Pushing to {}, which has no classification. Treating it as a public remote'.format(name or remote))
 
     to_push = []
     for push in sys.stdin.readlines():
@@ -361,4 +361,3 @@ if __name__ == '__main__':
         print_tty('')
         print_error('User has canceled push')
         sys.exit(1)
-


### PR DESCRIPTION
#### 18dbbee3f2c795f53639d1d776916df0f4c91430
<pre>
Hooks: Fix typo in pre-push script
<a href="https://bugs.webkit.org/show_bug.cgi?id=253822">https://bugs.webkit.org/show_bug.cgi?id=253822</a>

Reviewed by Alexey Proskuryakov.

The correct phrasing is &quot;no classification,&quot; not &quot;not classification.&quot;

* Tools\Scripts\hooks\pre-push:(main): Fix &quot;not&quot; typo.

Canonical link: <a href="https://commits.webkit.org/261606@main">https://commits.webkit.org/261606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7604f9767a3fd62ea47e8892d45417edc3cee50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/3976 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4591 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105237 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45841 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13718 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/588 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/93715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14397 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8091 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16190 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->