### PR TITLE
Delay background fetch loads when not online

### DIFF
--- a/LayoutTests/http/wpt/background-fetch/background-fetch-online.window-expected.txt
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-online.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS background fetch delayed until online
+

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-online.window.html
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-online.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/background-fetch/background-fetch-online.window.js
+++ b/LayoutTests/http/wpt/background-fetch/background-fetch-online.window.js
@@ -1,0 +1,51 @@
+// META: script=/service-workers/service-worker/resources/test-helpers.sub.js
+// META: script=/background-fetch/resources/utils.js
+
+'use strict';
+
+function backgroundFetchDownloaded(id)
+{
+  const state = JSON.parse(testRunner.backgroundFetchState(id));
+  return state.downloaded;
+}
+
+function backgroundFetchIsPaused(id)
+{
+  const state = JSON.parse(testRunner.backgroundFetchState(id));
+  return state.isPaused;
+}
+
+promise_test(async t => {
+  if (!window.testRunner)
+    return;
+
+  const serviceWorkerRegistration = await service_worker_unregister_and_register(t, "sw.js", ".");
+  add_completion_callback(() => serviceWorkerRegistration.unregister());
+  await wait_for_state(t, serviceWorkerRegistration.installing, 'activated');
+
+  assert_true(navigator.onLine, "onLine");
+
+  const offlinePromise = new Promise(resolve => window.onoffline = resolve);
+  testRunner.setOnLineOverride(false);
+  await offlinePromise;
+
+  const id = uniqueId();
+  await serviceWorkerRegistration.backgroundFetch.fetch(id, ['resources/trickle-range.py?ms=2&count=5000']);
+
+  const internalId = testRunner.getBackgroundFetchIdentifier();
+  assert_greater_than(internalId.length, 0);
+
+  // Let's wait a bit to get some data.
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  assert_equals(backgroundFetchDownloaded(internalId), 0, "load is not started");
+
+  const onlinePromise = new Promise(resolve => window.ononline = resolve);
+  testRunner.setOnLineOverride(true);
+  await onlinePromise;
+
+  let cptr = 0;
+  while(!backgroundFetchDownloaded(internalId) && ++cptr < 20)
+    await new Promise(resolve => setTimeout(resolve, 500));
+  assert_less_than(cptr, 20, "load is started");
+}, "background fetch delayed until online");

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1997,6 +1997,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/network/NetworkLoadInformation.h
     platform/network/NetworkLoadMetrics.h
     platform/network/NetworkStateNotifier.h
+    platform/network/NetworkStateOnLineOverride.h
     platform/network/NetworkStorageSession.h
     platform/network/NetworkingContext.h
     platform/network/ParsedContentRange.h

