### PR TITLE
Rename AbstractFrame to Frame

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1235,7 +1235,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/cache/MemoryCache.h
 
     page/AbstractDOMWindow.h
-    page/AbstractFrame.h
     page/AbstractFrameView.h
     page/ActivityState.h
     page/ActivityStateChangeObserver.h
@@ -1277,6 +1276,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/EventHandler.h
     page/FocusController.h
     page/FocusDirection.h
+    page/Frame.h
     page/FrameDestructionObserver.h
     page/FrameDestructionObserverInlines.h
     page/FrameFlattening.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1808,7 +1808,6 @@ mathml/MathMLTokenElement.cpp
 mathml/MathMLUnderOverElement.cpp
 mathml/MathMLUnknownElement.cpp
 page/AbstractDOMWindow.cpp
-page/AbstractFrame.cpp
 page/ActivityState.cpp
 page/AutoscrollController.cpp
 page/BarProp.cpp
@@ -1834,6 +1833,7 @@ page/DragController.cpp
 page/EventHandler.cpp
 page/EventSource.cpp
 page/FocusController.cpp
+page/Frame.cpp
 page/FrameDestructionObserver.cpp
 page/FrameSnapshotting.cpp
 page/FrameTree.cpp

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.h
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.h
@@ -23,7 +23,7 @@
 namespace WebCore {
 
 class AbstractDOMWindow;
-class AbstractFrame;
+class Frame;
 
 JSDOMWindow* asJSDOMWindow(JSC::JSGlobalObject*);
 const JSDOMWindow* asJSDOMWindow(const JSC::JSGlobalObject*);

--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -29,8 +29,8 @@
 #include "config.h"
 #include "JSWindowProxy.h"
 
-#include "AbstractFrame.h"
 #include "CommonVM.h"
+#include "Frame.h"
 #include "GCController.h"
 #include "JSDOMWindow.h"
 #include "JSDOMWindowProperties.h"

--- a/Source/WebCore/bindings/js/JSWindowProxy.h
+++ b/Source/WebCore/bindings/js/JSWindowProxy.h
@@ -40,7 +40,7 @@ class Debugger;
 namespace WebCore {
 
 class AbstractDOMWindow;
-class AbstractFrame;
+class Frame;
 
 class WEBCORE_EXPORT JSWindowProxy final : public JSC::JSProxy {
 public:
@@ -77,7 +77,7 @@ private:
 };
 
 // JSWindowProxy is a little odd in that it's not a traditional wrapper and has no back pointer.
-// It is, however, strongly owned by AbstractFrame via its WindowProxy, so we can get one from a WindowProxy.
+// It is, however, strongly owned by Frame via its WindowProxy, so we can get one from a WindowProxy.
 WEBCORE_EXPORT JSC::JSValue toJS(JSC::JSGlobalObject*, WindowProxy&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, WindowProxy* windowProxy) { return windowProxy ? toJS(lexicalGlobalObject, *windowProxy) : JSC::jsNull(); }
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject*, WindowProxy& windowProxy) { return toJS(lexicalGlobalObject, windowProxy); }

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -52,7 +52,7 @@ static void collectGarbageAfterWindowProxyDestruction()
         GCController::singleton().garbageCollectSoon();
 }
 
-WindowProxy::WindowProxy(AbstractFrame& frame)
+WindowProxy::WindowProxy(Frame& frame)
     : m_frame(frame)
     , m_jsWindowProxies(makeUniqueRef<ProxyMap>())
 {
@@ -64,7 +64,7 @@ WindowProxy::~WindowProxy()
     ASSERT(m_jsWindowProxies->isEmpty());
 }
 
-AbstractFrame* WindowProxy::frame() const
+Frame* WindowProxy::frame() const
 {
     return m_frame.get();
 }

