### PR TITLE
Clean up ScrollerPairMac, and fix a bug with RTL scrollbars

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -27,7 +27,7 @@
 
 #if PLATFORM(MAC)
 
-#include <WebCore/FloatPoint.h>
+#include "ScrollTypes.h"
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS CALayer;
@@ -36,13 +36,13 @@ OBJC_CLASS WebScrollerImpDelegateMac;
 
 namespace WebCore {
 
+class FloatPoint;
 class ScrollerPairMac;
 
 class ScrollerMac {
+    friend class ScrollerPairMac;
 public:
-    enum class Orientation { Vertical, Horizontal };
-    
-    ScrollerMac(ScrollerPairMac&, Orientation);
+    ScrollerMac(ScrollerPairMac&, ScrollbarOrientation);
 
     ~ScrollerMac();
 
@@ -50,23 +50,22 @@ public:
 
     ScrollerPairMac& pair() { return m_pair; }
 
-    Orientation orientation() const { return m_orientation; }
+    ScrollbarOrientation orientation() const { return m_orientation; }
 
     CALayer *hostLayer() const { return m_hostLayer.get(); }
     void setHostLayer(CALayer *);
 
     RetainPtr<NSScrollerImp> takeScrollerImp() { return std::exchange(m_scrollerImp, { }); }
     NSScrollerImp *scrollerImp() { return m_scrollerImp.get(); }
-    void setscrollerImp(NSScrollerImp *imp) { m_scrollerImp = imp; }
+    void setScrollerImp(NSScrollerImp *imp) { m_scrollerImp = imp; }
 
-
-    WebCore::FloatPoint convertFromContent(const WebCore::FloatPoint&) const;
+    FloatPoint convertFromContent(const FloatPoint&) const;
 
     void updateValues();
 
 private:
     ScrollerPairMac& m_pair;
-    const Orientation m_orientation;
+    const ScrollbarOrientation m_orientation;
 
     RetainPtr<CALayer> m_hostLayer;
     RetainPtr<NSScrollerImp> m_scrollerImp;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -314,7 +314,7 @@ enum class FeatureToAnimate {
 
 namespace WebCore {
 
-ScrollerMac::ScrollerMac(ScrollerPairMac& pair, Orientation orientation)
+ScrollerMac::ScrollerMac(ScrollerPairMac& pair, ScrollbarOrientation orientation)
     : m_pair(pair)
     , m_orientation(orientation)
 {
@@ -331,7 +331,7 @@ void ScrollerMac::attach()
     m_scrollerImpDelegate = adoptNS([[WebScrollerImpDelegateMac alloc] initWithScroller:this]);
 
     NSScrollerStyle newStyle = [m_pair.scrollerImpPair() scrollerStyle];
-    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:newStyle controlSize:NSControlSizeRegular horizontal:m_orientation == Orientation::Horizontal replacingScrollerImp:nil];
+    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:newStyle controlSize:NSControlSizeRegular horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil];
     [m_scrollerImp setDelegate:m_scrollerImpDelegate.get()];
 }
 
@@ -344,7 +344,7 @@ void ScrollerMac::setHostLayer(CALayer *layer)
 
     [m_scrollerImp setLayer:layer];
 
-    if (m_orientation == Orientation::Vertical)
+    if (m_orientation == ScrollbarOrientation::Vertical)
         [m_pair.scrollerImpPair() setVerticalScrollerImp:layer ? m_scrollerImp.get() : nil];
     else
         [m_pair.scrollerImpPair() setHorizontalScrollerImp:layer ?  m_scrollerImp.get() : nil];
@@ -365,9 +365,9 @@ void ScrollerMac::updateValues()
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-WebCore::FloatPoint ScrollerMac::convertFromContent(const WebCore::FloatPoint& point) const
+FloatPoint ScrollerMac::convertFromContent(const FloatPoint& point) const
 {
-    return WebCore::FloatPoint { [m_hostLayer convertPoint:point fromLayer:[m_hostLayer superlayer]] };
+    return FloatPoint { [m_hostLayer convertPoint:point fromLayer:[m_hostLayer superlayer]] };
 }
 
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -43,19 +43,24 @@ class ScrollingTreeScrollingNode;
 
 namespace WebCore {
 
+// Controls a pair of NSScrollerImps via a pair of ScrollerMac. The NSScrollerImps need to remain internal to this class.
 class ScrollerPairMac {
     WTF_MAKE_FAST_ALLOCATED;
+    friend class ScrollerMac;
 public:
     ScrollerPairMac(WebCore::ScrollingTreeScrollingNode&);
     void init();
 
     ~ScrollerPairMac();
 
-    ScrollerMac& verticalScroller() { return m_verticalScroller; }
-    ScrollerMac& horizontalScroller() { return m_horizontalScroller; }
-
     void handleWheelEventPhase(PlatformWheelEventPhase);
     bool handleMouseEvent(const WebCore::PlatformMouseEvent&);
+    
+    void setUsePresentationValues(bool);
+    bool isUsingPresentationValues() const { return m_usingPresentationValues; }
+    
+    void setVerticalScrollbarPresentationValue(float);
+    void setHorizontalScrollbarPresentationValue(float);
 
     void updateValues();
 
@@ -67,30 +72,35 @@ public:
         float value;
         float proportion;
     };
-    Values valuesForOrientation(ScrollerMac::Orientation);
+    Values valuesForOrientation(ScrollbarOrientation);
 
-    NSScrollerImpPair *scrollerImpPair() { return m_scrollerImpPair.get(); }
-    NSScrollerImp *scrollerImpHorizontal() { return horizontalScroller().scrollerImp(); }
-    NSScrollerImp *scrollerImpVertical() { return verticalScroller().scrollerImp(); }
-    
     void releaseReferencesToScrollerImpsOnTheMainThread();
     
     bool hasScrollerImp();
 
+    // Only for use by WebScrollerImpPairDelegateMac. Do not use elsewhere!
+    ScrollerMac& verticalScroller() { return m_verticalScroller; }
+    ScrollerMac& horizontalScroller() { return m_horizontalScroller; }
+
 private:
+
+    NSScrollerImp *scrollerImpHorizontal() { return horizontalScroller().scrollerImp(); }
+    NSScrollerImp *scrollerImpVertical() { return verticalScroller().scrollerImp(); }
+
+    NSScrollerImpPair *scrollerImpPair() { return m_scrollerImpPair.get(); }
+
     WebCore::ScrollingTreeScrollingNode& m_scrollingNode;
 
     ScrollerMac m_verticalScroller;
     ScrollerMac m_horizontalScroller;
 
-    WebCore::FloatSize m_contentSize;
-    WebCore::FloatRect m_visibleContentRect;
-
     WebCore::IntPoint m_lastKnownMousePosition;
-    std::optional<WebCore::FloatPoint> m_lastScrollPosition;
+    std::optional<WebCore::FloatPoint> m_lastScrollOffset;
 
     RetainPtr<NSScrollerImpPair> m_scrollerImpPair;
     RetainPtr<WebScrollerImpPairDelegateMac> m_scrollerImpPairDelegate;
+    
+    std::atomic<bool> m_usingPresentationValues { false };
 };
 
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -121,8 +121,8 @@ namespace WebCore {
 
 ScrollerPairMac::ScrollerPairMac(WebCore::ScrollingTreeScrollingNode& node)
     : m_scrollingNode(node)
-    , m_verticalScroller(*this, ScrollerMac::Orientation::Vertical)
-    , m_horizontalScroller(*this, ScrollerMac::Orientation::Horizontal)
+    , m_verticalScroller(*this, ScrollbarOrientation::Vertical)
+    , m_horizontalScroller(*this, ScrollbarOrientation::Horizontal)
 {
 }
 
@@ -174,20 +174,37 @@ bool ScrollerPairMac::handleMouseEvent(const WebCore::PlatformMouseEvent& event)
     return true;
 }
 
+void ScrollerPairMac::setUsePresentationValues(bool inMomentumPhase)
+{
+    m_usingPresentationValues = inMomentumPhase;
+    [scrollerImpHorizontal() setUsePresentationValue:m_usingPresentationValues];
+    [scrollerImpVertical() setUsePresentationValue:m_usingPresentationValues];
+}
+
+void ScrollerPairMac::setHorizontalScrollbarPresentationValue(float scrollbValue)
+{
+    [scrollerImpHorizontal() setPresentationValue:scrollbValue];
+}
+
+void ScrollerPairMac::setVerticalScrollbarPresentationValue(float scrollbValue)
+{
+    [scrollerImpVertical() setPresentationValue:scrollbValue];
+}
+
 void ScrollerPairMac::updateValues()
 {
-    auto position = m_scrollingNode.currentScrollPosition();
+    auto offset = m_scrollingNode.currentScrollOffset();
 
-    if (position != m_lastScrollPosition) {
-        if (m_lastScrollPosition) {
-            auto delta = position - *m_lastScrollPosition;
+    if (offset != m_lastScrollOffset) {
+        if (m_lastScrollOffset) {
+            auto delta = offset - *m_lastScrollOffset;
             [m_scrollerImpPair contentAreaScrolledInDirection:NSMakePoint(delta.width(), delta.height())];
         }
-        m_lastScrollPosition = position;
+        m_lastScrollOffset = offset;
     }
 
-    m_verticalScroller.updateValues();
     m_horizontalScroller.updateValues();
+    m_verticalScroller.updateValues();
 }
 
 WebCore::FloatSize ScrollerPairMac::visibleSize() const
@@ -200,17 +217,17 @@ bool ScrollerPairMac::useDarkAppearance() const
     return m_scrollingNode.useDarkAppearanceForScrollbars();
 }
 
-ScrollerPairMac::Values ScrollerPairMac::valuesForOrientation(ScrollerMac::Orientation orientation)
+ScrollerPairMac::Values ScrollerPairMac::valuesForOrientation(ScrollbarOrientation orientation)
 {
     float position;
     float totalSize;
     float visibleSize;
-    if (orientation == ScrollerMac:: Orientation::Vertical) {
-        position = m_scrollingNode.currentScrollPosition().y();
+    if (orientation == ScrollbarOrientation::Vertical) {
+        position = m_scrollingNode.currentScrollOffset().y();
         totalSize = m_scrollingNode.totalContentsSize().height();
         visibleSize = m_scrollingNode.scrollableAreaSize().height();
     } else {
-        position = m_scrollingNode.currentScrollPosition().x();
+        position = m_scrollingNode.currentScrollOffset().x();
         totalSize = m_scrollingNode.totalContentsSize().width();
         visibleSize = m_scrollingNode.scrollableAreaSize().width();
     }

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -775,26 +775,26 @@ LayoutPoint ScrollableArea::constrainScrollPositionForOverhang(const LayoutPoint
     return constrainScrollPositionForOverhang(visibleContentRect(), totalContentsSize(), scrollPosition, scrollOrigin(), headerHeight(), footerHeight());
 }
 
-void ScrollableArea::computeScrollbarValueAndOverhang(float currentPosition, float totalSize, float visibleSize, float& doubleValue, float& overhangAmount)
+void ScrollableArea::computeScrollbarValueAndOverhang(float currentPosition, float totalSize, float visibleSize, float& scrollbarValue, float& overhangAmount)
 {
-    doubleValue = 0;
+    scrollbarValue = 0;
     overhangAmount = 0;
     float maximum = totalSize - visibleSize;
 
     if (currentPosition < 0) {
         // Scrolled past the top.
-        doubleValue = 0;
+        scrollbarValue = 0;
         overhangAmount = -currentPosition;
     } else if (visibleSize + currentPosition > totalSize) {
         // Scrolled past the bottom.
-        doubleValue = 1;
+        scrollbarValue = 1;
         overhangAmount = currentPosition + visibleSize - totalSize;
     } else {
         // Within the bounds of the scrollable area.
         if (maximum > 0)
-            doubleValue = currentPosition / maximum;
+            scrollbarValue = currentPosition / maximum;
         else
-            doubleValue = 0;
+            scrollbarValue = 0;
     }
 }
 

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -354,7 +354,7 @@ public:
 
     // Computes the double value for the scrollbar's current position and the current overhang amount.
     // This function is static so that it can be called from the main thread or the scrolling thread.
-    WEBCORE_EXPORT static void computeScrollbarValueAndOverhang(float currentPosition, float totalSize, float visibleSize, float& doubleValue, float& overhangAmount);
+    WEBCORE_EXPORT static void computeScrollbarValueAndOverhang(float currentPosition, float totalSize, float visibleSize, float& scrollbarValue, float& overhangAmount);
 
     static std::optional<BoxSide> targetSideForScrollDelta(FloatSize, ScrollEventAxis);
 


### PR DESCRIPTION
#### 478618b3a4aa237f81272cd2cbe27426323d897e
<pre>
Clean up ScrollerPairMac, and fix a bug with RTL scrollbars
<a href="https://bugs.webkit.org/show_bug.cgi?id=253871">https://bugs.webkit.org/show_bug.cgi?id=253871</a>
rdar://106682101

Reviewed by Aditya Keerthi.

A future patch may need to add locking around code that touches NSScrollerImp*, so it&apos;s helpful
if the NSScrollerImp* are hidden inside ScrollerPairMac/ScrollerMac, so do that.

Also do some other cleanup:
1. Replace ScrollerMac::Orientation with the existing ScrollbarOrientation enum
2. Move the calls to -setUsePresentationValue: and setPresentationValue: inside ScrollerPairMac
3. Have ScrollingTreeScrollingNodeDelegateMac::updateScrollbarPainters() use ScrollerPairMac::valuesForOrientation()
   and fix that code to use scroll offsets instead of positions, which fixes a bug where RTL scrollbars would sometimes
   flicker to the wrong positions.
4. Rename the &apos;doubleValue&apos; param to ScrollableArea::computeScrollbarValueAndOverhang() to scrollbarValue.

Canonical link: <a href="https://commits.webkit.org/261673@main">https://commits.webkit.org/261673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4b8701a76e55e2d1a8f5ddeec6a03645ae3a6b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4248 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5388 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118236 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46058 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13966 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/825 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14659 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8133 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16479 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->