--- a/Source/WebCore/platform/network/NetworkStateNotifier.cpp
+++ b/Source/WebCore/platform/network/NetworkStateNotifier.cpp
@@ -77,7 +77,17 @@ void NetworkStateNotifier::addListener(Function<void(bool)>&& listener)
 void NetworkStateNotifier::updateState()
 {
     auto wasOnLine = m_isOnLine;
-    updateStateWithoutNotifying();
+    switch (m_onLineOverride) {
+    case NetworkStateOnLineOverride::None:
+        updateStateWithoutNotifying();
+        break;
+    case NetworkStateOnLineOverride::OnLine:
+        m_isOnLine = true;
+        break;
+    case NetworkStateOnLineOverride::OffLine:
+        m_isOnLine = false;
+        break;
+    }
     if (m_isOnLine == wasOnLine)
         return;
     for (auto& listener : m_listeners)
@@ -87,6 +97,12 @@ void NetworkStateNotifier::updateState()
 void NetworkStateNotifier::updateStateSoon()
 {
     m_updateStateTimer.startOneShot(updateStateSoonInterval);
+}
+
+void NetworkStateNotifier::setOnLineOverrideForTesting(NetworkStateOnLineOverride onLineOverride)
+{
+    m_onLineOverride = onLineOverride;
+    m_updateStateTimer.startOneShot(0_s);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/NetworkStateNotifier.h
+++ b/Source/WebCore/platform/network/NetworkStateNotifier.h
@@ -25,9 +25,10 @@
 
 #pragma once
 
+#include "NetworkStateOnLineOverride.h"
+#include "Timer.h"
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
-#include "Timer.h"
 
 #if PLATFORM(IOS_FAMILY)
 OBJC_CLASS WebNetworkStateObserver;
@@ -52,6 +53,8 @@ public:
     WEBCORE_EXPORT bool onLine();
     WEBCORE_EXPORT void addListener(Function<void(bool isOnLine)>&&);
 
+    WEBCORE_EXPORT void setOnLineOverrideForTesting(NetworkStateOnLineOverride);
+
 private:
     friend NeverDestroyed<NetworkStateNotifier>;
 
@@ -74,6 +77,8 @@ private:
     std::optional<bool> m_isOnLine;
     Vector<Function<void(bool)>> m_listeners;
     Timer m_updateStateTimer;
+
+    NetworkStateOnLineOverride m_onLineOverride { NetworkStateOnLineOverride::None };
 
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<WebNetworkStateObserver> m_observer;

--- a/Source/WebCore/platform/network/NetworkStateOnLineOverride.h
+++ b/Source/WebCore/platform/network/NetworkStateOnLineOverride.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class NetworkStateOnLineOverride : uint8_t { None, OnLine, OffLine };
+
+} // namespace WebCore

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h
@@ -73,6 +73,7 @@ private:
 
     using FetchesMap = HashMap<String, std::unique_ptr<BackgroundFetch>>;
     HashMap<ServiceWorkerRegistrationKey, FetchesMap> m_fetches;
+    Vector<WeakPtr<BackgroundFetch>> m_pendingFetches;
 
     HashMap<BackgroundFetchRecordIdentifier, Ref<BackgroundFetch::Record>> m_records;
 };

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2942,4 +2942,10 @@ void NetworkProcess::requestBackgroundFetchPermission(PAL::SessionID sessionID, 
 }
 #endif
 
+void NetworkProcess::setOnLineOverrideForTesting(WebCore::NetworkStateOnLineOverride onLineOverride, CompletionHandler<void()>&& callback)
+{
+    NetworkStateNotifier::singleton().setOnLineOverrideForTesting(onLineOverride);
+    callback();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -91,6 +91,7 @@ class ResourceError;
 class UserContentURLPattern;
 enum class HTTPCookieAcceptPolicy : uint8_t;
 enum class IncludeHttpOnlyCookies : bool;
+enum class NetworkStateOnLineOverride : uint8_t;
 enum class StoredCredentialsPolicy : uint8_t;
 enum class StorageAccessPromptWasShown : bool;
 enum class StorageAccessWasGranted : bool;
@@ -414,6 +415,8 @@ public:
 #if ENABLE(SERVICE_WORKER)
     void requestBackgroundFetchPermission(PAL::SessionID, const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&);
 #endif
+
+    void setOnLineOverrideForTesting(WebCore::NetworkStateOnLineOverride, CompletionHandler<void()>&&);
 
 private:
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -241,5 +241,5 @@ messages -> NetworkProcess LegacyReceiver {
     ClearProxyConfigData(PAL::SessionID sessionID)
     SetProxyConfigData(PAL::SessionID sessionID, IPC::DataReference proxyConfigData, IPC::DataReference proxyIdentifierData)
 #endif
-
+    SetOnLineOverrideForTesting(enum:uint8_t WebCore::NetworkStateOnLineOverride onLineOverride) -> ();
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4896,6 +4896,13 @@ header: <WebCore/AcceleratedEffect.h>
 };
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)
 
