### PR TITLE
Concat with a CSSStyleSheet and shadowRoot.adoptedStyleSheets returns array in array

### DIFF
--- a/JSTests/stress/array-concat-runtime-array.js
+++ b/JSTests/stress/array-concat-runtime-array.js
@@ -1,0 +1,8 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = $vm.createRuntimeArray();
+var concat = [].concat(array);
+shouldBe(concat.length, 0);

--- a/LayoutTests/cssom/array-concat-adoptedStyleSheets-expected.txt
+++ b/LayoutTests/cssom/array-concat-adoptedStyleSheets-expected.txt
@@ -1,0 +1,15 @@
+Tests that Array.concat() behaves correctly with an observable array returned by adoptedStyleSheets.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.adoptedStyleSheets.length is 2
+PASS newArray.length is 3
+PASS document.adoptedStyleSheets.length is 2
+PASS newArray[0] is a
+PASS newArray[1] is b
+PASS newArray[2] is c
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/cssom/array-concat-adoptedStyleSheets.html
+++ b/LayoutTests/cssom/array-concat-adoptedStyleSheets.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that Array.concat() behaves correctly with an observable array returned by adoptedStyleSheets.");
+
+let a = new CSSStyleSheet;
+let b = new CSSStyleSheet;
+let c = new CSSStyleSheet;
+document.adoptedStyleSheets.push(b);
+document.adoptedStyleSheets.push(c);
+shouldBe("document.adoptedStyleSheets.length", "2");
+
+let newArray = [a].concat(document.adoptedStyleSheets);
+shouldBe("newArray.length", "3");
+shouldBe("document.adoptedStyleSheets.length", "2");
+shouldBe("newArray[0]", "a");
+shouldBe("newArray[1]", "b");
+shouldBe("newArray[2]", "c");
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 9d30cd47aaab9cda55030b7eb9ecbe8aef869564
<pre>
Concat with a CSSStyleSheet and shadowRoot.adoptedStyleSheets returns array in array
<a href="https://bugs.webkit.org/show_bug.cgi?id=253814">https://bugs.webkit.org/show_bug.cgi?id=253814</a>
rdar://106667776

Reviewed by Alexey Shvayka, Mark Lam, Keith Miller and Chris Dumez.

We should bail out from the fast path of Array.prototype.concat when the parameter is Array but not JSArray.
This is the case when the parameter is ProxyObject or DerivedArray e.g. JSObservableArray.
This patch adds checks for both types in the fast path and returns null to go to the slow path.

* LayoutTests/cssom/array-concat-adoptedStyleSheets-expected.txt: Added.
* LayoutTests/cssom/array-concat-adoptedStyleSheets.html: Added.
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::concatAppendOne):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/261604@main">https://commits.webkit.org/261604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbdd2de8bc6585f30e05d1884904bed3c7297d25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4065 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22753 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/4840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118036 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105331 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/100664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/673 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11932 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14487 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102028 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52677 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31893 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16284 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110072 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4404 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27194 "Passed tests") | 
<!--EWS-Status-Bubble-End-->