### PR TITLE
[JSC] Align error message for non-callable ProxyObject's "get" trap with its counterparts

### DIFF
--- a/JSTests/stress/proxy-basic.js
+++ b/JSTests/stress/proxy-basic.js
@@ -133,7 +133,7 @@ assert(Proxy.prototype === undefined);
                 proxy["foo"];
         } catch(e) {
             threw = true;
-            assert(e.toString() === "TypeError: 'get' property of a Proxy's handler object should be callable");
+            assert(e.toString() === "TypeError: 'get' property of a Proxy's handler should be callable");
         }
         assert(threw);
     }

--- a/JSTests/stress/proxy-get-missing-handler-inline-cache.js
+++ b/JSTests/stress/proxy-get-missing-handler-inline-cache.js
@@ -11,7 +11,7 @@ function shouldThrow(fn, expectedError) {
         throw new Error("Didn't throw!");
 }
 
-const callableGetTrapError = "TypeError: 'get' property of a Proxy's handler object should be callable";
+const callableGetTrapError = "TypeError: 'get' property of a Proxy's handler should be callable";
 
 shouldThrow(() => {
     var handler = {get: null};

--- a/Source/JavaScriptCore/builtins/ProxyHelpers.js
+++ b/Source/JavaScriptCore/builtins/ProxyHelpers.js
@@ -39,7 +39,7 @@ function performProxyObjectGet(receiver, propertyName)
         return @getByValWithThis(target, receiver, propertyName);
 
     if (!@isCallable(trap))
-        @throwTypeError("'get' property of a Proxy's handler object should be callable");
+        @throwTypeError("'get' property of a Proxy's handler should be callable");
 
     var trapResult = trap.@call(handler, target, propertyName, receiver);
 

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -117,7 +117,7 @@ static JSValue performProxyGet(JSGlobalObject* globalObject, ProxyObject* proxyO
 
     JSObject* handler = jsCast<JSObject*>(handlerValue);
     CallData callData;
-    JSValue getHandler = handler->getMethod(globalObject, callData, vm.propertyNames->get, "'get' property of a Proxy's handler object should be callable"_s);
+    JSValue getHandler = handler->getMethod(globalObject, callData, vm.propertyNames->get, "'get' property of a Proxy's handler should be callable"_s);
     RETURN_IF_EXCEPTION(scope, { });
 
     if (getHandler.isUndefined())


### PR DESCRIPTION
#### 5712e4c88966195c7b63070fef1dab2f18741fff
<pre>
[JSC] Align error message for non-callable ProxyObject&apos;s &quot;get&quot; trap with its counterparts
<a href="https://bugs.webkit.org/show_bug.cgi?id=253848">https://bugs.webkit.org/show_bug.cgi?id=253848</a>
&lt;rdar://problem/106664522&gt;

Reviewed by Yusuke Suzuki.

With this change, [[ProxyHandler]] is referred to as &quot;handler&quot; instead &quot;handler object&quot;,
just like in all other traps.

* JSTests/stress/proxy-basic.js:
* JSTests/stress/proxy-get-missing-handler-inline-cache.js:
* Source/JavaScriptCore/builtins/ProxyHelpers.js:
(linkTimeConstant.performProxyObjectGet):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::performProxyGet):

Canonical link: <a href="https://commits.webkit.org/261627@main">https://commits.webkit.org/261627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/471e05303f37d0c309fb185b550fd2fc62485437

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120895 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4826 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45911 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100657 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13793 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/666 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11922 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14477 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102018 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52669 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31890 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16274 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110062 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4416 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27191 "Passed tests") | 
<!--EWS-Status-Bubble-End-->