### PR TITLE
Use `auto*` instead of `LocalFrame*` whenever possible

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -364,7 +364,7 @@ bool AccessibilityObject::hasMisspelling() const
     if (!node())
         return false;
     
-    LocalFrame* frame = node()->document().frame();
+    auto* frame = node()->document().frame();
     if (!frame)
         return false;
     
@@ -399,7 +399,7 @@ std::optional<SimpleRange> AccessibilityObject::misspellingRange(const SimpleRan
     if (!node)
         return std::nullopt;
 
-    LocalFrame* frame = node->document().frame();
+    auto* frame = node->document().frame();
     if (!frame)
         return std::nullopt;
 
@@ -691,7 +691,7 @@ static std::optional<SimpleRange> rangeClosestToRange(const SimpleRange& referen
 
 std::optional<SimpleRange> AccessibilityObject::rangeOfStringClosestToRangeInDirection(const SimpleRange& referenceRange, AccessibilitySearchDirection searchDirection, const Vector<String>& searchStrings) const
 {
-    LocalFrame* frame = this->frame();
+    auto* frame = this->frame();
     if (!frame)
         return std::nullopt;
     
@@ -980,7 +980,7 @@ Vector<String> AccessibilityObject::performTextOperation(const AccessibilityText
     if (operation.textRanges.isEmpty())
         return result;
 
-    LocalFrame* frame = this->frame();
+    auto* frame = this->frame();
     if (!frame)
         return result;
 
@@ -1138,8 +1138,8 @@ bool AccessibilityObject::press()
     Element* actionElem = actionElement();
     if (!actionElem)
         return false;
-    if (LocalFrame* f = actionElem->document().frame())
-        f->loader().resetMultipleFormSubmissionProtection();
+    if (auto* frame = actionElem->document().frame())
+        frame->loader().resetMultipleFormSubmissionProtection();
     
     // Hit test at this location to determine if there is a sub-node element that should act
     // as the target of the action.
@@ -1198,11 +1198,11 @@ LocalFrame* AccessibilityObject::frame() const
 
 LocalFrame* AccessibilityObject::mainFrame() const
 {
-    Document* document = topDocument();
+    auto* document = topDocument();
     if (!document)
         return nullptr;
     
-    LocalFrame* frame = document->frame();
+    auto* frame = document->frame();
     if (!frame)
         return nullptr;
     

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -680,7 +680,7 @@ String AccessibilityRenderObject::textUnderElement(AccessibilityTextUnderElement
         }
 
         if (nodeDocument && textRange) {
-            if (LocalFrame* frame = nodeDocument->frame()) {
+            if (auto* frame = nodeDocument->frame()) {
                 // catch stale WebCoreAXObject (see <rdar://problem/3960196>)
                 if (frame->document() != nodeDocument)
                     return { };
@@ -1829,7 +1829,7 @@ bool AccessibilityRenderObject::setValue(const String& string)
     
     // We should use the editor's insertText to mimic typing into the field.
     // Also only do this when the field is in editing mode.
-    if (LocalFrame* frame = renderer.document().frame()) {
+    if (auto* frame = renderer.document().frame()) {
         Editor& editor = frame->editor();
         if (element.shouldUseInputMethod()) {
             editor.clearText();
@@ -2168,7 +2168,7 @@ bool AccessibilityRenderObject::isVisiblePositionRangeInDifferentDocument(const 
     VisibleSelection newSelection = VisibleSelection(range.start, range.end);
     if (Document* newSelectionDocument = newSelection.base().document()) {
         if (RefPtr newSelectionFrame = newSelectionDocument->frame()) {
-            LocalFrame* frame = this->frame();
+            auto* frame = this->frame();
             if (!frame || (newSelectionFrame != frame && newSelectionDocument != frame->document()))
                 return true;
         }

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -177,7 +177,7 @@ void JSDOMWindowBase::printErrorMessage(const String& message) const
 bool JSDOMWindowBase::supportsRichSourceInfo(const JSGlobalObject* object)
 {
     const JSDOMWindowBase* thisObject = static_cast<const JSDOMWindowBase*>(object);
-    LocalFrame* frame = thisObject->wrapped().frame();
+    auto* frame = thisObject->wrapped().frame();
     if (!frame)
         return false;
 
@@ -230,7 +230,7 @@ bool JSDOMWindowBase::shouldInterruptScriptBeforeTimeout(const JSGlobalObject* o
 RuntimeFlags JSDOMWindowBase::javaScriptRuntimeFlags(const JSGlobalObject* object)
 {
     const JSDOMWindowBase* thisObject = static_cast<const JSDOMWindowBase*>(object);
-    LocalFrame* frame = thisObject->wrapped().frame();
+    auto* frame = thisObject->wrapped().frame();
     if (!frame)
         return RuntimeFlags();
     return frame->settings().javaScriptRuntimeFlags();

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -191,7 +191,7 @@ RefPtr<JSLazyEventListener> JSLazyEventListener::create(CreationArguments&& argu
     // FIXME: We should be able to provide source information for frameless documents too (e.g. for importing nodes from XMLHttpRequest.responseXML).
     TextPosition position;
     URL sourceURL;
-    if (LocalFrame* frame = arguments.document.frame()) {
+    if (auto* frame = arguments.document.frame()) {
         if (!frame->script().canExecuteScripts(AboutToCreateEventListener))
             return nullptr;
         position = frame->script().eventHandlerPosition();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8035,7 +8035,7 @@ bool Document::hasFocus() const
     Page* page = this->page();
     if (!page || !page->focusController().isActive() || !page->focusController().isFocused())
         return false;
-    if (LocalFrame* focusedFrame = page->focusController().focusedFrame()) {
+    if (auto* focusedFrame = page->focusController().focusedFrame()) {
         if (focusedFrame->tree().isDescendantOf(frame()))
             return true;
     }

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -144,7 +144,7 @@ void DocumentMarkerController::invalidateRectsForMarkersInNode(Node& node)
 
 static void updateMainFrameLayoutIfNeeded(Document& document)
 {
-    LocalFrame* frame = document.frame();
+    auto* frame = document.frame();
     if (!frame)
         return;
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -544,7 +544,7 @@ bool Element::dispatchKeyEvent(const PlatformKeyboardEvent& platformEvent)
 {
     auto event = KeyboardEvent::create(platformEvent, document().windowProxy());
 
-    if (LocalFrame* frame = document().frame()) {
+    if (auto* frame = document().frame()) {
         if (frame->eventHandler().accessibilityPreventsEventPropagation(event))
             event->stopPropagation();
     }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2509,7 +2509,7 @@ void Node::defaultEventHandler(Event& event)
             startNode = startNode->parentOrShadowHostNode();
         
         if (startNode && startNode->renderer()) {
-            if (LocalFrame* frame = document().frame())
+            if (auto* frame = document().frame())
                 frame->eventHandler().defaultWheelEventHandler(startNode, downcast<WheelEvent>(event));
         }
 #if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/dom/VisitedLinkState.cpp
+++ b/Source/WebCore/dom/VisitedLinkState.cpp
@@ -110,7 +110,7 @@ InsideLink VisitedLinkState::determineLinkStateSlowCase(const Element& element)
     if (!hash)
         return InsideLink::InsideVisited;
 
-    LocalFrame* frame = element.document().frame();
+    auto* frame = element.document().frame();
     if (!frame)
         return InsideLink::InsideUnvisited;
 

--- a/Source/WebCore/editing/TextCheckingHelper.cpp
+++ b/Source/WebCore/editing/TextCheckingHelper.cpp
@@ -336,7 +336,7 @@ auto TextCheckingHelper::findFirstMisspelledWordOrUngrammaticalPhrase(bool check
                 if (checkGrammar)
                     checkingTypes.add(TextCheckingType::Grammar);
                 VisibleSelection currentSelection;
-                if (LocalFrame* frame = paragraphRange.start.document().frame())
+                if (auto* frame = paragraphRange.start.document().frame())
                     currentSelection = frame->selection().selection();
                 checkTextOfParagraph(*m_client.textChecker(), paragraphString, checkingTypes, results, currentSelection);
 

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -145,7 +145,7 @@ std::optional<DetectedItem> DataDetection::detectItemAroundHitTestResult(const H
 
         contextRange = rangeExpandedAroundPositionByCharacters(position, 250);
     } else {
-        LocalFrame* frame = node->document().frame();
+        auto* frame = node->document().frame();
         if (!frame)
             return { };
 

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -1265,7 +1265,7 @@ BOOL HTMLConverter::_addAttachmentForElement(Element& element, NSURL *url, BOOL 
     BOOL retval = NO;
     BOOL notFound = NO;
     RetainPtr<NSFileWrapper> fileWrapper;
-    LocalFrame* frame = element.document().frame();
+    auto* frame = element.document().frame();
     DocumentLoader *dataSource = frame->loader().frameHasLoaded() ? frame->loader().documentLoader() : 0;
     BOOL ignoreOrientation = YES;
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -143,7 +143,7 @@ static Element* effectiveElementForNode(Node& node)
 
 static void buildRendererHighlight(RenderObject* renderer, const InspectorOverlay::Highlight::Config& highlightConfig, InspectorOverlay::Highlight& highlight, InspectorOverlay::CoordinateSystem coordinateSystem)
 {
-    LocalFrame* containingFrame = renderer->document().frame();
+    auto* containingFrame = renderer->document().frame();
     if (!containingFrame)
         return;
 
@@ -318,7 +318,7 @@ static void drawShapeHighlight(GraphicsContext& context, Node& node, InspectorOv
     if (!shapeOutsideInfo)
         return;
 
-    LocalFrame* containingFrame = node.document().frame();
+    auto* containingFrame = node.document().frame();
     if (!containingFrame)
         return;
 
@@ -1561,7 +1561,7 @@ std::optional<InspectorOverlay::Highlight::GridHighlightOverlay> InspectorOverla
     float gridStartY = rowPositions[0];
     float gridEndY = rowPositions[rowPositions.size() - 1];
 
-    LocalFrame* containingFrame = node->document().frame();
+    auto* containingFrame = node->document().frame();
     if (!containingFrame)
         return { };
     FrameView* containingView = containingFrame->view();
@@ -1912,10 +1912,10 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
 
     auto itemsAtStartOfLine = m_page.inspectorController().ensureDOMAgent().flexibleBoxRendererCachedItemsAtStartOfLine(renderFlex);
 
-    LocalFrame* containingFrame = node->document().frame();
+    auto* containingFrame = node->document().frame();
     if (!containingFrame)
         return { };
-    FrameView* containingView = containingFrame->view();
+    auto* containingView = containingFrame->view();
 
     auto computedStyle = node->computedStyle();
     if (!computedStyle)

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1263,12 +1263,12 @@ RefPtr<Protocol::CSS::CSSStyleSheetBody> InspectorStyleSheet::buildObjectForStyl
 
 RefPtr<Protocol::CSS::CSSStyleSheetHeader> InspectorStyleSheet::buildObjectForStyleSheetInfo()
 {
-    CSSStyleSheet* styleSheet = pageStyleSheet();
+    auto* styleSheet = pageStyleSheet();
     if (!styleSheet)
         return nullptr;
 
-    Document* document = styleSheet->ownerDocument();
-    LocalFrame* frame = document ? document->frame() : nullptr;
+    auto* document = styleSheet->ownerDocument();
+    auto* frame = document ? document->frame() : nullptr;
     return Protocol::CSS::CSSStyleSheetHeader::create()
         .setStyleSheetId(id())
         .setOrigin(m_origin)

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -674,7 +674,7 @@ void InspectorNetworkAgent::didFailLoading(ResourceLoaderIdentifier identifier, 
     String requestId = IdentifiersFactory::requestId(identifier.toUInt64());
 
     if (loader && m_resourcesData->resourceType(requestId) == InspectorPageAgent::DocumentResource) {
-        LocalFrame* frame = loader->frame();
+        auto* frame = loader->frame();
         if (frame && frame->loader().documentLoader() && frame->document()) {
             m_resourcesData->addResourceSharedBuffer(requestId,
                 frame->loader().documentLoader()->mainResourceData(),

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -775,7 +775,7 @@ Protocol::ErrorStringOr<std::tuple<String, bool /* base64Encoded */>> InspectorP
 {
     Protocol::ErrorString errorString;
 
-    LocalFrame* frame = assertFrame(errorString, frameId);
+    auto* frame = assertFrame(errorString, frameId);
     if (!frame)
         return makeUnexpected(errorString);
 
@@ -808,7 +808,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::GenericTypes::SearchMatch>>>
         }
     }
 
-    LocalFrame* frame = assertFrame(errorString, frameId);
+    auto* frame = assertFrame(errorString, frameId);
     if (!frame)
         return makeUnexpected(errorString);
 
@@ -947,7 +947,7 @@ String InspectorPageAgent::loaderId(DocumentLoader* loader)
 
 LocalFrame* InspectorPageAgent::assertFrame(Protocol::ErrorString& errorString, const Protocol::Network::FrameId& frameId)
 {
-    LocalFrame* frame = frameForId(frameId);
+    auto* frame = frameForId(frameId);
     if (!frame)
         errorString = "Missing frame for given frameId"_s;
     return frame;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -518,7 +518,7 @@ void FrameLoader::submitForm(Ref<FormSubmission>&& submission)
     if (!m_frame.document()->contentSecurityPolicy()->allowFormAction(formAction))
         return;
 
-    LocalFrame* targetFrame = findFrameForNavigation(submission->target(), &submission->state().sourceDocument());
+    auto* targetFrame = findFrameForNavigation(submission->target(), &submission->state().sourceDocument());
     if (!targetFrame) {
         if (!DOMWindow::allowPopUp(m_frame) && !UserGestureIndicator::processingUserGesture())
             return;
@@ -1341,10 +1341,10 @@ void FrameLoader::loadFrameRequest(FrameLoadRequest&& request, Event* event, Ref
     auto completionHandler = [this, protectedFrame = Ref { m_frame }, formState = WeakPtr { formState }, frameName = request.frameName()] {
         // FIXME: It's possible this targetFrame will not be the same frame that was targeted by the actual
         // load if frame names have changed.
-        LocalFrame* sourceFrame = formState ? formState->sourceDocument().frame() : &m_frame;
+        auto* sourceFrame = formState ? formState->sourceDocument().frame() : &m_frame;
         if (!sourceFrame)
             sourceFrame = &m_frame;
-        LocalFrame* targetFrame = sourceFrame->loader().findFrameForNavigation(frameName);
+        auto* targetFrame = sourceFrame->loader().findFrameForNavigation(frameName);
         if (targetFrame && targetFrame != sourceFrame) {
             if (auto* page = targetFrame->page(); page && isInVisibleAndActivePage(*sourceFrame))
                 page->chrome().focus();
@@ -1523,7 +1523,7 @@ void FrameLoader::load(FrameLoadRequest&& request)
         return;
 
     if (!request.frameName().isEmpty()) {
-        LocalFrame* frame = findFrameForNavigation(request.frameName());
+        auto* frame = findFrameForNavigation(request.frameName());
         if (frame) {
             request.setShouldCheckNewWindowPolicy(false);
             if (&frame->loader() != this) {

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -107,7 +107,7 @@ static ImageEventSender& loadEventSender()
 
 static inline bool pageIsBeingDismissed(Document& document)
 {
-    LocalFrame* frame = document.frame();
+    auto* frame = document.frame();
     return frame && frame->loader().pageDismissalEventBeingDispatched() != FrameLoader::PageDismissalType::None;
 }
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -236,7 +236,7 @@ LocalFrame* CachedResourceLoader::frame() const
 
 ResourceErrorOr<CachedResourceHandle<CachedImage>> CachedResourceLoader::requestImage(CachedResourceRequest&& request, ImageLoading imageLoading)
 {
-    if (LocalFrame* frame = this->frame()) {
+    if (auto* frame = this->frame()) {
         if (frame->loader().pageDismissalEventBeingDispatched() != FrameLoader::PageDismissalType::None) {
             if (Document* document = frame->document())
                 request.upgradeInsecureRequestIfNeeded(*document);
@@ -445,7 +445,7 @@ bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const
     case CachedResource::Type::CSSStyleSheet:
         // These resource can inject script into the current document (Script,
         // XSL) or exfiltrate the content of the current document (CSS).
-        if (LocalFrame* frame = this->frame()) {
+        if (auto* frame = this->frame()) {
             if (!MixedContentChecker::canRunInsecureContent(*frame, m_document->securityOrigin(), url))
                 return false;
             auto& top = frame->tree().top();
@@ -467,7 +467,7 @@ bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const
     case CachedResource::Type::SVGFontResource:
     case CachedResource::Type::FontResource: {
         // These resources can corrupt only the frame's pixels.
-        if (LocalFrame* frame = this->frame()) {
+        if (auto* frame = this->frame()) {
             if (!MixedContentChecker::canDisplayInsecureContent(*frame, m_document->securityOrigin(), contentTypeFromResourceType(type), url, MixedContentChecker::AlwaysDisplayInNonStrictMode::Yes))
                 return false;
             auto& topFrame = frame->tree().top();
@@ -1538,7 +1538,7 @@ void CachedResourceLoader::reloadImagesIfNotDeferred()
 
 CachePolicy CachedResourceLoader::cachePolicy(CachedResource::Type type, const URL& url) const
 {
-    LocalFrame* frame = this->frame();
+    auto* frame = this->frame();
     if (!frame)
         return CachePolicy::Verify;
 

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -238,7 +238,7 @@ static void removeAllBeforeUnloadEventListeners(DOMWindow* domWindow)
 static bool allowsBeforeUnloadListeners(DOMWindow* window)
 {
     ASSERT_ARG(window, window);
-    LocalFrame* frame = window->frame();
+    auto* frame = window->frame();
     if (!frame)
         return false;
     if (!frame->page())

--- a/Source/WebCore/page/DOMWindowExtension.cpp
+++ b/Source/WebCore/page/DOMWindowExtension.cpp
@@ -109,7 +109,7 @@ void DOMWindowExtension::willDestroyGlobalObjectInFrame()
     Ref<DOMWindowExtension> protectedThis(*this);
 
     if (!m_wasDetached) {
-        LocalFrame* frame = this->frame();
+        auto* frame = this->frame();
         ASSERT(frame);
         frame->loader().client().dispatchWillDestroyGlobalObjectForDOMWindowExtension(this);
     }
@@ -131,7 +131,7 @@ void DOMWindowExtension::willDetachGlobalObjectFromFrame()
     // while there is still work to do.
     Ref<DOMWindowExtension> protectedThis(*this);
 
-    LocalFrame* frame = this->frame();
+    auto* frame = this->frame();
     ASSERT(frame);
     frame->loader().client().dispatchWillDestroyGlobalObjectForDOMWindowExtension(this);
 

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -250,7 +250,7 @@ Element* FocusNavigationScope::owner() const
     ASSERT(m_treeScopeRootNode);
     if (is<ShadowRoot>(*m_treeScopeRootNode))
         return downcast<ShadowRoot>(*m_treeScopeRootNode).host();
-    if (LocalFrame* frame = m_treeScopeRootNode->document().frame())
+    if (auto* frame = m_treeScopeRootNode->document().frame())
         return frame->ownerElement();
     return nullptr;
 }
@@ -394,7 +394,7 @@ void FocusController::setFocusedFrame(LocalFrame* frame)
 
 LocalFrame& FocusController::focusedOrMainFrame() const
 {
-    if (LocalFrame* frame = focusedFrame())
+    if (auto* frame = focusedFrame())
         return *frame;
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
     ASSERT(localMainFrame);

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -227,7 +227,7 @@ ExceptionOr<void> Location::replace(DOMWindow& activeWindow, DOMWindow& firstWin
     ASSERT(frame->document());
     ASSERT(frame->document()->domWindow());
 
-    LocalFrame* firstFrame = firstWindow.frame();
+    auto* firstFrame = firstWindow.frame();
     if (!firstFrame || !firstFrame->document())
         return { };
 
@@ -276,7 +276,7 @@ ExceptionOr<void> Location::setLocation(DOMWindow& incumbentWindow, DOMWindow& f
     auto* frame = this->frame();
     ASSERT(frame);
 
-    LocalFrame* firstFrame = firstWindow.frame();
+    auto* firstFrame = firstWindow.frame();
     if (!firstFrame || !firstFrame->document())
         return { };
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3057,7 +3057,7 @@ void Page::addRelevantRepaintedObject(RenderObject* object, const LayoutRect& ob
         && ratioOfViewThatIsUnpainted < gMaximumUnpaintedAreaRatio) {
         m_isCountingRelevantRepaintedObjects = false;
         resetRelevantPaintedObjectCounter();
-        if (LocalFrame* frame = dynamicDowncast<LocalFrame>(mainFrame()))
+        if (auto* frame = dynamicDowncast<LocalFrame>(mainFrame()))
             frame->loader().didReachLayoutMilestone(DidHitRelevantRepaintedObjectsAreaThreshold);
     }
 }

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -293,7 +293,7 @@ int PrintContext::pageNumberForElement(Element* element, const FloatSize& pageSi
     if (!box)
         return -1;
 
-    LocalFrame* frame = element->document().frame();
+    auto* frame = element->document().frame();
     FloatRect pageRect(FloatPoint(0, 0), pageSizeInPixels);
     PrintContext printContext(frame);
     printContext.begin(pageRect.width(), pageRect.height());

--- a/Source/WebCore/page/gtk/DragControllerGtk.cpp
+++ b/Source/WebCore/page/gtk/DragControllerGtk.cpp
@@ -72,7 +72,7 @@ void DragController::cleanupAfterSystemDrag()
 
 void DragController::declareAndWriteDragImage(DataTransfer& dataTransfer, Element& element, const URL& url, const String& label)
 {
-    LocalFrame* frame = element.document().frame();
+    auto* frame = element.document().frame();
     ASSERT(frame);
     frame->editor().writeImageToPasteboard(dataTransfer.pasteboard(), element, url, label);
 }

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -189,7 +189,7 @@ LocalFrame* HitTestResult::targetFrame() const
     if (!m_innerURLElement)
         return nullptr;
 
-    LocalFrame* frame = m_innerURLElement->document().frame();
+    auto* frame = m_innerURLElement->document().frame();
     if (!frame)
         return nullptr;
 
@@ -201,7 +201,7 @@ bool HitTestResult::isSelected() const
     if (!m_innerNonSharedNode)
         return false;
 
-    LocalFrame* frame = m_innerNonSharedNode->document().frame();
+    auto* frame = m_innerNonSharedNode->document().frame();
     if (!frame)
         return false;
 
@@ -213,7 +213,7 @@ String HitTestResult::selectedText() const
     if (!m_innerNonSharedNode)
         return emptyString();
 
-    LocalFrame* frame = m_innerNonSharedNode->document().frame();
+    auto* frame = m_innerNonSharedNode->document().frame();
     if (!frame)
         return emptyString();
 
@@ -611,7 +611,7 @@ bool HitTestResult::isOverTextInsideFormControlElement() const
     if (!is<Element>(*node) || !downcast<Element>(*node).isTextField())
         return false;
 
-    LocalFrame* frame = node->document().frame();
+    auto* frame = node->document().frame();
     if (!frame)
         return false;
 
@@ -750,11 +750,11 @@ Vector<String> HitTestResult::dictationAlternatives() const
     if (!m_innerNonSharedNode)
         return Vector<String>();
 
-    DocumentMarker* marker = m_innerNonSharedNode->document().markers().markerContainingPoint(pointInInnerNodeFrame(), DocumentMarker::DictationAlternatives);
+    auto* marker = m_innerNonSharedNode->document().markers().markerContainingPoint(pointInInnerNodeFrame(), DocumentMarker::DictationAlternatives);
     if (!marker)
         return Vector<String>();
 
-    LocalFrame* frame = innerNonSharedNode()->document().frame();
+    auto* frame = innerNonSharedNode()->document().frame();
     if (!frame)
         return Vector<String>();
 

--- a/Source/WebCore/rendering/ImageQualityController.cpp
+++ b/Source/WebCore/rendering/ImageQualityController.cpp
@@ -140,7 +140,7 @@ InterpolationQuality ImageQualityController::chooseInterpolationQuality(Graphics
     }
 
     // If the containing FrameView is being resized, paint at low quality until resizing is finished.
-    if (LocalFrame* frame = object->document().frame()) {
+    if (auto* frame = object->document().frame()) {
         bool frameViewIsCurrentlyInLiveResize = frame->view() && frame->view()->inLiveResize();
         if (frameViewIsCurrentlyInLiveResize) {
             set(object, innerMap, layer, size);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1271,7 +1271,7 @@ bool RenderTheme::isFocused(const RenderObject& renderer) const
         delegate = downcast<SliderThumbElement>(*element).hostInput();
 
     Document& document = delegate->document();
-    LocalFrame* frame = document.frame();
+    auto* frame = document.frame();
     return delegate == document.focusedElement() && frame && frame->selection().isFocusedAndActive();
 }
 

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -880,7 +880,7 @@ static void writeSelection(TextStream& ts, const RenderBox& renderer)
     if (!renderer.isRenderView())
         return;
 
-    LocalFrame* frame = renderer.document().frame();
+    auto* frame = renderer.document().frame();
     if (!frame)
         return;
 

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -87,7 +87,7 @@ float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize
     float zoomFactor = 1.0f;
     if (!useSVGZoomRules) {
         zoomFactor = style->effectiveZoom();
-        LocalFrame* frame = document.frame();
+        auto* frame = document.frame();
         if (frame && style->textZoom() != TextZoom::Reset)
             zoomFactor *= frame->textZoomFactor();
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2498,9 +2498,9 @@ ExceptionOr<RefPtr<NodeList>> Internals::nodesFromRect(Document& document, int c
     if (!document.frame() || !document.frame()->view())
         return Exception { InvalidAccessError };
 
-    LocalFrame* frame = document.frame();
-    FrameView* frameView = document.view();
-    RenderView* renderView = document.renderView();
+    auto* frame = document.frame();
+    auto* frameView = document.view();
+    auto* renderView = document.renderView();
     if (!renderView)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -474,7 +474,7 @@ void WebAutomationSessionProxy::resolveChildFrameWithOrdinal(WebCore::PageIdenti
         return;
     }
 
-    WebCore::LocalFrame* coreFrame = frame->coreFrame();
+    auto* coreFrame = frame->coreFrame();
     if (!coreFrame) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;
@@ -562,7 +562,7 @@ void WebAutomationSessionProxy::resolveChildFrameWithName(WebCore::PageIdentifie
         return;
     }
 
-    WebCore::LocalFrame* coreFrame = frame->coreFrame();
+    auto* coreFrame = frame->coreFrame();
     if (!coreFrame) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -73,7 +73,7 @@ WKURLRef WKBundleFrameCopyProvisionalURL(WKBundleFrameRef frameRef)
 
 WKFrameLoadState WKBundleFrameGetFrameLoadState(WKBundleFrameRef frameRef)
 {
-    WebCore::LocalFrame* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    auto* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
     if (!coreFrame)
         return kWKFrameLoadStateFinished;
 
@@ -147,7 +147,7 @@ WKBundlePageRef WKBundleFrameGetPage(WKBundleFrameRef frameRef)
 
 void WKBundleFrameClearOpener(WKBundleFrameRef frameRef)
 {
-    WebCore::LocalFrame* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    auto* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
     if (coreFrame)
         coreFrame->loader().setOpener(0);
 }
@@ -260,7 +260,7 @@ WKDataRef WKBundleFrameCopyWebArchiveFilteringSubframes(WKBundleFrameRef frameRe
 
 bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
 {
-    WebCore::LocalFrame* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    auto* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
     if (!coreFrame)
         return true;
 
@@ -274,7 +274,7 @@ WKBundleHitTestResultRef WKBundleFrameCreateHitTestResult(WKBundleFrameRef frame
 
 WKSecurityOriginRef WKBundleFrameCopySecurityOrigin(WKBundleFrameRef frameRef)
 {
-    WebCore::LocalFrame* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    auto* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
     if (!coreFrame)
         return 0;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -201,11 +201,11 @@ RefPtr<WebImage> InjectedBundleNodeHandle::renderedImage(SnapshotOptions options
     if (!m_node)
         return nullptr;
 
-    LocalFrame* frame = m_node->document().frame();
+    auto* frame = m_node->document().frame();
     if (!frame)
         return nullptr;
 
-    FrameView* frameView = frame->view();
+    auto* frameView = frame->view();
     if (!frameView)
         return nullptr;
 
@@ -412,7 +412,7 @@ RefPtr<WebFrame> InjectedBundleNodeHandle::documentFrame()
     if (!m_node || !m_node->isDocumentNode())
         return nullptr;
 
-    LocalFrame* frame = downcast<Document>(*m_node).frame();
+    auto* frame = downcast<Document>(*m_node).frame();
     if (!frame)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -179,7 +179,7 @@ void InjectedBundle::setAsynchronousSpellCheckingEnabled(bool enabled)
 
 int InjectedBundle::numberOfPages(WebFrame* frame, double pageWidthInPixels, double pageHeightInPixels)
 {
-    LocalFrame* coreFrame = frame ? frame->coreFrame() : 0;
+    auto* coreFrame = frame ? frame->coreFrame() : nullptr;
     if (!coreFrame)
         return -1;
     if (!pageWidthInPixels)
@@ -192,11 +192,11 @@ int InjectedBundle::numberOfPages(WebFrame* frame, double pageWidthInPixels, dou
 
 int InjectedBundle::pageNumberForElementById(WebFrame* frame, const String& id, double pageWidthInPixels, double pageHeightInPixels)
 {
-    LocalFrame* coreFrame = frame ? frame->coreFrame() : 0;
+    auto* coreFrame = frame ? frame->coreFrame() : nullptr;
     if (!coreFrame)
         return -1;
 
-    Element* element = coreFrame->document()->getElementById(id);
+    auto* element = coreFrame->document()->getElementById(id);
     if (!element)
         return -1;
 
@@ -210,7 +210,7 @@ int InjectedBundle::pageNumberForElementById(WebFrame* frame, const String& id, 
 
 String InjectedBundle::pageSizeAndMarginsInPixels(WebFrame* frame, int pageIndex, int width, int height, int marginTop, int marginRight, int marginBottom, int marginLeft)
 {
-    LocalFrame* coreFrame = frame ? frame->coreFrame() : 0;
+    auto* coreFrame = frame ? frame->coreFrame() : nullptr;
     if (!coreFrame)
         return String();
 
@@ -219,7 +219,7 @@ String InjectedBundle::pageSizeAndMarginsInPixels(WebFrame* frame, int pageIndex
 
 bool InjectedBundle::isPageBoxVisible(WebFrame* frame, int pageIndex)
 {
-    LocalFrame* coreFrame = frame ? frame->coreFrame() : 0;
+    auto* coreFrame = frame ? frame->coreFrame() : nullptr;
     if (!coreFrame)
         return false;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -71,7 +71,7 @@ InjectedBundleDOMWindowExtension::~InjectedBundleDOMWindowExtension()
 
 WebFrame* InjectedBundleDOMWindowExtension::frame() const
 {
-    LocalFrame* frame = m_coreExtension->frame();
+    auto* frame = m_coreExtension->frame();
     if (!frame)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -61,11 +61,11 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleHitTestResult::urlElementHandle()
 
 WebFrame* InjectedBundleHitTestResult::frame() const
 {
-    Node* node = m_hitTestResult.innerNonSharedNode();
+    auto* node = m_hitTestResult.innerNonSharedNode();
     if (!node)
         return nullptr;
 
-    LocalFrame* frame = node->document().frame();
+    auto* frame = node->document().frame();
     if (!frame)
         return nullptr;
 
@@ -74,7 +74,7 @@ WebFrame* InjectedBundleHitTestResult::frame() const
 
 WebFrame* InjectedBundleHitTestResult::targetFrame() const
 {
-    LocalFrame* frame = m_hitTestResult.targetFrame();
+    auto* frame = m_hitTestResult.targetFrame();
     if (!frame)
         return nullptr;
 
@@ -150,15 +150,15 @@ IntRect InjectedBundleHitTestResult::imageRect() const
         
     // The image rect in HitTestResult is in frame coordinates, but we need it in WKView
     // coordinates since WebKit2 clients don't have enough context to do the conversion themselves.
-    WebFrame* webFrame = frame();
+    auto* webFrame = frame();
     if (!webFrame)
         return imageRect;
     
-    LocalFrame* coreFrame = webFrame->coreFrame();
+    auto* coreFrame = webFrame->coreFrame();
     if (!coreFrame)
         return imageRect;
     
-    FrameView* view = coreFrame->view();
+    auto* view = coreFrame->view();
     if (!view)
         return imageRect;
     

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -672,7 +672,7 @@ void WebFrameLoaderClient::dispatchDidFailProvisionalLoad(const ResourceError& e
     }
 
     // Notify the UIProcess.
-    WebCore::LocalFrame* coreFrame = m_frame->coreFrame();
+    auto* coreFrame = m_frame->coreFrame();
     webPage->send(Messages::WebPageProxy::DidFailProvisionalLoadForFrame(m_frame->frameID(), m_frame->info(), request, navigationID, coreFrame->loader().provisionalLoadErrorBeingHandledURL().string(), error, willContinueLoading, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get()), willInternallyHandleFailure));
 
     // If we have a load listener, notify it.

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -78,7 +78,7 @@ void WebContextMenuClient::searchWithSpotlight()
     if (!localMainFrame)
         return;
 
-    LocalFrame* selectionFrame = [&] () -> LocalFrame* {
+    auto* selectionFrame = [&] () -> LocalFrame* {
         for (AbstractFrame* selectionFrame = localMainFrame; selectionFrame; selectionFrame = selectionFrame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(selectionFrame);
             if (!localFrame)

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -136,7 +136,7 @@ static LocalFrame* frameWithSelection(Page* page)
 
 void FindController::updateFindUIAfterPageScroll(bool found, const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, DidWrap didWrap, FindUIOriginator originator)
 {
-    LocalFrame* selectedFrame = frameWithSelection(m_webPage->corePage());
+    auto* selectedFrame = frameWithSelection(m_webPage->corePage());
 
 #if ENABLE(PDFKIT_PLUGIN)
     auto* pluginView = mainFramePlugIn();
@@ -259,7 +259,7 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
     if (!pluginView)
 #endif
     {
-        if (LocalFrame* selectedFrame = frameWithSelection(m_webPage->corePage())) {
+        if (auto* selectedFrame = frameWithSelection(m_webPage->corePage())) {
             if (selectedFrame->selection().selectionBounds().isEmpty()) {
                 auto result = m_webPage->corePage()->findTextMatches(string, coreOptions, maxMatchCount);
                 m_findMatches = WTFMove(result.ranges);
@@ -352,7 +352,7 @@ void FindController::getImageForFindMatch(uint32_t matchIndex)
 {
     if (matchIndex >= m_findMatches.size())
         return;
-    LocalFrame* frame = m_findMatches[matchIndex].start.document().frame();
+    auto* frame = m_findMatches[matchIndex].start.document().frame();
     if (!frame)
         return;
 
@@ -377,7 +377,7 @@ void FindController::selectFindMatch(uint32_t matchIndex)
 {
     if (matchIndex >= m_findMatches.size())
         return;
-    LocalFrame* frame = m_findMatches[matchIndex].start.document().frame();
+    auto* frame = m_findMatches[matchIndex].start.document().frame();
     if (!frame)
         return;
     frame->selection().setSelection(m_findMatches[matchIndex]);
@@ -389,7 +389,7 @@ void FindController::indicateFindMatch(uint32_t matchIndex)
 
     selectFindMatch(matchIndex);
 
-    LocalFrame* selectedFrame = frameWithSelection(m_webPage->corePage());
+    auto* selectedFrame = frameWithSelection(m_webPage->corePage());
     if (!selectedFrame)
         return;
 
@@ -462,7 +462,7 @@ void FindController::willFindString()
 
 void FindController::didFindString()
 {
-    LocalFrame* selectedFrame = frameWithSelection(m_webPage->corePage());
+    auto* selectedFrame = frameWithSelection(m_webPage->corePage());
     if (!selectedFrame)
         return;
 
@@ -499,7 +499,7 @@ void FindController::deviceScaleFactorDidChange()
 {
     ASSERT(isShowingOverlay());
 
-    LocalFrame* selectedFrame = frameWithSelection(m_webPage->corePage());
+    auto* selectedFrame = frameWithSelection(m_webPage->corePage());
     if (!selectedFrame)
         return;
 
@@ -511,7 +511,7 @@ void FindController::redraw()
     if (!m_isShowingFindIndicator)
         return;
 
-    LocalFrame* selectedFrame = frameWithSelection(m_webPage->corePage());
+    auto* selectedFrame = frameWithSelection(m_webPage->corePage());
     if (!selectedFrame)
         return;
 
@@ -602,7 +602,7 @@ void FindController::drawRect(PageOverlay&, GraphicsContext& graphicsContext, co
     if (!m_isShowingFindIndicator)
         return;
 
-    if (LocalFrame* selectedFrame = frameWithSelection(m_webPage->corePage())) {
+    if (auto* selectedFrame = frameWithSelection(m_webPage->corePage())) {
         IntRect findIndicatorRect = selectedFrame->view()->contentsToRootView(enclosingIntRect(selectedFrame->selection().selectionBounds(FrameSelection::ClipToVisibleContent::No)));
 
         if (findIndicatorRect != m_findIndicatorRect) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1857,8 +1857,8 @@ void WebPage::loadSimulatedRequestAndResponse(LoadParameters&& loadParameters, R
 
 void WebPage::navigateToPDFLinkWithSimulatedClick(const String& url, IntPoint documentPoint, IntPoint screenPoint)
 {
-    LocalFrame* mainFrame = m_mainFrame->coreFrame();
-    Document* mainFrameDocument = mainFrame->document();
+    auto* mainFrame = m_mainFrame->coreFrame();
+    auto* mainFrameDocument = mainFrame->document();
     if (!mainFrameDocument)
         return;
 
@@ -2092,7 +2092,7 @@ double WebPage::textZoomFactor() const
         return pluginView->pageScaleFactor();
 #endif
 
-    LocalFrame* frame = m_mainFrame->coreFrame();
+    auto* frame = m_mainFrame->coreFrame();
     if (!frame)
         return 1;
     return frame->textZoomFactor();
@@ -2107,7 +2107,7 @@ void WebPage::setTextZoomFactor(double zoomFactor)
     }
 #endif
 
-    LocalFrame* frame = m_mainFrame->coreFrame();
+    auto* frame = m_mainFrame->coreFrame();
     if (!frame)
         return;
     frame->setTextZoomFactor(static_cast<float>(zoomFactor));
@@ -2120,7 +2120,7 @@ double WebPage::pageZoomFactor() const
         return pluginView->pageScaleFactor();
 #endif
 
-    LocalFrame* frame = m_mainFrame->coreFrame();
+    auto* frame = m_mainFrame->coreFrame();
     if (!frame)
         return 1;
     return frame->pageZoomFactor();
@@ -2135,7 +2135,7 @@ void WebPage::setPageZoomFactor(double zoomFactor)
     }
 #endif
 
-    LocalFrame* frame = m_mainFrame->coreFrame();
+    auto* frame = m_mainFrame->coreFrame();
     if (!frame)
         return;
     frame->setPageZoomFactor(static_cast<float>(zoomFactor));
@@ -2211,7 +2211,7 @@ void WebPage::setPageAndTextZoomFactors(double pageZoomFactor, double textZoomFa
     }
 #endif
 
-    LocalFrame* frame = m_mainFrame->coreFrame();
+    auto* frame = m_mainFrame->coreFrame();
     if (!frame)
         return;
     return frame->setPageAndTextZoomFactors(static_cast<float>(pageZoomFactor), static_cast<float>(textZoomFactor));
@@ -2658,7 +2658,7 @@ void WebPage::setFooterBannerHeight(int height)
 void WebPage::takeSnapshot(IntRect snapshotRect, IntSize bitmapSize, uint32_t options, CompletionHandler<void(const WebKit::ShareableBitmapHandle&)>&& completionHandler)
 {
     ShareableBitmapHandle handle;
-    LocalFrame* coreFrame = m_mainFrame->coreFrame();
+    auto* coreFrame = m_mainFrame->coreFrame();
     if (!coreFrame) {
         completionHandler(handle);
         return;
@@ -2692,11 +2692,11 @@ void WebPage::takeSnapshot(IntRect snapshotRect, IntSize bitmapSize, uint32_t op
 
 RefPtr<WebImage> WebPage::scaledSnapshotWithOptions(const IntRect& rect, double additionalScaleFactor, SnapshotOptions options)
 {
-    LocalFrame* coreFrame = m_mainFrame->coreFrame();
+    auto* coreFrame = m_mainFrame->coreFrame();
     if (!coreFrame)
         return nullptr;
 
-    FrameView* frameView = coreFrame->view();
+    auto* frameView = coreFrame->view();
     if (!frameView)
         return nullptr;
 
@@ -2804,11 +2804,11 @@ RefPtr<WebImage> WebPage::snapshotAtSize(const IntRect& rect, const IntSize& bit
 
 RefPtr<WebImage> WebPage::snapshotNode(WebCore::Node& node, SnapshotOptions options, unsigned maximumPixelCount)
 {
-    LocalFrame* coreFrame = m_mainFrame->coreFrame();
+    auto* coreFrame = m_mainFrame->coreFrame();
     if (!coreFrame)
         return nullptr;
 
-    FrameView* frameView = coreFrame->view();
+    auto* frameView = coreFrame->view();
     if (!frameView)
         return nullptr;
 
@@ -2874,7 +2874,7 @@ void WebPage::pageDidScroll()
 void WebPage::pageStoppedScrolling()
 {
     // Maintain the current history item's scroll position up-to-date.
-    if (LocalFrame* frame = m_mainFrame->coreFrame())
+    if (auto* frame = m_mainFrame->coreFrame())
         frame->loader().history().saveScrollPositionAndViewStateToItem(frame->loader().history().currentItem());
 }
 
@@ -5746,7 +5746,7 @@ void WebPage::beginPrinting(FrameIdentifier frameID, const PrintInfo& printInfo)
     if (!frame)
         return;
 
-    LocalFrame* coreFrame = frame->coreFrame();
+    auto* coreFrame = frame->coreFrame();
     if (!coreFrame)
         return;
 
@@ -6232,7 +6232,7 @@ AbstractFrame* WebPage::mainFrame() const
 // FIXME: This should return an AbstractFrameView.
 FrameView* WebPage::mainFrameView() const
 {
-    if (LocalFrame* frame = dynamicDowncast<LocalFrame>(mainFrame()))
+    if (auto* frame = dynamicDowncast<LocalFrame>(mainFrame()))
         return frame->view();
     return nullptr;
 }

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebFrameIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebFrameIOS.mm
@@ -96,7 +96,7 @@ using namespace WebCore;
 
 - (void)clearSelection
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     if (frame)
         frame->selection().clearCurrentSelection();
     
@@ -106,7 +106,7 @@ using namespace WebCore;
 {
     WebTextSelectionState state = WebTextSelectionStateNone;
 
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     FrameSelection& frameSelection = frame->selection();
 
     if (frameSelection.isCaret())
@@ -130,7 +130,7 @@ using namespace WebCore;
 
 - (CGRect)closestCaretRectInMarkedTextRangeForPoint:(CGPoint)point
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     if (!frame)
         return { };
 
@@ -182,7 +182,7 @@ using namespace WebCore;
 - (void)collapseSelection
 {
     if ([self selectionState] == WebTextSelectionStateRange) {
-        LocalFrame* frame = [self coreFrame];
+        auto* frame = [self coreFrame];
         FrameSelection& frameSelection = frame->selection();
         VisiblePosition end(frameSelection.selection().end());
         frameSelection.moveTo(end);
@@ -192,7 +192,7 @@ using namespace WebCore;
 - (void)extendSelection:(BOOL)start
 {
     if ([self selectionState] == WebTextSelectionStateRange) {
-        LocalFrame* frame = [self coreFrame];
+        auto* frame = [self coreFrame];
         const VisibleSelection& originalSelection = frame->selection().selection();
         if (start) {
             VisiblePosition start = startOfWord(originalSelection.start());
@@ -246,43 +246,43 @@ using namespace WebCore;
 
 - (void)setRangedSelectionBaseToCurrentSelection
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     frame->setRangedSelectionBaseToCurrentSelection();
 }
 
 - (void)setRangedSelectionBaseToCurrentSelectionStart
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     frame->setRangedSelectionBaseToCurrentSelectionStart();
 }
 
 - (void)setRangedSelectionBaseToCurrentSelectionEnd
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     frame->setRangedSelectionBaseToCurrentSelectionEnd();
 }
 
 - (void)clearRangedSelectionInitialExtent
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     frame->clearRangedSelectionInitialExtent();
 }
 
 - (void)setRangedSelectionInitialExtentToCurrentSelectionStart
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     frame->setRangedSelectionInitialExtentToCurrentSelectionStart();
 }
 
 - (void)setRangedSelectionInitialExtentToCurrentSelectionEnd
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     frame->setRangedSelectionInitialExtentToCurrentSelectionEnd();
 }
 
 - (void)setRangedSelectionWithExtentPoint:(CGPoint)point
 {    
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     FrameSelection& frameSelection = frame->selection();
     VisiblePosition pos = [self visiblePositionForPoint:point];
     VisibleSelection base = frame->rangedSelectionBase();
@@ -306,7 +306,7 @@ using namespace WebCore;
 
 - (BOOL)setRangedSelectionExtentPoint:(CGPoint)extentPoint baseIsStart:(BOOL)baseIsStart allowFlipping:(BOOL)allowFlipping
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     VisibleSelection rangedSelectionBase(frame->rangedSelectionBase());
     VisiblePosition baseStart(rangedSelectionBase.start(), rangedSelectionBase.affinity());
     VisiblePosition baseEnd;
@@ -402,7 +402,7 @@ using namespace WebCore;
     // expected to take the flip into account in subsequent calls to this function (for at
     // least as long as a single, logical selection session continues).
 
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     FrameSelection& frameSelection = frame->selection();
     VisiblePosition base([self visiblePositionForPoint:basePoint]);
     VisiblePosition extent([self visiblePositionForPoint:extentPoint]);
@@ -446,7 +446,7 @@ using namespace WebCore;
     // don't care about base/extent.
     VisiblePosition first([self visiblePositionForPoint:firstPoint]);
     VisiblePosition second([self visiblePositionForPoint:secondPoint]);
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     FrameSelection& frameSelection = frame->selection();
     frameSelection.moveTo(first, second);
 }
@@ -456,7 +456,7 @@ using namespace WebCore;
     // This method ensures that selection ends doesn't contract such that it no
     // longer contains these points. This is the desirable behavior when the
     // user does the tap-and-a-half + drag operation.
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     const VisibleSelection& originalSelection = frame->selection().selection();
     Position ensureStart([self visiblePositionForPoint:initialStartPoint].deepEquivalent());
     Position ensureEnd([self visiblePositionForPoint:initialEndPoint].deepEquivalent());
@@ -468,7 +468,7 @@ using namespace WebCore;
 
 - (void)aggressivelyExpandSelectionToWordContainingCaretSelection
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     FrameSelection& frameSelection = frame->selection();
     VisiblePosition end = frameSelection.selection().visibleEnd();
     if (end == endOfDocument(end) && end != startOfDocument(end) && end == startOfLine(end))
@@ -503,7 +503,7 @@ using namespace WebCore;
 
 - (void)expandSelectionToSentence
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     FrameSelection& frameSelection = frame->selection();
     VisiblePosition pos = frameSelection.selection().start();
     VisiblePosition start = startOfSentence(pos);
@@ -513,7 +513,7 @@ using namespace WebCore;
 
 - (WKWritingDirection)selectionBaseWritingDirection
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     switch (frame->editor().baseWritingDirectionForSelectionStart()) {
     case WritingDirection::LeftToRight:
         return WKWritingDirectionLeftToRight;
@@ -551,7 +551,7 @@ using namespace WebCore;
 {
     WKWritingDirection originalDirection = [self selectionBaseWritingDirection];
 
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     if (!frame->selection().selection().isContentEditable())
         return;
     
@@ -590,7 +590,7 @@ using namespace WebCore;
 
 - (void)moveSelectionToPoint:(CGPoint)point
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     FrameSelection& frameSelection = frame->selection();
     VisiblePosition pos = [self _visiblePositionForPoint:point];
     frameSelection.moveTo(pos);
@@ -743,7 +743,7 @@ static VisiblePosition SimpleSmartExtendEnd(const VisiblePosition& start, const 
     if ([self selectionState] != WebTextSelectionStateRange)
         return;
     
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     FrameSelection& frameSelection = frame->selection();
     auto start = frameSelection.selection().visibleStart();
     auto end = frameSelection.selection().visibleEnd();
@@ -794,13 +794,13 @@ static VisiblePosition SimpleSmartExtendEnd(const VisiblePosition& start, const 
 
 - (BOOL)renderedCharactersExceed:(NSUInteger)threshold
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     return frame->view()->renderedCharactersExceed(threshold);
 }
 
 - (CGRect)elementRectAtPoint:(CGPoint)point
 {
-    LocalFrame* frame = [self coreFrame];
+    auto* frame = [self coreFrame];
     IntPoint adjustedPoint = frame->view()->windowToContents(roundedIntPoint(point));
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent };
     HitTestResult result = frame->eventHandler().hitTestResultAtPoint(adjustedPoint, hitType);

--- a/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
+++ b/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
@@ -155,7 +155,7 @@ using namespace JSC;
 
 - (WebFrame *)webFrame
 {
-    LocalFrame* frame = core(self)->frame();
+    auto* frame = core(self)->frame();
     if (!frame)
         return nil;
     return kit(frame);

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -292,7 +292,7 @@ static OptionSet<RenderAsTextFlag> toRenderAsTextFlags(WebRenderTreeAsTextOption
 
 - (int)numberOfPagesWithPageWidth:(float)pageWidthInPixels pageHeight:(float)pageHeightInPixels
 {
-    LocalFrame* coreFrame = _private->coreFrame;
+    auto coreFrame = _private->coreFrame;
     if (!coreFrame)
         return -1;
 
@@ -301,7 +301,7 @@ static OptionSet<RenderAsTextFlag> toRenderAsTextFlags(WebRenderTreeAsTextOption
 
 - (void)printToCGContext:(CGContextRef)cgContext pageWidth:(float)pageWidthInPixels pageHeight:(float)pageHeightInPixels
 {
-    LocalFrame* coreFrame = _private->coreFrame;
+    auto coreFrame = _private->coreFrame;
     if (!coreFrame)
         return;
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -265,13 +265,13 @@ NSMenu *WebContextMenuClient::contextMenuForEvent(NSEvent *event, NSView *view, 
 
 void WebContextMenuClient::showContextMenu()
 {
-    Page* page = [m_webView page];
+    auto page = [m_webView page];
     if (!page)
         return;
-    LocalFrame* frame = page->contextMenuController().hitTestResult().innerNodeFrame();
+    auto* frame = page->contextMenuController().hitTestResult().innerNodeFrame();
     if (!frame)
         return;
-    FrameView* frameView = frame->view();
+    auto* frameView = frame->view();
     if (!frameView)
         return;
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -591,7 +591,7 @@ void WebEditorClient::updateEditorStateAfterLayoutIfEditabilityChanged()
     if (m_lastEditorStateWasContentEditable == EditorStateIsContentEditable::Unset)
         return;
 
-    LocalFrame* frame = core([m_webView _selectedOrMainFrame]);
+    auto* frame = core([m_webView _selectedOrMainFrame]);
     if (!frame)
         return;
 

--- a/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
@@ -186,11 +186,11 @@ static BOOL shouldRoundScrollOrigin(WebDynamicScrollBarsView *view)
     if (![documentView isKindOfClass:[WebHTMLView class]])
         return NO;
 
-    LocalFrame* frame = core([(WebHTMLView *)documentView _frame]);
+    auto* frame = core([(WebHTMLView *)documentView _frame]);
     if (!frame)
         return NO;
     
-    FrameView *frameView = frame->view();
+    auto* frameView = frame->view();
     if (!frameView)
         return NO;
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -180,7 +180,7 @@ static RetainPtr<NSArray> createNSArray(const HashSet<String, ASCIICaseInsensiti
         [webFrame _commitData:data];
 
     // If the document is a stand-alone media document, now is the right time to cancel the WebKit load
-    LocalFrame* coreFrame = core(webFrame);
+    auto* coreFrame = core(webFrame);
     if (coreFrame->document()->isMediaDocument() && coreFrame->loader().documentLoader())
         coreFrame->loader().documentLoader()->cancelMainResourceLoad(coreFrame->loader().client().pluginWillHandleLoadError(coreFrame->loader().documentLoader()->response()));
 
@@ -234,7 +234,7 @@ static RetainPtr<NSArray> createNSArray(const HashSet<String, ASCIICaseInsensiti
         return adoptNS([[NSString alloc] initWithData:parsedArchiveData ? parsedArchiveData->createNSData().get() : nil encoding:NSUTF8StringEncoding]).autorelease();
     }
 
-    LocalFrame* coreFrame = core([_private->dataSource webFrame]);
+    auto* coreFrame = core([_private->dataSource webFrame]);
     if (!coreFrame)
         return nil;
     Document* document = coreFrame->document();

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1800,7 +1800,7 @@ static void resetWebViewToConsistentState(const WTR::TestOptions& options, Reset
         WebCoreTestSupport::resetInternalsObject([mainFrame globalContext]);
 
 #if !PLATFORM(IOS_FAMILY)
-    if (WebCore::LocalFrame* frame = [webView _mainCoreFrame])
+    if (auto* frame = [webView _mainCoreFrame])
         WebCoreTestSupport::clearWheelEventTestMonitor(*frame);
 #endif
 


### PR DESCRIPTION
#### f62762091cdaa9a92daae4cb95b9eea18a6a6318
<pre>
Use `auto*` instead of `LocalFrame*` whenever possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=253845">https://bugs.webkit.org/show_bug.cgi?id=253845</a>

Reviewed by Darin Adler.

* Source/WebCore/*:
* Source/WebKit/*:
* Source/WebKitLegacy/*:

Canonical link: <a href="https://commits.webkit.org/261605@main">https://commits.webkit.org/261605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75b6a9d02e299a7d0cddaa0902facc7d51ee7f19

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4059 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22745 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/4838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118028 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105324 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13795 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/667 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14479 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52670 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8090 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16276 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->