--- a/Source/WebCore/bindings/js/WindowProxy.h
+++ b/Source/WebCore/bindings/js/WindowProxy.h
@@ -33,8 +33,8 @@ class Debugger;
 namespace WebCore {
 
 class AbstractDOMWindow;
-class AbstractFrame;
 class DOMWrapperWorld;
+class Frame;
 class JSDOMGlobalObject;
 class JSWindowProxy;
 
@@ -43,14 +43,14 @@ class WindowProxy : public RefCounted<WindowProxy> {
 public:
     using ProxyMap = HashMap<RefPtr<DOMWrapperWorld>, JSC::Strong<JSWindowProxy>>;
 
-    static Ref<WindowProxy> create(AbstractFrame& frame)
+    static Ref<WindowProxy> create(Frame& frame)
     {
         return adoptRef(*new WindowProxy(frame));
     }
 
     WEBCORE_EXPORT ~WindowProxy();
 
-    WEBCORE_EXPORT AbstractFrame* frame() const;
+    WEBCORE_EXPORT Frame* frame() const;
     void detachFromFrame();
 
     void destroyJSWindowProxy(DOMWrapperWorld&);
@@ -90,12 +90,12 @@ public:
     WEBCORE_EXPORT AbstractDOMWindow* window() const;
 
 private:
-    explicit WindowProxy(AbstractFrame&);
+    explicit WindowProxy(Frame&);
 
     JSWindowProxy& createJSWindowProxy(DOMWrapperWorld&);
     WEBCORE_EXPORT JSWindowProxy& createJSWindowProxyWithInitializedScript(DOMWrapperWorld&);
 
-    WeakPtr<AbstractFrame> m_frame;
+    WeakPtr<Frame> m_frame;
     UniqueRef<ProxyMap> m_jsWindowProxies;
 };
 

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
@@ -82,7 +82,7 @@ void DeviceOrientationAndMotionAccessController::shouldAllowAccess(const Documen
         if (permissionState != DeviceOrientationOrMotionPermissionState::Granted)
             return;
 
-        for (AbstractFrame* frame = m_topDocument.frame(); frame && frame->window(); frame = frame->tree().traverseNext()) {
+        for (Frame* frame = m_topDocument.frame(); frame && frame->window(); frame = frame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -466,7 +466,7 @@ static bool canAccessAncestor(const SecurityOrigin& activeSecurityOrigin, LocalF
         return false;
 
     const bool isLocalActiveOrigin = activeSecurityOrigin.isLocal();
-    for (RefPtr<AbstractFrame> ancestorFrame = targetFrame; ancestorFrame; ancestorFrame = ancestorFrame->tree().parent()) {
+    for (RefPtr<Frame> ancestorFrame = targetFrame; ancestorFrame; ancestorFrame = ancestorFrame->tree().parent()) {
         RefPtr localAncestor = dynamicDowncast<LocalFrame>(ancestorFrame.get());
         if (!localAncestor)
             continue;
@@ -6220,7 +6220,7 @@ void Document::setTransformSource(std::unique_ptr<TransformSource> source)
 void Document::setDesignMode(InheritedBool value)
 {
     m_designMode = value;
-    for (RefPtr<AbstractFrame> frame = m_frame.get(); frame; frame = frame->tree().traverseNext(m_frame.get())) {
+    for (RefPtr<Frame> frame = m_frame.get(); frame; frame = frame->tree().traverseNext(m_frame.get())) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame || !localFrame->document())
             continue;

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -231,7 +231,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
 
         // A descendant browsing context's document has a non-empty fullscreen element stack.
         bool descendentHasNonEmptyStack = false;
-        for (AbstractFrame* descendant = frame() ? frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
+        for (auto* descendant = frame() ? frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(descendant);
             if (!localFrame)
                 continue;
@@ -415,7 +415,7 @@ void FullscreenManager::finishExitFullscreen(Document& currentDocument, ExitMode
 
     // Let descendantDocs be an ordered set consisting of doc’s descendant browsing contexts' active documents whose fullscreen element is non-null, if any, in tree order.
     Deque<Ref<Document>> descendantDocuments;
-    for (AbstractFrame* descendant = currentDocument.frame() ? currentDocument.frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
+    for (auto* descendant = currentDocument.frame() ? currentDocument.frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(descendant);
         if (!localFrame || !localFrame->document())
             continue;

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -473,7 +473,7 @@ Element* TreeScope::findAnchor(StringView name)
     return nullptr;
 }
 
-static Element* focusedFrameOwnerElement(AbstractFrame* focusedFrame, LocalFrame* currentFrame)
+static Element* focusedFrameOwnerElement(Frame* focusedFrame, LocalFrame* currentFrame)
 {
     for (; focusedFrame; focusedFrame = focusedFrame->tree().parent()) {
         if (focusedFrame->tree().parent() == currentFrame)

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -69,7 +69,7 @@ UserGestureToken::UserGestureToken(ProcessingUserGestureState state, UserGesture
     }
 
     auto& documentOrigin = document->securityOrigin();
-    for (AbstractFrame* frame = &documentFrame->tree().top(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &documentFrame->tree().top(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -116,7 +116,7 @@ UserGestureIndicator::UserGestureIndicator(std::optional<ProcessingUserGestureSt
         document->topDocument().setUserDidInteractWithPage(true);
         if (auto* frame = document->frame()) {
             if (!frame->hasHadUserInteraction()) {
-                for (AbstractFrame *ancestor = frame; ancestor; ancestor = ancestor->tree().parent()) {
+                for (Frame *ancestor = frame; ancestor; ancestor = ancestor->tree().parent()) {
                     auto* localAncestor = dynamicDowncast<LocalFrame>(ancestor);
                     if (!localAncestor)
                         continue;

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -54,7 +54,7 @@ RenderWidget* HTMLFrameOwnerElement::renderWidget() const
     return downcast<RenderWidget>(renderer());
 }
 
-void HTMLFrameOwnerElement::setContentFrame(AbstractFrame& frame)
+void HTMLFrameOwnerElement::setContentFrame(Frame& frame)
 {
     // Make sure we will not end up with two frames referencing the same owner element.
     ASSERT(!m_contentFrame || m_contentFrame->ownerElement() != this);
@@ -136,7 +136,7 @@ bool HTMLFrameOwnerElement::isProhibitedSelfReference(const URL& completeURL) co
 {
     // We allow one level of self-reference because some websites depend on that, but we don't allow more than one.
     bool foundOneSelfReference = false;
-    for (AbstractFrame* frame = document().frame(); frame; frame = frame->tree().parent()) {
+    for (Frame* frame = document().frame(); frame; frame = frame->tree().parent()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "AbstractFrame.h"
+#include "Frame.h"
 #include "HTMLElement.h"
 #include "ReferrerPolicy.h"
 #include "SecurityContext.h"
@@ -37,11 +37,11 @@ class HTMLFrameOwnerElement : public HTMLElement {
 public:
     virtual ~HTMLFrameOwnerElement();
 
-    AbstractFrame* contentFrame() const { return m_contentFrame.get(); }
+    Frame* contentFrame() const { return m_contentFrame.get(); }
     WEBCORE_EXPORT WindowProxy* contentWindow() const;
     WEBCORE_EXPORT Document* contentDocument() const;
 
-    WEBCORE_EXPORT void setContentFrame(AbstractFrame&);
+    WEBCORE_EXPORT void setContentFrame(Frame&);
     void clearContentFrame();
 
     void disconnectContentFrame();
@@ -76,7 +76,7 @@ private:
     bool isKeyboardFocusable(KeyboardEvent*) const override;
     bool isFrameOwnerElement() const final { return true; }
 
-    WeakPtr<AbstractFrame> m_contentFrame;
+    WeakPtr<Frame> m_contentFrame;
     SandboxFlags m_sandboxFlags { SandboxNone };
 };
 
@@ -107,7 +107,7 @@ private:
     ContainerNode* m_root;
 };
 
-inline HTMLFrameOwnerElement* AbstractFrame::ownerElement() const
+inline HTMLFrameOwnerElement* Frame::ownerElement() const
 {
     return m_ownerElement.get();
 }

--- a/Source/WebCore/inspector/PageDebugger.cpp
+++ b/Source/WebCore/inspector/PageDebugger.cpp
@@ -148,7 +148,7 @@ void PageDebugger::reportException(JSGlobalObject* state, JSC::Exception* except
 void PageDebugger::setJavaScriptPaused(const PageGroup& pageGroup, bool paused)
 {
     for (auto& page : pageGroup.pages()) {
-        for (AbstractFrame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        for (Frame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -351,7 +351,7 @@ void InspectorDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReaso
 Vector<Document*> InspectorDOMAgent::documents()
 {
     Vector<Document*> result;
-    for (AbstractFrame* frame = m_document->frame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = m_document->frame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -307,7 +307,7 @@ Protocol::Page::ResourceType InspectorPageAgent::cachedResourceTypeJSON(const Ca
 
 LocalFrame* InspectorPageAgent::findFrameWithSecurityOrigin(Page& page, const String& originRawString)
 {
-    for (AbstractFrame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -619,7 +619,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Page::Cookie>>> InspectorPag
 {
     ListHashSet<Cookie> allRawCookies;
 
-    for (AbstractFrame* frame = &m_inspectedPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_inspectedPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -730,7 +730,7 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::setCookie(Ref<JSON::Object>&& 
     if (!cookie)
         return makeUnexpected(errorString);
 
-    for (AbstractFrame* frame = &m_inspectedPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_inspectedPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -749,7 +749,7 @@ Protocol::ErrorStringOr<void> InspectorPageAgent::setCookie(Ref<JSON::Object>&& 
 Protocol::ErrorStringOr<void> InspectorPageAgent::deleteCookie(const String& cookieName, const String& url)
 {
     URL parsedURL({ }, url);
-    for (AbstractFrame* frame = &m_inspectedPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_inspectedPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -854,7 +854,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Page::SearchResult>>> Inspec
     auto searchStringType = (isRegex && *isRegex) ? ContentSearchUtilities::SearchStringType::Regex : ContentSearchUtilities::SearchStringType::ContainsString;
     auto regex = ContentSearchUtilities::createRegularExpressionForSearchString(text, caseSensitive && *caseSensitive, searchStringType);
 
-    for (AbstractFrame* frame = &m_inspectedPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_inspectedPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -1142,7 +1142,7 @@ Ref<Protocol::Page::FrameResourceTree> InspectorPageAgent::buildObjectForFrameTr
     }
 
     RefPtr<JSON::ArrayOf<Protocol::Page::FrameResourceTree>> childrenArray;
-    for (AbstractFrame* child = frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
+    for (Frame* child = frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
         if (!childrenArray) {
             childrenArray = JSON::ArrayOf<Protocol::Page::FrameResourceTree>::create();
             result->setChildFrames(*childrenArray);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -877,7 +877,7 @@ bool FrameLoader::allChildrenAreComplete() const
 
 bool FrameLoader::allAncestorsAreComplete() const
 {
-    for (AbstractFrame* ancestor = &m_frame; ancestor; ancestor = ancestor->tree().parent()) {
+    for (Frame* ancestor = &m_frame; ancestor; ancestor = ancestor->tree().parent()) {
         auto* localAncestor = dynamicDowncast<LocalFrame>(ancestor);
         if (!localAncestor)
             continue;
@@ -1058,7 +1058,7 @@ String FrameLoader::outgoingReferrer() const
 {
     // See http://www.whatwg.org/specs/web-apps/current-work/#fetching-resources
     // for why we walk the parent chain for srcdoc documents.
-    AbstractFrame* frame = &m_frame;
+    Frame* frame = &m_frame;
     while (frame && is<LocalFrame>(frame) && downcast<LocalFrame>(frame)->document()->isSrcdocDocument()) {
         frame = frame->tree().parent();
         // Srcdoc documents cannot be top-level documents, by definition,
@@ -1135,7 +1135,7 @@ void FrameLoader::updateFirstPartyForCookies()
 
 void FrameLoader::setFirstPartyForCookies(const URL& url)
 {
-    for (AbstractFrame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
+    for (Frame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -1143,7 +1143,7 @@ void FrameLoader::setFirstPartyForCookies(const URL& url)
     }
 
     RegistrableDomain registrableDomain(url);
-    for (AbstractFrame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
+    for (Frame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -1248,7 +1248,7 @@ void FrameLoader::completed()
 {
     Ref protectedFrame { m_frame };
 
-    for (AbstractFrame* descendant = m_frame.tree().traverseNext(&m_frame); descendant; descendant = descendant->tree().traverseNext(&m_frame)) {
+    for (auto* descendant = m_frame.tree().traverseNext(&m_frame); descendant; descendant = descendant->tree().traverseNext(&m_frame)) {
         auto* localDescendant = dynamicDowncast<LocalFrame>(descendant);
         if (!localDescendant)
             continue;
@@ -1266,7 +1266,7 @@ void FrameLoader::completed()
 
 void FrameLoader::started()
 {
-    for (AbstractFrame* frame = &m_frame; frame; frame = frame->tree().parent()) {
+    for (Frame* frame = &m_frame; frame; frame = frame->tree().parent()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -1893,7 +1893,7 @@ void FrameLoader::stopAllLoaders(ClearProvisionalItem clearProvisionalItem, Stop
     if (clearProvisionalItem == ClearProvisionalItem::Yes)
         history().setProvisionalItem(nullptr);
 
-    for (RefPtr<AbstractFrame> child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+    for (RefPtr child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
         RefPtr localChild = dynamicDowncast<LocalFrame>(child.get());
         if (!localChild)
             continue;
@@ -1931,7 +1931,7 @@ void FrameLoader::stopForBackForwardCache()
     if (m_documentLoader)
         m_documentLoader->stopLoading();
 
-    for (RefPtr<AbstractFrame> child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+    for (RefPtr child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
         RefPtr localChild = dynamicDowncast<LocalFrame>(child.get());
         if (!localChild)
             continue;
@@ -2178,7 +2178,7 @@ void FrameLoader::commitProvisionalLoad()
 
         Vector<Ref<LocalFrame>> targetFrames;
         targetFrames.append(m_frame);
-        for (AbstractFrame* child = m_frame.tree().firstChild(); child; child = child->tree().traverseNext(&m_frame)) {
+        for (auto* child = m_frame.tree().firstChild(); child; child = child->tree().traverseNext(&m_frame)) {
             auto* localChild = dynamicDowncast<LocalFrame>(child);
             if (!localChild)
                 continue;
@@ -2880,7 +2880,7 @@ void FrameLoader::checkLoadComplete()
     // FIXME: Always traversing the entire frame tree is a bit inefficient, but 
     // is currently needed in order to null out the previous history item for all frames.
     Vector<Ref<LocalFrame>, 16> frames;
-    for (AbstractFrame* frame = &m_frame.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (auto* frame = &m_frame.mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -2900,7 +2900,7 @@ int FrameLoader::numPendingOrLoadingRequests(bool recurse) const
         return m_frame.document()->cachedResourceLoader().requestCount();
 
     int count = 0;
-    for (AbstractFrame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
+    for (Frame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -3441,7 +3441,7 @@ bool FrameLoader::shouldClose()
     // Store all references to each subframe in advance since beforeunload's event handler may modify frame
     Vector<Ref<LocalFrame>, 16> targetFrames;
     targetFrames.append(m_frame);
-    for (AbstractFrame* child = m_frame.tree().firstChild(); child; child = child->tree().traverseNext(&m_frame)) {
+    for (auto* child = m_frame.tree().firstChild(); child; child = child->tree().traverseNext(&m_frame)) {
         auto* localChild = dynamicDowncast<LocalFrame>(child);
         if (!localChild)
             continue;

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -54,7 +54,6 @@
 
 namespace WebCore {
 
-class AbstractFrame;
 class Archive;
 class CachedFrameBase;
 class CachedPage;
@@ -65,6 +64,7 @@ class DOMWrapperWorld;
 class Document;
 class DocumentLoader;
 class Event;
+class Frame;
 class FormState;
 class FormSubmission;
 class FrameLoadRequest;

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -220,7 +220,7 @@ void FrameLoader::HistoryController::saveDocumentState()
 // history item.
 void FrameLoader::HistoryController::saveDocumentAndScrollState()
 {
-    for (AbstractFrame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
+    for (Frame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/AbstractDOMWindow.h
+++ b/Source/WebCore/page/AbstractDOMWindow.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class AbstractFrame;
+class Frame;
 
 // FIXME: Rename DOMWindow to LocalWindow and AbstractDOMWindow to DOMWindow.
 class AbstractDOMWindow : public RefCounted<AbstractDOMWindow>, public EventTarget {
@@ -44,7 +44,7 @@ public:
 
     const GlobalWindowIdentifier& identifier() const { return m_identifier; }
 
-    virtual AbstractFrame* frame() const = 0;
+    virtual Frame* frame() const = 0;
 
     virtual bool isLocalDOMWindow() const = 0;
     virtual bool isRemoteDOMWindow() const = 0;

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -56,6 +56,7 @@
 #include "HTMLImageElement.h"
 #include "HTMLTableElement.h"
 #include "HitTestResult.h"
+#include "ImageBuffer.h"
 #include "ImageOverlay.h"
 #include "InspectorController.h"
 #include "LocalFrame.h"

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1585,7 +1585,7 @@ bool DOMWindow::consumeTransientActivation()
     if (!hasTransientActivation())
         return false;
 
-    for (RefPtr<AbstractFrame> frame = this->frame() ? &this->frame()->tree().top() : nullptr; frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr<Frame> frame = this->frame() ? &this->frame()->tree().top() : nullptr; frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame)
             continue;
@@ -1616,7 +1616,7 @@ void DOMWindow::notifyActivated(MonotonicTime activationTime)
     if (!securityOrigin)
         return;
 
-    RefPtr<AbstractFrame> descendant = frame();
+    RefPtr<Frame> descendant = frame();
     while ((descendant = descendant->tree().traverseNext(frame()))) {
         auto* localDescendant = dynamicDowncast<LocalFrame>(descendant.get());
         if (!localDescendant)

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -114,7 +114,7 @@ bool MouseWheelRegionOverlay::updateRegion()
 #else
     auto region = makeUnique<Region>();
     
-    for (const AbstractFrame* frame = &m_page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (auto* frame = &m_page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -365,7 +365,7 @@ void FocusController::setFocusedFrame(LocalFrame* frame)
         oldFrame->selection().setFocused(false);
         oldFrame->document()->dispatchWindowEvent(Event::create(eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No));
 #if ENABLE(SERVICE_WORKER)
-        AbstractFrame* frame = oldFrame.get();
+        Frame* frame = oldFrame.get();
         do {
             if (auto* localFrame = dynamicDowncast<LocalFrame>(frame))
                 localFrame->document()->updateServiceWorkerClientData();
@@ -378,7 +378,7 @@ void FocusController::setFocusedFrame(LocalFrame* frame)
         newFrame->selection().setFocused(true);
         newFrame->document()->dispatchWindowEvent(Event::create(eventNames().focusEvent, Event::CanBubble::No, Event::IsCancelable::No));
 #if ENABLE(SERVICE_WORKER)
-        AbstractFrame* frame = newFrame.get();
+        Frame* frame = newFrame.get();
         do {
             if (auto* localFrame = dynamicDowncast<LocalFrame>(frame))
                 localFrame->document()->updateServiceWorkerClientData();
@@ -973,7 +973,7 @@ void FocusController::setIsVisibleAndActiveInternal(bool contentIsVisible)
 
     contentAreaDidShowOrHide(view, contentIsVisible);
 
-    for (AbstractFrame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "config.h"
-#include "AbstractFrame.h"
+#include "Frame.h"
 
 #include "DocumentInlines.h"
 #include "HTMLFrameOwnerElement.h"
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrameOwnerElement* ownerElement, AbstractFrame* parent)
+Frame::Frame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrameOwnerElement* ownerElement, Frame* parent)
     : m_page(page)
     , m_frameID(frameID)
     , m_treeNode(*this, parent)
@@ -48,30 +48,30 @@ AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, FrameType fram
         parent->tree().appendChild(*this);
 }
 
-AbstractFrame::~AbstractFrame()
+Frame::~Frame()
 {
     m_windowProxy->detachFromFrame();
 }
 
-void AbstractFrame::resetWindowProxy()
+void Frame::resetWindowProxy()
 {
     m_windowProxy->detachFromFrame();
     m_windowProxy = WindowProxy::create(*this);
 }
 
-void AbstractFrame::detachFromPage()
+void Frame::detachFromPage()
 {
     m_page = nullptr;
 }
 
-void AbstractFrame::disconnectOwnerElement()
+void Frame::disconnectOwnerElement()
 {
     if (m_ownerElement) {
         m_ownerElement->clearContentFrame();
         m_ownerElement = nullptr;
     }
 
-    // FIXME: This is a layering violation. Move this code so AbstractFrame doesn't do anything with its Document.
+    // FIXME: This is a layering violation. Move this code so Frame doesn't do anything with its Document.
     if (auto* document = is<LocalFrame>(*this) ? downcast<LocalFrame>(*this).document() : nullptr)
         document->frameWasDisconnectedFromOwner();
 }

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -41,10 +41,9 @@ class Settings;
 class WeakPtrImplWithEventTargetData;
 class WindowProxy;
 
-// FIXME: Rename Frame to LocalFrame and AbstractFrame to Frame.
-class AbstractFrame : public ThreadSafeRefCounted<AbstractFrame, WTF::DestructionThread::Main>, public CanMakeWeakPtr<AbstractFrame> {
+class Frame : public ThreadSafeRefCounted<Frame, WTF::DestructionThread::Main>, public CanMakeWeakPtr<Frame> {
 public:
-    virtual ~AbstractFrame();
+    virtual ~Frame();
 
     enum class FrameType : bool { Local, Remote };
     FrameType frameType() const { return m_frameType; }
@@ -56,7 +55,7 @@ public:
     FrameIdentifier frameID() const { return m_frameID; }
     inline Page* page() const; // Defined in Page.h.
     Settings& settings() const { return m_settings.get(); }
-    AbstractFrame& mainFrame() const { return m_mainFrame; }
+    Frame& mainFrame() const { return m_mainFrame; }
     bool isMainFrame() const { return this == &m_mainFrame; }
 
     WEBCORE_EXPORT void detachFromPage();
@@ -67,7 +66,7 @@ public:
     virtual bool preventsParentFromBeingComplete() const = 0;
 
 protected:
-    AbstractFrame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, AbstractFrame* parent);
+    Frame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, Frame* parent);
     void resetWindowProxy();
 
 private:
@@ -79,7 +78,7 @@ private:
     mutable FrameTree m_treeNode;
     Ref<WindowProxy> m_windowProxy;
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
-    AbstractFrame& m_mainFrame;
+    Frame& m_mainFrame;
     const Ref<Settings> m_settings;
     FrameType m_frameType;
 };

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-FrameTree::FrameTree(AbstractFrame& thisFrame, AbstractFrame* parentFrame)
+FrameTree::FrameTree(Frame& thisFrame, Frame* parentFrame)
     : m_thisFrame(static_cast<LocalFrame&>(thisFrame))
     , m_parent(parentFrame)
 {
@@ -67,16 +67,16 @@ void FrameTree::clearName()
     m_uniqueName = nullAtom();
 }
 
-AbstractFrame* FrameTree::parent() const
+Frame* FrameTree::parent() const
 {
     return m_parent.get();
 }
 
-void FrameTree::appendChild(AbstractFrame& child)
+void FrameTree::appendChild(Frame& child)
 {
     ASSERT(child.page() == m_thisFrame.page());
     child.tree().m_parent = m_thisFrame;
-    WeakPtr<AbstractFrame> oldLast = m_lastChild;
+    WeakPtr<Frame> oldLast = m_lastChild;
     m_lastChild = child;
 
     if (oldLast) {
@@ -90,10 +90,10 @@ void FrameTree::appendChild(AbstractFrame& child)
     ASSERT(!m_lastChild->tree().m_nextSibling);
 }
 
-void FrameTree::removeChild(AbstractFrame& child)
+void FrameTree::removeChild(Frame& child)
 {
-    WeakPtr<AbstractFrame>& newLocationForPrevious = m_lastChild == &child ? m_lastChild : child.tree().m_nextSibling->tree().m_previousSibling;
-    RefPtr<AbstractFrame>& newLocationForNext = m_firstChild == &child ? m_firstChild : child.tree().m_previousSibling->tree().m_nextSibling;
+    WeakPtr<Frame>& newLocationForPrevious = m_lastChild == &child ? m_lastChild : child.tree().m_nextSibling->tree().m_previousSibling;
+    RefPtr<Frame>& newLocationForNext = m_firstChild == &child ? m_firstChild : child.tree().m_previousSibling->tree().m_nextSibling;
 
     child.tree().m_parent = nullptr;
     newLocationForPrevious = std::exchange(child.tree().m_previousSibling, nullptr);
@@ -122,7 +122,7 @@ AtomString FrameTree::generateUniqueName() const
     return makeAtomString("<!--frame", ++m_frameIDGenerator, "-->");
 }
 
-static bool inScope(AbstractFrame& frame, TreeScope& scope)
+static bool inScope(Frame& frame, TreeScope& scope)
 {
     auto* localFrame = dynamicDowncast<LocalFrame>(frame);
     if (!localFrame)
@@ -136,7 +136,7 @@ static bool inScope(AbstractFrame& frame, TreeScope& scope)
     return &owner->treeScope() == &scope;
 }
 
-AbstractFrame* FrameTree::scopedChild(unsigned index, TreeScope* scope) const
+Frame* FrameTree::scopedChild(unsigned index, TreeScope* scope) const
 {
     if (!scope)
         return nullptr;
@@ -153,7 +153,7 @@ AbstractFrame* FrameTree::scopedChild(unsigned index, TreeScope* scope) const
     return nullptr;
 }
 
-AbstractFrame* FrameTree::scopedChild(const AtomString& name, TreeScope* scope) const
+Frame* FrameTree::scopedChild(const AtomString& name, TreeScope* scope) const
 {
     if (!scope)
         return nullptr;
@@ -179,7 +179,7 @@ inline unsigned FrameTree::scopedChildCount(TreeScope* scope) const
     return scopedCount;
 }
 
-AbstractFrame* FrameTree::scopedChild(unsigned index) const
+Frame* FrameTree::scopedChild(unsigned index) const
 {
     auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame);
     if (!localFrame)
@@ -187,7 +187,7 @@ AbstractFrame* FrameTree::scopedChild(unsigned index) const
     return scopedChild(index, localFrame->document());
 }
 
-AbstractFrame* FrameTree::scopedChild(const AtomString& name) const
+Frame* FrameTree::scopedChild(const AtomString& name) const
 {
     auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame);
     if (!localFrame)
@@ -220,7 +220,7 @@ unsigned FrameTree::descendantCount() const
     return count;
 }
 
-AbstractFrame* FrameTree::child(unsigned index) const
+Frame* FrameTree::child(unsigned index) const
 {
     auto* result = firstChild();
     for (unsigned i = 0; result && i != index; ++i)
@@ -228,7 +228,7 @@ AbstractFrame* FrameTree::child(unsigned index) const
     return result;
 }
 
-AbstractFrame* FrameTree::child(const AtomString& name) const
+Frame* FrameTree::child(const AtomString& name) const
 {
     for (auto* child = firstChild(); child; child = child->tree().nextSibling()) {
         if (child->tree().uniqueName() == name)
@@ -239,7 +239,7 @@ AbstractFrame* FrameTree::child(const AtomString& name) const
 
 // FrameTree::find() only returns frames in pages that are related to the active
 // page by an opener <-> openee relationship.
-static bool isFrameFamiliarWith(AbstractFrame& abstractFrameA, AbstractFrame& abstractFrameB)
+static bool isFrameFamiliarWith(Frame& abstractFrameA, Frame& abstractFrameB)
 {
     if (abstractFrameA.page() == abstractFrameB.page())
         return true;
@@ -259,7 +259,7 @@ static bool isFrameFamiliarWith(AbstractFrame& abstractFrameA, AbstractFrame& ab
     return (frameAOpener && frameAOpener->page() == frameB->page()) || (frameBOpener && frameBOpener->page() == frameA->page()) || (frameAOpener && frameBOpener && frameAOpener->page() == frameBOpener->page());
 }
 
-AbstractFrame* FrameTree::find(const AtomString& name, AbstractFrame& activeFrame) const
+Frame* FrameTree::find(const AtomString& name, Frame& activeFrame) const
 {
     if (isSelfTargetFrameName(name))
         return &m_thisFrame;
@@ -282,7 +282,7 @@ AbstractFrame* FrameTree::find(const AtomString& name, AbstractFrame& activeFram
 
     // Then the rest of the tree.
     auto* localFrame = dynamicDowncast<LocalFrame>(m_thisFrame);
-    for (AbstractFrame* frame = localFrame ? dynamicDowncast<LocalFrame>(localFrame->mainFrame()) : nullptr; frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = localFrame ? dynamicDowncast<LocalFrame>(localFrame->mainFrame()) : nullptr; frame; frame = frame->tree().traverseNext()) {
         if (frame->tree().uniqueName() == name)
             return frame;
     }
@@ -296,7 +296,7 @@ AbstractFrame* FrameTree::find(const AtomString& name, AbstractFrame& activeFram
     for (auto& otherPage : page->group().pages()) {
         if (&otherPage == page || otherPage.isClosing())
             continue;
-        for (AbstractFrame* frame = &otherPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        for (Frame* frame = &otherPage.mainFrame(); frame; frame = frame->tree().traverseNext()) {
             if (frame->tree().uniqueName() == name && isFrameFamiliarWith(activeFrame, *frame))
                 return frame;
         }
@@ -305,7 +305,7 @@ AbstractFrame* FrameTree::find(const AtomString& name, AbstractFrame& activeFram
     return nullptr;
 }
 
-bool FrameTree::isDescendantOf(const AbstractFrame* ancestor) const
+bool FrameTree::isDescendantOf(const Frame* ancestor) const
 {
     if (!ancestor)
         return false;
@@ -313,14 +313,14 @@ bool FrameTree::isDescendantOf(const AbstractFrame* ancestor) const
     if (m_thisFrame.page() != ancestor->page())
         return false;
 
-    for (AbstractFrame* frame = &m_thisFrame; frame; frame = frame->tree().parent()) {
+    for (Frame* frame = &m_thisFrame; frame; frame = frame->tree().parent()) {
         if (frame == ancestor)
             return true;
     }
     return false;
 }
 
-AbstractFrame* FrameTree::traverseNext(const AbstractFrame* stayWithin) const
+Frame* FrameTree::traverseNext(const Frame* stayWithin) const
 {
     auto* child = firstChild();
     if (child) {
@@ -353,7 +353,7 @@ AbstractFrame* FrameTree::traverseNext(const AbstractFrame* stayWithin) const
     return nullptr;
 }
 
-AbstractFrame* FrameTree::traverseNextSkippingChildren(const AbstractFrame* stayWithin) const
+Frame* FrameTree::traverseNextSkippingChildren(const Frame* stayWithin) const
 {
     if (&m_thisFrame == stayWithin)
         return nullptr;
@@ -362,7 +362,7 @@ AbstractFrame* FrameTree::traverseNextSkippingChildren(const AbstractFrame* stay
     return nextAncestorSibling(stayWithin);
 }
 
-AbstractFrame* FrameTree::nextAncestorSibling(const AbstractFrame* stayWithin) const
+Frame* FrameTree::nextAncestorSibling(const Frame* stayWithin) const
 {
     ASSERT(!nextSibling());
     ASSERT(&m_thisFrame != stayWithin);
@@ -375,7 +375,7 @@ AbstractFrame* FrameTree::nextAncestorSibling(const AbstractFrame* stayWithin) c
     return nullptr;
 }
 
-AbstractFrame* FrameTree::firstRenderedChild() const
+Frame* FrameTree::firstRenderedChild() const
 {
     auto* child = firstChild();
     if (!child)
@@ -399,7 +399,7 @@ AbstractFrame* FrameTree::firstRenderedChild() const
     return nullptr;
 }
 
-AbstractFrame* FrameTree::nextRenderedSibling() const
+Frame* FrameTree::nextRenderedSibling() const
 {
     auto* sibling = &m_thisFrame;
 
@@ -412,7 +412,7 @@ AbstractFrame* FrameTree::nextRenderedSibling() const
     return nullptr;
 }
 
-AbstractFrame* FrameTree::traverseNextRendered(const AbstractFrame* stayWithin) const
+Frame* FrameTree::traverseNextRendered(const Frame* stayWithin) const
 {
     auto* child = firstRenderedChild();
     if (child) {
@@ -445,7 +445,7 @@ AbstractFrame* FrameTree::traverseNextRendered(const AbstractFrame* stayWithin) 
     return nullptr;
 }
 
-AbstractFrame* FrameTree::traverseNext(CanWrap canWrap, DidWrap* didWrap) const
+Frame* FrameTree::traverseNext(CanWrap canWrap, DidWrap* didWrap) const
 {
     if (auto* result = traverseNext())
         return result;
@@ -462,7 +462,7 @@ AbstractFrame* FrameTree::traverseNext(CanWrap canWrap, DidWrap* didWrap) const
     return nullptr;
 }
 
-AbstractFrame* FrameTree::traversePrevious(CanWrap canWrap, DidWrap* didWrap) const
+Frame* FrameTree::traversePrevious(CanWrap canWrap, DidWrap* didWrap) const
 {
     // FIXME: besides the wrap feature, this is just the traversePreviousNode algorithm
 
@@ -482,7 +482,7 @@ AbstractFrame* FrameTree::traversePrevious(CanWrap canWrap, DidWrap* didWrap) co
     return nullptr;
 }
 
-AbstractFrame* FrameTree::traverseNextInPostOrder(CanWrap canWrap) const
+Frame* FrameTree::traverseNextInPostOrder(CanWrap canWrap) const
 {
     if (m_nextSibling)
         return m_nextSibling->tree().deepFirstChild();
@@ -493,7 +493,7 @@ AbstractFrame* FrameTree::traverseNextInPostOrder(CanWrap canWrap) const
     return nullptr;
 }
 
-AbstractFrame* FrameTree::deepFirstChild() const
+Frame* FrameTree::deepFirstChild() const
 {
     auto* result = &m_thisFrame;
     while (auto* next = result->tree().firstChild())
@@ -501,7 +501,7 @@ AbstractFrame* FrameTree::deepFirstChild() const
     return result;
 }
 
-AbstractFrame* FrameTree::deepLastChild() const
+Frame* FrameTree::deepLastChild() const
 {
     auto* result = &m_thisFrame;
     for (auto* last = lastChild(); last; last = last->tree().lastChild())
@@ -510,7 +510,7 @@ AbstractFrame* FrameTree::deepLastChild() const
     return result;
 }
 
-AbstractFrame& FrameTree::top() const
+Frame& FrameTree::top() const
 {
     auto* frame = &m_thisFrame;
     for (auto* parent = &m_thisFrame; parent; parent = parent->tree().parent())
@@ -568,7 +568,7 @@ static void printIndent(int indent)
         printf("    ");
 }
 
-static void printFrames(const WebCore::AbstractFrame& frame, const WebCore::AbstractFrame* targetFrame, int indent)
+static void printFrames(const WebCore::Frame& frame, const WebCore::Frame* targetFrame, int indent)
 {
     if (&frame == targetFrame) {
         printf("--> ");
@@ -601,7 +601,7 @@ static void printFrames(const WebCore::AbstractFrame& frame, const WebCore::Abst
         printFrames(*child, targetFrame, indent + 1);
 }
 
-void showFrameTree(const WebCore::AbstractFrame* frame)
+void showFrameTree(const WebCore::Frame* frame)
 {
     if (!frame) {
         printf("Null input frame\n");

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -28,7 +28,7 @@ namespace WebCore {
 enum class CanWrap : bool { No, Yes };
 enum class DidWrap : bool { No, Yes };
 
-class AbstractFrame;
+class Frame;
 class LocalFrame;
 class TreeScope;
 
@@ -37,7 +37,7 @@ class FrameTree {
 public:
     static constexpr unsigned invalidCount = static_cast<unsigned>(-1);
 
-    FrameTree(AbstractFrame& thisFrame, AbstractFrame* parentFrame);
+    FrameTree(Frame& thisFrame, Frame* parentFrame);
 
     ~FrameTree();
 
@@ -45,68 +45,68 @@ public:
     const AtomString& uniqueName() const { return m_uniqueName; }
     WEBCORE_EXPORT void setName(const AtomString&);
     WEBCORE_EXPORT void clearName();
-    WEBCORE_EXPORT AbstractFrame* parent() const;
+    WEBCORE_EXPORT Frame* parent() const;
 
-    AbstractFrame* nextSibling() const { return m_nextSibling.get(); }
-    AbstractFrame* previousSibling() const { return m_previousSibling.get(); }
-    AbstractFrame* firstChild() const { return m_firstChild.get(); }
-    AbstractFrame* lastChild() const { return m_lastChild.get(); }
+    Frame* nextSibling() const { return m_nextSibling.get(); }
+    Frame* previousSibling() const { return m_previousSibling.get(); }
+    Frame* firstChild() const { return m_firstChild.get(); }
+    Frame* lastChild() const { return m_lastChild.get(); }
 
-    AbstractFrame* firstRenderedChild() const;
-    AbstractFrame* nextRenderedSibling() const;
+    Frame* firstRenderedChild() const;
+    Frame* nextRenderedSibling() const;
 
-    WEBCORE_EXPORT bool isDescendantOf(const AbstractFrame* ancestor) const;
+    WEBCORE_EXPORT bool isDescendantOf(const Frame* ancestor) const;
     
-    WEBCORE_EXPORT AbstractFrame* traverseNext(const AbstractFrame* stayWithin = nullptr) const;
-    AbstractFrame* traverseNextSkippingChildren(const AbstractFrame* stayWithin = nullptr) const;
+    WEBCORE_EXPORT Frame* traverseNext(const Frame* stayWithin = nullptr) const;
+    Frame* traverseNextSkippingChildren(const Frame* stayWithin = nullptr) const;
     // Rendered means being the main frame or having an ownerRenderer. It may not have been parented in the Widget tree yet (see WidgetHierarchyUpdatesSuspensionScope).
-    WEBCORE_EXPORT AbstractFrame* traverseNextRendered(const AbstractFrame* stayWithin = nullptr) const;
-    WEBCORE_EXPORT AbstractFrame* traverseNext(CanWrap, DidWrap* = nullptr) const;
-    WEBCORE_EXPORT AbstractFrame* traversePrevious(CanWrap, DidWrap* = nullptr) const;
+    WEBCORE_EXPORT Frame* traverseNextRendered(const Frame* stayWithin = nullptr) const;
+    WEBCORE_EXPORT Frame* traverseNext(CanWrap, DidWrap* = nullptr) const;
+    WEBCORE_EXPORT Frame* traversePrevious(CanWrap, DidWrap* = nullptr) const;
 
-    AbstractFrame* traverseNextInPostOrder(CanWrap) const;
+    Frame* traverseNextInPostOrder(CanWrap) const;
 
-    WEBCORE_EXPORT void appendChild(AbstractFrame&);
+    WEBCORE_EXPORT void appendChild(Frame&);
     void detachFromParent() { m_parent = nullptr; }
-    WEBCORE_EXPORT void removeChild(AbstractFrame&);
+    WEBCORE_EXPORT void removeChild(Frame&);
 
-    AbstractFrame* child(unsigned index) const;
-    AbstractFrame* child(const AtomString& name) const;
-    WEBCORE_EXPORT AbstractFrame* find(const AtomString& name, AbstractFrame& activeFrame) const;
+    Frame* child(unsigned index) const;
+    Frame* child(const AtomString& name) const;
+    WEBCORE_EXPORT Frame* find(const AtomString& name, Frame& activeFrame) const;
     WEBCORE_EXPORT unsigned childCount() const;
     unsigned descendantCount() const;
-    WEBCORE_EXPORT AbstractFrame& top() const;
+    WEBCORE_EXPORT Frame& top() const;
     unsigned depth() const;
 
-    WEBCORE_EXPORT AbstractFrame* scopedChild(unsigned index) const;
-    WEBCORE_EXPORT AbstractFrame* scopedChild(const AtomString& name) const;
+    WEBCORE_EXPORT Frame* scopedChild(unsigned index) const;
+    WEBCORE_EXPORT Frame* scopedChild(const AtomString& name) const;
     unsigned scopedChildCount() const;
 
     void resetFrameIdentifiers() { m_frameIDGenerator = 0; }
 
 private:
-    AbstractFrame* deepFirstChild() const;
-    AbstractFrame* deepLastChild() const;
-    AbstractFrame* nextAncestorSibling(const AbstractFrame* stayWithin) const;
+    Frame* deepFirstChild() const;
+    Frame* deepLastChild() const;
+    Frame* nextAncestorSibling(const Frame* stayWithin) const;
 
     bool scopedBy(TreeScope*) const;
-    AbstractFrame* scopedChild(unsigned index, TreeScope*) const;
-    AbstractFrame* scopedChild(const AtomString& name, TreeScope*) const;
+    Frame* scopedChild(unsigned index, TreeScope*) const;
+    Frame* scopedChild(const AtomString& name, TreeScope*) const;
     unsigned scopedChildCount(TreeScope*) const;
 
     AtomString uniqueChildName(const AtomString& requestedName) const;
     AtomString generateUniqueName() const;
 
-    AbstractFrame& m_thisFrame;
+    Frame& m_thisFrame;
 
-    WeakPtr<AbstractFrame> m_parent;
+    WeakPtr<Frame> m_parent;
     AtomString m_name; // The actual frame name (may be empty).
     AtomString m_uniqueName;
 
-    RefPtr<AbstractFrame> m_nextSibling;
-    WeakPtr<AbstractFrame> m_previousSibling;
-    RefPtr<AbstractFrame> m_firstChild;
-    WeakPtr<AbstractFrame> m_lastChild;
+    RefPtr<Frame> m_nextSibling;
+    WeakPtr<Frame> m_previousSibling;
+    RefPtr<Frame> m_firstChild;
+    WeakPtr<Frame> m_lastChild;
     mutable unsigned m_scopedChildCount { invalidCount };
     mutable uint64_t m_frameIDGenerator { 0 };
 };
@@ -123,5 +123,5 @@ bool isTopTargetFrameName(StringView);
 
 #if ENABLE(TREE_DEBUGGING)
 // Outside the WebCore namespace for ease of invocation from the debugger.
-WEBCORE_EXPORT void showFrameTree(const WebCore::AbstractFrame*);
+WEBCORE_EXPORT void showFrameTree(const WebCore::Frame*);
 #endif

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -1211,7 +1211,7 @@ bool FrameView::flushCompositingStateIncludingSubframes()
 {
     bool allFramesFlushed = flushCompositingStateForThisFrame(m_frame.get());
 
-    for (AbstractFrame* child = m_frame->tree().firstRenderedChild(); child; child = child->tree().traverseNextRendered(m_frame.ptr())) {
+    for (Frame* child = m_frame->tree().firstRenderedChild(); child; child = child->tree().traverseNextRendered(m_frame.ptr())) {
         auto* localChild = dynamicDowncast<LocalFrame>(child);
         if (!localChild)
             continue;
@@ -1474,7 +1474,7 @@ bool FrameView::useSlowRepaintsIfNotOverlapped() const
 
 void FrameView::updateCanBlitOnScrollRecursively()
 {
-    for (AbstractFrame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
+    for (Frame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -2893,7 +2893,7 @@ void FrameView::applyRecursivelyWithVisibleRect(const Function<void(FrameView& f
 
     // Recursive call for subframes. We cache the current FrameView's windowClipRect to avoid recomputing it for every subframe.
     SetForScope windowClipRectCache(m_cachedWindowClipRect, &windowClipRect);
-    for (AbstractFrame* childFrame = m_frame->tree().firstChild(); childFrame; childFrame = childFrame->tree().nextSibling()) {
+    for (Frame* childFrame = m_frame->tree().firstChild(); childFrame; childFrame = childFrame->tree().nextSibling()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(childFrame);
         if (!localFrame)
             continue;
@@ -3480,7 +3480,7 @@ void FrameView::updateBackgroundRecursively(const std::optional<Color>& backgrou
 #endif
 #endif
 
-    for (AbstractFrame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
+    for (Frame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -4855,7 +4855,7 @@ void FrameView::paintContentsForSnapshot(GraphicsContext& context, const IntRect
     // in the render tree only. This will allow us to restore the selection from the DOM
     // after we paint the snapshot.
     if (shouldPaintSelection == ExcludeSelection) {
-        for (AbstractFrame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
+        for (Frame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;
@@ -4874,7 +4874,7 @@ void FrameView::paintContentsForSnapshot(GraphicsContext& context, const IntRect
 
     // Restore selection.
     if (shouldPaintSelection == ExcludeSelection) {
-        for (AbstractFrame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
+        for (Frame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;
@@ -5546,7 +5546,7 @@ void FrameView::setTracksRepaints(bool trackRepaints)
             m_frame->document()->updateLayout();
     }
 
-    for (AbstractFrame* frame = &m_frame->tree().top(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_frame->tree().top(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -5715,7 +5715,7 @@ bool FrameView::isFlippedDocument() const
 
 void FrameView::notifyWidgetsInAllFrames(WidgetNotification notification)
 {
-    for (AbstractFrame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
+    for (Frame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -5921,7 +5921,7 @@ ScrollBehaviorForFixedElements FrameView::scrollBehaviorForFixedElements() const
     return m_frame->settings().backgroundShouldExtendBeyondPage() ? StickToViewportBounds : StickToDocumentBounds;
 }
 
-AbstractFrame& FrameView::frame() const
+Frame& FrameView::frame() const
 {
     return m_frame;
 }

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -51,11 +51,11 @@ class TextStream;
 namespace WebCore {
 
 class AXObjectCache;
-class AbstractFrame;
 class ContainerNode;
 class Element;
 class EventRegionContext;
 class FloatSize;
+class Frame;
 class GraphicsContext;
 class HTMLFrameOwnerElement;
 class LocalFrame;
@@ -107,7 +107,7 @@ public:
     FrameViewType viewType() const final { return FrameViewType::Local; }
 
     // FIXME: This should return Frame. If it were a RemoteFrame, we would have a RemoteFrameView.
-    WEBCORE_EXPORT AbstractFrame& frame() const;
+    WEBCORE_EXPORT Frame& frame() const;
 
     WEBCORE_EXPORT RenderView* renderView() const;
 

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -149,8 +149,8 @@ static inline float parentTextZoomFactor(LocalFrame* frame)
     return parent->textZoomFactor();
 }
 
-LocalFrame::LocalFrame(Page& page, UniqueRef<FrameLoaderClient>&& frameLoaderClient, FrameIdentifier identifier, HTMLFrameOwnerElement* ownerElement, AbstractFrame* parent)
-    : AbstractFrame(page, identifier, FrameType::Local, ownerElement, parent)
+LocalFrame::LocalFrame(Page& page, UniqueRef<FrameLoaderClient>&& frameLoaderClient, FrameIdentifier identifier, HTMLFrameOwnerElement* ownerElement, Frame* parent)
+    : Frame(page, identifier, FrameType::Local, ownerElement, parent)
     , m_loader(makeUniqueRef<FrameLoader>(*this, WTFMove(frameLoaderClient)))
     , m_navigationScheduler(makeUniqueRef<NavigationScheduler>(*this))
     , m_script(makeUniqueRef<ScriptController>(*this))
@@ -191,7 +191,7 @@ Ref<LocalFrame> LocalFrame::createSubframe(Page& page, UniqueRef<FrameLoaderClie
     return adoptRef(*new LocalFrame(page, WTFMove(client), identifier, &ownerElement, ownerElement.document().frame()));
 }
 
-Ref<LocalFrame> LocalFrame::createSubframeHostedInAnotherProcess(Page& page, UniqueRef<FrameLoaderClient>&& client, FrameIdentifier identifier, AbstractFrame& parent)
+Ref<LocalFrame> LocalFrame::createSubframeHostedInAnotherProcess(Page& page, UniqueRef<FrameLoaderClient>&& client, FrameIdentifier identifier, Frame& parent)
 {
     return adoptRef(*new LocalFrame(page, WTFMove(client), identifier, nullptr, &parent));
 }

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -27,9 +27,9 @@
 
 #pragma once
 
-#include "AbstractFrame.h"
 #include "AdjustViewSizeOrNot.h"
 #include "Document.h"
+#include "Frame.h"
 #include "PageIdentifier.h"
 #include "ScrollTypes.h"
 #include "UserScriptTypes.h"
@@ -113,11 +113,11 @@ enum OverflowScrollAction { DoNotPerformOverflowScroll, PerformOverflowScroll };
 using NodeQualifier = Function<Node* (const HitTestResult&, Node* terminationNode, IntRect* nodeBounds)>;
 #endif
 
-class LocalFrame final : public AbstractFrame {
+class LocalFrame final : public Frame {
 public:
     WEBCORE_EXPORT static Ref<LocalFrame> createMainFrame(Page&, UniqueRef<FrameLoaderClient>&&, FrameIdentifier);
     WEBCORE_EXPORT static Ref<LocalFrame> createSubframe(Page&, UniqueRef<FrameLoaderClient>&&, FrameIdentifier, HTMLFrameOwnerElement&);
-    WEBCORE_EXPORT static Ref<LocalFrame> createSubframeHostedInAnotherProcess(Page&, UniqueRef<FrameLoaderClient>&&, FrameIdentifier, AbstractFrame& parent);
+    WEBCORE_EXPORT static Ref<LocalFrame> createSubframeHostedInAnotherProcess(Page&, UniqueRef<FrameLoaderClient>&&, FrameIdentifier, Frame& parent);
 
     WEBCORE_EXPORT void init();
 #if PLATFORM(IOS_FAMILY)
@@ -293,7 +293,7 @@ public:
 private:
     friend class NavigationDisabler;
 
-    LocalFrame(Page&, UniqueRef<FrameLoaderClient>&&, FrameIdentifier, HTMLFrameOwnerElement*, AbstractFrame* parent);
+    LocalFrame(Page&, UniqueRef<FrameLoaderClient>&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame* parent);
 
     void dropChildren();
 
@@ -373,5 +373,5 @@ WTF::TextStream& operator<<(WTF::TextStream&, const LocalFrame&);
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LocalFrame)
-static bool isType(const WebCore::AbstractFrame& frame) { return frame.frameType() == WebCore::AbstractFrame::FrameType::Local; }
+static bool isType(const WebCore::Frame& frame) { return frame.frameType() == WebCore::Frame::FrameType::Local; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -309,8 +309,8 @@ public:
 
     EditorClient& editorClient() { return m_editorClient.get(); }
 
-    AbstractFrame& mainFrame() { return m_mainFrame.get(); }
-    const AbstractFrame& mainFrame() const { return m_mainFrame.get(); }
+    Frame& mainFrame() { return m_mainFrame.get(); }
+    const Frame& mainFrame() const { return m_mainFrame.get(); }
 
     bool openedByDOM() const;
     WEBCORE_EXPORT void setOpenedByDOM();
@@ -1094,7 +1094,7 @@ private:
     const std::unique_ptr<ProgressTracker> m_progress;
 
     const std::unique_ptr<BackForwardController> m_backForwardController;
-    Ref<AbstractFrame> m_mainFrame;
+    Ref<Frame> m_mainFrame;
 
     RefPtr<PluginData> m_pluginData;
 
@@ -1395,7 +1395,7 @@ inline PageGroup& Page::group()
     return *m_group;
 }
 
-inline Page* AbstractFrame::page() const
+inline Page* Frame::page() const
 {
     return m_page.get();
 }

--- a/Source/WebCore/page/PageGroupLoadDeferrer.cpp
+++ b/Source/WebCore/page/PageGroupLoadDeferrer.cpp
@@ -44,7 +44,7 @@ PageGroupLoadDeferrer::PageGroupLoadDeferrer(Page& page, bool deferSelf)
 
         // This code is not logically part of load deferring, but we do not want JS code executed beneath modal
         // windows or sheets, which is exactly when PageGroupLoadDeferrer is used.
-        for (AbstractFrame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
+        for (Frame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;
@@ -66,7 +66,7 @@ PageGroupLoadDeferrer::~PageGroupLoadDeferrer()
             continue;
         page->setDefersLoading(false);
 
-        for (AbstractFrame* frame = &page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        for (Frame* frame = &page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -231,7 +231,7 @@ void PageSerializer::serializeFrame(LocalFrame* frame)
         }
     }
 
-    for (AbstractFrame* childFrame = frame->tree().firstChild(); childFrame; childFrame = childFrame->tree().nextSibling()) {
+    for (auto* childFrame = frame->tree().firstChild(); childFrame; childFrame = childFrame->tree().nextSibling()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(childFrame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -40,7 +40,7 @@ Ref<RemoteFrame> RemoteFrame::createMainFrame(Page& page, UniqueRef<RemoteFrameC
     return adoptRef(*new RemoteFrame(page, WTFMove(client), identifier, nullptr, nullptr, std::nullopt));
 }
 
-Ref<RemoteFrame> RemoteFrame::createSubframe(Page& page, UniqueRef<RemoteFrameClient>&& client, FrameIdentifier identifier, AbstractFrame& parent)
+Ref<RemoteFrame> RemoteFrame::createSubframe(Page& page, UniqueRef<RemoteFrameClient>&& client, FrameIdentifier identifier, Frame& parent)
 {
     return adoptRef(*new RemoteFrame(page, WTFMove(client), identifier, nullptr, &parent, std::nullopt));
 }
@@ -50,8 +50,8 @@ Ref<RemoteFrame> RemoteFrame::createSubframeWithContentsInAnotherProcess(Page& p
     return adoptRef(*new RemoteFrame(page, WTFMove(client), identifier, &ownerElement, ownerElement.document().frame(), layerHostingContextIdentifier));
 }
 
-RemoteFrame::RemoteFrame(Page& page, UniqueRef<RemoteFrameClient>&& client, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement, AbstractFrame* parent, Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier)
-    : AbstractFrame(page, frameID, FrameType::Remote, ownerElement, parent)
+RemoteFrame::RemoteFrame(Page& page, UniqueRef<RemoteFrameClient>&& client, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement, Frame* parent, Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier)
+    : Frame(page, frameID, FrameType::Remote, ownerElement, parent)
     , m_window(RemoteDOMWindow::create(*this, GlobalWindowIdentifier { Process::identifier(), WindowIdentifier::generate() }))
     , m_client(WTFMove(client))
     , m_layerHostingContextIdentifier(layerHostingContextIdentifier)

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "AbstractFrame.h"
+#include "Frame.h"
 #include "LayerHostingContextIdentifier.h"
 #include <wtf/RefPtr.h>
 #include <wtf/TypeCasts.h>
@@ -38,17 +38,17 @@ class RemoteFrameClient;
 class RemoteFrameView;
 class WeakPtrImplWithEventTargetData;
 
-class RemoteFrame final : public AbstractFrame {
+class RemoteFrame final : public Frame {
 public:
     WEBCORE_EXPORT static Ref<RemoteFrame> createMainFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier);
-    WEBCORE_EXPORT static Ref<RemoteFrame> createSubframe(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, AbstractFrame& parent);
+    WEBCORE_EXPORT static Ref<RemoteFrame> createSubframe(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, Frame& parent);
     WEBCORE_EXPORT static Ref<RemoteFrame> createSubframeWithContentsInAnotherProcess(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, HTMLFrameOwnerElement&, LayerHostingContextIdentifier);
     ~RemoteFrame();
 
     RemoteDOMWindow& window() const;
 
-    void setOpener(AbstractFrame* opener) { m_opener = opener; }
-    AbstractFrame* opener() const { return m_opener.get(); }
+    void setOpener(Frame* opener) { m_opener = opener; }
+    Frame* opener() const { return m_opener.get(); }
 
     WEBCORE_EXPORT void didFinishLoadInAnotherProcess();
 
@@ -61,7 +61,7 @@ public:
     Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
 
 private:
-    WEBCORE_EXPORT explicit RemoteFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, HTMLFrameOwnerElement*, AbstractFrame*, Markable<LayerHostingContextIdentifier>);
+    WEBCORE_EXPORT explicit RemoteFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame*, Markable<LayerHostingContextIdentifier>);
 
     void frameDetached() final;
     bool preventsParentFromBeingComplete() const final;
@@ -70,7 +70,7 @@ private:
     AbstractDOMWindow* virtualWindow() const final;
 
     Ref<RemoteDOMWindow> m_window;
-    RefPtr<AbstractFrame> m_opener;
+    RefPtr<Frame> m_opener;
     RefPtr<RemoteFrameView> m_view;
     UniqueRef<RemoteFrameClient> m_client;
     Markable<LayerHostingContextIdentifier> m_layerHostingContextIdentifier;
@@ -80,5 +80,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::RemoteFrame)
-static bool isType(const WebCore::AbstractFrame& frame) { return frame.frameType() == WebCore::AbstractFrame::FrameType::Remote; }
+static bool isType(const WebCore::Frame& frame) { return frame.frameType() == WebCore::Frame::FrameType::Remote; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -184,7 +184,7 @@ void SettingsBase::setMinimumDOMTimerInterval(Seconds interval)
     if (!m_page)
         return;
 
-    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -311,7 +311,7 @@ void SettingsBase::setNeedsRelayoutAllFrames()
     if (!m_page)
         return;
 
-    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -354,7 +354,7 @@ void SettingsBase::imageLoadingSettingsTimerFired()
     if (!m_page)
         return;
 
-    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -425,7 +425,7 @@ void SettingsBase::layerBasedSVGEngineEnabledChanged()
     if (!m_page)
         return;
 
-    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (auto* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -504,7 +504,7 @@ bool canScrollInDirection(const LocalFrame* frame, FocusDirection direction)
 static LayoutRect rectToAbsoluteCoordinates(LocalFrame* initialFrame, const LayoutRect& initialRect)
 {
     LayoutRect rect = initialRect;
-    for (AbstractFrame* frame = initialFrame; frame; frame = frame->tree().parent()) {
+    for (Frame* frame = initialFrame; frame; frame = frame->tree().parent()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -180,7 +180,7 @@ ContentChangeObserver::ContentChangeObserver(Document& document)
 
 static void willNotProceedWithClick(LocalFrame& mainFrame)
 {
-    for (AbstractFrame* frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/mac/PageMac.mm
+++ b/Source/WebCore/page/mac/PageMac.mm
@@ -95,7 +95,7 @@ void Page::addSchedulePair(Ref<SchedulePair>&& pair)
         m_scheduledRunLoopPairs = makeUnique<SchedulePairHashSet>();
     m_scheduledRunLoopPairs->add(pair.ptr());
 
-    for (AbstractFrame* frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -116,7 +116,7 @@ void Page::removeSchedulePair(Ref<SchedulePair>&& pair)
 
     m_scheduledRunLoopPairs->remove(pair.ptr());
 
-    for (AbstractFrame* frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -337,7 +337,7 @@ void ServicesOverlayController::removeAllPotentialHighlightsOfType(DataDetectorH
 void ServicesOverlayController::buildPhoneNumberHighlights()
 {
     Vector<SimpleRange> phoneNumberRanges;
-    for (AbstractFrame* frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -451,7 +451,7 @@ FrameView* AsyncScrollingCoordinator::frameViewForScrollingNode(ScrollingNodeID 
 
     // Walk the frame tree to find the matching FrameView. This is not ideal, but avoids back pointers to FrameViews
     // from ScrollingTreeStateNodes.
-    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (auto* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -350,7 +350,7 @@ void ScrollingCoordinator::updateSynchronousScrollingReasons(FrameView& frameVie
 
 void ScrollingCoordinator::updateSynchronousScrollingReasonsForAllFrames()
 {
-    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/plugins/PluginInfoProvider.cpp
+++ b/Source/WebCore/plugins/PluginInfoProvider.cpp
@@ -56,7 +56,7 @@ void PluginInfoProvider::refresh(bool reloadPages)
         if (!reloadPages)
             continue;
 
-        for (AbstractFrame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        for (Frame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -653,7 +653,7 @@ void RenderLayerCompositor::updateScrollCoordinatedLayersAfterFlushIncludingSubf
     updateScrollCoordinatedLayersAfterFlush();
 
     auto& frame = m_renderView.frameView().frame();
-    for (AbstractFrame* subframe = frame.tree().firstChild(); subframe; subframe = subframe->tree().traverseNext(&frame)) {
+    for (auto* subframe = frame.tree().firstChild(); subframe; subframe = subframe->tree().traverseNext(&frame)) {
         auto* localFrame = dynamicDowncast<LocalFrame>(subframe);
         if (!localFrame)
             continue;
@@ -2573,7 +2573,7 @@ void RenderLayerCompositor::setIsInWindow(bool isInWindow)
 
 void RenderLayerCompositor::invalidateEventRegionForAllFrames()
 {
-    for (AbstractFrame* frame = &page().mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &page().mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -924,7 +924,7 @@ static void updateLayoutIgnoringPendingStylesheetsIncludingSubframes(Document& d
 {
     document.updateLayoutIgnorePendingStylesheets();
     auto* frame = document.frame();
-    for (AbstractFrame* subframe = frame; subframe; subframe = subframe->tree().traverseNext(frame)) {
+    for (Frame* subframe = frame; subframe; subframe = subframe->tree().traverseNext(frame)) {
         auto* localFrame = dynamicDowncast<LocalFrame>(subframe);
         if (!localFrame)
             continue;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1246,7 +1246,7 @@ ExceptionOr<void> Internals::suspendAnimations() const
         return Exception { InvalidAccessError };
 
     document->ensureTimelinesController().suspendAnimations();
-    for (AbstractFrame* frame = document->frame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = document->frame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -1264,7 +1264,7 @@ ExceptionOr<void> Internals::resumeAnimations() const
         return Exception { InvalidAccessError };
 
     document->ensureTimelinesController().resumeAnimations();
-    for (AbstractFrame* frame = document->frame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = document->frame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -2996,7 +2996,7 @@ unsigned Internals::numberOfScrollableAreas()
     if (frame->view()->scrollableAreas())
         count += frame->view()->scrollableAreas()->computeSize();
 
-    for (AbstractFrame* child = frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
+    for (Frame* child = frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
         auto* localChild = dynamicDowncast<LocalFrame>(child);
         if (!localChild)
             continue;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -341,7 +341,7 @@ InjectedBundle::DocumentIDToURLMap InjectedBundle::liveDocumentURLs(bool exclude
 
     if (excludeDocumentsInPageGroupPages) {
         Page::forEachPage([&](Page& page) {
-            for (AbstractFrame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+            for (auto* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
                 auto* localFrame = dynamicDowncast<LocalFrame>(frame);
                 if (!localFrame)
                     continue;

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -134,7 +134,7 @@ void WebUserContentController::addContentWorlds(const Vector<std::pair<ContentWo
                     return;
 
                 auto& mainFrame = page.mainFrame();
-                for (AbstractFrame* frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
+                for (auto* frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
                     auto* localFrame = dynamicDowncast<LocalFrame>(frame);
                     if (!localFrame)
                         continue;
@@ -440,7 +440,7 @@ void WebUserContentController::addUserScriptInternal(InjectedBundleScriptWorld& 
                 return;
             }
 
-            for (AbstractFrame* frame = localMainFrame; frame; frame = frame->tree().traverseNext(localMainFrame)) {
+            for (WebCore::Frame* frame = localMainFrame; frame; frame = frame->tree().traverseNext(localMainFrame)) {
                 auto* localFrame = dynamicDowncast<LocalFrame>(frame);
                 if (!localFrame)
                     continue;

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -79,7 +79,7 @@ void WebContextMenuClient::searchWithSpotlight()
         return;
 
     auto* selectionFrame = [&] () -> LocalFrame* {
-        for (AbstractFrame* selectionFrame = localMainFrame; selectionFrame; selectionFrame = selectionFrame->tree().traverseNext()) {
+        for (Frame* selectionFrame = localMainFrame; selectionFrame; selectionFrame = selectionFrame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(selectionFrame);
             if (!localFrame)
                 continue;

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -124,7 +124,7 @@ uint32_t FindController::replaceMatches(const Vector<uint32_t>& matchIndices, co
 
 static LocalFrame* frameWithSelection(Page* page)
 {
-    for (AbstractFrame* frame = &page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (auto* frame = &page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -527,7 +527,7 @@ Vector<FloatRect> FindController::rectsForTextMatchesInRect(IntRect clipRect)
 
     FrameView* mainFrameView = localMainFrame->view();
 
-    for (AbstractFrame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -363,7 +363,7 @@ Vector<WebCore::FloatRect> WebFoundTextRangeController::rectsForTextMatchesInRec
 
     RefPtr mainFrameView = localMainFrame->view();
 
-    for (WebCore::AbstractFrame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
+    for (WebCore::Frame* frame = localMainFrame; frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -112,7 +112,7 @@ static uint64_t generateListenerID()
     return uniqueListenerID++;
 }
 
-void WebFrame::initWithCoreMainFrame(WebPage& page, AbstractFrame& coreFrame, bool receivedMainFrameIdentifierFromUIProcess)
+void WebFrame::initWithCoreMainFrame(WebPage& page, Frame& coreFrame, bool receivedMainFrameIdentifierFromUIProcess)
 {
     ASSERT(!m_frameID);
     m_frameID = coreFrame.frameID();
@@ -188,7 +188,7 @@ WebPage* WebFrame::page() const
     return nullptr;
 }
 
-WebFrame* WebFrame::fromCoreFrame(const AbstractFrame& frame)
+WebFrame* WebFrame::fromCoreFrame(const Frame& frame)
 {
     if (auto* localFrame = dynamicDowncast<LocalFrame>(frame)) {
         auto* webFrameLoaderClient = toWebFrameLoaderClient(localFrame->loader().client());
@@ -470,7 +470,7 @@ String WebFrame::contentsAsString() const
 
     if (isFrameSet()) {
         StringBuilder builder;
-        for (AbstractFrame* child = m_coreFrame->tree().firstChild(); child; child = child->tree().nextSibling()) {
+        for (Frame* child = m_coreFrame->tree().firstChild(); child; child = child->tree().nextSibling()) {
             if (!builder.isEmpty())
                 builder.append(' ');
 
@@ -606,7 +606,7 @@ Ref<API::Array> WebFrame::childFrames()
     Vector<RefPtr<API::Object>> vector;
     vector.reserveInitialCapacity(size);
 
-    for (AbstractFrame* child = m_coreFrame->tree().firstChild(); child; child = child->tree().nextSibling()) {
+    for (Frame* child = m_coreFrame->tree().firstChild(); child; child = child->tree().nextSibling()) {
         WebFrame* webFrame = WebFrame::fromCoreFrame(*child);
         ASSERT(webFrame);
         if (!webFrame)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -52,8 +52,8 @@ class Array;
 }
 
 namespace WebCore {
-class AbstractFrame;
 class CertificateInfo;
+class Frame;
 class HTMLFrameOwnerElement;
 class IntPoint;
 class IntRect;
@@ -79,14 +79,14 @@ public:
     static Ref<WebFrame> createSubframe(WebPage&, WebFrame& parent, const AtomString& frameName, WebCore::HTMLFrameOwnerElement&);
     ~WebFrame();
 
-    void initWithCoreMainFrame(WebPage&, WebCore::AbstractFrame&, bool receivedMainFrameIdentifierFromUIProcess);
+    void initWithCoreMainFrame(WebPage&, WebCore::Frame&, bool receivedMainFrameIdentifierFromUIProcess);
 
     // Called when the FrameLoaderClient (and therefore the WebCore::Frame) is being torn down.
     void invalidate();
 
     WebPage* page() const;
 
-    static WebFrame* fromCoreFrame(const WebCore::AbstractFrame&);
+    static WebFrame* fromCoreFrame(const WebCore::Frame&);
     WebCore::LocalFrame* coreFrame() const;
     WebCore::RemoteFrame* coreRemoteFrame() const;
 
@@ -221,7 +221,7 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 
-    WeakPtr<WebCore::AbstractFrame> m_coreFrame;
+    WeakPtr<WebCore::Frame> m_coreFrame;
     WeakPtr<WebPage> m_page;
 
     struct PolicyCheck {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3961,7 +3961,7 @@ void WebPage::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& parame
 
     if (auto* newWorld = m_userContentController->addContentWorld(worldData)) {
         auto& coreWorld = newWorld->coreWorld();
-        for (RefPtr<AbstractFrame> frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        for (RefPtr<Frame> frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
             if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get()))
                 localFrame->loader().client().dispatchGlobalObjectAvailable(coreWorld);
         }
@@ -3987,7 +3987,7 @@ void WebPage::getContentsAsString(ContentAsStringIncludesChildFrames includeChil
         break;
     case ContentAsStringIncludesChildFrames::Yes:
         StringBuilder builder;
-        for (RefPtr<AbstractFrame> frame = m_mainFrame->coreFrame(); frame; frame = frame->tree().traverseNextRendered()) {
+        for (RefPtr<Frame> frame = m_mainFrame->coreFrame(); frame; frame = frame->tree().traverseNextRendered()) {
             if (auto webFrame = WebFrame::fromCoreFrame(*frame))
                 builder.append(builder.isEmpty() ? "" : "\n\n", webFrame->contentsAsString());
         }
@@ -4010,7 +4010,7 @@ void WebPage::getRenderTreeExternalRepresentation(CompletionHandler<void(const S
 
 static LocalFrame* frameWithSelection(Page* page)
 {
-    for (AbstractFrame* frame = &page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -4401,7 +4401,7 @@ void WebPage::setDataDetectionResults(NSArray *detectionResults)
 
 void WebPage::removeDataDetectedLinks(CompletionHandler<void(const DataDetectionResult&)>&& completionHandler)
 {
-    for (RefPtr<AbstractFrame> frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame)
             continue;
@@ -4423,7 +4423,7 @@ void WebPage::removeDataDetectedLinks(CompletionHandler<void(const DataDetection
 void WebPage::detectDataInAllFrames(OptionSet<WebCore::DataDetectorType> dataDetectorTypes, CompletionHandler<void(const DataDetectionResult&)>&& completionHandler)
 {
     DataDetectionResult mainFrameResult;
-    for (RefPtr<AbstractFrame> frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame)
             continue;
@@ -5288,7 +5288,7 @@ void WebPage::changeSpellingToWord(const String& word)
 
 void WebPage::unmarkAllMisspellings()
 {
-    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -5299,7 +5299,7 @@ void WebPage::unmarkAllMisspellings()
 
 void WebPage::unmarkAllBadGrammar()
 {
-    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -6181,7 +6181,7 @@ static bool pageContainsAnyHorizontalScrollbars(LocalFrame* mainFrame)
             return true;
     }
 
-    for (AbstractFrame* frame = mainFrame; frame; frame = frame->tree().traverseNext()) {
+    for (Frame* frame = mainFrame; frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -6224,7 +6224,7 @@ void WebPage::recomputeShortCircuitHorizontalWheelEventsState()
     send(Messages::WebPageProxy::SetCanShortCircuitHorizontalWheelEvents(m_canShortCircuitHorizontalWheelEvents));
 }
 
-AbstractFrame* WebPage::mainFrame() const
+Frame* WebPage::mainFrame() const
 {
     return m_page ? &m_page->mainFrame() : nullptr;
 }
@@ -8357,7 +8357,7 @@ void WebPage::restoreAppHighlightsAndScrollToIndex(const Vector<SharedMemory::Ha
 void WebPage::setAppHighlightsVisibility(WebCore::HighlightVisibility appHighlightVisibility)
 {
     m_appHighlightsVisible = appHighlightVisibility;
-    for (RefPtr<AbstractFrame> frame = m_mainFrame->coreFrame(); frame; frame = frame->tree().traverseNextRendered()) {
+    for (RefPtr<Frame> frame = m_mainFrame->coreFrame(); frame; frame = frame->tree().traverseNextRendered()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame)
             continue;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -581,7 +581,7 @@ public:
 
     WebFrame& mainWebFrame() const { return m_mainFrame; }
 
-    WebCore::AbstractFrame* mainFrame() const; // May return nullptr.
+    WebCore::Frame* mainFrame() const; // May return nullptr.
     WebCore::FrameView* mainFrameView() const; // May return nullptr.
 
     std::optional<WebCore::SimpleRange> currentSelectionAsRange();

--- a/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
@@ -142,7 +142,7 @@ void FindController::resetMatchIndex()
 
 static void setSelectionChangeUpdatesEnabledInAllFrames(WebPage& page, bool enabled)
 {
-    for (AbstractFrame* coreFrame = page.mainFrame(); coreFrame; coreFrame = coreFrame->tree().traverseNext()) {
+    for (auto* coreFrame = page.mainFrame(); coreFrame; coreFrame = coreFrame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(coreFrame);
         if (!localFrame)
             continue;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3806,7 +3806,7 @@ void WebPage::dynamicViewportSizeUpdate(const FloatSize& viewLayoutSize, const W
 
     frameView.updateLayoutAndStyleIfNeededRecursive();
 
-    // FIXME: Move settings from Frame to AbstractFrame and remove this check.
+    // FIXME: Move settings from Frame to Frame and remove this check.
     auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
     if (!localFrame)
         return;
@@ -3904,7 +3904,7 @@ void WebPage::resetIdempotentTextAutosizingIfNeeded(double previousInitialScale)
 void WebPage::resetTextAutosizing()
 {
 #if ENABLE(TEXT_AUTOSIZING)
-    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (auto* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -431,7 +431,7 @@ static NSURL *createUniqueWebDataURL();
 #endif
 
     auto coreFrame = _private->coreFrame;
-    for (WebCore::AbstractFrame* abstractFrame = coreFrame; abstractFrame; abstractFrame = abstractFrame->tree().traverseNext(coreFrame)) {
+    for (WebCore::Frame* abstractFrame = coreFrame; abstractFrame; abstractFrame = abstractFrame->tree().traverseNext(coreFrame)) {
         auto* frame = dynamicDowncast<WebCore::LocalFrame>(abstractFrame);
         if (!frame)
             continue;
@@ -472,7 +472,7 @@ static NSURL *createUniqueWebDataURL();
 - (void)_unmarkAllBadGrammar
 {
     auto coreFrame = _private->coreFrame;
-    for (WebCore::AbstractFrame* abstractFrame = coreFrame; abstractFrame; abstractFrame = abstractFrame->tree().traverseNext(coreFrame)) {
+    for (WebCore::Frame* abstractFrame = coreFrame; abstractFrame; abstractFrame = abstractFrame->tree().traverseNext(coreFrame)) {
         auto* frame = dynamicDowncast<WebCore::LocalFrame>(abstractFrame);
         if (!frame)
             continue;
@@ -485,7 +485,7 @@ static NSURL *createUniqueWebDataURL();
 {
 #if !PLATFORM(IOS_FAMILY)
     auto coreFrame = _private->coreFrame;
-    for (WebCore::AbstractFrame* abstractFrame = coreFrame; abstractFrame; abstractFrame = abstractFrame->tree().traverseNext(coreFrame)) {
+    for (WebCore::Frame* abstractFrame = coreFrame; abstractFrame; abstractFrame = abstractFrame->tree().traverseNext(coreFrame)) {
         auto* frame = dynamicDowncast<WebCore::LocalFrame>(abstractFrame);
         if (!frame)
             continue;
@@ -523,7 +523,7 @@ static NSURL *createUniqueWebDataURL();
     // FIXME: 4186050 is one known case that makes this debug check fail.
     BOOL found = NO;
     auto coreFrame = _private->coreFrame;
-    for (WebCore::AbstractFrame* abstractFrame = coreFrame; abstractFrame; abstractFrame = abstractFrame->tree().traverseNext(coreFrame)) {
+    for (WebCore::Frame* abstractFrame = coreFrame; abstractFrame; abstractFrame = abstractFrame->tree().traverseNext(coreFrame)) {
         auto* frame = dynamicDowncast<WebCore::LocalFrame>(abstractFrame);
         if (!frame)
             continue;
@@ -540,7 +540,7 @@ static NSURL *createUniqueWebDataURL();
 - (WebFrame *)_findFrameWithSelection
 {
     auto coreFrame = _private->coreFrame;
-    for (WebCore::AbstractFrame* abstractFrame = coreFrame; abstractFrame; abstractFrame = abstractFrame->tree().traverseNext(coreFrame)) {
+    for (WebCore::Frame* abstractFrame = coreFrame; abstractFrame; abstractFrame = abstractFrame->tree().traverseNext(coreFrame)) {
         auto* frame = dynamicDowncast<WebCore::LocalFrame>(abstractFrame);
         if (!frame)
             continue;
@@ -1874,7 +1874,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
         return;
     
     auto coreFrame = core(self);
-    for (WebCore::AbstractFrame* frame = coreFrame; frame; frame = frame->tree().traverseNext(coreFrame)) {
+    for (WebCore::Frame* frame = coreFrame; frame; frame = frame->tree().traverseNext(coreFrame)) {
         auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -2561,7 +2561,7 @@ static NSURL *createUniqueWebDataURL()
     if (!coreFrame)
         return @[];
     NSMutableArray *children = [NSMutableArray arrayWithCapacity:coreFrame->tree().childCount()];
-    for (WebCore::AbstractFrame* child = coreFrame->tree().firstChild(); child; child = child->tree().nextSibling())
+    for (auto* child = coreFrame->tree().firstChild(); child; child = child->tree().nextSibling())
         [children addObject:kit(dynamicDowncast<WebCore::LocalFrame>(child))];
     return children;
 }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1907,7 +1907,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 - (void)updateLayoutIgnorePendingStyleSheets
 {
     WebThreadRun(^{
-        for (WebCore::AbstractFrame* frame = [self _mainCoreFrame]; frame; frame = frame->tree().traverseNext()) {
+        for (WebCore::Frame* frame = [self _mainCoreFrame]; frame; frame = frame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
             if (!localFrame)
                 continue;
@@ -3807,7 +3807,7 @@ IGNORE_WARNINGS_END
 
 - (void)_attachScriptDebuggerToAllFrames
 {
-    for (WebCore::AbstractFrame* frame = [self _mainCoreFrame]; frame; frame = frame->tree().traverseNext()) {
+    for (WebCore::Frame* frame = [self _mainCoreFrame]; frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -3817,7 +3817,7 @@ IGNORE_WARNINGS_END
 
 - (void)_detachScriptDebuggerFromAllFrames
 {
-    for (WebCore::AbstractFrame* frame = [self _mainCoreFrame]; frame; frame = frame->tree().traverseNext()) {
+    for (WebCore::Frame* frame = [self _mainCoreFrame]; frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -4140,7 +4140,7 @@ IGNORE_WARNINGS_END
 - (BOOL)_isUsingAcceleratedCompositing
 {
     auto* coreFrame = [self _mainCoreFrame];
-    for (WebCore::AbstractFrame* frame = coreFrame; frame; frame = frame->tree().traverseNext(coreFrame)) {
+    for (WebCore::Frame* frame = coreFrame; frame; frame = frame->tree().traverseNext(coreFrame)) {
         auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -4192,7 +4192,7 @@ IGNORE_WARNINGS_END
 - (BOOL)_isSoftwareRenderable
 {
     auto* coreFrame = [self _mainCoreFrame];
-    for (WebCore::AbstractFrame* frame = coreFrame; frame; frame = frame->tree().traverseNext(coreFrame)) {
+    for (WebCore::Frame* frame = coreFrame; frame; frame = frame->tree().traverseNext(coreFrame)) {
         auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -6265,7 +6265,7 @@ static NSString * const backingPropertyOldScaleFactorKey = @"NSBackingPropertyOl
 
     auto* coreFrame = [self _mainCoreFrame];
 #if !PLATFORM(IOS_FAMILY)
-    for (WebCore::AbstractFrame* frame = coreFrame; frame; frame = frame->tree().traverseNext(coreFrame)) {
+    for (WebCore::Frame* frame = coreFrame; frame; frame = frame->tree().traverseNext(coreFrame)) {
         auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -6277,7 +6277,7 @@ static NSString * const backingPropertyOldScaleFactorKey = @"NSBackingPropertyOl
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_windowWillClose:) name:NSWindowWillCloseNotification object:hostWindow];
 #endif
     _private->hostWindow = hostWindow;
-    for (WebCore::AbstractFrame* frame = coreFrame; frame; frame = frame->tree().traverseNext(coreFrame)) {
+    for (WebCore::Frame* frame = coreFrame; frame; frame = frame->tree().traverseNext(coreFrame)) {
         auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
         if (!localFrame)
             continue;


### PR DESCRIPTION
#### 7651b3eb50d3e41d859357345a2c1759b6a4659b
<pre>
Rename AbstractFrame to Frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=253853">https://bugs.webkit.org/show_bug.cgi?id=253853</a>

Reviewed by Darin Adler.

Rename AbstractFrame to Frame, now that the subclasses are LocalFrame and
RemoteFrame.

* Source/WebCore/*:
* Source/WebKit/*:
* Source/WebKitLegacy/*:

Canonical link: <a href="https://commits.webkit.org/261612@main">https://commits.webkit.org/261612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a66f0ce5cfddd823e0744690cf0c4641e159cc3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4092 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/120928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12507 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/4866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118080 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/16935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105361 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/98892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/45942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/703 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14519 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/9989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52708 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/8094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16323 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4409 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->