### PR TITLE
Prefer XCTAssertEqualObjects over XCTAssertEqual

### DIFF
--- a/Source/WebKit/SwiftOverlay/Tests/JavaScriptToSwiftTypeConversions.swift
+++ b/Source/WebKit/SwiftOverlay/Tests/JavaScriptToSwiftTypeConversions.swift
@@ -59,7 +59,7 @@ final class JavaScriptToSwiftConversions : XCTestCase {
         webView.evaluateJavaScript(javaScript, in: nil, in: .defaultClient) { result in
             do {
                 let actualValue = try result.get() as? T
-                XCTAssertEqual(actualValue, expectedValue)
+                XCTAssertEqualObjects(actualValue, expectedValue)
                 evaluationExpectation.fulfill()
             } catch {
                 XCTFail("Evaluating \(javaScript.debugDescription) failed with error: \(error)")
@@ -129,7 +129,7 @@ final class JavaScriptToSwiftConversions : XCTestCase {
             return
         }
 
-        XCTAssertEqual(result, "Hello, world!")
+        XCTAssertEqualObjects(result, "Hello, world!")
     }
     #endif
 }

--- a/Source/WebKit/SwiftOverlay/Tests/WebKitTests.swift
+++ b/Source/WebKit/SwiftOverlay/Tests/WebKitTests.swift
@@ -43,16 +43,16 @@ class WebKitTests: XCTestCase {
         XCTAssert(type(of: configuration.rect) == Optional<CGRect>.self)
 
         configuration.rect = nil
-        XCTAssertEqual(configuration.rect, nil)
+        XCTAssertEqualObjects(configuration.rect, nil)
 
         configuration.rect = .null
-        XCTAssertEqual(configuration.rect, nil)
+        XCTAssertEqualObjects(configuration.rect, nil)
 
         configuration.rect = CGRect.zero
-        XCTAssertEqual(configuration.rect, .zero)
+        XCTAssertEqualObjects(configuration.rect, .zero)
 
         let originalPhoneBounds = CGRect(x: 0, y: 0, width: 320, height: 480)
         configuration.rect = originalPhoneBounds
-        XCTAssertEqual(configuration.rect, originalPhoneBounds)
+        XCTAssertEqualObjects(configuration.rect, originalPhoneBounds)
     }
 }


### PR DESCRIPTION
<pre>
Prefer XCTAssertEqualObjects over XCTAssertEqual
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebKit/SwiftOverlay/Tests/JavaScriptToSwiftTypeConversions.swift:
(JavaScriptToSwiftConversions : XCTestCase):
* Source/WebKit/SwiftOverlay/Tests/WebKitTests.swift:
(XCTestCase):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e851f02e800824d256b0b1d82983bf034d4e42d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121522 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6043 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118824 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17495 "1 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106128 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46518 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14484 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1331 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10669 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53323 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17043 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->