+header: <WebCore/NetworkStateOnLineOverride.h>
+enum class WebCore::NetworkStateOnLineOverride : uint8_t {
+    None,
+    OnLine,
+    OffLine
+};
+
 #if PLATFORM(MAC)
 header: <WebCore/CaretAnimator.h>
 [CustomHeader] enum class WebCore::CaretAnimatorType : uint8_t {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -51,6 +51,7 @@
 #import "_WKWebsiteDataStoreConfigurationInternal.h"
 #import "_WKWebsiteDataStoreDelegate.h"
 #import <WebCore/Credential.h>
+#import <WebCore/NetworkStateOnLineOverride.h>
 #import <WebCore/RegistrationDatabase.h>
 #import <WebCore/ServiceWorkerClientData.h>
 #import <WebCore/WebCoreObjCExtras.h>
@@ -1201,6 +1202,20 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         return nil;
 
     return *identifier;
+}
+
+-(void)_overrideNetworkStateOnlineForTesting:(bool)onLine completionHandler:(void(^)(void))completionHandler
+{
+    _websiteDataStore->setOnLineOverrideForTesting(onLine ? WebCore::NetworkStateOnLineOverride::OnLine : WebCore::NetworkStateOnLineOverride::OffLine, [completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
+}
+
+-(void)_resetNetworkStateOnlineOverrideForTesting:(void(^)(void))completionHandler
+{
+    _websiteDataStore->setOnLineOverrideForTesting(WebCore::NetworkStateOnLineOverride::None, [completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
 }
 
 - (NSString *)_webPushPartition

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -123,6 +123,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteDataStoreFetchOptions) {
 -(void)_scopeURL:(NSURL *)scopeURL hasPushSubscriptionForTesting:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_originDirectoryForTesting:(NSURL *)origin topOrigin:(NSURL *)topOrigin type:(NSString *)dataType completionHandler:(void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 -(void)_setBackupExclusionPeriodForTesting:(double)seconds completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
+-(void)_overrideNetworkStateOnlineForTesting:(bool)onLine completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+-(void)_resetNetworkStateOnlineOverrideForTesting:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 -(void)_getAllBackgroundFetchIdentifiers:(void(^)(NSArray<NSString *> *identifiers))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 -(void)_getBackgroundFetchState:(NSString *) identifier completionHandler:(void(^)(NSDictionary *state))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1941,6 +1941,16 @@ void NetworkProcessProxy::notifyMediaStreamingActivity(bool activity)
     send(Messages::NetworkProcess::NotifyMediaStreamingActivity(activity), 0);
 }
 
+void NetworkProcessProxy::setOnLineOverrideForTesting(WebCore::NetworkStateOnLineOverride value,  CompletionHandler<void()>&& callback)
+{
+    if (!canSendMessage()) {
+        callback();
+        return;
+    }
+
+    sendWithAsyncReply(Messages::NetworkProcess::SetOnLineOverrideForTesting(value), WTFMove(callback));
+}
+
 void NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebsiteDataType> dataTypes, const WebCore::ClientOrigin& origin, PAL::SessionID sessionID, WebPageProxyIdentifier webPageProxyID, CompletionHandler<void()>&& completionHandler)
 {
     RELEASE_LOG(Process, "%p - NetworkProcessProxy::deleteWebsiteDataInWebProcessesForOrigin - webPageProxyID=%" PRIu64 " - BEGIN", this, webPageProxyID.toUInt64());

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -72,6 +72,7 @@ class SharedBuffer;
 class ProtectionSpace;
 class ResourceRequest;
 class SecurityOrigin;
+enum class NetworkStateOnLineOverride : uint8_t;
 enum class ShouldSample : bool;
 enum class StorageAccessPromptWasShown : bool;
 enum class StorageAccessWasGranted : bool;
@@ -328,6 +329,8 @@ public:
 #endif
 
     void notifyMediaStreamingActivity(bool);
+
+    void setOnLineOverrideForTesting(WebCore::NetworkStateOnLineOverride, CompletionHandler<void()>&&);
 
 private:
     explicit NetworkProcessProxy();

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -37,6 +37,7 @@
 #import "WebProcessProxy.h"
 #import "WebResourceLoadStatisticsStore.h"
 #import "WebsiteDataStoreParameters.h"
+#import <WebCore/NetworkStateOnLineOverride.h>
 #import <WebCore/NetworkStorageSession.h>
 #import <WebCore/RegistrableDomain.h>
 #import <WebCore/RuntimeApplicationChecks.h>

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2398,4 +2398,9 @@ void WebsiteDataStore::setProxyConfigData(const API::Data& data, uuid_t proxyIde
 }
 #endif // HAVE(NW_PROXY_CONFIG)
 
+void WebsiteDataStore::setOnLineOverrideForTesting(WebCore::NetworkStateOnLineOverride value, CompletionHandler<void()>&& completionHandler)
+{
+    networkProcess().setOnLineOverrideForTesting(value, WTFMove(completionHandler));
+}
+
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -80,6 +80,7 @@ class ResourceRequest;
 class SecurityOrigin;
 class LocalWebLockRegistry;
 class PrivateClickMeasurement;
+enum class NetworkStateOnLineOverride : uint8_t;
 struct RecentSearch;
 
 struct MockWebAuthenticationConfiguration;
@@ -446,7 +447,9 @@ public:
     void clearProxyConfigData();
     void setProxyConfigData(const API::Data&, uuid_t proxyIdentifier);
 #endif
-    
+
+    void setOnLineOverrideForTesting(WebCore::NetworkStateOnLineOverride, CompletionHandler<void()>&&);
+
 private:
     enum class ForceReinitialization : bool { No, Yes };
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -226,6 +226,8 @@ interface TestRunner {
     DOMString lastUpdatedBackgroundFetchIdentifier();
     DOMString backgroundFetchState(DOMString identifier);
 
+    undefined setOnLineOverride(boolean value);
+
     // Geolocation
     undefined setGeolocationPermission(boolean value);
     undefined setMockGeolocationPosition(double latitude, double longitude, double accuracy, optional double? altitude, optional double? altitudeAccuracy, optional double? heading, optional double? speed, optional double? floorLevel);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -969,6 +969,11 @@ void TestRunner::simulateClickBackgroundFetch(JSStringRef identifier)
     postSynchronousPageMessageWithReturnValue("SimulateClickBackgroundFetch", toWK(identifier));
 }
 
+void TestRunner::setOnLineOverride(bool value)
+{
+    postSynchronousPageMessageWithReturnValue("SetOnLineOverride", adoptWK(WKBooleanCreate(value)));
+}
+
 void TestRunner::setGeolocationPermission(bool enabled)
 {
     // FIXME: This should be done by frame.

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -309,6 +309,8 @@ public:
     JSRetainPtr<JSStringRef> lastUpdatedBackgroundFetchIdentifier() const;
     JSRetainPtr<JSStringRef> backgroundFetchState(JSStringRef);
 
+    void setOnLineOverride(bool);
+
     // Geolocation.
     void setGeolocationPermission(bool);
     void setMockGeolocationPosition(double latitude, double longitude, double accuracy, std::optional<double> altitude, std::optional<double> altitudeAccuracy, std::optional<double> heading, std::optional<double> speed, std::optional<double> floorLevel);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -863,7 +863,11 @@ void TestController::resumeBackgroundFetch(WKStringRef)
 void TestController::simulateClickBackgroundFetch(WKStringRef)
 {
 }
-#endif
+
+void TestController::setOnLineOverride(bool)
+{
+}
+#endif // !PLATFORM(COCOA)
 
 void TestController::createWebViewWithOptions(const TestOptions& options)
 {

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -417,6 +417,8 @@ public:
     WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> backgroundFetchState(WKStringRef);
 
+    void setOnLineOverride(bool);
+
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);
     WKRetainPtr<WKContextConfigurationRef> generateContextConfiguration(const TestOptions&) const;
@@ -722,6 +724,7 @@ private:
     
 #if PLATFORM(COCOA)
     bool m_hasSetApplicationBundleIdentifier { false };
+    bool m_hasOnLineOverride { false };
 #endif
 
     bool m_isSpeechRecognitionPermissionGranted { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -974,6 +974,12 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         TestController::singleton().simulateClickBackgroundFetch(stringValue(messageBody));
         return nullptr;
     }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "SetOnLineOverride")) {
+        TestController::singleton().setOnLineOverride(booleanValue(messageBody));
+        return nullptr;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "LastAddedBackgroundFetchIdentifier"))
         return TestController::singleton().lastAddedBackgroundFetchIdentifier();
     if (WKStringIsEqualToUTF8CString(messageName, "LastRemovedBackgroundFetchIdentifier"))

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -333,6 +333,15 @@ void TestController::cocoaResetStateToConsistentValues(const TestOptions& option
     }
 
     WebCoreTestSupport::setAdditionalSupportedImageTypesForTesting(String::fromLatin1(options.additionalSupportedImageTypes().c_str()));
+
+    if (m_hasOnLineOverride) {
+        m_hasOnLineOverride = false;
+        __block bool isDone = false;
+        [globalWebViewConfiguration().get().websiteDataStore _resetNetworkStateOnlineOverrideForTesting:^() {
+            isDone = true;
+        }];
+        platformRunUntil(isDone, noTimeout);
+    }
 }
 
 void TestController::platformWillRunTest(const TestInvocation& testInvocation)
@@ -660,6 +669,16 @@ WKRetainPtr<WKStringRef> TestController::backgroundFetchState(WKStringRef identi
     }];
     platformRunUntil(isDone, noTimeout);
     return toWK(backgroundFetchState);
