### PR TITLE
Consolidate nested Interaction Regions where it makes sense

### DIFF
--- a/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
+++ b/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
@@ -1,0 +1,39 @@
+Nested  Nested  Nested Secondary
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction
+            (rect (0,0) width=125 height=100)
+)
+        (borderRadius 12.00),
+        (interaction
+            (rect (128,0) width=125 height=100)
+)
+        (borderRadius 12.00),
+        (interaction
+            (rect (148,20) width=85 height=60)
+)
+        (borderRadius 8.00),
+        (interaction
+            (rect (256,0) width=126 height=100)
+)
+        (borderRadius 12.00),
+        (interaction
+            (rect (293,20) width=69 height=20)
+)
+        (borderRadius 5.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/consolidated-nested-regions.html
+++ b/LayoutTests/interaction-region/consolidated-nested-regions.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    .nested {
+        position: relative;
+        display: inline-block;
+        padding: 10px;
+        cursor: pointer;
+    }
+    .secondary {
+        position: absolute;
+        top: 0;
+        right: 0;
+        border-radius: 5px;
+    }
+</style>
+<body>
+<div class="nested" style="border-radius: 12px;">
+    <div class="nested">
+        <div class="nested">
+            <div class="nested">
+                Nested
+            </div>
+        </div>
+    </div>
+</div>
+<div class="nested" style="border-radius: 12px;">
+    <div class="nested">
+        <div class="nested" style="background: green; border-radius: 8px">
+            <div class="nested">
+                Nested
+            </div>
+        </div>
+    </div>
+</div>
+<div class="nested" style="border-radius: 12px;">
+    <div class="nested">
+        <div class="nested">
+            <div class="nested">
+                Nested
+            </div>
+            <a href="#" class="secondary">Secondary</a>
+        </div>
+    </div>
+</div>
+
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -62,6 +62,7 @@ public:
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     void uniteInteractionRegions(const Region&, RenderObject&);
+    bool shouldConsolidateInteractionRegion(IntRect, RenderObject&);
     void copyInteractionRegionsToEventRegion();
 #endif
 
@@ -74,6 +75,7 @@ private:
     Vector<InteractionRegion> m_interactionRegions;
     HashSet<IntRect> m_interactionRects;
     HashSet<IntRect> m_occlusionRects;
+    HashMap<ElementIdentifier, IntRect> m_discoveredInteractionRectsByElement;
 #endif
 };
 


### PR DESCRIPTION
#### f3c76a7cf2ec4544d2d496403a3a6b3c13a75daa
<pre>
Consolidate nested Interaction Regions where it makes sense
<a href="https://bugs.webkit.org/show_bug.cgi?id=253899">https://bugs.webkit.org/show_bug.cgi?id=253899</a>
&lt;rdar://103458420&gt;

Reviewed by Tim Horton.

Keep track of discovered interaction region rects on the `EventRegionContext`
to find opportunities for consolidation.

* Source/WebCore/rendering/EventRegion.h:
Add an &lt;ElementIdentifier, IntRect&gt;  HashMap to the context.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
Check if the candidate region should be consolidated before adding it.
(WebCore::EventRegionContext::shouldConsolidateInteractionRegion):
Walk up the RenderTree looking for existing Interaction Regions containing
the candidate one. If there&apos;s too much margin exposed between the 2 rects
we&apos;ll keep the regions distinct. We also stop the search on elements that are
&quot;visually delimited&quot; (with a border / background style).

* LayoutTests/interaction-region/consolidated-nested-regions-expected.txt: Added.
* LayoutTests/interaction-region/consolidated-nested-regions.html: Added.
Add test covering cases where we should and shouldn&apos;t consolidate.

Canonical link: <a href="https://commits.webkit.org/261763@main">https://commits.webkit.org/261763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3036ce7dcfee079b4a41b36afecd02732e5e5ee6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5471 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105616 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46121 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14042 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/95213 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14724 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52907 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8204 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16561 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->