### PR TITLE
Fix data race found by TSan in AudioScheduledSourceNode

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.h
@@ -82,7 +82,8 @@ protected:
 
     bool requiresTailProcessing() const final { return false; }
 
-    PlaybackState m_playbackState { UNSCHEDULED_STATE };
+    // This is accessed from the main thread and the audio thread.
+    std::atomic<PlaybackState> m_playbackState { UNSCHEDULED_STATE };
 
     // m_startTime is the time to start playing based on the context's timeline (0 or a time less than the context's current time means "now").
     double m_startTime { 0 }; // in seconds


### PR DESCRIPTION
#### b0b96aa8e1b2fce0e445fb209902536ec08f1edc
<pre>
Fix data race found by TSan in AudioScheduledSourceNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=253898">https://bugs.webkit.org/show_bug.cgi?id=253898</a>

Reviewed by Jer Noble.

AudioScheduledSourceNode::m_playbackState was accessed from several threads
without synchronization. Use std::atomic&lt;&gt; to address the issue.

* Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.h:

Canonical link: <a href="https://commits.webkit.org/261693@main">https://commits.webkit.org/261693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9cc1c1a232601179f2317db1443605e97526bcb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4227 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121031 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5371 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118215 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17032 "5 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46046 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13945 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/810 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10170 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52813 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8153 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16457 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->