### PR TITLE
Rename AbstractDOMWindow to DOMWindow

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1234,7 +1234,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/cache/KeepaliveRequestTracker.h
     loader/cache/MemoryCache.h
 
-    page/AbstractDOMWindow.h
     page/AbstractFrameView.h
     page/ActivityState.h
     page/ActivityStateChangeObserver.h
@@ -1255,6 +1254,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/CrossSiteNavigationDataTransfer.h
     page/DOMSelection.h
     page/DOMTimer.h
+    page/DOMWindow.h
     page/DOMWindowExtension.h
     page/DatabaseProvider.h
     page/DebugOverlayRegions.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1807,7 +1807,6 @@ mathml/MathMLSpaceElement.cpp
 mathml/MathMLTokenElement.cpp
 mathml/MathMLUnderOverElement.cpp
 mathml/MathMLUnknownElement.cpp
-page/AbstractDOMWindow.cpp
 page/ActivityState.cpp
 page/AutoscrollController.cpp
 page/BarProp.cpp
@@ -1820,6 +1819,7 @@ page/ContextMenuController.cpp
 page/Crypto.cpp
 page/DOMSelection.cpp
 page/DOMTimer.cpp
+page/DOMWindow.cpp
 page/DOMWindowExtension.cpp
 page/DatabaseProvider.cpp
 page/DebugPageOverlays.cpp

--- a/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
@@ -111,7 +111,7 @@ static ALWAYS_INLINE bool allowsLegacyExpandoIndexedProperties()
 }
 
 template <DOMWindowType windowType>
-bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess(JSDOMGlobalObject* thisObject, AbstractDOMWindow& window, JSGlobalObject& lexicalGlobalObject, PropertyName propertyName, PropertySlot& slot, const String& errorMessage)
+bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess(JSDOMGlobalObject* thisObject, DOMWindow& window, JSGlobalObject& lexicalGlobalObject, PropertyName propertyName, PropertySlot& slot, const String& errorMessage)
 {
     VM& vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -171,8 +171,8 @@ bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess(JSDOMGlobalObject* thisO
     slot.setUndefined();
     return false;
 }
-template bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess<DOMWindowType::Local>(JSDOMGlobalObject*, AbstractDOMWindow&, JSGlobalObject&, PropertyName, PropertySlot&, const String&);
-template bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess<DOMWindowType::Remote>(JSDOMGlobalObject*, AbstractDOMWindow&, JSGlobalObject&, PropertyName, PropertySlot&, const String&);
+template bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess<DOMWindowType::Local>(JSDOMGlobalObject*, DOMWindow&, JSGlobalObject&, PropertyName, PropertySlot&, const String&);
+template bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess<DOMWindowType::Remote>(JSDOMGlobalObject*, DOMWindow&, JSGlobalObject&, PropertyName, PropertySlot&, const String&);
 
 // https://html.spec.whatwg.org/#crossorigingetownpropertyhelper-(-o,-p-)
 bool handleCommonCrossOriginProperties(JSObject* thisObject, VM& vm, PropertyName propertyName, PropertySlot& slot)

--- a/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.h
+++ b/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.h
@@ -22,14 +22,14 @@
 
 namespace WebCore {
 
-class AbstractDOMWindow;
+class DOMWindow;
 class Frame;
 
 JSLocalDOMWindow* asJSLocalDOMWindow(JSC::JSGlobalObject*);
 const JSLocalDOMWindow* asJSLocalDOMWindow(const JSC::JSGlobalObject*);
 
 enum class DOMWindowType : bool { Local, Remote };
-template<DOMWindowType> bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess(JSDOMGlobalObject*, AbstractDOMWindow&, JSC::JSGlobalObject&, JSC::PropertyName, JSC::PropertySlot&, const String&);
+template<DOMWindowType> bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess(JSDOMGlobalObject*, DOMWindow&, JSC::JSGlobalObject&, JSC::PropertyName, JSC::PropertySlot&, const String&);
 
 enum class CrossOriginObject : bool { Window, Location };
 template<CrossOriginObject> void addCrossOriginOwnPropertyNames(JSC::JSGlobalObject&, JSC::PropertyNameArray&);

--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -58,14 +58,14 @@ inline JSWindowProxy::JSWindowProxy(VM& vm, Structure& structure, DOMWrapperWorl
 {
 }
 
-void JSWindowProxy::finishCreation(VM& vm, AbstractDOMWindow& window)
+void JSWindowProxy::finishCreation(VM& vm, DOMWindow& window)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
     setWindow(window);
 }
 
-JSWindowProxy& JSWindowProxy::create(VM& vm, AbstractDOMWindow& window, DOMWrapperWorld& world)
+JSWindowProxy& JSWindowProxy::create(VM& vm, DOMWindow& window, DOMWrapperWorld& world)
 {
     auto& structure = *Structure::create(vm, 0, jsNull(), TypeInfo(PureForwardingProxyType, StructureFlags), info());
     auto& proxy = *new (NotNull, allocateCell<JSWindowProxy>(vm)) JSWindowProxy(vm, structure, world);
@@ -86,7 +86,7 @@ void JSWindowProxy::setWindow(VM& vm, JSDOMGlobalObject& window)
     GCController::singleton().garbageCollectSoon();
 }
 
-void JSWindowProxy::setWindow(AbstractDOMWindow& domWindow)
+void JSWindowProxy::setWindow(DOMWindow& domWindow)
 {
     // Replacing JSLocalDOMWindow via telling JSWindowProxy to use the same LocalDOMWindow it already uses makes no sense,
     // so we'd better never try to.
@@ -148,7 +148,7 @@ void JSWindowProxy::attachDebugger(JSC::Debugger* debugger)
         currentDebugger->detach(globalObject, JSC::Debugger::TerminatingDebuggingSession);
 }
 
-AbstractDOMWindow& JSWindowProxy::wrapped() const
+DOMWindow& JSWindowProxy::wrapped() const
 {
     auto* window = this->window();
     if (auto* jsWindow = jsDynamicCast<JSRemoteDOMWindowBase*>(window))

--- a/Source/WebCore/bindings/js/JSWindowProxy.h
+++ b/Source/WebCore/bindings/js/JSWindowProxy.h
@@ -39,7 +39,7 @@ class Debugger;
 
 namespace WebCore {
 
-class AbstractDOMWindow;
+class DOMWindow;
 class Frame;
 
 class WEBCORE_EXPORT JSWindowProxy final : public JSC::JSProxy {
@@ -50,18 +50,18 @@ public:
 
     template<typename CellType, JSC::SubspaceAccess> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm) { return subspaceForImpl(vm); }
 
-    static JSWindowProxy& create(JSC::VM&, AbstractDOMWindow&, DOMWrapperWorld&);
+    static JSWindowProxy& create(JSC::VM&, DOMWindow&, DOMWrapperWorld&);
 
     DECLARE_INFO;
 
     JSDOMGlobalObject* window() const { return static_cast<JSDOMGlobalObject*>(target()); }
 
     void setWindow(JSC::VM&, JSDOMGlobalObject&);
-    void setWindow(AbstractDOMWindow&);
+    void setWindow(DOMWindow&);
 
     WindowProxy* windowProxy() const;
 
-    AbstractDOMWindow& wrapped() const;
+    DOMWindow& wrapped() const;
     static WindowProxy* toWrapped(JSC::VM&, JSC::JSValue);
 
     DOMWrapperWorld& world() { return m_world; }
@@ -70,7 +70,7 @@ public:
 
 private:
     JSWindowProxy(JSC::VM&, JSC::Structure&, DOMWrapperWorld&);
-    void finishCreation(JSC::VM&, AbstractDOMWindow&);
+    void finishCreation(JSC::VM&, DOMWindow&);
     static JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM&);
 
     Ref<DOMWrapperWorld> m_world;

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -131,7 +131,7 @@ JSWindowProxy& WindowProxy::createJSWindowProxyWithInitializedScript(DOMWrapperW
     return windowProxy;
 }
 
-void WindowProxy::clearJSWindowProxiesNotMatchingDOMWindow(AbstractDOMWindow* newDOMWindow, bool goingIntoBackForwardCache)
+void WindowProxy::clearJSWindowProxiesNotMatchingDOMWindow(DOMWindow* newDOMWindow, bool goingIntoBackForwardCache)
 {
     if (m_jsWindowProxies->isEmpty())
         return;
@@ -155,7 +155,7 @@ void WindowProxy::clearJSWindowProxiesNotMatchingDOMWindow(AbstractDOMWindow* ne
         collectGarbageAfterWindowProxyDestruction();
 }
 
-void WindowProxy::setDOMWindow(AbstractDOMWindow* newDOMWindow)
+void WindowProxy::setDOMWindow(DOMWindow* newDOMWindow)
 {
     ASSERT(newDOMWindow);
 
@@ -199,7 +199,7 @@ void WindowProxy::attachDebugger(JSC::Debugger* debugger)
         windowProxy->attachDebugger(debugger);
 }
 
-AbstractDOMWindow* WindowProxy::window() const
+DOMWindow* WindowProxy::window() const
 {
     return m_frame ? m_frame->window() : nullptr;
 }

--- a/Source/WebCore/bindings/js/WindowProxy.h
+++ b/Source/WebCore/bindings/js/WindowProxy.h
@@ -32,7 +32,7 @@ class Debugger;
 
 namespace WebCore {
 
-class AbstractDOMWindow;
+class DOMWindow;
 class DOMWrapperWorld;
 class Frame;
 class JSDOMGlobalObject;
@@ -80,14 +80,14 @@ public:
 
     WEBCORE_EXPORT JSDOMGlobalObject* globalObject(DOMWrapperWorld&);
 
-    void clearJSWindowProxiesNotMatchingDOMWindow(AbstractDOMWindow*, bool goingIntoBackForwardCache);
+    void clearJSWindowProxiesNotMatchingDOMWindow(DOMWindow*, bool goingIntoBackForwardCache);
 
-    WEBCORE_EXPORT void setDOMWindow(AbstractDOMWindow*);
+    WEBCORE_EXPORT void setDOMWindow(DOMWindow*);
 
     // Debugger can be nullptr to detach any existing Debugger.
     void attachDebugger(JSC::Debugger*); // Attaches/detaches in all worlds/window proxies.
 
-    WEBCORE_EXPORT AbstractDOMWindow* window() const;
+    WEBCORE_EXPORT DOMWindow* window() const;
 
 private:
     explicit WindowProxy(Frame&);

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -33,8 +33,8 @@
 
 namespace WebCore {
 
-class AbstractDOMWindow;
 class AbstractFrameView;
+class DOMWindow;
 class HTMLFrameOwnerElement;
 class Page;
 class Settings;
@@ -50,7 +50,7 @@ public:
 
     WindowProxy& windowProxy() { return m_windowProxy; }
     const WindowProxy& windowProxy() const { return m_windowProxy; }
-    AbstractDOMWindow* window() const { return virtualWindow(); }
+    DOMWindow* window() const { return virtualWindow(); }
     FrameTree& tree() const { return m_treeNode; }
     FrameIdentifier frameID() const { return m_frameID; }
     inline Page* page() const; // Defined in Page.h.
@@ -70,7 +70,7 @@ protected:
     void resetWindowProxy();
 
 private:
-    virtual AbstractDOMWindow* virtualWindow() const = 0;
+    virtual DOMWindow* virtualWindow() const = 0;
     virtual AbstractFrameView* virtualView() const = 0;
 
     WeakPtr<Page> m_page;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -406,7 +406,7 @@ void LocalDOMWindow::setCanShowModalDialogOverride(bool allow)
 }
 
 LocalDOMWindow::LocalDOMWindow(Document& document)
-    : AbstractDOMWindow(GlobalWindowIdentifier { Process::identifier(), WindowIdentifier::generate() })
+    : DOMWindow(GlobalWindowIdentifier { Process::identifier(), WindowIdentifier::generate() })
     , ContextDestructionObserver(&document)
 {
     ASSERT(frame());

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
-#include "AbstractDOMWindow.h"
 #include "Base64Utilities.h"
 #include "ContextDestructionObserver.h"
+#include "DOMWindow.h"
 #include "ExceptionOr.h"
 #include "ImageBitmap.h"
 #include "LocalFrame.h"
@@ -112,7 +112,7 @@ struct WindowPostMessageOptions : public StructuredSerializeOptions {
 };
 
 class LocalDOMWindow final
-    : public AbstractDOMWindow
+    : public DOMWindow
     , public ContextDestructionObserver
     , public Base64Utilities
     , public WindowOrWorkerGlobalScope
@@ -516,6 +516,6 @@ WebCoreOpaqueRoot root(LocalDOMWindow*);
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LocalDOMWindow)
-    static bool isType(const WebCore::AbstractDOMWindow& window) { return window.isLocalDOMWindow(); }
+    static bool isType(const WebCore::DOMWindow& window) { return window.isLocalDOMWindow(); }
     static bool isType(const WebCore::EventTarget& target) { return target.eventTargetInterface() == WebCore::LocalDOMWindowEventTargetInterfaceType; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -909,7 +909,7 @@ LocalDOMWindow* LocalFrame::window() const
     return document() ? document()->domWindow() : nullptr;
 }
 
-AbstractDOMWindow* LocalFrame::virtualWindow() const
+DOMWindow* LocalFrame::virtualWindow() const
 {
     return window();
 }

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -301,7 +301,7 @@ private:
     bool preventsParentFromBeingComplete() const final;
 
     AbstractFrameView* virtualView() const final;
-    AbstractDOMWindow* virtualWindow() const final;
+    DOMWindow* virtualWindow() const final;
 
     HashSet<FrameDestructionObserver*> m_destructionObservers;
 

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RemoteDOMWindow);
 
 RemoteDOMWindow::RemoteDOMWindow(RemoteFrame& frame, GlobalWindowIdentifier&& identifier)
-    : AbstractDOMWindow(WTFMove(identifier))
+    : DOMWindow(WTFMove(identifier))
     , m_frame(frame)
 {
 }

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "AbstractDOMWindow.h"
+#include "DOMWindow.h"
 #include "RemoteFrame.h"
 #include <JavaScriptCore/Strong.h>
 #include <wtf/IsoMalloc.h>
@@ -44,7 +44,7 @@ class LocalDOMWindow;
 class Document;
 class Location;
 
-class RemoteDOMWindow final : public AbstractDOMWindow {
+class RemoteDOMWindow final : public DOMWindow {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(RemoteDOMWindow, WEBCORE_EXPORT);
 public:
     static Ref<RemoteDOMWindow> create(RemoteFrame& frame, GlobalWindowIdentifier&& identifier)
@@ -82,5 +82,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::RemoteDOMWindow)
-    static bool isType(const WebCore::AbstractDOMWindow& window) { return window.isRemoteDOMWindow(); }
+    static bool isType(const WebCore::DOMWindow& window) { return window.isRemoteDOMWindow(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -60,7 +60,7 @@ RemoteFrame::RemoteFrame(Page& page, UniqueRef<RemoteFrameClient>&& client, Fram
 
 RemoteFrame::~RemoteFrame() = default;
 
-AbstractDOMWindow* RemoteFrame::virtualWindow() const
+DOMWindow* RemoteFrame::virtualWindow() const
 {
     return &window();
 }

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -67,7 +67,7 @@ private:
     bool preventsParentFromBeingComplete() const final;
 
     AbstractFrameView* virtualView() const final;
-    AbstractDOMWindow* virtualWindow() const final;
+    DOMWindow* virtualWindow() const final;
 
     Ref<RemoteDOMWindow> m_window;
     RefPtr<Frame> m_opener;

--- a/Source/WebKitLegacy/mac/DOM/DOMAbstractView.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMAbstractView.mm
@@ -94,7 +94,7 @@ DOMAbstractView *kit(WebCore::LocalDOMWindow* value)
     return wrapper.autorelease();
 }
 
-DOMAbstractView *kit(WebCore::AbstractDOMWindow* value)
+DOMAbstractView *kit(WebCore::DOMWindow* value)
 {
     if (!is<WebCore::LocalDOMWindow>(value))
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMAbstractViewInternal.h
+++ b/Source/WebKitLegacy/mac/DOM/DOMAbstractViewInternal.h
@@ -26,14 +26,14 @@
 #import <WebKitLegacy/DOMAbstractView.h>
 
 namespace WebCore {
-class AbstractDOMWindow;
+class DOMWindow;
 class LocalDOMWindow;
 class WindowProxy;
 }
 
 WebCore::LocalDOMWindow* core(DOMAbstractView *);
 DOMAbstractView *kit(WebCore::LocalDOMWindow*);
-DOMAbstractView *kit(WebCore::AbstractDOMWindow*);
+DOMAbstractView *kit(WebCore::DOMWindow*);
 DOMAbstractView *kit(WebCore::WindowProxy*);
 WebCore::WindowProxy* toWindowProxy(DOMAbstractView *);
 


### PR DESCRIPTION
#### 1c7b0ed34d20cef2c5335fe8c64f19254df064ac
<pre>
Rename AbstractDOMWindow to DOMWindow
<a href="https://bugs.webkit.org/show_bug.cgi?id=253914">https://bugs.webkit.org/show_bug.cgi?id=253914</a>

Reviewed by Ryosuke Niwa.

Rename AbstractDOMWindow to DOMWindow, now that DOMWindow was renamed to
LocalDOMWindow.

* Source/WebCore/*:
* Source/WebKitLegacy/*:

Canonical link: <a href="https://commits.webkit.org/261662@main">https://commits.webkit.org/261662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/302a4702d55ab49a5941845b65074906fbe7fa10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4252 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12775 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118240 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105529 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13970 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/834 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52838 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16483 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4449 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->