### PR TITLE
Prefer strcpy over memcpy where appropiate

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -190,8 +190,7 @@ static void vprintf_stderr_with_prefix(const char* prefix, const char* format, v
     size_t formatLength = strlen(format);
     Vector<char> formatWithPrefix(prefixLength + formatLength + 1);
     memcpy(formatWithPrefix.data(), prefix, prefixLength);
-    memcpy(formatWithPrefix.data() + prefixLength, format, formatLength);
-    formatWithPrefix[prefixLength + formatLength] = 0;
+    strcpy(formatWithPrefix.data() + prefixLength, format);
 
     ALLOW_NONLITERAL_FORMAT_BEGIN
     vprintf_stderr_common(formatWithPrefix.data(), args);

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -111,7 +111,7 @@ void CString::grow(size_t newLength)
     ASSERT(newLength > length());
 
     auto newBuffer = CStringBuffer::createUninitialized(newLength);
-    memcpy(newBuffer->mutableData(), m_buffer->data(), length() + 1);
+    strcpy(newBuffer->mutableData(), m_buffer->data());
     m_buffer = WTFMove(newBuffer);
 }
 

--- a/Source/WebCore/loader/FTPDirectoryParser.cpp
+++ b/Source/WebCore/loader/FTPDirectoryParser.cpp
@@ -327,7 +327,7 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
                         /* if VMS has been detected and there is only one token and that
                          * token was a VMS filename then this is a multiline VMS LIST entry.
                          */
-                        if (pos >= (sizeof(state.carryBuffer) - 1))
+                        if (pos > (sizeof(state.carryBuffer) - 1))
                             pos = (sizeof(state.carryBuffer) - 1); /* shouldn't happen */
                         memcpy(state.carryBuffer, p, pos);
                         state.carryBufferLength = pos;

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -243,7 +243,7 @@ void convertImagePixels(const ConstPixelBufferConversionView& source, const Pixe
 
 #if USE(ACCELERATE) && USE(CG)
     if (source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat) {
-        // FIXME: Can thes both just use per-row memcpy?
+        // FIXME: Can these both just use per-row memcpy?
         if (source.format.alphaFormat == AlphaPremultiplication::Premultiplied)
             convertImagePixelsUnaccelerated<convertSinglePixelPremultipliedToPremultiplied<PixelFormatConversion::None>>(source, destination, destinationSize);
         else

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -179,8 +179,7 @@ HGLOBAL createGlobalData(const Vector<char>& vector)
     if (!vm)
         return 0;
     char* buffer = static_cast<char*>(GlobalLock(vm));
-    memcpy(buffer, vector.data(), vector.size());
-    buffer[vector.size()] = 0;
+    strcpy(buffer, vector.data());
     GlobalUnlock(vm);
     return vm;
 }
@@ -190,8 +189,8 @@ HGLOBAL createGlobalData(const uint8_t* data, size_t length)
     HGLOBAL vm = ::GlobalAlloc(GPTR, length + 1);
     if (!vm)
         return 0;
-    uint8_t* buffer = static_cast<uint8_t*>(GlobalLock(vm));
-    memcpy(buffer, data, length);
+    char* buffer = static_cast<char*>(GlobalLock(vm));
+    strcpy(buffer, static_cast<char*>(data));
     buffer[length] = 0;
     GlobalUnlock(vm);
     return vm;
@@ -752,8 +751,7 @@ void setUTF8Data(IDataObject* data, FORMATETC* format, const Vector<String>& dat
     if (!medium.hGlobal)
         return;
     char* buffer = static_cast<char*>(GlobalLock(medium.hGlobal));
-    memcpy(buffer, charString.data(), stringLength);
-    buffer[stringLength] = 0;
+    strcpy(buffer, charString.data());
     GlobalUnlock(medium.hGlobal);
     data->SetData(format, &medium, FALSE);
     ::GlobalFree(medium.hGlobal);


### PR DESCRIPTION
<pre>
Prefer strcpy over memcpy where appropriate
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3c55120e3c21ea0b7da5b31c94b5037edbf9a3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112424 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4203 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121020 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5242 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105478 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46026 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100767 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13924 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/94983 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12035 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10151 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102199 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52795 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31926 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16433 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110238 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27229 "Passed tests") | 
<!--EWS-Status-Bubble-End-->