### PR TITLE
WebCore: Prefer mutableCopy over mutableCopyWithZone

### DIFF
--- a/Source/WebCore/platform/mac/WebNSAttributedStringExtras.mm
+++ b/Source/WebCore/platform/mac/WebNSAttributedStringExtras.mm
@@ -49,8 +49,8 @@ NSAttributedString *attributedStringByStrippingAttachmentCharacters(NSAttributed
 
     attachmentRange = [originalString rangeOfString:attachmentCharString.get().get()];
     if (attachmentRange.location != NSNotFound && attachmentRange.length > 0) {
-        auto newAttributedString = adoptNS([attributedString mutableCopyWithZone:NULL]);
-        
+        auto newAttributedString = adoptNS([attributedString mutableCopy]);
+
         while (attachmentRange.location != NSNotFound && attachmentRange.length > 0) {
             [newAttributedString replaceCharactersInRange:attachmentRange withString:@""];
             attachmentRange = [[newAttributedString string] rangeOfString:attachmentCharString.get().get()];

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
@@ -722,7 +722,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
     // CoreMedia will explicitly add a user agent header. Remove if present.
     RetainPtr<NSMutableURLRequest> mutableRequest;
     if (auto* userAgentValue = [request valueForHTTPHeaderField:@"User-Agent"]) {
-        mutableRequest = adoptNS([request mutableCopyWithZone:nil]);
+        mutableRequest = adoptNS([request mutableCopy]);
         [mutableRequest setValue:nil forHTTPHeaderField:@"User-Agent"];
         request = mutableRequest.get();
     }


### PR DESCRIPTION
#### c0b2221b92ed2006b6216173610b438198f5a620
<pre>
WebCore: Prefer mutableCopy over mutableCopyWithZone
<a href="https://bugs.webkit.org/show_bug.cgi?id=253825">https://bugs.webkit.org/show_bug.cgi?id=253825</a>

Reviewed by Chris Dumez.

The mutableCopyWithZone method is not overridden, nor is the
zone parameter even acknowledged anymore by the Objective-C
runtime. We should replace calls to mutableCopyWithZone with
calls to mutableCopy.

* Source/WebCore/platform/mac/WebNSAttributedStringExtras.mm:
  (attributedStringByStrippingAttachmentCharacters): Replace
  mutableCopyWithZone with mutableCopy.

* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
  (initWithSession): Ditto.

Canonical link: <a href="https://commits.webkit.org/262083@main">https://commits.webkit.org/262083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad97b9b0d65c92aac05f7a367a00f6ffc6f14483

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/557 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/695 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/518 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/570 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/485 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/453 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/484 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/499 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/119 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/492 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->