### PR TITLE
[GStreamer][EME] Added support to check support of cryptoblockformat

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -104,6 +104,8 @@ GStreamerRegistryScanner::ElementFactories::ElementFactories(OptionSet<ElementFa
         rtpPayloaderFactories = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_PAYLOADER, GST_RANK_MARGINAL);
     if (types.contains(Type::RtpDepayloader))
         rtpDepayloaderFactories = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DEPAYLOADER, GST_RANK_MARGINAL);
+    if (types.contains(Type::Decryptor))
+        decryptorFactories = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECRYPTOR, GST_RANK_MARGINAL);
 }
 
 GStreamerRegistryScanner::ElementFactories::~ElementFactories()
@@ -118,6 +120,7 @@ GStreamerRegistryScanner::ElementFactories::~ElementFactories()
     gst_plugin_feature_list_free(muxerFactories);
     gst_plugin_feature_list_free(rtpPayloaderFactories);
     gst_plugin_feature_list_free(rtpDepayloaderFactories);
+    gst_plugin_feature_list_free(decryptorFactories);
 }
 
 const char* GStreamerRegistryScanner::ElementFactories::elementFactoryTypeToString(GStreamerRegistryScanner::ElementFactories::Type factoryType)
@@ -143,6 +146,8 @@ const char* GStreamerRegistryScanner::ElementFactories::elementFactoryTypeToStri
         return "RTP payloader";
     case Type::RtpDepayloader:
         return "RTP depayloader";
+    case Type::Decryptor:
+        return "Decryptor";
     case Type::All:
         break;
     }
@@ -173,6 +178,8 @@ GList* GStreamerRegistryScanner::ElementFactories::factory(GStreamerRegistryScan
         return rtpPayloaderFactories;
     case GStreamerRegistryScanner::ElementFactories::Type::RtpDepayloader:
         return rtpDepayloaderFactories;
+    case GStreamerRegistryScanner::ElementFactories::Type::Decryptor:
+        return decryptorFactories;
     case GStreamerRegistryScanner::ElementFactories::Type::All:
         break;
     }
@@ -659,6 +666,42 @@ MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(
         return SupportsType::IsNotSupported;
 
     const auto& codecs = contentType.codecs();
+
+#if ENABLE(ENCRYPTED_MEDIA)
+    String cryptoblockformat = contentType.parameter("cryptoblockformat"_s);
+    if (!cryptoblockformat.isEmpty()) {
+        OptionSet<ElementFactories::Type> factoryTypes;
+        factoryTypes.add(ElementFactories::Type::Decryptor);
+        auto factories = ElementFactories(factoryTypes);
+
+        // https://developers.google.com/youtube/devices/living-room/certification-requirements
+        // section 15.1.3: The isTypeSupported method MUST support the cryptoblockformat mime-type
+        // parameter, and MUST support subsample as a parameter value.
+        if (cryptoblockformat != "subsample"_s)
+            return SupportsType::IsNotSupported;
+
+        if (!containerType.endsWith("webm"_s))
+            return SupportsType::IsNotSupported;
+
+#if GST_CHECK_VERSION(1, 22, 0)
+        for (const auto& mimeCodec : codecs) {
+            auto codecCaps = adoptGRef(gst_codec_utils_caps_from_mime_codec(mimeCodec.ascii().data()));
+            if (!codecCaps) {
+                GST_WARNING("Unable to convert codec %s to caps", mimeCodec.ascii().data());
+                continue;
+            }
+            auto* structure = gst_caps_get_structure(codecCaps.get(), 0);
+            const char* name = gst_structure_get_name(structure);
+            auto caps = adoptGRef(gst_caps_new_simple("application/x-webm-enc", "original-media-type", G_TYPE_STRING, name, nullptr));
+            if (!factories.hasElementForCaps(ElementFactories::Type::Decryptor, caps))
+                return SupportsType::IsNotSupported;
+        }
+#else
+        if (!factories.hasElementForMediaType(ElementFactories::Type::Decryptor, "application/x-webm-enc"))
+            return SupportsType::IsNotSupported;
+#endif // GST_CHECK_VERSION(1, 22, 0)
+    }
+#endif // ENABLE(ENCRYPTED_MEDIA)
 
     // Spec says we should not return "probably" if the codecs string is empty.
     if (codecs.isEmpty())

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -124,7 +124,8 @@ protected:
             Muxer        = 1 << 7,
             RtpPayloader = 1 << 8,
             RtpDepayloader = 1 << 9,
-            All          = (1 << 9) - 1
+            Decryptor    = 1 << 10,
+            All          = (1 << 10) - 1
         };
 
         explicit ElementFactories(OptionSet<Type>);
