### PR TITLE
Fix wasm name section parsing

### DIFF
--- a/JSTests/wasm/stress/simple-inline-stacktrace-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-2.js
@@ -11,10 +11,10 @@ for (let i = 0; i < 10000; ++i) {
     } catch (e) {
         let str = e.stack.toString()
         let trace = str.split('\n')
-        let expected = ["*", "wasm-stub@[wasm code]", "<?>.wasm-function[11]@[wasm code]",
-            "<?>.wasm-function[17]@[wasm code]", "<?>.wasm-function[16]@[wasm code]", "<?>.wasm-function[15]@[wasm code]",
-            "<?>.wasm-function[14]@[wasm code]", "<?>.wasm-function[13]@[wasm code]", "<?>.wasm-function[12]@[wasm code]",
-            "<?>.wasm-function[18]@[wasm code]", "wasm-stub@[wasm code]", "*"]
+        let expected = ["*", "wasm-stub@[wasm code]", "<?>.wasm-function[g]@[wasm code]",
+        "<?>.wasm-function[f]@[wasm code]", "<?>.wasm-function[e]@[wasm code]", "<?>.wasm-function[d]@[wasm code]",
+        "<?>.wasm-function[c]@[wasm code]", "<?>.wasm-function[b]@[wasm code]", "<?>.wasm-function[a]@[wasm code]",
+        "<?>.wasm-function[main]@[wasm code]", "wasm-stub@[wasm code]", "*"]
         if (trace.length != expected.length)
             throw "unexpected length"
         for (let i = 0; i < trace.length; ++i) {

--- a/JSTests/wasm/stress/simple-inline-stacktrace.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace.js
@@ -8,10 +8,10 @@ for (let i = 0; i < 10000; ++i) {
     } catch (e) {
         let str = e.stack.toString()
         let trace = str.split('\n')
-        let expected = ["*", "wasm-stub@[wasm code]", "<?>.wasm-function[11]@[wasm code]",
-            "<?>.wasm-function[17]@[wasm code]", "<?>.wasm-function[16]@[wasm code]", "<?>.wasm-function[15]@[wasm code]",
-            "<?>.wasm-function[14]@[wasm code]", "<?>.wasm-function[13]@[wasm code]", "<?>.wasm-function[12]@[wasm code]",
-            "<?>.wasm-function[18]@[wasm code]", "wasm-stub@[wasm code]", "*"]
+        let expected = ["*", "wasm-stub@[wasm code]", "<?>.wasm-function[g]@[wasm code]",
+            "<?>.wasm-function[f]@[wasm code]", "<?>.wasm-function[e]@[wasm code]", "<?>.wasm-function[d]@[wasm code]",
+            "<?>.wasm-function[c]@[wasm code]", "<?>.wasm-function[b]@[wasm code]", "<?>.wasm-function[a]@[wasm code]",
+            "<?>.wasm-function[main]@[wasm code]", "wasm-stub@[wasm code]", "*"]
         if (trace.length != expected.length)
             throw "unexpected length"
         for (let i = 0; i < trace.length; ++i) {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -552,6 +552,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, dumpUnlinkedDFGValidation, false, Normal, nullptr) \
     v(Bool, dumpWasmOpcodeStatistics, false, Normal, nullptr) \
     v(Bool, dumpCompilerConstructionSite, false, Normal, nullptr) \
+    v(Bool, dumpWasmWarnings, false, Normal, nullptr) \
     \
     /* Feature Flags */\
     \

--- a/Source/JavaScriptCore/wasm/WasmNameSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmNameSectionParser.cpp
@@ -45,7 +45,7 @@ auto NameSectionParser::parse() -> Result
         WASM_PARSER_FAIL_IF(!parseVarUInt32(payloadLength), "can't get payload length for payload ", payloadNumber);
         WASM_PARSER_FAIL_IF(payloadLength > length() - m_offset, "payload length is too big for payload ", payloadNumber);
         const auto payloadStart = m_offset;
-        
+
         if (!isValidNameType(nameType)) {
             // Unknown name section entries are simply ignored. This allows us to support newer toolchains without breaking older features.
             m_offset += payloadLength;
@@ -78,22 +78,26 @@ auto NameSectionParser::parse() -> Result
         }
         case NameType::Local: {
             // Ignore local names for now, we don't do anything with them but we still need to parse them in order to properly ignore them.
-            uint32_t functionIndex;
-            uint32_t count;
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't get local's function index for payload ", payloadNumber);
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get local count for payload ", payloadNumber);
-            for (uint32_t local = 0; local < count; ++local) {
-                uint32_t index;
-                uint32_t nameLen;
-                Name nameString;
-                WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get local ", local, " index for payload ", payloadNumber);
-                WASM_PARSER_FAIL_IF(!parseVarUInt32(nameLen), "can't get local ", local, "'s name length for payload ", payloadNumber);
-                WASM_PARSER_FAIL_IF(!consumeUTF8String(nameString, nameLen), "can't get local ", local, "'s name of length ", nameLen, " for payload ", payloadNumber);
+            uint32_t functionCount;
+            WASM_PARSER_FAIL_IF(!parseVarUInt32(functionCount), "can't get function count for local name payload ", payloadNumber);
+            for (uint32_t function = 0; function < functionCount; ++function) {
+                uint32_t functionIndex;
+                uint32_t count;
+                WASM_PARSER_FAIL_IF(!parseVarUInt32(functionIndex), "can't get local's function index for payload ", payloadNumber);
+                WASM_PARSER_FAIL_IF(!parseVarUInt32(count), "can't get local count for payload ", payloadNumber);
+                for (uint32_t local = 0; local < count; ++local) {
+                    uint32_t index;
+                    uint32_t nameLen;
+                    Name nameString;
+                    WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get local ", local, " index for payload ", payloadNumber);
+                    WASM_PARSER_FAIL_IF(!parseVarUInt32(nameLen), "can't get local ", local, "'s name length for payload ", payloadNumber);
+                    WASM_PARSER_FAIL_IF(!consumeUTF8String(nameString, nameLen), "can't get local ", local, "'s name of length ", nameLen, " for payload ", payloadNumber);
+                }
             }
             break;
         }
         }
-        WASM_PARSER_FAIL_IF(payloadStart + payloadLength != m_offset);
+        WASM_PARSER_FAIL_IF(payloadStart + payloadLength != m_offset, "payload for name section is not correct size, expected ", payloadLength, " got ", m_offset - payloadStart);
     }
     return nameSection;
 }

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -1303,8 +1303,11 @@ auto SectionParser::parseCustom() -> PartialResult
     Name branchHintsName = { 'm', 'e', 't', 'a', 'd', 'a', 't', 'a', '.', 'c', 'o', 'd', 'e', '.', 'b', 'r', 'a', 'n', 'c', 'h', '_', 'h', 'i', 'n', 't' };
     if (section.name == nameName) {
         NameSectionParser nameSectionParser(section.payload.begin(), section.payload.size(), m_info);
-        if (auto nameSection = nameSectionParser.parse())
+        auto nameSection = nameSectionParser.parse();
+        if (nameSection)
             m_info->nameSection = WTFMove(*nameSection);
+        else
+            dataLogLnIf(Options::dumpWasmWarnings(), "Could not parse name section: ", nameSection.error());
     } else if (section.name == branchHintsName) {
         BranchHintsSectionParser branchHintsSectionParser(section.payload.begin(), section.payload.size(), m_info);
         branchHintsSectionParser.parse();


### PR DESCRIPTION
#### bb185db3a774b5139bfb762f767ea3cdfbb6e18d
<pre>
Fix wasm name section parsing
rdar://106657580

Reviewed by Yusuke Suzuki.

Simple bug fix for wasm custom name section locals parsing.

* JSTests/wasm/stress/simple-inline-stacktrace-2.js:
(i.catch):
* JSTests/wasm/stress/simple-inline-stacktrace.js:
(i.catch):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmNameSectionParser.cpp:
(JSC::Wasm::NameSectionParser::parse):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseCustom):

Canonical link: <a href="https://commits.webkit.org/261694@main">https://commits.webkit.org/261694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0190a25179cd9b4c889b831c0ac1bc31fc246b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4313 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121096 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5446 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118306 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46107 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100844 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14027 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/887 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12128 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14709 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102319 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20048 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52892 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31963 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8154 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16545 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110358 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27263 "Passed tests") | 
<!--EWS-Status-Bubble-End-->