### PR TITLE
fast/events/touch/ios/long-press-on-editable.html fails

### DIFF
--- a/LayoutTests/fast/events/touch/ios/long-press-on-editable.html
+++ b/LayoutTests/fast/events/touch/ios/long-press-on-editable.html
@@ -27,7 +27,7 @@
             var target = document.getElementById('target');
             if (testRunner.runUIScript) {
                 testRunner.runUIScript(getPressScript(), function(result) {
-                    var selectionText = document.getSelection().toString();
+                    var selectionText = textarea.value.substring(textarea.selectionStart, textarea.selectionEnd);
                     if (selectionText == "PressMe")
                         output += 'PASS: Selected: ' + selectionText;
                     else
@@ -52,7 +52,7 @@
 </head>
 <body>
 <div id="target">
-	<textarea>PressMe</textarea>
+	<textarea id="textarea">PressMe</textarea>
     This test requires UIScriptController to run.
 </div>
 </body>


### PR DESCRIPTION
#### 1fc0ffe58052be365c706ce52abb939033721c83
<pre>
fast/events/touch/ios/long-press-on-editable.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=253863">https://bugs.webkit.org/show_bug.cgi?id=253863</a>

Reviewed by Wenson Hsieh.

The test failure was caused by the test relying on getSelection().toString() to include
the selected text within textarea&apos;s shadow tree. Updated the test to rely on textarea.value
and textarea.selectionStart textarea.selectionEnd instead.

* LayoutTests/fast/events/touch/ios/long-press-on-editable.html:

Canonical link: <a href="https://commits.webkit.org/261643@main">https://commits.webkit.org/261643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1d5c36c521e7eee9cf1db433f042033ec62340f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120924 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4858 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105356 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45934 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13822 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/693 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14513 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52697 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16315 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4433 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->