+}
+
+void TestController::setOnLineOverride(bool value)
+{
+    m_hasOnLineOverride = true;
+    __block bool isDone = false;
+    [globalWebViewConfiguration().get().websiteDataStore _overrideNetworkStateOnlineForTesting:value completionHandler:^() {
+        isDone = true;
+    }];
+    platformRunUntil(isDone, noTimeout);
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### 9d72021a57fe0a6acd2f8871e0856d7b22971da4
<pre>
Delay background fetch loads when not online
<a href="https://bugs.webkit.org/show_bug.cgi?id=252991">https://bugs.webkit.org/show_bug.cgi?id=252991</a>
rdar://problem/105974392

Reviewed by NOBODY (OOPS!).

Before starting a background fetch load, check whether we are online or not.
If not, add the background fetch to pending fetches.
BackgroundFetchEngine listens to online events and will start pending fetches when online.

Add a test runner API and related infrastructure to control whether online or offline.

* LayoutTests/http/wpt/background-fetch/background-fetch-online.window-expected.txt: Added.
* LayoutTests/http/wpt/background-fetch/background-fetch-online.window.html: Added.
* LayoutTests/http/wpt/background-fetch/background-fetch-online.window.js: Added.
(backgroundFetchDownloaded):
(backgroundFetchIsPaused):
(promise_test.async t):
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/network/NetworkStateNotifier.cpp:
(WebCore::NetworkStateNotifier::updateState):
(WebCore::NetworkStateNotifier::setOnLineOverrideForTesting):
* Source/WebCore/platform/network/NetworkStateNotifier.h:
* Source/WebCore/platform/network/NetworkStateOnLineOverride.h: Added.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp:
(WebCore::BackgroundFetchEngine::BackgroundFetchEngine):
(WebCore::BackgroundFetchEngine::startBackgroundFetch):
(WebCore::BackgroundFetchEngine::addFetchFromStore):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::setOnLineOverrideForTesting):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _overrideNetworkStateOnlineForTesting:completionHandler:]):
(-[WKWebsiteDataStore _resetNetworkStateOnlineOverrideForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::setOnLineOverrideForTesting):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::setOnLineOverrideForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setOnLineOverride):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::setOnLineOverride):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaResetStateToConsistentValues):
(WTR::TestController::setOnLineOverride):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d72021a57fe0a6acd2f8871e0856d7b22971da4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112377 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4154 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120979 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/4950 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/16985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/45998 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13883 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/751 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/94548 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10196 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52756 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16384 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->