### PR TITLE
[ews] Allow any WebKit committer to stop ongoing build

### DIFF
--- a/Tools/CISupport/ews-build/master.cfg
+++ b/Tools/CISupport/ews-build/master.cfg
@@ -70,6 +70,7 @@ if not is_test_mode_enabled:
     authz = util.Authz(
         allowRules=[util.AnyEndpointMatcher(role='Buildbot-Administrators', defaultDeny=False),
                     util.RebuildBuildEndpointMatcher(role='Contributors'),
+                    util.StopBuildEndpointMatcher(role='Committers'),
                     util.AnyControlEndpointMatcher(role='Buildbot-Administrators')],
         roleMatchers=[util.RolesFromGroups(groupPrefix='WebKit/')]
     )


### PR DESCRIPTION
#### 41f47a0b64bd15c6fbb39b800f9327432d4935f6
<pre>
[ews] Allow any WebKit committer to stop ongoing build
<a href="https://bugs.webkit.org/show_bug.cgi?id=253669">https://bugs.webkit.org/show_bug.cgi?id=253669</a>

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-build/master.cfg:

Canonical link: <a href="https://commits.webkit.org/261654@main">https://commits.webkit.org/261654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0c3f27840d83d0e94310ce0eff10dad6120e036

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21612 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1116 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/4243 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit; Failed to upload built product") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116530 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/22951 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12759 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/4243 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit; Failed to upload built product") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118231 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/22951 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1116 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105520 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/22951 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1116 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1116 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12759 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/111225 "Passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/19993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1116 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/16474 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4442 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->