### PR TITLE
Skip more tests with large WASM memories on memory-limited platforms

### DIFF
--- a/JSTests/wasm/stress/externref-result-tuple.js
+++ b/JSTests/wasm/stress/externref-result-tuple.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture == "arm"
+//@ skip if $architecture == "arm" or $memoryLimited
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/wasm/stress/only-referenced.js
+++ b/JSTests/wasm/stress/only-referenced.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture != 'x86_64' && $architecture != "arm64"
+//@ skip if ($architecture != 'x86_64' && $architecture != "arm64") or $memoryLimited
 (async function () {
   let bytes0 = readFile('./resources/only-referenced.wasm', 'binary');
   let global1 = new WebAssembly.Global({value: 'externref', mutable: true}, {});


### PR DESCRIPTION
#### 33854d7c1777604887c498e3a776b633726d6856
<pre>
Skip more tests with large WASM memories on memory-limited platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=253893">https://bugs.webkit.org/show_bug.cgi?id=253893</a>
rdar://106216202

Reviewed by Justin Michaud.

Skips WASM stress tests externref-result-tuple.js and only-referenced.js on
memory-limited platforms since they allocate huge (~2.5GB) WASM memories.

* JSTests/wasm/stress/externref-result-tuple.js:
* JSTests/wasm/stress/only-referenced.js:

Canonical link: <a href="https://commits.webkit.org/261698@main">https://commits.webkit.org/261698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aea4a342131292780961a767a6109ce0f65b9e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121021 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5279 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105481 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46029 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100768 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13927 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/94998 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12036 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10150 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102202 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52802 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31927 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8159 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16436 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110241 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27230 "Passed tests") | 
<!--EWS-Status-Bubble-End-->