### PR TITLE
[JSC] Keep used locals alive for iterator_next / iterator_open

### DIFF
--- a/JSTests/stress/iterator-next-osr-exit-dead-1.js
+++ b/JSTests/stress/iterator-next-osr-exit-dead-1.js
@@ -1,0 +1,8 @@
+//@ runDefault("--thresholdForOptimizeAfterWarmUp=100", "--useConcurrentJIT=0")
+let obj = [];
+
+for (let i = 0; i < 10; i++) {
+    let [a] = obj;
+    obj.length = 1;
+    for (let j = 0; j < 10000; j++) { }
+}

--- a/JSTests/stress/iterator-next-osr-exit-dead-2.js
+++ b/JSTests/stress/iterator-next-osr-exit-dead-2.js
@@ -1,0 +1,14 @@
+//@ runDefault("--thresholdForOptimizeAfterWarmUp=100")
+let obj = [0];
+
+for (let i = 0; i < 10; i++) {
+    let [a, b] = obj;
+    obj.length = 2;
+
+    for (let i = 0; i < 1e5; i++) {
+        switch (Symbol) {
+            case Symbol:
+        }
+    }
+}
+

--- a/Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp
@@ -299,8 +299,8 @@ void computeUsesForBytecodeIndexImpl(const JSInstruction* instruction, Checkpoin
 
     case op_iterator_next: {
         auto bytecode = instruction->as<OpIteratorNext>();
-        useAtEachCheckpoint(bytecode.m_iterator);
-        useAtEachCheckpointStartingWith(OpIteratorNext::computeNext, bytecode.m_next, bytecode.m_iterable);
+        useAtEachCheckpoint(bytecode.m_iterator, bytecode.m_next);
+        useAtEachCheckpointStartingWith(OpIteratorNext::computeNext, bytecode.m_iterable);
         return;
     }
 


### PR DESCRIPTION
#### 49a82e3d03250e03f408b7a8aff80313b849932c
<pre>
[JSC] Keep used locals alive for iterator_next / iterator_open
<a href="https://bugs.webkit.org/show_bug.cgi?id=253907">https://bugs.webkit.org/show_bug.cgi?id=253907</a>
rdar://102754257

Reviewed by Keith Miller and Justin Michaud.

iterator_next and iterator_open can create a graph of DFG nodes. But this is problematic for OSR exit node liveness tracking.
We have phantom insertion phase to keep uses of instructions alive properly. But that analysis has an assumption that one instruction
cannot create a graph. As a result, the phase does block local analysis, and if the local is not used on that basic block,
we do not insert phantoms. Let&apos;s see

Block #0
    @0 GetLocal(local0)
    @1 Use(@0)
    @2 Jump(#1)
Block #1
    @3 ForceOSRExit

In #1, we do not know that local0 needs to be kept alive even if local0 is alive in bytecode. And phantom insertion phase cannot insert phantoms
to keep them alive since local0 operand in #1 is not filled.

This patch adds keepUsesOfCurrentInstructionAlive helper function and call it in the prologue of newly created basic block for one instruction.
This inserts all the uses of the instruction explicitly via GetLocal.

Block #0
    @0 GetLocal(local0)
    @1 Use(@0)
    @2 Jump(#1)
Block #1
    @3 GetLocal(local0)
    @4 ForceOSRExit

With this function, we insert @3 for local0, and now phatom insertion phase will see operand for local0 is filled in #1,
and appropriately insert Phantom into #1 too.

* JSTests/stress/iterator-next-osr-exit-dead-1.js: Added.
* JSTests/stress/iterator-next-osr-exit-dead-2.js: Added.
(i.i.switch):
* Source/JavaScriptCore/bytecode/BytecodeUseDef.cpp:
(JSC::computeUsesForBytecodeIndexImpl):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::keepUsesOfCurrentInstructionAlive):
(JSC::DFG::ByteCodeParser::parseBlock):

Canonical link: <a href="https://commits.webkit.org/261668@main">https://commits.webkit.org/261668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/676d5f26c8cf165d0d6c0b28ddbc9936a7566964

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121044 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5381 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118232 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105521 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/98999 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/796 "4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46053 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100791 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13962 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/828 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12065 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14655 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102242 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/19994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52832 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31938 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16475 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110281 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4452 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27241 "Passed tests") | 
<!--EWS-Status-Bubble-End-->