### PR TITLE
Use inline iterator in RenderRubyRun::layoutBlock

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -69,6 +69,8 @@ public:
 
     float inkOverflowTop() const;
     float inkOverflowBottom() const;
+    float scrollableOverflowTop() const;
+    float scrollableOverflowBottom() const;
 
     const RenderStyle& style() const { return isFirst() ? formattingContextRoot().firstLineStyle() : formattingContextRoot().style(); }
 
@@ -213,6 +215,20 @@ inline float LineBox::inkOverflowBottom() const
 {
     return WTF::switchOn(m_pathVariant, [](const auto& path) {
         return path.inkOverflowBottom();
+    });
+}
+
+inline float LineBox::scrollableOverflowTop() const
+{
+    return WTF::switchOn(m_pathVariant, [](const auto& path) {
+        return path.scrollableOverflowTop();
+    });
+}
+
+inline float LineBox::scrollableOverflowBottom() const
+{
+    return WTF::switchOn(m_pathVariant, [](const auto& path) {
+        return path.scrollableOverflowBottom();
     });
 }
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
@@ -53,6 +53,8 @@ public:
     float logicalWidth() const { return m_rootInlineBox->lineBoxWidth().toFloat(); }
     float inkOverflowTop() const { return m_rootInlineBox->logicalTopVisualOverflow(); }
     float inkOverflowBottom() const { return m_rootInlineBox->logicalBottomVisualOverflow(); }
+    float scrollableOverflowTop() const { return m_rootInlineBox->logicalTopLayoutOverflow(); }
+    float scrollableOverflowBottom() const { return m_rootInlineBox->logicalBottomLayoutOverflow(); }
 
     bool hasEllipsis() const { return !!m_rootInlineBox->ellipsisBox(); }
     FloatRect ellipsisVisualRectIgnoringBlockDirection() const

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -54,6 +54,8 @@ public:
     float logicalWidth() const { return line().lineBoxLogicalRect().width(); }
     float inkOverflowTop() const { return line().inkOverflow().y(); }
     float inkOverflowBottom() const { return line().inkOverflow().maxY(); }
+    float scrollableOverflowTop() const { return line().scrollableOverflow().y(); }
+    float scrollableOverflowBottom() const { return line().scrollableOverflow().maxY(); }
 
     bool hasEllipsis() const { return line().hasEllipsis(); }
     FloatRect ellipsisVisualRectIgnoringBlockDirection() const { return *line().ellipsisVisualRect(); }


### PR DESCRIPTION
#### d342ad39cf9a7af43ec29c36d73cd39a45c0749a
<pre>
Use inline iterator in RenderRubyRun::layoutBlock
<a href="https://bugs.webkit.org/show_bug.cgi?id=253881">https://bugs.webkit.org/show_bug.cgi?id=253881</a>
rdar://106693280

Reviewed by Alan Baradlay.

Don&apos;t access legacy line layout directly.

* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
(WebCore::InlineIterator::LineBox::scrollableOverflowTop const):
(WebCore::InlineIterator::LineBox::scrollableOverflowBottom const):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h:
(WebCore::InlineIterator::LineBoxIteratorLegacyPath::scrollableOverflowTop const):
(WebCore::InlineIterator::LineBoxIteratorLegacyPath::scrollableOverflowBottom const):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
(WebCore::InlineIterator::LineBoxIteratorModernPath::scrollableOverflowTop const):
(WebCore::InlineIterator::LineBoxIteratorModernPath::scrollableOverflowBottom const):
* Source/WebCore/rendering/RenderRubyRun.cpp:
(WebCore::RenderRubyRun::layoutBlock):

Canonical link: <a href="https://commits.webkit.org/261631@main">https://commits.webkit.org/261631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f189b76645f376c9f851ef533d9c811b573b0d27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120964 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4910 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105406 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45971 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13867 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/738 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14561 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52743 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8112 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16365 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->