### PR TITLE
[git-webkit] Allow independent installation of hooks

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.0.0',
+    version='6.0.1',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 0, 0)
+version = Version(6, 0, 1)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -40,6 +40,7 @@ from .find import Find, Info
 from .pickable import Pickable
 from .publish import Publish
 from .install_git_lfs import InstallGitLFS
+from .install_hooks import InstallHooks
 from .land import Land
 from .log import Log
 from .pull import Pull
@@ -94,7 +95,7 @@ def main(
         PullRequest, Revert, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
         Pickable, CherryPick, Trace, Track, Show, Publish,
-        Classify,
+        Classify, InstallHooks,
     ] + (programs or [])
     if subversion:
         programs.append(SetupGitSvn)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import re
+import sys
+
+from .command import Command
+from webkitbugspy import radar
+from webkitcorepy import run, string_utils
+from webkitscmpy import log, local, remote
+
+
+class InstallHooks(Command):
+    name = 'install-hooks'
+    help = 'Re-install all hooks from this repository into this checkout'
+
+    REMOTE_RE = re.compile(r'(?P<protcol>[^@:]+)(@|://)(?P<host>[^:/]+)(/|:)(?P<path>[^\.]+[^\./])(\.git)?/?')
+    MODES = ('default', 'publish', 'no-radar')
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            'arguments', nargs='*',
+            type=str, default=None,
+            help='Name of specific hooks to be installed',
+        )
+        parser.add_argument(
+            '--mode', default=cls.MODES[0],
+            help='Set default mode for installed hooks ({})'.format(string_utils.join(cls.MODES, conjunction='or')),
+        )
+
+    @classmethod
+    def _security_levels(cls, repository):
+        proc = run(
+            [local.Git.executable(), 'config', '--get-regexp', 'webkitscmpy.remotes'],
+            capture_output=True, cwd=repository.root_path,
+            encoding='utf-8',
+        )
+        if proc.returncode:
+            return {}
+
+        levels_by_name = {}
+        remotes_by_name = {}
+        for line in proc.stdout.splitlines():
+            key, value = line.split(' ', 1)
+            parts = key.split('.')
+            if len(parts) != 4:
+                continue
+            if parts[3] == 'url':
+                remotes_by_name[parts[2]] = value
+            elif parts[3] == 'security-level':
+                levels_by_name[parts[2]] = int(value)
+
+        result = {}
+        for name, rmt in remotes_by_name.items():
+            match = cls.REMOTE_RE.match(rmt)
+            if match:
+                result['{}:{}'.format(match.group('host'), match.group('path'))] = levels_by_name.get(name, None)
+
+        proc = run(
+            [local.Git.executable(), 'config', '--get-regexp', 'remote.+url'],
+            capture_output=True, cwd=repository.root_path,
+            encoding='utf-8',
+        )
+        if proc.returncode:
+            return result
+        for line in proc.stdout.splitlines():
+            _, value = line.split(' ', 1)
+            match = cls.REMOTE_RE.match(value)
+            if not match:
+                continue
+            key = '{}:{}'.format(match.group('host'), match.group('path'))
+            if key in result:
+                continue
+            repo = 'https://{}/{}'.format(match.group('host'), match.group('path'))
+            if not remote.GitHub.is_webserver(repo):
+                continue
+            parent = ((remote.GitHub(repo).request() or {}).get('parent') or {}).get('full_name')
+            if not parent:
+                continue
+            parent_key = '{}:{}'.format(match.group('host'), parent)
+            if parent_key in result:
+                result[key] = result[parent_key]
+        return result
+
+    @classmethod
+    def main(cls, args, repository, hooks=None, **kwargs):
+        if not isinstance(repository, local.Git):
+            sys.stderr.write('Can only install hooks in a native git repository\n')
+            return 1
+        if not hooks:
+            sys.stderr.write('No hooks to install\n')
+            return 1
+
+        candidates = os.listdir(hooks)
+        if getattr(args, 'arguments', []):
+            hook_names = []
+            for argument in args.arguments:
+                if argument in candidates:
+                    hook_names.append(argument)
+                else:
+                    sys.stderr.write("'{}' is not a configured hook in this repository\n".format(argument))
+        else:
+            hook_names = candidates
+
+        if not hook_names:
+            sys.stderr.write('No matching hooks in repository to install\n')
+            return 1
+
+        security_levels = cls._security_levels(repository)
+        for hook in hook_names:
+            source_path = os.path.join(hooks, hook)
+            if not os.path.isfile(source_path):
+                continue
+            log.info("Configuring and copying hook '{}' for this repository".format(hook))
+            with open(source_path, 'r') as f:
+                from jinja2 import Template
+                contents = Template(f.read()).render(
+                    location=source_path,
+                    python=os.path.basename(sys.executable),
+                    prefer_radar=bool(radar.Tracker.radarclient()),
+                    default_pre_push_mode="'{}'".format(getattr(args, 'mode', cls.MODES[0])),
+                    security_levels=security_levels,
+                )
+
+            target = os.path.join(repository.common_directory, 'hooks', hook)
+            if not os.path.exists(os.path.dirname(target)):
+                os.makedirs(os.path.dirname(target))
+            with open(target, 'w') as f:
+                f.write(contents)
+                f.write('\n')
+            os.chmod(target, 0o775)
+
+        print('Successfully installed {} repository hooks'.format(len(hook_names)))
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
@@ -236,4 +236,4 @@ Fetching 'fork'
             self.assertDictEqual({
                 'example.org:project/project': 0,
                 'example.org:project/project-security': 1,
-            }, program.Setup._security_levels(local.Git(self.path)))
+            }, program.InstallHooks._security_levels(local.Git(self.path)))


### PR DESCRIPTION
#### a4daad5b9fbd26d557088037f54dc0935a437182
<pre>
[git-webkit] Allow independent installation of hooks
<a href="https://bugs.webkit.org/show_bug.cgi?id=253897">https://bugs.webkit.org/show_bug.cgi?id=253897</a>
rdar://106716871

Reviewed by Elliott Williams.

Move hook installation into an independent program so services can install specific hooks.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Include InstallHooks program.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py: Added.
(InstallHooks.parser): Allow caller to specify default mode and specific hook to install.
(InstallHooks._security_levels): Moved from Setup._security_levels.
(InstallHooks.main): Moveed hook installation from Setup.git.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.git): Move hook installation to InstallHooks.
(Setup._security_levels): Move to InstallHooks._security_levels.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:

Canonical link: <a href="https://commits.webkit.org/261653@main">https://commits.webkit.org/261653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0601440710f09f10c06988a8608e421510d7304

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112472 "Failed to checkout and rebase branch from PR 11509") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4251 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22959 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118239 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/100246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105528 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/115891 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/111233 "Failed to checkout and rebase branch from PR 11509") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/52833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/16482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4440 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->