@@ -147,6 +148,7 @@ protected:
         GList* muxerFactories { nullptr };
         GList* rtpPayloaderFactories { nullptr };
         GList* rtpDepayloaderFactories { nullptr };
+        GList* decryptorFactories { nullptr };
     };
 
     void initializeDecoders(const ElementFactories&);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2678,6 +2678,8 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamer::supportsType(const MediaE
     if (parameters.type.raw().startsWith("image"_s))
         return result;
 
+    registerWebKitGStreamerElements();
+
     auto& gstRegistryScanner = GStreamerRegistryScanner::singleton();
     result = gstRegistryScanner.isContentTypeSupported(GStreamerRegistryScanner::Configuration::Decoding, parameters.type, parameters.contentTypesRequiringHardwareSupport);
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
@@ -47,7 +47,6 @@ GST_DEBUG_CATEGORY(webkitMediaThunderDecryptDebugCategory);
 #define GST_CAT_DEFAULT webkitMediaThunderDecryptDebugCategory
 
 static const char* cencEncryptionMediaTypes[] = { "video/mp4", "audio/mp4", "video/x-h264", "video/x-h265", "audio/mpeg", "audio/x-eac3", "audio/x-ac3", "audio/x-flac", "video/x-vp9", nullptr };
-static const char** cbcsEncryptionMediaTypes = cencEncryptionMediaTypes;
 static const char* webmEncryptionMediaTypes[] = { "video/webm", "audio/webm", "video/x-vp9", "audio/x-opus", "audio/x-vorbis", "video/x-vp8", nullptr };
 
 static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src",
@@ -90,11 +89,6 @@ static GRefPtr<GstCaps> createSinkPadTemplateCaps()
             gst_caps_append_structure(caps.get(), gst_structure_new("application/x-cenc", "original-media-type", G_TYPE_STRING,
                 cencEncryptionMediaTypes[i], "protection-system", G_TYPE_STRING, GStreamerEMEUtilities::keySystemToUuid(keySystem), nullptr));
         }
-    }
-
-    for (int i = 0; cbcsEncryptionMediaTypes[i]; ++i) {
-        gst_caps_append_structure(caps.get(), gst_structure_new("application/x-cbcs", "original-media-type", G_TYPE_STRING,
-            cbcsEncryptionMediaTypes[i], nullptr));
     }
 
     if (supportedKeySystems.contains(GStreamerEMEUtilities::s_WidevineKeySystem) || supportedKeySystems.contains(GStreamerEMEUtilities::s_ClearKeyKeySystem)) {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -462,6 +462,8 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamerMSE::supportsType(const Med
     if (ok && videoDecodingLimits && width == videoDecodingLimits->mediaMaxWidth && height == videoDecodingLimits->mediaMaxHeight && frameRate > videoDecodingLimits->mediaMaxFrameRate)
         return result;
 
+    registerWebKitGStreamerElements();
+
     GST_DEBUG("Checking mime-type \"%s\"", parameters.type.raw().utf8().data());
     auto& gstRegistryScanner = GStreamerRegistryScannerMSE::singleton();
     result = gstRegistryScanner.isContentTypeSupported(GStreamerRegistryScanner::Configuration::Decoding, parameters.type, parameters.contentTypesRequiringHardwareSupport);


### PR DESCRIPTION
#### 8f08fa82eddb19e066a11d1a0c0833008613843d
<pre>
[GStreamer][EME] Added support to check support of cryptoblockformat
<a href="https://bugs.webkit.org/show_bug.cgi?id=253000">https://bugs.webkit.org/show_bug.cgi?id=253000</a>

Reviewed by Xabier Rodriguez-Calvar.

Inspired from downstream WPE 2.22 patch:
<a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/e5b91c2bb7732e1047e3f52aa6f6651e0e1f02da">https://github.com/WebPlatformForEmbedded/WPEWebKit/commit/e5b91c2bb7732e1047e3f52aa6f6651e0e1f02da</a>

Fixes YT cert test: &quot;Format Support Tests&quot; -&gt; &quot;1. isTypeSupported cryptoblockformat&quot;

Also drive-by change suggested by Xabier, remove the application/x-cbcs check in the Thunder
decryptor as that is now cenc with a cypher-mode.

* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isContentTypeSupported const):

Canonical link: <a href="https://commits.webkit.org/261684@main">https://commits.webkit.org/261684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99564bb198a46ae4925da709dfbf667433362ffe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4328 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12865 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118320 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105615 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/867 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14041 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/904 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14723 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52909 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8143 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16560 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->