### PR TITLE
Ignore calc() values on colgroup elements

### DIFF
--- a/LayoutTests/fast/table/calculated-width-on-col-within-colgroup-expected.txt
+++ b/LayoutTests/fast/table/calculated-width-on-col-within-colgroup-expected.txt
@@ -1,0 +1,2 @@
+PASS
+crbug.com/446936: Use a used value of Auto on col elements that have a calc value. This is permitted by the spec and avoids ASSERTs.

--- a/LayoutTests/fast/table/calculated-width-on-col-within-colgroup.html
+++ b/LayoutTests/fast/table/calculated-width-on-col-within-colgroup.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+    col {
+        width: calc(-10in - 10%);
+    }
+</style>
+<script src="../../resources/check-layout.js"></script>
+<table>
+    <colgroup width="200">
+        <col data-expected-width=200>
+        <col data-expected-width=200>
+    </colgroup>
+    <tr>
+        <td data-expected-width=200></td>
+        <td data-expected-width=200></td>
+    </tr>
+</table>
+<script>
+    checkLayout('table')
+</script>
+<p> crbug.com/446936: Use a used value of Auto on col elements that have a calc value. This is permitted by the spec and avoids ASSERTs.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/auto-layout-calc-width-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/auto-layout-calc-width-001-expected.txt
@@ -1,0 +1,5 @@
+Calc width on col is treated as auto in auto tables
+
+
+PASS #theTable 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/auto-layout-calc-width-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/auto-layout-calc-width-001.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<link rel="author" title="David Grogan" href="dgrogan@chromium.org">
+<link rel="author" title="Xiaocheng Hu" href="xiaochengh@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#distributing-width-to-columns">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/94">
+
+<style>
+table {
+  width: 200px;
+  border-collapse: collapse;
+  table-layout: auto;
+  height: 20px;
+}
+
+td {
+  padding: 0px;
+  background: lime;
+  outline: 1px solid blue;
+}
+</style>
+
+<h2>Calc width on col is treated as auto in auto tables</h2>
+
+<table id=theTable>
+  <col style="width:calc(20% + 80px)">
+  <tr>
+    <td data-expected-width=100></td>
+    <td data-expected-width=100></td>
+  </tr>
+</table>
+
+<script>
+checkLayout('#theTable')
+</script>

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2002 Lars Knoll (knoll@kde.org)
  *           (C) 2002 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003, 2006, 2008, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -153,7 +154,7 @@ void AutoTableLayout::fullRecalc()
             groupLogicalWidth = column->style().logicalWidth();
         else {
             Length colLogicalWidth = column->style().logicalWidth();
-            if (colLogicalWidth.isAuto())
+            if (colLogicalWidth.isCalculated() || colLogicalWidth.isAuto())
                 colLogicalWidth = groupLogicalWidth;
             if ((colLogicalWidth.isFixed() || colLogicalWidth.isPercentOrCalculated()) && colLogicalWidth.isZero())
                 colLogicalWidth = Length();


### PR DESCRIPTION
#### f013f2c88a3b61a7935de1c53bff8ba598f5fcbc
<pre>
Ignore calc() values on colgroup elements

<a href="https://bugs.webkit.org/show_bug.cgi?id=253841">https://bugs.webkit.org/show_bug.cgi?id=253841</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit to Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=193912

This patch add condition to ignore calc() values on &apos;colgroup&apos; elements to align with
web-spec and it progresses WPT test case as well.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(AutoTableLayout::fullRecalc): Add &apos;isCalculated&apos; condition
* LayoutTests/fast/table/calculated-width-on-col-within-colgroup.html: Add Test Case
* LayoutTests/fast/table/calculated-width-on-col-within-colgroup-expected.txt: Add Test Case Expectation
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/auto-layout-calc-width-001.html: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/auto-layout-calc-width-001-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/261623@main">https://commits.webkit.org/261623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5f1bf43cee3f46f49ab4dc49cfd72f067b677da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120952 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4892 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118108 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105391 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98914 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/677 "4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45962 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13852 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14546 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52733 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/8105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16350 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4415 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->