### PR TITLE
Concat with a CSSStyleSheet and shadowRoot.adoptedStyleSheets returns array in array

### DIFF
--- a/LayoutTests/cssom/array-concat-adoptedStyleSheets-expected.txt
+++ b/LayoutTests/cssom/array-concat-adoptedStyleSheets-expected.txt
@@ -1,0 +1,15 @@
+Tests that Array.concat() behaves correctly with an observable array returned by adoptedStyleSheets.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.adoptedStyleSheets.length is 2
+PASS newArray.length is 3
+PASS document.adoptedStyleSheets.length is 2
+PASS newArray[0] is a
+PASS newArray[1] is b
+PASS newArray[2] is c
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/cssom/array-concat-adoptedStyleSheets.html
+++ b/LayoutTests/cssom/array-concat-adoptedStyleSheets.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that Array.concat() behaves correctly with an observable array returned by adoptedStyleSheets.");
+
+let a = new CSSStyleSheet;
+let b = new CSSStyleSheet;
+let c = new CSSStyleSheet;
+document.adoptedStyleSheets.push(b);
+document.adoptedStyleSheets.push(c);
+shouldBe("document.adoptedStyleSheets.length", "2");
+
+let newArray = [a].concat(document.adoptedStyleSheets);
+shouldBe("newArray.length", "3");
+shouldBe("document.adoptedStyleSheets.length", "2");
+shouldBe("newArray[0]", "a");
+shouldBe("newArray[1]", "b");
+shouldBe("newArray[2]", "c");
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 2b91282f933eae97a1a663f45e8bf6946ffcfc35
<pre>
Concat with a CSSStyleSheet and shadowRoot.adoptedStyleSheets returns array in array
<a href="https://bugs.webkit.org/show_bug.cgi?id=253814">https://bugs.webkit.org/show_bug.cgi?id=253814</a>

Reviewed by NOBODY (OOPS!).

Per the EcmaScript specification for Array.prototype.concat [1], it should
&quot;spread&quot; the second parameter if isArray() returns true. However, our
implementation would only do so if isJSArray() returns true for the second
parameter. This was causing concat() to not do the right thing when the
second parameter was a JSObservableArray [2].

In this patch, I kept the JSArray code path as a fast path and add support for
array-like objects as a slow path.

[1] <a href="https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.concat">https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.concat</a>
[2] <a href="https://webidl.spec.whatwg.org/#es-observable-array">https://webidl.spec.whatwg.org/#es-observable-array</a>

* LayoutTests/cssom/array-concat-adoptedStyleSheets-expected.txt: Added.
* LayoutTests/cssom/array-concat-adoptedStyleSheets.html: Added.
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::concatAppendOne):
(JSC::concatAppendArrayLike):
(JSC::JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b91282f933eae97a1a663f45e8bf6946ffcfc35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22706 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4788 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/117986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105284 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45879 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100626 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13762 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/629 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11886 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14441 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/101975 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52628 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31880 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16236 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110018 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27180 "Passed tests") | 
<!--EWS-Status-Bubble-End-->