### PR TITLE
[JSC] Generate PCToCodeOriginMap for WasmBBQJIT when sampling profiler is enabled

### DIFF
--- a/Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp
+++ b/Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp
@@ -145,7 +145,7 @@ PCToCodeOriginMapBuilder::PCToCodeOriginMapBuilder(WasmTag, B3::PCToOriginMap b3
 }
 #endif
 
-void PCToCodeOriginMapBuilder::appendItem(MacroAssembler::Label label, const CodeOrigin& codeOrigin)
+void PCToCodeOriginMapBuilder::appendItemSlow(MacroAssembler::Label label, const CodeOrigin& codeOrigin)
 {
     if (!m_shouldBuildMapping)
         return;

--- a/Source/JavaScriptCore/jit/PCToCodeOriginMap.h
+++ b/Source/JavaScriptCore/jit/PCToCodeOriginMap.h
@@ -51,6 +51,9 @@ class PCToCodeOriginMapBuilder {
 public:
     PCToCodeOriginMapBuilder(VM&);
     PCToCodeOriginMapBuilder(PCToCodeOriginMapBuilder&& other);
+    PCToCodeOriginMapBuilder(bool shouldBuildMapping)
+        : m_shouldBuildMapping(shouldBuildMapping)
+    { }
 
 #if ENABLE(FTL_JIT)
     enum JSTag { JSCodeOriginMap };
@@ -62,12 +65,18 @@ public:
     PCToCodeOriginMapBuilder(WasmTag, B3::PCToOriginMap);
 #endif
 
-    void appendItem(MacroAssembler::Label, const CodeOrigin&);
+    void appendItem(MacroAssembler::Label label, const CodeOrigin& origin)
+    {
+        if (!m_shouldBuildMapping)
+            return;
+        appendItemSlow(label, origin);
+    }
     static CodeOrigin defaultCodeOrigin() { return CodeOrigin(BytecodeIndex(0)); }
 
     bool didBuildMapping() const { return m_shouldBuildMapping; }
 
 private:
+    void appendItemSlow(MacroAssembler::Label, const CodeOrigin&);
 
     struct CodeRange {
         MacroAssembler::Label start;

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -509,6 +509,8 @@ struct AirIRGeneratorBase {
 
     void dump(const ControlStack&, const Stack* expressionStack);
     void setParser(FunctionParser<Derived>* parser) { m_parser = parser; };
+    ALWAYS_INLINE void willParseOpcode() { }
+    ALWAYS_INLINE void didParseOpcode() { }
     void didFinishParsingLocals() { }
     void didPopValueFromStack() { }
 

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -664,6 +664,8 @@ public:
 
     void dump(const ControlStack&, const Stack* expressionStack);
     void setParser(FunctionParser<B3IRGenerator>* parser) { m_parser = parser; };
+    ALWAYS_INLINE void willParseOpcode() { }
+    ALWAYS_INLINE void didParseOpcode() { }
     void didFinishParsingLocals() { }
     void didPopValueFromStack() { --m_stackSize; }
 
@@ -5257,6 +5259,11 @@ void computePCToCodeOriginMap(CompilationContext& context, LinkBuffer& linkBuffe
     if (context.procedure && context.procedure->needsPCToOriginMap()) {
         B3::PCToOriginMap originMap = context.procedure->releasePCToOriginMap();
         context.pcToCodeOriginMap = Box<PCToCodeOriginMap>::create(PCToCodeOriginMapBuilder(PCToCodeOriginMapBuilder::WasmCodeOriginMap, WTFMove(originMap)), linkBuffer);
+        return;
+    }
+    if (context.pcToCodeOriginMapBuilder) {
+        context.pcToCodeOriginMap = Box<PCToCodeOriginMap>::create(WTFMove(*context.pcToCodeOriginMapBuilder), linkBuffer);
+        return;
     }
 }
 

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.h
@@ -55,6 +55,7 @@ struct CompilationContext {
     std::unique_ptr<OpaqueByproducts> wasmEntrypointByproducts;
     std::unique_ptr<B3::Procedure> procedure;
     Box<PCToCodeOriginMap> pcToCodeOriginMap;
+    Box<PCToCodeOriginMapBuilder> pcToCodeOriginMapBuilder;
     Vector<CCallHelpers::Label> catchEntrypoints;
 };
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -354,11 +354,12 @@ auto FunctionParser<Context>::parseBody() -> PartialResult
             m_context.dump(m_controlStack, &m_expressionStack);
         }
 
+        m_context.willParseOpcode();
         if (m_unreachableBlocks)
             WASM_FAIL_IF_HELPER_FAILS(parseUnreachableExpression());
-        else {
+        else
             WASM_FAIL_IF_HELPER_FAILS(parseExpression());
-        }
+        m_context.didParseOpcode();
     }
     WASM_FAIL_IF_HELPER_FAILS(m_context.endTopLevel(&m_signature, m_expressionStack));
 

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -370,6 +370,8 @@ public:
     PartialResult WARN_UNUSED_RETURN addUnreachable();
     PartialResult WARN_UNUSED_RETURN addCrash();
 
+    ALWAYS_INLINE void willParseOpcode() { }
+    ALWAYS_INLINE void didParseOpcode() { }
     void didFinishParsingLocals();
 
     void setParser(FunctionParser<LLIntGenerator>* parser) { m_parser = parser; };


### PR DESCRIPTION
#### 32be87b75f2b616ed994fcdb7792347d8ba599b8
<pre>
[JSC] Generate PCToCodeOriginMap for WasmBBQJIT when sampling profiler is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=253867">https://bugs.webkit.org/show_bug.cgi?id=253867</a>
rdar://problem/106677398

Reviewed by Tadeu Zagallo.

This patch makes WasmBBQJIT generate PCToCodeOriginMap when useSamplingProfiler is true so that we can
get per-wasm-offset sampling profiler data. This patch extends WasmFunctionParser and add willParseOpcode / didParseOpcode
hooks. They are empty in most of generators, but in WasmBBQJIT, we use it to notify to PCToCodeOriginMapBuilder.
PCToCodeOriginMapBuilder does nothing when useSamplingProfiler is false. And it generates necessary metadata when
useSamplingProfiler is true. And we wire generated map to the existing wasm PCToCodeOriginMap registry so that we can get
sampling profiler data like this.

    Hottest bytecodes as &lt;numSamples   &apos;functionName#hash:JITType:bytecodeIndex&apos;&gt;
       242    &apos;&lt;?&gt;.wasm-function[301]:LLInt:nil&apos;
        93    &apos;&lt;?&gt;.wasm-function[141]:BBQ:0x1fa&apos;
        29    &apos;&lt;?&gt;.wasm-function[141]:BBQ:0x44f&apos;
        28    &apos;&lt;?&gt;.wasm-function[400]:BBQ:0x0&apos;
        22    &apos;_platform_memmove#&lt;nil&gt;:None:&lt;nil&gt;&apos;
        20    &apos;expandFileStorage#&lt;nil&gt;:FTL:bc#383&apos;
        19    &apos;&lt;?&gt;.wasm-function[400]:BBQ:0x199&apos;

* Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp:
(JSC::PCToCodeOriginMapBuilder::appendItemSlow):
(JSC::PCToCodeOriginMapBuilder::appendItem): Deleted.
* Source/JavaScriptCore/jit/PCToCodeOriginMap.h:
(JSC::PCToCodeOriginMapBuilder::PCToCodeOriginMapBuilder):
(JSC::PCToCodeOriginMapBuilder::appendItem):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::AirIRGeneratorBase::willParseOpcode):
(JSC::Wasm::AirIRGeneratorBase::didParseOpcode):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::willParseOpcode):
(JSC::Wasm::B3IRGenerator::didParseOpcode):
(JSC::Wasm::computePCToCodeOriginMap):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJIT::willParseOpcode):
(JSC::Wasm::BBQJIT::didParseOpcode):
(JSC::Wasm::BBQJIT::takePCToCodeOriginMapBuilder):
(JSC::Wasm::parseAndCompileBBQ):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBody):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::willParseOpcode):
(JSC::Wasm::LLIntGenerator::didParseOpcode):

Canonical link: <a href="https://commits.webkit.org/261639@main">https://commits.webkit.org/261639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/332cb26900eacf090ec63b22da011b3ad1b9609d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4094 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120930 "Failed to compile WebKit") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4864 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45940 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100692 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/704 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/94330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/11959 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14521 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102076 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52709 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31902 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16325 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110120 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4430 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27203 "Passed tests") | 
<!--EWS-Status-Bubble-End-->