### PR TITLE
gcGLSpanDynamicExtent is defined in incorrect header, GCGLSpan.h included in wrong order

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -29,6 +29,7 @@
 
 #include "ActivityStateChangeObserver.h"
 #include "ExceptionOr.h"
+#include "GCGLSpan.h"
 #include "GPUBasedCanvasRenderingContext.h"
 #include "GraphicsContextGL.h"
 #include "ImageBuffer.h"
@@ -61,8 +62,6 @@
 #if ENABLE(WEBXR)
 #include "JSDOMPromiseDeferredForward.h"
 #endif
-
-#include "GCGLSpan.h"
 
 namespace JSC {
 class AbstractSlotVisitor;

--- a/Source/WebCore/platform/graphics/GCGLSpan.h
+++ b/Source/WebCore/platform/graphics/GCGLSpan.h
@@ -31,9 +31,9 @@
 #include <type_traits>
 #include <wtf/Vector.h>
 
-// inline constexpr size_t gcGLSpanDynamicExtent = std::numeric_limits<size_t>::max();
+inline constexpr size_t gcGLSpanDynamicExtent = std::numeric_limits<size_t>::max();
 
-template<typename T, size_t Extent>
+template<typename T, size_t Extent = gcGLSpanDynamicExtent>
 class GCGLSpan {
 public:
     explicit GCGLSpan(T* array, size_t size = Extent)

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -36,6 +36,7 @@
 #include "Image.h"
 #include "IntRect.h"
 #include "IntSize.h"
+#include <limits>
 #include <wtf/FunctionDispatcher.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
@@ -48,9 +49,7 @@
 #endif
 #endif
 
-inline constexpr size_t gcGLSpanDynamicExtent = std::numeric_limits<size_t>::max();
-
-template<typename T, size_t Extent = gcGLSpanDynamicExtent>
+template<typename T, size_t Extent = std::numeric_limits<size_t>::max()>
 class GCGLSpan;
 
 template<typename... Types>


### PR DESCRIPTION
#### dc49732e1b44b7405737516475ba1c705904fa67
<pre>
gcGLSpanDynamicExtent is defined in incorrect header, GCGLSpan.h included in wrong order
<a href="https://bugs.webkit.org/show_bug.cgi?id=253887">https://bugs.webkit.org/show_bug.cgi?id=253887</a>
rdar://problem/106701929

Reviewed by NOBODY (OOPS!).

Include GCGLSpan.h in the position where the project coding guidelines
tell.

gcGLSpanDynamicExtent is part of GCGLSpan.h, and that&apos;s where it should
be defined.

Default values for template parameters of forward declared types should
be defined as they need to be. gcGLSpanDynamicExtent cannot be defined
in one forward declaration site; this is not logical. If there was two
forward declare sites, then what?

* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GCGLSpan.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc49732e1b44b7405737516475ba1c705904fa67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112386 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21530 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1026 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4163 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/120990 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116450 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22868 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12649 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/87/builds/4163 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118152 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/22868 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/90/builds/1026 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105436 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/22868 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/90/builds/1026 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/105436 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13892 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/90/builds/1026 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/105436 "Failed to compile WebKit") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14590 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/85/builds/12649 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19936 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/90/builds/1026 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16396 "Failed to compile WebKit") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->