### PR TITLE
Zydis fails to build in Debug mode with -Werror=type-limits (GCC 12.2 / SCCACHE)

### DIFF
--- a/Source/JavaScriptCore/disassembler/zydis/Zydis/ZydisDecoder.c
+++ b/Source/JavaScriptCore/disassembler/zydis/Zydis/ZydisDecoder.c
@@ -34,6 +34,11 @@
 #include "ZydisInternalDecoderData.h"
 #include "ZydisInternalSharedData.h"
 
+#if defined(ZYAN_GCC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+
 /* ============================================================================================== */
 /* Internal enums and types                                                                       */
 /* ============================================================================================== */
@@ -5118,6 +5123,10 @@ ZyanStatus ZydisDecoderDecodeBuffer(const ZydisDecoder* decoder, const void* buf
 
     return ZYAN_STATUS_SUCCESS;
 }
+
+#if defined(ZYAN_GCC)
+#pragma GCC diagnostic pop
+#endif
 
 /* ============================================================================================== */
 

--- a/Source/JavaScriptCore/disassembler/zydis/Zydis/ZydisSharedData.c
+++ b/Source/JavaScriptCore/disassembler/zydis/Zydis/ZydisSharedData.c
@@ -112,6 +112,12 @@ void ZydisGetInstructionDefinition(ZydisInstructionEncoding encoding, ZyanU16 id
 /* ---------------------------------------------------------------------------------------------- */
 
 #ifndef ZYDIS_MINIMAL_MODE
+
+#if defined(ZYAN_GCC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+
 ZyanU8 ZydisGetOperandDefinitions(const ZydisInstructionDefinition* definition,
     const ZydisOperandDefinition** operand)
 {
@@ -124,6 +130,11 @@ ZyanU8 ZydisGetOperandDefinitions(const ZydisInstructionDefinition* definition,
     *operand = &OPERAND_DEFINITIONS[definition->operand_reference];
     return definition->operand_count;
 }
+
+#if defined(ZYAN_GCC)
+#pragma GCC diagnostic pop
+#endif
+
 #endif
 
 /* ---------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
#### 4f087256dcd6e55f75e9a37db9de504f608b77ab
<pre>
Zydis fails to build in Debug mode with -Werror=type-limits (GCC 12.2 / SCCACHE)
<a href="https://bugs.webkit.org/show_bug.cgi?id=252309">https://bugs.webkit.org/show_bug.cgi?id=252309</a>

Reviewed by Yusuke Suzuki.

Suppress -Wtype-limits while this gets fixed in zydis upstream.

Canonical link: <a href="https://commits.webkit.org/261696@main">https://commits.webkit.org/261696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7baaf06620e8259d9f22d3e37560f78b49554987

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112560 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4335 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121113 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12872 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5480 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118327 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46128 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100862 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14048 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/908 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12150 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14730 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102340 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52913 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31966 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8156 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16567 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110380 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27266 "Passed tests") | 
<!--EWS-Status-Bubble-End-->