### PR TITLE
Use RefPtr when dealing with API::Object*

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -327,7 +327,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
 
 - (void)_callReplyWithID:(uint64_t)replyID blockInvocation:(const WebKit::UserData&)blockInvocation
 {
-    auto encodedInvocation = blockInvocation.object();
+    auto encodedInvocation = blockInvocation.object().get();
     if (!encodedInvocation || encodedInvocation->type() != API::Object::Type::Dictionary)
         return;
 

--- a/Source/WebKit/Shared/API/c/WKContextMenuItem.cpp
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItem.cpp
@@ -150,7 +150,7 @@ WKArrayRef WKContextMenuCopySubmenuItems(WKContextMenuItemRef itemRef)
 WKTypeRef WKContextMenuItemGetUserData(WKContextMenuItemRef itemRef)
 {
 #if ENABLE(CONTEXT_MENUS)
-    return WebKit::toAPI(WebKit::toImpl(itemRef)->userData());
+    return WebKit::toAPI(WebKit::toImpl(itemRef)->userData().get());
 #else
     UNUSED_PARAM(itemRef);
     return 0;

--- a/Source/WebKit/Shared/UserData.cpp
+++ b/Source/WebKit/Shared/UserData.cpp
@@ -124,7 +124,7 @@ static RefPtr<API::Object> transformGraph(API::Object& object, const UserData::T
     return transformer.transformObject(object);
 }
 
-RefPtr<API::Object> UserData::transform(API::Object* object, const Transformer& transformer)
+RefPtr<API::Object> UserData::transform(const RefPtr<API::Object>& object, const Transformer& transformer)
 {
     if (!object)
         return nullptr;
@@ -145,7 +145,7 @@ bool UserData::decode(IPC::Decoder& decoder, UserData& userData)
     return decode(decoder, userData.m_object);
 }
 
-void UserData::encode(IPC::Encoder& encoder, const API::Object* object)
+void UserData::encode(IPC::Encoder& encoder, const RefPtr<API::Object>& object)
 {
     if (!object) {
         encoder << API::Object::Type::Null;

--- a/Source/WebKit/Shared/UserData.h
+++ b/Source/WebKit/Shared/UserData.h
@@ -47,14 +47,14 @@ public:
         virtual bool shouldTransformObject(const API::Object&) const = 0;
         virtual RefPtr<API::Object> transformObject(API::Object&) const = 0;
     };
-    static RefPtr<API::Object> transform(API::Object*, const Transformer&);
+    static RefPtr<API::Object> transform(const RefPtr<API::Object>&, const Transformer&);
 
-    API::Object* object() const { return m_object.get(); }
+    RefPtr<API::Object> object() const { return m_object; }
 
     void encode(IPC::Encoder&) const;
     static bool decode(IPC::Decoder&, UserData&) WARN_UNUSED_RETURN;
 
-    static void encode(IPC::Encoder&, const API::Object*);
+    static void encode(IPC::Encoder&, const RefPtr<API::Object>&);
     static bool decode(IPC::Decoder&, RefPtr<API::Object>&) WARN_UNUSED_RETURN;
 
 private:

--- a/Source/WebKit/Shared/WebConnection.cpp
+++ b/Source/WebKit/Shared/WebConnection.cpp
@@ -47,7 +47,7 @@ void WebConnection::initializeConnectionClient(const WKConnectionClientBase* cli
     m_client.initialize(client);
 }
 
-void WebConnection::postMessage(const String& messageName, API::Object* messageBody)
+void WebConnection::postMessage(const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     if (!hasValidConnection())
         return;

--- a/Source/WebKit/Shared/WebConnection.h
+++ b/Source/WebKit/Shared/WebConnection.h
@@ -41,14 +41,14 @@ public:
     virtual ~WebConnection();
 
     void initializeConnectionClient(const WKConnectionClientBase*);
-    void postMessage(const String&, API::Object*);
+    void postMessage(const String&, const RefPtr<API::Object>&);
     void didClose();
 
 protected:
     explicit WebConnection();
 
-    virtual RefPtr<API::Object> transformHandlesToObjects(API::Object*) = 0;
-    virtual RefPtr<API::Object> transformObjectsToHandles(API::Object*) = 0;
+    virtual RefPtr<API::Object> transformHandlesToObjects(const RefPtr<API::Object>&) = 0;
+    virtual RefPtr<API::Object> transformObjectsToHandles(const RefPtr<API::Object>&) = 0;
 
     // IPC::MessageReceiver
     // Implemented in generated WebConnectionMessageReceiver.cpp

--- a/Source/WebKit/Shared/WebConnectionClient.cpp
+++ b/Source/WebKit/Shared/WebConnectionClient.cpp
@@ -32,12 +32,12 @@
 
 namespace WebKit {
 
-void WebConnectionClient::didReceiveMessage(WebConnection* connection, const String& messageName, API::Object* messageBody)
+void WebConnectionClient::didReceiveMessage(WebConnection* connection, const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     if (!m_client.didReceiveMessage)
         return;
     
-    m_client.didReceiveMessage(toAPI(connection), toAPI(messageName.impl()), toAPI(messageBody), m_client.base.clientInfo);
+    m_client.didReceiveMessage(toAPI(connection), toAPI(messageName.impl()), toAPI(messageBody.get()), m_client.base.clientInfo);
 }
 
 void WebConnectionClient::didClose(WebConnection* connection)

--- a/Source/WebKit/Shared/WebConnectionClient.h
+++ b/Source/WebKit/Shared/WebConnectionClient.h
@@ -44,7 +44,7 @@ class WebConnection;
 
 class WebConnectionClient : public API::Client<WKConnectionClientBase> {
 public:
-    void didReceiveMessage(WebConnection*, const String&, API::Object*);
+    void didReceiveMessage(WebConnection*, const String&, const RefPtr<API::Object>&);
     void didClose(WebConnection*);
 };
 

--- a/Source/WebKit/Shared/WebContextMenuItem.cpp
+++ b/Source/WebKit/Shared/WebContextMenuItem.cpp
@@ -71,12 +71,12 @@ Ref<API::Array> WebContextMenuItem::submenuItemsAsAPIArray() const
     return API::Array::create(WTFMove(submenuItems));
 }
 
-API::Object* WebContextMenuItem::userData() const
+RefPtr<API::Object> WebContextMenuItem::userData() const
 {
     return m_webContextMenuItemData.userData();
 }
 
-void WebContextMenuItem::setUserData(API::Object* userData)
+void WebContextMenuItem::setUserData(const RefPtr<API::Object>& userData)
 {
     m_webContextMenuItemData.setUserData(userData);
 }

--- a/Source/WebKit/Shared/WebContextMenuItem.h
+++ b/Source/WebKit/Shared/WebContextMenuItem.h
@@ -53,8 +53,8 @@ public:
 
     Ref<API::Array> submenuItemsAsAPIArray() const;
 
-    API::Object* userData() const;
-    void setUserData(API::Object*);
+    RefPtr<API::Object> userData() const;
+    void setUserData(const RefPtr<API::Object>&);
 
     const WebContextMenuItemData& data() { return m_webContextMenuItemData; }
 

--- a/Source/WebKit/Shared/WebContextMenuItemData.cpp
+++ b/Source/WebKit/Shared/WebContextMenuItemData.cpp
@@ -92,12 +92,12 @@ ContextMenuItem WebContextMenuItemData::core() const
     return ContextMenuItem(m_action, m_title, m_enabled, m_checked, subMenuItems, m_indentationLevel);
 }
 
-API::Object* WebContextMenuItemData::userData() const
+RefPtr<API::Object> WebContextMenuItemData::userData() const
 {
-    return m_userData.get();
+    return m_userData;
 }
 
-void WebContextMenuItemData::setUserData(API::Object* userData)
+void WebContextMenuItemData::setUserData(const RefPtr<API::Object>& userData)
 {
     m_userData = userData;
 }

--- a/Source/WebKit/Shared/WebContextMenuItemData.h
+++ b/Source/WebKit/Shared/WebContextMenuItemData.h
@@ -58,8 +58,8 @@ public:
     
     WebCore::ContextMenuItem core() const;
     
-    API::Object* userData() const;
-    void setUserData(API::Object*);
+    RefPtr<API::Object> userData() const;
+    void setUserData(const RefPtr<API::Object>&);
     
     void encode(IPC::Encoder&) const;
     static std::optional<WebContextMenuItemData> decode(IPC::Decoder&);

--- a/Source/WebKit/UIProcess/API/APIContextMenuClient.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuClient.h
@@ -53,14 +53,14 @@ class ContextMenuClient {
 public:
     virtual ~ContextMenuClient() { }
 
-    virtual void getContextMenuFromProposedMenu(WebKit::WebPageProxy&, Vector<Ref<WebKit::WebContextMenuItem>>&& proposedMenu, WebKit::WebContextMenuListenerProxy& listener, const WebKit::WebHitTestResultData&, API::Object* /* userData */) { listener.useContextMenuItems(WTFMove(proposedMenu)); }
+    virtual void getContextMenuFromProposedMenu(WebKit::WebPageProxy&, Vector<Ref<WebKit::WebContextMenuItem>>&& proposedMenu, WebKit::WebContextMenuListenerProxy& listener, const WebKit::WebHitTestResultData&, const RefPtr<API::Object>& /* userData */) { listener.useContextMenuItems(WTFMove(proposedMenu)); }
     virtual void customContextMenuItemSelected(WebKit::WebPageProxy&, const WebKit::WebContextMenuItemData&) { }
     virtual void showContextMenu(WebKit::WebPageProxy&, const WebCore::IntPoint&, const Vector<Ref<WebKit::WebContextMenuItem>>&) { }
     virtual bool canShowContextMenu() const { return false; }
     virtual bool hideContextMenu(WebKit::WebPageProxy&) { return false; }
 
 #if PLATFORM(MAC)
-    virtual void menuFromProposedMenu(WebKit::WebPageProxy&, NSMenu *menu, const WebKit::ContextMenuContextData&, API::Object*, CompletionHandler<void(RetainPtr<NSMenu>&&)>&& completionHandler) { completionHandler(menu); }
+    virtual void menuFromProposedMenu(WebKit::WebPageProxy&, NSMenu *menu, const WebKit::ContextMenuContextData&, const RefPtr<API::Object>&, CompletionHandler<void(RetainPtr<NSMenu>&&)>&& completionHandler) { completionHandler(menu); }
 #endif
 };
 

--- a/Source/WebKit/UIProcess/API/APIFormClient.h
+++ b/Source/WebKit/UIProcess/API/APIFormClient.h
@@ -41,7 +41,7 @@ class FormClient {
 public:
     virtual ~FormClient() { }
 
-    virtual void willSubmitForm(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, WebKit::WebFrameProxy&, const Vector<std::pair<WTF::String, WTF::String>>&, API::Object*, WTF::Function<void(void)>&& completionHandler)
+    virtual void willSubmitForm(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, WebKit::WebFrameProxy&, const Vector<std::pair<WTF::String, WTF::String>>&, const RefPtr<API::Object>&, WTF::Function<void(void)>&& completionHandler)
     {
         completionHandler();
     }

--- a/Source/WebKit/UIProcess/API/APIInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/API/APIInjectedBundleClient.h
@@ -41,8 +41,8 @@ class InjectedBundleClient {
 public:
     virtual ~InjectedBundleClient() = default;
 
-    virtual void didReceiveMessageFromInjectedBundle(WebKit::WebProcessPool&, const WTF::String&, API::Object*) { }
-    virtual void didReceiveSynchronousMessageFromInjectedBundle(WebKit::WebProcessPool&, const WTF::String&, API::Object*, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler) { completionHandler(nullptr); }
+    virtual void didReceiveMessageFromInjectedBundle(WebKit::WebProcessPool&, const WTF::String&, const RefPtr<API::Object>&) { }
+    virtual void didReceiveSynchronousMessageFromInjectedBundle(WebKit::WebProcessPool&, const WTF::String&, const RefPtr<API::Object>&, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler) { completionHandler(nullptr); }
     virtual RefPtr<API::Object> getInjectedBundleInitializationUserData(WebKit::WebProcessPool&) { return nullptr; }
 };
 

--- a/Source/WebKit/UIProcess/API/APILoaderClient.h
+++ b/Source/WebKit/UIProcess/API/APILoaderClient.h
@@ -53,17 +53,17 @@ class LoaderClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~LoaderClient() { }
-    virtual void didStartProvisionalLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, API::Object*) { }
-    virtual void didReceiveServerRedirectForProvisionalLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, API::Object*) { }
-    virtual void didFailProvisionalLoadWithErrorForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, const WebCore::ResourceError&, API::Object*) { }
-    virtual void didFinishLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, API::Object*) { }
-    virtual void didFailLoadWithErrorForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, const WebCore::ResourceError&, API::Object*) { }
-    virtual void didFirstVisuallyNonEmptyLayoutForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Object*) { }
+    virtual void didStartProvisionalLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, const RefPtr<API::Object>&) { }
+    virtual void didReceiveServerRedirectForProvisionalLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, const RefPtr<API::Object>&) { }
+    virtual void didFailProvisionalLoadWithErrorForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, const WebCore::ResourceError&, const RefPtr<API::Object>&) { }
+    virtual void didFinishLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, const RefPtr<API::Object>&) { }
+    virtual void didFailLoadWithErrorForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, const WebCore::ResourceError&, const RefPtr<API::Object>&) { }
+    virtual void didFirstVisuallyNonEmptyLayoutForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, const RefPtr<API::Object>&) { }
     virtual void didReachLayoutMilestone(WebKit::WebPageProxy&, OptionSet<WebCore::LayoutMilestone>) { }
     virtual bool shouldKeepCurrentBackForwardListItemInList(WebKit::WebPageProxy&, WebKit::WebBackForwardListItem&) { return true; }
     virtual bool processDidCrash(WebKit::WebPageProxy&) { return false; }
     virtual void didChangeBackForwardList(WebKit::WebPageProxy&, WebKit::WebBackForwardListItem*, Vector<Ref<WebKit::WebBackForwardListItem>>&&) { }
-    virtual void didCommitLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, API::Object*) { }
+    virtual void didCommitLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, const RefPtr<API::Object>&) { }
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIMessageListener.h
+++ b/Source/WebKit/UIProcess/API/APIMessageListener.h
@@ -33,7 +33,7 @@ namespace API {
 class MessageListener : public ObjectImpl<Object::Type::MessageListener> {
     WTF_MAKE_NONCOPYABLE(MessageListener);
 public:
-    static Ref<MessageListener> create(CompletionHandler<void(RefPtr<API::Object>)>&& reply)
+    static Ref<MessageListener> create(CompletionHandler<void(RefPtr<API::Object>&&)>&& reply)
     {
         return adoptRef(*new MessageListener(WTFMove(reply)));
     }
@@ -44,10 +44,10 @@ public:
     }
 
 private:
-    MessageListener(CompletionHandler<void(RefPtr<API::Object>)>&& reply)
+    MessageListener(CompletionHandler<void(RefPtr<API::Object>&&)>&& reply)
         : m_reply(WTFMove(reply)) { }
 
-    CompletionHandler<void(RefPtr<API::Object>)> m_reply;
+    CompletionHandler<void(RefPtr<API::Object>&&)> m_reply;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -54,7 +54,7 @@ namespace API {
 struct SubstituteData {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
-    SubstituteData(Vector<uint8_t>&& content, const WTF::String& MIMEType, const WTF::String& encoding, const WTF::String& baseURL, API::Object* userData, WebCore::SubstituteData::SessionHistoryVisibility sessionHistoryVisibility = WebCore::SubstituteData::SessionHistoryVisibility::Hidden)
+    SubstituteData(Vector<uint8_t>&& content, const WTF::String& MIMEType, const WTF::String& encoding, const WTF::String& baseURL, const RefPtr<API::Object>& userData, WebCore::SubstituteData::SessionHistoryVisibility sessionHistoryVisibility = WebCore::SubstituteData::SessionHistoryVisibility::Hidden)
         : content(WTFMove(content))
         , MIMEType(MIMEType)
         , encoding(encoding)

--- a/Source/WebKit/UIProcess/API/APINavigationClient.h
+++ b/Source/WebKit/UIProcess/API/APINavigationClient.h
@@ -77,27 +77,27 @@ class NavigationClient {
 public:
     virtual ~NavigationClient() { }
 
-    virtual void didStartProvisionalNavigation(WebKit::WebPageProxy&, const WebCore::ResourceRequest&, Navigation*, Object*) { }
+    virtual void didStartProvisionalNavigation(WebKit::WebPageProxy&, const WebCore::ResourceRequest&, Navigation*, const RefPtr<Object>&) { }
     virtual void didStartProvisionalLoadForFrame(WebKit::WebPageProxy&, WebCore::ResourceRequest&&, WebKit::FrameInfoData&&) { }
-    virtual void didReceiveServerRedirectForProvisionalNavigation(WebKit::WebPageProxy&, Navigation*, Object*) { }
+    virtual void didReceiveServerRedirectForProvisionalNavigation(WebKit::WebPageProxy&, Navigation*, const RefPtr<Object>&) { }
     virtual void willPerformClientRedirect(WebKit::WebPageProxy&, const WTF::String& destinationURL, double) { }
     virtual void didPerformClientRedirect(WebKit::WebPageProxy&, const WTF::String& sourceURL, const WTF::String& destinationURL) { }
     virtual void didCancelClientRedirect(WebKit::WebPageProxy&) { }
-    virtual void didFailProvisionalNavigationWithError(WebKit::WebPageProxy&, WebKit::FrameInfoData&&, Navigation*, const WebCore::ResourceError&, Object*) { }
+    virtual void didFailProvisionalNavigationWithError(WebKit::WebPageProxy&, WebKit::FrameInfoData&&, Navigation*, const WebCore::ResourceError&, const RefPtr<Object>&) { }
     virtual void didFailProvisionalLoadWithErrorForFrame(WebKit::WebPageProxy&, WebCore::ResourceRequest&&, const WebCore::ResourceError&, WebKit::FrameInfoData&&) { }
-    virtual void didCommitNavigation(WebKit::WebPageProxy&, Navigation*, Object*) { }
+    virtual void didCommitNavigation(WebKit::WebPageProxy&, Navigation*, const RefPtr<Object>&) { }
     virtual void didCommitLoadForFrame(WebKit::WebPageProxy&, WebCore::ResourceRequest&&, WebKit::FrameInfoData&&) { }
-    virtual void didFinishDocumentLoad(WebKit::WebPageProxy&, Navigation*, Object*) { }
-    virtual void didFinishNavigation(WebKit::WebPageProxy&, Navigation*, Object*) { }
+    virtual void didFinishDocumentLoad(WebKit::WebPageProxy&, Navigation*, const RefPtr<Object>&) { }
+    virtual void didFinishNavigation(WebKit::WebPageProxy&, Navigation*, const RefPtr<Object>&) { }
     virtual void didFinishLoadForFrame(WebKit::WebPageProxy&, WebCore::ResourceRequest&&, WebKit::FrameInfoData&&) { }
     virtual void didFailLoadDueToNetworkConnectionIntegrity(WebKit::WebPageProxy&, const WTF::URL&) { }
-    virtual void didFailNavigationWithError(WebKit::WebPageProxy&, const WebKit::FrameInfoData&, Navigation*, const WebCore::ResourceError&, Object*) { }
+    virtual void didFailNavigationWithError(WebKit::WebPageProxy&, const WebKit::FrameInfoData&, Navigation*, const WebCore::ResourceError&, const RefPtr<Object>&) { }
     virtual void didFailLoadWithErrorForFrame(WebKit::WebPageProxy&, WebCore::ResourceRequest&&, const WebCore::ResourceError&, WebKit::FrameInfoData&&) { }
-    virtual void didSameDocumentNavigation(WebKit::WebPageProxy&, Navigation*, WebKit::SameDocumentNavigationType, Object*) { }
+    virtual void didSameDocumentNavigation(WebKit::WebPageProxy&, Navigation*, WebKit::SameDocumentNavigationType, const RefPtr<Object>&) { }
     virtual void didChangeLookalikeCharacters(WebKit::WebPageProxy&, const WTF::URL&, const WTF::URL&) { }
 
-    virtual void didDisplayInsecureContent(WebKit::WebPageProxy&, API::Object*) { }
-    virtual void didRunInsecureContent(WebKit::WebPageProxy&, API::Object*) { }
+    virtual void didDisplayInsecureContent(WebKit::WebPageProxy&, const RefPtr<API::Object>&) { }
+    virtual void didRunInsecureContent(WebKit::WebPageProxy&, const RefPtr<API::Object>&) { }
 
     virtual void renderingProgressDidChange(WebKit::WebPageProxy&, OptionSet<WebCore::LayoutMilestone>) { }
 

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -110,7 +110,7 @@ public:
     virtual void runJavaScriptPrompt(WebKit::WebPageProxy&, const WTF::String&, const WTF::String&, WebKit::WebFrameProxy*, WebKit::FrameInfoData&&, Function<void(const WTF::String&)>&& completionHandler) { completionHandler(WTF::String()); }
 
     virtual void setStatusText(WebKit::WebPageProxy*, const WTF::String&) { }
-    virtual void mouseDidMoveOverElement(WebKit::WebPageProxy&, const WebKit::WebHitTestResultData&, OptionSet<WebKit::WebEventModifier>, Object*) { }
+    virtual void mouseDidMoveOverElement(WebKit::WebPageProxy&, const WebKit::WebHitTestResultData&, OptionSet<WebKit::WebEventModifier>, const RefPtr<Object>&) { }
 
     virtual void didNotHandleKeyEvent(WebKit::WebPageProxy*, const WebKit::NativeWebKeyboardEvent&) { }
     virtual void didNotHandleWheelEvent(WebKit::WebPageProxy*, const WebKit::NativeWebWheelEvent&) { }
@@ -196,9 +196,9 @@ public:
     virtual void shouldAllowDeviceOrientationAndMotionAccess(WebKit::WebPageProxy&, WebKit::WebFrameProxy& webFrameProxy, WebKit::FrameInfoData&&, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(false); }
 #endif
 
-    virtual void didClickAutoFillButton(WebKit::WebPageProxy&, Object*) { }
+    virtual void didClickAutoFillButton(WebKit::WebPageProxy&, const RefPtr<Object>&) { }
 
-    virtual void didResignInputElementStrongPasswordAppearance(WebKit::WebPageProxy&, Object*) { }
+    virtual void didResignInputElementStrongPasswordAppearance(WebKit::WebPageProxy&, const RefPtr<Object>&) { }
 
     virtual void imageOrMediaDocumentSizeChanged(const WebCore::IntSize&) { }
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -963,12 +963,12 @@ void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuCl
         }
 
     private:
-        void getContextMenuFromProposedMenu(WebPageProxy& page, Vector<Ref<WebKit::WebContextMenuItem>>&& proposedMenuVector, WebKit::WebContextMenuListenerProxy& contextMenuListener, const WebHitTestResultData& hitTestResultData, API::Object* userData) override
+        void getContextMenuFromProposedMenu(WebPageProxy& page, Vector<Ref<WebKit::WebContextMenuItem>>&& proposedMenuVector, WebKit::WebContextMenuListenerProxy& contextMenuListener, const WebHitTestResultData& hitTestResultData, const RefPtr<API::Object>& userData) override
         {
             if (m_client.base.version >= 4 && m_client.getContextMenuFromProposedMenuAsync) {
                 auto proposedMenuItems = toAPIObjectVector(proposedMenuVector);
                 auto webHitTestResult = API::HitTestResult::create(hitTestResultData);
-                m_client.getContextMenuFromProposedMenuAsync(toAPI(&page), toAPI(API::Array::create(WTFMove(proposedMenuItems)).ptr()), toAPI(&contextMenuListener), toAPI(webHitTestResult.ptr()), toAPI(userData), m_client.base.clientInfo);
+                m_client.getContextMenuFromProposedMenuAsync(toAPI(&page), toAPI(API::Array::create(WTFMove(proposedMenuItems)).ptr()), toAPI(&contextMenuListener), toAPI(webHitTestResult.ptr()), toAPI(userData.get()), m_client.base.clientInfo);
                 return;
             }
             
@@ -987,9 +987,9 @@ void WKPageSetPageContextMenuClient(WKPageRef pageRef, const WKPageContextMenuCl
             WKArrayRef newMenu = nullptr;
             if (m_client.base.version >= 2) {
                 auto webHitTestResult = API::HitTestResult::create(hitTestResultData);
-                m_client.getContextMenuFromProposedMenu(toAPI(&page), toAPI(API::Array::create(WTFMove(proposedMenuItems)).ptr()), &newMenu, toAPI(webHitTestResult.ptr()), toAPI(userData), m_client.base.clientInfo);
+                m_client.getContextMenuFromProposedMenu(toAPI(&page), toAPI(API::Array::create(WTFMove(proposedMenuItems)).ptr()), &newMenu, toAPI(webHitTestResult.ptr()), toAPI(userData.get()), m_client.base.clientInfo);
             } else
-                m_client.getContextMenuFromProposedMenu_deprecatedForUseWithV0(toAPI(&page), toAPI(API::Array::create(WTFMove(proposedMenuItems)).ptr()), &newMenu, toAPI(userData), m_client.base.clientInfo);
+                m_client.getContextMenuFromProposedMenu_deprecatedForUseWithV0(toAPI(&page), toAPI(API::Array::create(WTFMove(proposedMenuItems)).ptr()), &newMenu, toAPI(userData.get()), m_client.base.clientInfo);
 
             RefPtr<API::Array> array = adoptRef(toImpl(newMenu));
 
@@ -1185,60 +1185,60 @@ void WKPageSetPageLoaderClient(WKPageRef pageRef, const WKPageLoaderClientBase* 
 
     private:
         
-        void didCommitLoadForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, API::Object* userData) override
+        void didCommitLoadForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, const RefPtr<API::Object>& userData) override
         {
             if (!m_client.didCommitLoadForFrame)
                 return;
 
-            m_client.didCommitLoadForFrame(toAPI(&page), toAPI(&frame), toAPI(userData), m_client.base.clientInfo);
+            m_client.didCommitLoadForFrame(toAPI(&page), toAPI(&frame), toAPI(userData.get()), m_client.base.clientInfo);
         }
         
-        void didStartProvisionalLoadForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, API::Object* userData) override
+        void didStartProvisionalLoadForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, const RefPtr<API::Object>& userData) override
         {
             if (!m_client.didStartProvisionalLoadForFrame)
                 return;
 
-            m_client.didStartProvisionalLoadForFrame(toAPI(&page), toAPI(&frame), toAPI(userData), m_client.base.clientInfo);
+            m_client.didStartProvisionalLoadForFrame(toAPI(&page), toAPI(&frame), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didReceiveServerRedirectForProvisionalLoadForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, API::Object* userData) override
+        void didReceiveServerRedirectForProvisionalLoadForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, const RefPtr<API::Object>& userData) override
         {
             if (!m_client.didReceiveServerRedirectForProvisionalLoadForFrame)
                 return;
 
-            m_client.didReceiveServerRedirectForProvisionalLoadForFrame(toAPI(&page), toAPI(&frame), toAPI(userData), m_client.base.clientInfo);
+            m_client.didReceiveServerRedirectForProvisionalLoadForFrame(toAPI(&page), toAPI(&frame), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didFailProvisionalLoadWithErrorForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, const WebCore::ResourceError& error, API::Object* userData) override
+        void didFailProvisionalLoadWithErrorForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, const WebCore::ResourceError& error, const RefPtr<API::Object>& userData) override
         {
             if (!m_client.didFailProvisionalLoadWithErrorForFrame)
                 return;
 
-            m_client.didFailProvisionalLoadWithErrorForFrame(toAPI(&page), toAPI(&frame), toAPI(error), toAPI(userData), m_client.base.clientInfo);
+            m_client.didFailProvisionalLoadWithErrorForFrame(toAPI(&page), toAPI(&frame), toAPI(error), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didFinishLoadForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, API::Object* userData) override
+        void didFinishLoadForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, const RefPtr<API::Object>& userData) override
         {
             if (!m_client.didFinishLoadForFrame)
                 return;
 
-            m_client.didFinishLoadForFrame(toAPI(&page), toAPI(&frame), toAPI(userData), m_client.base.clientInfo);
+            m_client.didFinishLoadForFrame(toAPI(&page), toAPI(&frame), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didFailLoadWithErrorForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, const WebCore::ResourceError& error, API::Object* userData) override
+        void didFailLoadWithErrorForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Navigation*, const WebCore::ResourceError& error, const RefPtr<API::Object>& userData) override
         {
             if (!m_client.didFailLoadWithErrorForFrame)
                 return;
 
-            m_client.didFailLoadWithErrorForFrame(toAPI(&page), toAPI(&frame), toAPI(error), toAPI(userData), m_client.base.clientInfo);
+            m_client.didFailLoadWithErrorForFrame(toAPI(&page), toAPI(&frame), toAPI(error), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didFirstVisuallyNonEmptyLayoutForFrame(WebPageProxy& page, WebFrameProxy& frame, API::Object* userData) override
+        void didFirstVisuallyNonEmptyLayoutForFrame(WebPageProxy& page, WebFrameProxy& frame, const RefPtr<API::Object>& userData) override
         {
             if (!m_client.didFirstVisuallyNonEmptyLayoutForFrame)
                 return;
 
-            m_client.didFirstVisuallyNonEmptyLayoutForFrame(toAPI(&page), toAPI(&frame), toAPI(userData), m_client.base.clientInfo);
+            m_client.didFirstVisuallyNonEmptyLayoutForFrame(toAPI(&page), toAPI(&frame), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
         void didReachLayoutMilestone(WebPageProxy& page, OptionSet<WebCore::LayoutMilestone> milestones) override
@@ -1767,7 +1767,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             m_client.setStatusText(toAPI(page), toAPI(text.impl()), m_client.base.clientInfo);
         }
 
-        void mouseDidMoveOverElement(WebPageProxy& page, const WebHitTestResultData& data, OptionSet<WebKit::WebEventModifier> modifiers, API::Object* userData) final
+        void mouseDidMoveOverElement(WebPageProxy& page, const WebHitTestResultData& data, OptionSet<WebKit::WebEventModifier> modifiers, const RefPtr<API::Object>& userData) final
         {
             if (!m_client.mouseDidMoveOverElement && !m_client.mouseDidMoveOverElement_deprecatedForUseWithV0)
                 return;
@@ -1776,12 +1776,12 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
                 return;
 
             if (!m_client.base.version) {
-                m_client.mouseDidMoveOverElement_deprecatedForUseWithV0(toAPI(&page), toAPI(modifiers), toAPI(userData), m_client.base.clientInfo);
+                m_client.mouseDidMoveOverElement_deprecatedForUseWithV0(toAPI(&page), toAPI(modifiers), toAPI(userData.get()), m_client.base.clientInfo);
                 return;
             }
 
             auto apiHitTestResult = API::HitTestResult::create(data);
-            m_client.mouseDidMoveOverElement(toAPI(&page), toAPI(apiHitTestResult.ptr()), toAPI(modifiers), toAPI(userData), m_client.base.clientInfo);
+            m_client.mouseDidMoveOverElement(toAPI(&page), toAPI(apiHitTestResult.ptr()), toAPI(modifiers), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
         void didNotHandleKeyEvent(WebPageProxy* page, const NativeWebKeyboardEvent& event) final
@@ -2049,20 +2049,20 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             m_client.isPlayingAudioDidChange(toAPI(&page), m_client.base.clientInfo);
         }
 
-        void didClickAutoFillButton(WebPageProxy& page, API::Object* userInfo) final
+        void didClickAutoFillButton(WebPageProxy& page, const RefPtr<API::Object>& userInfo) final
         {
             if (!m_client.didClickAutoFillButton)
                 return;
 
-            m_client.didClickAutoFillButton(toAPI(&page), toAPI(userInfo), m_client.base.clientInfo);
+            m_client.didClickAutoFillButton(toAPI(&page), toAPI(userInfo.get()), m_client.base.clientInfo);
         }
 
-        void didResignInputElementStrongPasswordAppearance(WebPageProxy& page, API::Object* userInfo) final
+        void didResignInputElementStrongPasswordAppearance(WebPageProxy& page, const RefPtr<API::Object>& userInfo) final
         {
             if (!m_client.didResignInputElementStrongPasswordAppearance)
                 return;
 
-            m_client.didResignInputElementStrongPasswordAppearance(toAPI(&page), toAPI(userInfo), m_client.base.clientInfo);
+            m_client.didResignInputElementStrongPasswordAppearance(toAPI(&page), toAPI(userInfo.get()), m_client.base.clientInfo);
         }
 
 #if ENABLE(POINTER_LOCK)
@@ -2241,60 +2241,60 @@ void WKPageSetPageNavigationClient(WKPageRef pageRef, const WKPageNavigationClie
             m_client.decidePolicyForNavigationResponse(toAPI(&page), toAPI(navigationResponse.ptr()), toAPI(listener.ptr()), nullptr, m_client.base.clientInfo);
         }
 
-        void didStartProvisionalNavigation(WebPageProxy& page, const ResourceRequest&, API::Navigation* navigation, API::Object* userData) override
+        void didStartProvisionalNavigation(WebPageProxy& page, const ResourceRequest&, API::Navigation* navigation, const RefPtr<API::Object>& userData) override
         {
             if (m_client.didStartProvisionalNavigation)
-                m_client.didStartProvisionalNavigation(toAPI(&page), toAPI(navigation), toAPI(userData), m_client.base.clientInfo);
+                m_client.didStartProvisionalNavigation(toAPI(&page), toAPI(navigation), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didReceiveServerRedirectForProvisionalNavigation(WebPageProxy& page, API::Navigation* navigation, API::Object* userData) override
+        void didReceiveServerRedirectForProvisionalNavigation(WebPageProxy& page, API::Navigation* navigation, const RefPtr<API::Object>& userData) override
         {
             if (!m_client.didReceiveServerRedirectForProvisionalNavigation)
                 return;
-            m_client.didReceiveServerRedirectForProvisionalNavigation(toAPI(&page), toAPI(navigation), toAPI(userData), m_client.base.clientInfo);
+            m_client.didReceiveServerRedirectForProvisionalNavigation(toAPI(&page), toAPI(navigation), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didFailProvisionalNavigationWithError(WebPageProxy& page, FrameInfoData&& frameInfo, API::Navigation* navigation, const WebCore::ResourceError& error, API::Object* userData) override
+        void didFailProvisionalNavigationWithError(WebPageProxy& page, FrameInfoData&& frameInfo, API::Navigation* navigation, const WebCore::ResourceError& error, const RefPtr<API::Object>& userData) override
         {
             if (frameInfo.isMainFrame) {
                 if (m_client.didFailProvisionalNavigation)
-                    m_client.didFailProvisionalNavigation(toAPI(&page), toAPI(navigation), toAPI(error), toAPI(userData), m_client.base.clientInfo);
+                    m_client.didFailProvisionalNavigation(toAPI(&page), toAPI(navigation), toAPI(error), toAPI(userData.get()), m_client.base.clientInfo);
             } else {
                 if (m_client.didFailProvisionalLoadInSubframe)
-                    m_client.didFailProvisionalLoadInSubframe(toAPI(&page), toAPI(navigation), toAPI(API::FrameInfo::create(WTFMove(frameInfo), &page).ptr()), toAPI(error), toAPI(userData), m_client.base.clientInfo);
+                    m_client.didFailProvisionalLoadInSubframe(toAPI(&page), toAPI(navigation), toAPI(API::FrameInfo::create(WTFMove(frameInfo), &page).ptr()), toAPI(error), toAPI(userData.get()), m_client.base.clientInfo);
             }
         }
 
-        void didCommitNavigation(WebPageProxy& page, API::Navigation* navigation, API::Object* userData) override
+        void didCommitNavigation(WebPageProxy& page, API::Navigation* navigation, const RefPtr<API::Object>& userData) override
         {
             if (m_client.didCommitNavigation)
-                m_client.didCommitNavigation(toAPI(&page), toAPI(navigation), toAPI(userData), m_client.base.clientInfo);
+                m_client.didCommitNavigation(toAPI(&page), toAPI(navigation), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didFinishNavigation(WebPageProxy& page, API::Navigation* navigation, API::Object* userData) override
+        void didFinishNavigation(WebPageProxy& page, API::Navigation* navigation, const RefPtr<API::Object>& userData) override
         {
             if (m_client.didFinishNavigation)
-                m_client.didFinishNavigation(toAPI(&page), toAPI(navigation), toAPI(userData), m_client.base.clientInfo);
+                m_client.didFinishNavigation(toAPI(&page), toAPI(navigation), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didFailNavigationWithError(WebPageProxy& page, const FrameInfoData&, API::Navigation* navigation, const WebCore::ResourceError& error, API::Object* userData) override
+        void didFailNavigationWithError(WebPageProxy& page, const FrameInfoData&, API::Navigation* navigation, const WebCore::ResourceError& error, const RefPtr<API::Object>& userData) override
         {
             if (m_client.didFailNavigation)
-                m_client.didFailNavigation(toAPI(&page), toAPI(navigation), toAPI(error), toAPI(userData), m_client.base.clientInfo);
+                m_client.didFailNavigation(toAPI(&page), toAPI(navigation), toAPI(error), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didFinishDocumentLoad(WebPageProxy& page, API::Navigation* navigation, API::Object* userData) override
+        void didFinishDocumentLoad(WebPageProxy& page, API::Navigation* navigation, const RefPtr<API::Object>& userData) override
         {
             if (!m_client.didFinishDocumentLoad)
                 return;
-            m_client.didFinishDocumentLoad(toAPI(&page), toAPI(navigation), toAPI(userData), m_client.base.clientInfo);
+            m_client.didFinishDocumentLoad(toAPI(&page), toAPI(navigation), toAPI(userData.get()), m_client.base.clientInfo);
         }
 
-        void didSameDocumentNavigation(WebPageProxy& page, API::Navigation* navigation, WebKit::SameDocumentNavigationType navigationType, API::Object* userData) override
+        void didSameDocumentNavigation(WebPageProxy& page, API::Navigation* navigation, WebKit::SameDocumentNavigationType navigationType, const RefPtr<API::Object>& userData) override
         {
             if (!m_client.didSameDocumentNavigation)
                 return;
-            m_client.didSameDocumentNavigation(toAPI(&page), toAPI(navigation), toAPI(navigationType), toAPI(userData), m_client.base.clientInfo);
+            m_client.didSameDocumentNavigation(toAPI(&page), toAPI(navigation), toAPI(navigationType), toAPI(userData.get()), m_client.base.clientInfo);
         }
         
         void renderingProgressDidChange(WebPageProxy& page, OptionSet<WebCore::LayoutMilestone> milestones) override

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3625,7 +3625,7 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
 
         virtual ~FormClient() { }
 
-        void willSubmitForm(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, WebKit::WebFrameProxy& sourceFrame, const Vector<std::pair<WTF::String, WTF::String>>& textFieldValues, API::Object* userData, WTF::Function<void(void)>&& completionHandler) override
+        void willSubmitForm(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, WebKit::WebFrameProxy& sourceFrame, const Vector<std::pair<WTF::String, WTF::String>>& textFieldValues, const RefPtr<API::Object>& userData, WTF::Function<void(void)>&& completionHandler) override
         {
             if (userData && userData->type() != API::Object::Type::Data) {
                 ASSERT(!userData || userData->type() == API::Object::Type::Data);
@@ -3646,7 +3646,7 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
                 [valueMap setObject:pair.second forKey:pair.first];
 
             NSObject <NSSecureCoding> *userObject = nil;
-            if (API::Data* data = static_cast<API::Data*>(userData)) {
+            if (API::Data* data = static_cast<API::Data*>(userData.get())) {
                 auto nsData = adoptNS([[NSData alloc] initWithBytesNoCopy:const_cast<unsigned char*>(data->bytes()) length:data->size() freeWhenDone:NO]);
                 auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:nsData.get() error:nullptr]);
                 unarchiver.get().decodingFailurePolicy = NSDecodingFailurePolicyRaiseException;

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp
@@ -35,12 +35,12 @@ public:
     }
 
 private:
-    void getContextMenuFromProposedMenu(WebPageProxy&, Vector<Ref<WebKit::WebContextMenuItem>>&& proposedMenu, WebKit::WebContextMenuListenerProxy& contextMenuListener, const WebHitTestResultData& hitTestResultData, API::Object* userData) override
+    void getContextMenuFromProposedMenu(WebPageProxy&, Vector<Ref<WebKit::WebContextMenuItem>>&& proposedMenu, WebKit::WebContextMenuListenerProxy& contextMenuListener, const WebHitTestResultData& hitTestResultData, const RefPtr<API::Object>& userData) override
     {
         GRefPtr<GVariant> variant;
         if (userData) {
             ASSERT(userData->type() == API::Object::Type::String);
-            CString userDataString = static_cast<API::String*>(userData)->string().utf8();
+            CString userDataString = static_cast<API::String*>(userData.get())->string().utf8();
             variant = adoptGRef(g_variant_parse(nullptr, userDataString.data(), userDataString.data() + userDataString.length(), nullptr, nullptr));
         }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitFormClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFormClient.cpp
@@ -37,7 +37,7 @@ public:
     }
 
 private:
-    void willSubmitForm(WebPageProxy&, WebFrameProxy&, WebFrameProxy&, const Vector<std::pair<String, String>>& values, API::Object*, WTF::Function<void(void)>&& completionHandler) override
+    void willSubmitForm(WebPageProxy&, WebFrameProxy&, WebFrameProxy&, const Vector<std::pair<String, String>>& values, const RefPtr<API::Object>&, WTF::Function<void(void)>&& completionHandler) override
     {
         GRefPtr<WebKitFormSubmissionRequest> request = adoptGRef(webkitFormSubmissionRequestCreate(values, WebFormSubmissionListenerProxy::create(WTFMove(completionHandler))));
         webkitWebViewSubmitFormRequest(m_webView, request.get());

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp
@@ -49,17 +49,17 @@ public:
     }
 
 private:
-    void didStartProvisionalNavigation(WebPageProxy&, const ResourceRequest&, API::Navigation*, API::Object* /* userData */) override
+    void didStartProvisionalNavigation(WebPageProxy&, const ResourceRequest&, API::Navigation*, const RefPtr<API::Object>& /* userData */) override
     {
         webkitWebViewLoadChanged(m_webView, WEBKIT_LOAD_STARTED);
     }
 
-    void didReceiveServerRedirectForProvisionalNavigation(WebPageProxy&, API::Navigation*, API::Object* /* userData */) override
+    void didReceiveServerRedirectForProvisionalNavigation(WebPageProxy&, API::Navigation*, const RefPtr<API::Object>& /* userData */) override
     {
         webkitWebViewLoadChanged(m_webView, WEBKIT_LOAD_REDIRECTED);
     }
 
-    void didFailProvisionalNavigationWithError(WebPageProxy&, FrameInfoData&& frameInfo, API::Navigation*, const ResourceError& resourceError, API::Object* /* userData */) override
+    void didFailProvisionalNavigationWithError(WebPageProxy&, FrameInfoData&& frameInfo, API::Navigation*, const ResourceError& resourceError, const RefPtr<API::Object>& /* userData */) override
     {
         if (!frameInfo.isMainFrame)
             return;
@@ -72,17 +72,17 @@ private:
             webkitWebViewLoadFailed(m_webView, WEBKIT_LOAD_STARTED, resourceError.failingURL().string().utf8().data(), error.get());
     }
 
-    void didCommitNavigation(WebPageProxy&, API::Navigation*, API::Object* /* userData */) override
+    void didCommitNavigation(WebPageProxy&, API::Navigation*, const RefPtr<API::Object>& /* userData */) override
     {
         webkitWebViewLoadChanged(m_webView, WEBKIT_LOAD_COMMITTED);
     }
 
-    void didFinishNavigation(WebPageProxy&, API::Navigation*, API::Object* /* userData */) override
+    void didFinishNavigation(WebPageProxy&, API::Navigation*, const RefPtr<API::Object>& /* userData */) override
     {
         webkitWebViewLoadChanged(m_webView, WEBKIT_LOAD_FINISHED);
     }
 
-    void didFailNavigationWithError(WebPageProxy&, const FrameInfoData& frameInfo, API::Navigation*, const ResourceError& resourceError, API::Object* /* userData */) override
+    void didFailNavigationWithError(WebPageProxy&, const FrameInfoData& frameInfo, API::Navigation*, const ResourceError& resourceError, const RefPtr<API::Object>& /* userData */) override
     {
         if (!frameInfo.isMainFrame)
             return;
@@ -91,12 +91,12 @@ private:
         webkitWebViewLoadFailed(m_webView, WEBKIT_LOAD_COMMITTED, resourceError.failingURL().string().utf8().data(), error.get());
     }
 
-    void didDisplayInsecureContent(WebPageProxy&, API::Object* /* userData */) override
+    void didDisplayInsecureContent(WebPageProxy&, const RefPtr<API::Object>& /* userData */) override
     {
         webkitWebViewInsecureContentDetected(m_webView, WEBKIT_INSECURE_CONTENT_DISPLAYED);
     }
 
-    void didRunInsecureContent(WebPageProxy&, API::Object* /* userData */) override
+    void didRunInsecureContent(WebPageProxy&, const RefPtr<API::Object>& /* userData */) override
     {
         webkitWebViewInsecureContentDetected(m_webView, WEBKIT_INSECURE_CONTENT_RUN);
     }

--- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
@@ -100,7 +100,7 @@ private:
         webkitWebViewRunJavaScriptBeforeUnloadConfirm(m_webView, message.utf8(), WTFMove(completionHandler));
     }
 
-    void mouseDidMoveOverElement(WebPageProxy&, const WebHitTestResultData& data, OptionSet<WebEventModifier> modifiers, API::Object*) final
+    void mouseDidMoveOverElement(WebPageProxy&, const WebHitTestResultData& data, OptionSet<WebEventModifier> modifiers, const RefPtr<API::Object>&) final
     {
         webkitWebViewMouseTargetChanged(m_webView, data, modifiers);
     }

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -95,23 +95,23 @@ private:
         ~NavigationClient();
 
     private:
-        void didStartProvisionalNavigation(WebPageProxy&, const WebCore::ResourceRequest&, API::Navigation*, API::Object*) override;
+        void didStartProvisionalNavigation(WebPageProxy&, const WebCore::ResourceRequest&, API::Navigation*, const RefPtr<API::Object>&) override;
         void didStartProvisionalLoadForFrame(WebPageProxy&, WebCore::ResourceRequest&&, FrameInfoData&&) override;
-        void didReceiveServerRedirectForProvisionalNavigation(WebPageProxy&, API::Navigation*, API::Object*) override;
+        void didReceiveServerRedirectForProvisionalNavigation(WebPageProxy&, API::Navigation*, const RefPtr<API::Object>&) override;
         void willPerformClientRedirect(WebPageProxy&, const WTF::String&, double) override;
         void didPerformClientRedirect(WebPageProxy&, const WTF::String&, const WTF::String&) override;
         void didCancelClientRedirect(WebPageProxy&) override;
-        void didFailProvisionalNavigationWithError(WebPageProxy&, FrameInfoData&&, API::Navigation*, const WebCore::ResourceError&, API::Object*) override;
+        void didFailProvisionalNavigationWithError(WebPageProxy&, FrameInfoData&&, API::Navigation*, const WebCore::ResourceError&, const RefPtr<API::Object>&) override;
         void didFailProvisionalLoadWithErrorForFrame(WebPageProxy&, WebCore::ResourceRequest&&, const WebCore::ResourceError&, FrameInfoData&&) override;
-        void didCommitNavigation(WebPageProxy&, API::Navigation*, API::Object*) override;
+        void didCommitNavigation(WebPageProxy&, API::Navigation*, const RefPtr<API::Object>&) override;
         void didCommitLoadForFrame(WebKit::WebPageProxy&, WebCore::ResourceRequest&&, FrameInfoData&&) override;
-        void didFinishDocumentLoad(WebPageProxy&, API::Navigation*, API::Object*) override;
-        void didFinishNavigation(WebPageProxy&, API::Navigation*, API::Object*) override;
+        void didFinishDocumentLoad(WebPageProxy&, API::Navigation*, const RefPtr<API::Object>&) override;
+        void didFinishNavigation(WebPageProxy&, API::Navigation*, const RefPtr<API::Object>&) override;
         void didFinishLoadForFrame(WebPageProxy&, WebCore::ResourceRequest&&, FrameInfoData&&) override;
         void didFailLoadDueToNetworkConnectionIntegrity(WebPageProxy&, const URL&) override;
-        void didFailNavigationWithError(WebPageProxy&, const FrameInfoData&, API::Navigation*, const WebCore::ResourceError&, API::Object*) override;
+        void didFailNavigationWithError(WebPageProxy&, const FrameInfoData&, API::Navigation*, const WebCore::ResourceError&, const RefPtr<API::Object>&) override;
         void didFailLoadWithErrorForFrame(WebPageProxy&, WebCore::ResourceRequest&&, const WebCore::ResourceError&, FrameInfoData&&) override;
-        void didSameDocumentNavigation(WebPageProxy&, API::Navigation*, SameDocumentNavigationType, API::Object*) override;
+        void didSameDocumentNavigation(WebPageProxy&, API::Navigation*, SameDocumentNavigationType, const RefPtr<API::Object>&) override;
         void didChangeLookalikeCharacters(WebPageProxy&, const URL&, const URL&) override;
 
         void renderingProgressDidChange(WebPageProxy&, OptionSet<WebCore::LayoutMilestone>) override;

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -617,7 +617,7 @@ void NavigationState::NavigationClient::decidePolicyForNavigationResponse(WebPag
     }).get()];
 }
 
-void NavigationState::NavigationClient::didStartProvisionalNavigation(WebPageProxy&, const WebCore::ResourceRequest& request, API::Navigation* navigation, API::Object* userInfo)
+void NavigationState::NavigationClient::didStartProvisionalNavigation(WebPageProxy&, const WebCore::ResourceRequest& request, API::Navigation* navigation, const RefPtr<API::Object>& userInfo)
 {
     if (!m_navigationState)
         return;
@@ -644,7 +644,7 @@ void NavigationState::NavigationClient::didStartProvisionalLoadForFrame(WebPageP
         [(id <WKNavigationDelegatePrivate>)navigationDelegate.get() _webView:m_navigationState->m_webView didStartProvisionalLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page))];
 }
 
-void NavigationState::NavigationClient::didReceiveServerRedirectForProvisionalNavigation(WebPageProxy& page, API::Navigation* navigation, API::Object*)
+void NavigationState::NavigationClient::didReceiveServerRedirectForProvisionalNavigation(WebPageProxy& page, API::Navigation* navigation, const RefPtr<API::Object>&)
 {
     if (!m_navigationState)
         return;
@@ -730,7 +730,7 @@ static RetainPtr<NSError> createErrorWithRecoveryAttempter(WKWebView *webView, c
     return adoptNS([[NSError alloc] initWithDomain:originalError.domain code:originalError.code userInfo:userInfo.get()]);
 }
 
-void NavigationState::NavigationClient::didFailProvisionalNavigationWithError(WebPageProxy& page, FrameInfoData&& frameInfo, API::Navigation* navigation, const WebCore::ResourceError& error, API::Object*)
+void NavigationState::NavigationClient::didFailProvisionalNavigationWithError(WebPageProxy& page, FrameInfoData&& frameInfo, API::Navigation* navigation, const WebCore::ResourceError& error, const RefPtr<API::Object>&)
 {
     if (!m_navigationState)
         return;
@@ -768,7 +768,7 @@ void NavigationState::NavigationClient::didFailProvisionalLoadWithErrorForFrame(
         [(id <WKNavigationDelegatePrivate>)navigationDelegate _webView:m_navigationState->m_webView didFailProvisionalLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) withError:errorWithRecoveryAttempter.get()];
 }
 
-void NavigationState::NavigationClient::didCommitNavigation(WebPageProxy& page, API::Navigation* navigation, API::Object*)
+void NavigationState::NavigationClient::didCommitNavigation(WebPageProxy& page, API::Navigation* navigation, const RefPtr<API::Object>&)
 {
     if (!m_navigationState)
         return;
@@ -795,7 +795,7 @@ void NavigationState::NavigationClient::didCommitLoadForFrame(WebKit::WebPagePro
         [static_cast<id <WKNavigationDelegatePrivate>>(navigationDelegate.get()) _webView:m_navigationState->m_webView didCommitLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page))];
 }
 
-void NavigationState::NavigationClient::didFinishDocumentLoad(WebPageProxy& page, API::Navigation* navigation, API::Object*)
+void NavigationState::NavigationClient::didFinishDocumentLoad(WebPageProxy& page, API::Navigation* navigation, const RefPtr<API::Object>&)
 {
     if (!m_navigationState)
         return;
@@ -812,7 +812,7 @@ void NavigationState::NavigationClient::didFinishDocumentLoad(WebPageProxy& page
     [static_cast<id <WKNavigationDelegatePrivate>>(navigationDelegate.get()) _webView:m_navigationState->m_webView navigationDidFinishDocumentLoad:wrapper(navigation)];
 }
 
-void NavigationState::NavigationClient::didFinishNavigation(WebPageProxy&, API::Navigation* navigation, API::Object*)
+void NavigationState::NavigationClient::didFinishNavigation(WebPageProxy&, API::Navigation* navigation, const RefPtr<API::Object>&)
 {
     if (!m_navigationState)
         return;
@@ -865,7 +865,7 @@ void NavigationState::NavigationClient::didChangeLookalikeCharacters(WebPageProx
         [(id<WKNavigationDelegatePrivate>)navigationDelegate _webView:m_navigationState->m_webView didChangeLookalikeCharactersFromURL:originalURL toURL:adjustedURL];
 }
 
-void NavigationState::NavigationClient::didFailNavigationWithError(WebPageProxy& page, const FrameInfoData& frameInfo, API::Navigation* navigation, const WebCore::ResourceError& error, API::Object* userInfo)
+void NavigationState::NavigationClient::didFailNavigationWithError(WebPageProxy& page, const FrameInfoData& frameInfo, API::Navigation* navigation, const WebCore::ResourceError& error, const RefPtr<API::Object>& userInfo)
 {
     if (!m_navigationState)
         return;
@@ -898,7 +898,7 @@ void NavigationState::NavigationClient::didFailLoadWithErrorForFrame(WebPageProx
         [(id <WKNavigationDelegatePrivate>)navigationDelegate _webView:m_navigationState->m_webView didFailLoadWithRequest:request.nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) inFrame:wrapper(API::FrameInfo::create(WTFMove(frameInfo), &page)) withError:errorWithRecoveryAttempter.get()];
 }
 
-void NavigationState::NavigationClient::didSameDocumentNavigation(WebPageProxy&, API::Navigation* navigation, SameDocumentNavigationType navigationType, API::Object*)
+void NavigationState::NavigationClient::didSameDocumentNavigation(WebPageProxy&, API::Navigation* navigation, SameDocumentNavigationType navigationType, const RefPtr<API::Object>&)
 {
     if (!m_navigationState)
         return;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -74,7 +74,7 @@ private:
 
     private:
         // API::ContextMenuClient
-        void menuFromProposedMenu(WebPageProxy&, NSMenu *, const ContextMenuContextData&, API::Object*, CompletionHandler<void(RetainPtr<NSMenu>&&)>&&) override;
+        void menuFromProposedMenu(WebPageProxy&, NSMenu *, const ContextMenuContextData&, const RefPtr<API::Object>&, CompletionHandler<void(RetainPtr<NSMenu>&&)>&&) override;
 
         WeakPtr<UIDelegate> m_uiDelegate;
     };
@@ -104,14 +104,14 @@ private:
         void reachedApplicationCacheOriginQuota(WebPageProxy*, const WebCore::SecurityOrigin&, uint64_t currentQuota, uint64_t totalBytesNeeded, Function<void(unsigned long long)>&& completionHandler) final;
         bool lockScreenOrientation(WebPageProxy&, WebCore::ScreenOrientationType) final;
         void unlockScreenOrientation(WebPageProxy&) final;
-        void didResignInputElementStrongPasswordAppearance(WebPageProxy&, API::Object*) final;
+        void didResignInputElementStrongPasswordAppearance(WebPageProxy&, const RefPtr<API::Object>&) final;
         bool takeFocus(WebPageProxy*, WKFocusDirection) final;
         void handleAutoplayEvent(WebPageProxy&, WebCore::AutoplayEvent, OptionSet<WebCore::AutoplayEventFlags>) final;
         void decidePolicyForNotificationPermissionRequest(WebPageProxy&, API::SecurityOrigin&, CompletionHandler<void(bool allowed)>&&) final;
         void requestCookieConsent(CompletionHandler<void(WebCore::CookieConsentDecisionResult)>&&) final;
         void decidePolicyForModalContainer(OptionSet<WebCore::ModalContainerControlType>, CompletionHandler<void(WebCore::ModalContainerDecision)>&&) final;
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
-        void mouseDidMoveOverElement(WebPageProxy&, const WebHitTestResultData&, OptionSet<WebEventModifier>, API::Object*);
+        void mouseDidMoveOverElement(WebPageProxy&, const WebHitTestResultData&, OptionSet<WebEventModifier>, const RefPtr<API::Object>&);
 #endif
 
 #if PLATFORM(MAC)
@@ -134,7 +134,7 @@ private:
         void drawHeader(WebPageProxy&, WebFrameProxy&, WebCore::FloatRect&&) final;
         void drawFooter(WebPageProxy&, WebFrameProxy&, WebCore::FloatRect&&) final;
 
-        void didClickAutoFillButton(WebPageProxy&, API::Object*) final;
+        void didClickAutoFillButton(WebPageProxy&, const RefPtr<API::Object>&) final;
         void toolbarsAreVisible(WebPageProxy&, Function<void(bool)>&&) final;
         bool runOpenPanel(WebPageProxy&, WebFrameProxy*, FrameInfoData&&, API::OpenPanelParameters*, WebOpenPanelResultListenerProxy*) final;
         void saveDataToFileInDownloadsFolder(WebPageProxy*, const WTF::String&, const WTF::String&, const URL&, API::Data&) final;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -226,7 +226,7 @@ UIDelegate::ContextMenuClient::~ContextMenuClient()
 {
 }
 
-void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy&, NSMenu *menu, const ContextMenuContextData& data, API::Object* userInfo, CompletionHandler<void(RetainPtr<NSMenu>&&)>&& completionHandler)
+void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy&, NSMenu *menu, const ContextMenuContextData& data, const RefPtr<API::Object>& userInfo, CompletionHandler<void(RetainPtr<NSMenu>&&)>&& completionHandler)
 {
     if (!m_uiDelegate)
         return completionHandler(menu);
@@ -271,7 +271,7 @@ UIDelegate::UIClient::~UIClient()
 }
 
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
-void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy&, const WebHitTestResultData& data, OptionSet<WebEventModifier> modifiers, API::Object* userInfo)
+void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy&, const WebHitTestResultData& data, OptionSet<WebEventModifier> modifiers, const RefPtr<API::Object>& userInfo)
 {
     if (!m_uiDelegate)
         return;
@@ -499,7 +499,7 @@ void UIDelegate::UIClient::decidePolicyForGeolocationPermissionRequest(WebKit::W
     }).get()];
 }
 
-void UIDelegate::UIClient::didResignInputElementStrongPasswordAppearance(WebPageProxy&, API::Object* userInfo)
+void UIDelegate::UIClient::didResignInputElementStrongPasswordAppearance(WebPageProxy&, const RefPtr<API::Object>& userInfo)
 {
     if (!m_uiDelegate)
         return;
@@ -1022,7 +1022,7 @@ void UIDelegate::UIClient::toolbarsAreVisible(WebPageProxy&, Function<void(bool)
     }).get()];
 }
 
-void UIDelegate::UIClient::didClickAutoFillButton(WebPageProxy&, API::Object* userInfo)
+void UIDelegate::UIClient::didClickAutoFillButton(WebPageProxy&, const RefPtr<API::Object>& userInfo)
 {
     if (!m_uiDelegate)
         return;

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
@@ -98,7 +98,7 @@ public:
     LoaderClient(Function<void()>&& loadedCallback)
         : m_loadedCallback { WTFMove(loadedCallback) } { }
 
-    void didFinishLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, API::Object*) final
+    void didFinishLoadForFrame(WebKit::WebPageProxy&, WebKit::WebFrameProxy&, API::Navigation*, const RefPtr<API::Object>&) final
     {
         m_loadedCallback();
     }

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -477,7 +477,7 @@ public:
     virtual void restorePageState(std::optional<WebCore::FloatPoint> scrollPosition, const WebCore::FloatPoint& scrollOrigin, const WebCore::FloatBoxExtent& obscuredInsetsOnSave, double scale) = 0;
     virtual void restorePageCenterAndScale(std::optional<WebCore::FloatPoint> center, double scale) = 0;
 
-    virtual void elementDidFocus(const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState::Flag> activityStateChanges, API::Object* userData) = 0;
+    virtual void elementDidFocus(const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState::Flag> activityStateChanges, const RefPtr<API::Object>& userData) = 0;
     virtual void updateInputContextAfterBlurringAndRefocusingElement() = 0;
     virtual void elementDidBlur() = 0;
     virtual void focusedElementDidChangeInputMode(WebCore::InputMode) = 0;
@@ -583,8 +583,8 @@ public:
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     
 #if PLATFORM(MAC)
-    virtual void didPerformImmediateActionHitTest(const WebHitTestResultData&, bool contentPreventsDefault, API::Object*) = 0;
-    virtual NSObject *immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult>, uint64_t, RefPtr<API::Object>) = 0;
+    virtual void didPerformImmediateActionHitTest(const WebHitTestResultData&, bool contentPreventsDefault, const RefPtr<API::Object>&) = 0;
+    virtual NSObject *immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult>, uint64_t, const RefPtr<API::Object>&) = 0;
     virtual void didHandleAcceptedCandidate() = 0;
 #endif
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -174,7 +174,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
         send(Messages::WebPage::FreezeLayerTreeDueToSwipeAnimation());
 }
 
-void ProvisionalPageProxy::loadData(API::Navigation& navigation, const IPC::DataReference& data, const String& mimeType, const String& encoding, const String& baseURL, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, std::optional<WebsitePoliciesData>&& websitePolicies, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility)
+void ProvisionalPageProxy::loadData(API::Navigation& navigation, const IPC::DataReference& data, const String& mimeType, const String& encoding, const String& baseURL, const RefPtr<API::Object>& userData, WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, std::optional<WebsitePoliciesData>&& websitePolicies, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility)
 {
     PROVISIONALPAGEPROXY_RELEASE_LOG(ProcessSwapping, "loadData:");
     ASSERT(shouldTreatAsContinuingLoad != WebCore::ShouldTreatAsContinuingLoad::No);
@@ -182,7 +182,7 @@ void ProvisionalPageProxy::loadData(API::Navigation& navigation, const IPC::Data
     m_page.loadDataWithNavigationShared(m_process.copyRef(), m_webPageID, navigation, data, mimeType, encoding, baseURL, userData, shouldTreatAsContinuingLoad, isNavigatingToAppBoundDomain, WTFMove(websitePolicies), navigation.lastNavigationAction().shouldOpenExternalURLsPolicy, sessionHistoryVisibility);
 }
 
-void ProvisionalPageProxy::loadRequest(API::Navigation& navigation, WebCore::ResourceRequest&& request, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, std::optional<WebsitePoliciesData>&& websitePolicies, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume)
+void ProvisionalPageProxy::loadRequest(API::Navigation& navigation, WebCore::ResourceRequest&& request, const RefPtr<API::Object>& userData, WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, std::optional<WebsitePoliciesData>&& websitePolicies, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume)
 {
     PROVISIONALPAGEPROXY_RELEASE_LOG(ProcessSwapping, "loadRequest: existingNetworkResourceLoadIdentifierToResume=%" PRIu64, valueOrDefault(existingNetworkResourceLoadIdentifierToResume).toUInt64());
     ASSERT(shouldTreatAsContinuingLoad != WebCore::ShouldTreatAsContinuingLoad::No);

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -108,8 +108,8 @@ public:
 #endif
 #endif
 
-    void loadData(API::Navigation&, const IPC::DataReference&, const String& mimeType, const String& encoding, const String& baseURL, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&&, WebCore::SubstituteData::SessionHistoryVisibility);
-    void loadRequest(API::Navigation&, WebCore::ResourceRequest&&, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&& = std::nullopt, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume = std::nullopt);
+    void loadData(API::Navigation&, const IPC::DataReference&, const String& mimeType, const String& encoding, const String& baseURL, const RefPtr<API::Object>& userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&&, WebCore::SubstituteData::SessionHistoryVisibility);
+    void loadRequest(API::Navigation&, WebCore::ResourceRequest&&, const RefPtr<API::Object>& userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&& = std::nullopt, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume = std::nullopt);
     void goToBackForwardItem(API::Navigation&, WebBackForwardListItem&, RefPtr<API::WebsitePolicies>&&, WebCore::ShouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume = std::nullopt);
     void cancel();
 

--- a/Source/WebKit/UIProcess/WebConnectionToWebProcess.cpp
+++ b/Source/WebKit/UIProcess/WebConnectionToWebProcess.cpp
@@ -51,12 +51,12 @@ void WebConnectionToWebProcess::invalidate()
 
 // WebConnection
 
-RefPtr<API::Object> WebConnectionToWebProcess::transformHandlesToObjects(API::Object* object)
+RefPtr<API::Object> WebConnectionToWebProcess::transformHandlesToObjects(const RefPtr<API::Object>& object)
 {
     return m_process->transformHandlesToObjects(object);
 }
 
-RefPtr<API::Object> WebConnectionToWebProcess::transformObjectsToHandles(API::Object* object)
+RefPtr<API::Object> WebConnectionToWebProcess::transformObjectsToHandles(const RefPtr<API::Object>& object)
 {
     return m_process->transformObjectsToHandles(object);
 }

--- a/Source/WebKit/UIProcess/WebConnectionToWebProcess.h
+++ b/Source/WebKit/UIProcess/WebConnectionToWebProcess.h
@@ -43,8 +43,8 @@ private:
     WebConnectionToWebProcess(WebProcessProxy*);
 
     // WebConnection
-    RefPtr<API::Object> transformHandlesToObjects(API::Object*) override;
-    RefPtr<API::Object> transformObjectsToHandles(API::Object*) override;
+    RefPtr<API::Object> transformHandlesToObjects(const RefPtr<API::Object>&) override;
+    RefPtr<API::Object> transformObjectsToHandles(const RefPtr<API::Object>&) override;
     bool hasValidConnection() const override;
 
     // IPC::MessageSender

--- a/Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp
@@ -38,26 +38,26 @@ WebContextInjectedBundleClient::WebContextInjectedBundleClient(const WKContextIn
     initialize(client);
 }
 
-void WebContextInjectedBundleClient::didReceiveMessageFromInjectedBundle(WebProcessPool& processPool, const String& messageName, API::Object* messageBody)
+void WebContextInjectedBundleClient::didReceiveMessageFromInjectedBundle(WebProcessPool& processPool, const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     if (!m_client.didReceiveMessageFromInjectedBundle)
         return;
 
-    m_client.didReceiveMessageFromInjectedBundle(toAPI(&processPool), toAPI(messageName.impl()), toAPI(messageBody), m_client.base.clientInfo);
+    m_client.didReceiveMessageFromInjectedBundle(toAPI(&processPool), toAPI(messageName.impl()), toAPI(messageBody.get()), m_client.base.clientInfo);
 }
 
-void WebContextInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle(WebProcessPool& processPool, const String& messageName, API::Object* messageBody, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler)
+void WebContextInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle(WebProcessPool& processPool, const String& messageName, const RefPtr<API::Object>& messageBody, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler)
 {
     if (!m_client.didReceiveSynchronousMessageFromInjectedBundle && !m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener)
         return completionHandler(nullptr);
 
     if (m_client.didReceiveSynchronousMessageFromInjectedBundle) {
         WKTypeRef returnDataRef = nullptr;
-        m_client.didReceiveSynchronousMessageFromInjectedBundle(toAPI(&processPool), toAPI(messageName.impl()), toAPI(messageBody), &returnDataRef, m_client.base.clientInfo);
+        m_client.didReceiveSynchronousMessageFromInjectedBundle(toAPI(&processPool), toAPI(messageName.impl()), toAPI(messageBody.get()), &returnDataRef, m_client.base.clientInfo);
         return completionHandler(adoptRef(toImpl(returnDataRef)));
     }
 
-    m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener(toAPI(&processPool), toAPI(messageName.impl()), toAPI(messageBody), toAPI(API::MessageListener::create(WTFMove(completionHandler)).ptr()), m_client.base.clientInfo);
+    m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener(toAPI(&processPool), toAPI(messageName.impl()), toAPI(messageBody.get()), toAPI(API::MessageListener::create(WTFMove(completionHandler)).ptr()), m_client.base.clientInfo);
 }
 
 RefPtr<API::Object> WebContextInjectedBundleClient::getInjectedBundleInitializationUserData(WebProcessPool& processPool)

--- a/Source/WebKit/UIProcess/WebContextInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/WebContextInjectedBundleClient.h
@@ -47,8 +47,8 @@ class WebContextInjectedBundleClient : public API::InjectedBundleClient, public 
 public:
     explicit WebContextInjectedBundleClient(const WKContextInjectedBundleClientBase*);
 
-    void didReceiveMessageFromInjectedBundle(WebProcessPool&, const WTF::String&, API::Object*) override;
-    void didReceiveSynchronousMessageFromInjectedBundle(WebProcessPool&, const WTF::String&, API::Object*, CompletionHandler<void(RefPtr<API::Object>)>&&) override;
+    void didReceiveMessageFromInjectedBundle(WebProcessPool&, const WTF::String&, const RefPtr<API::Object>&) override;
+    void didReceiveSynchronousMessageFromInjectedBundle(WebProcessPool&, const WTF::String&, const RefPtr<API::Object>&, CompletionHandler<void(RefPtr<API::Object>)>&&) override;
     RefPtr<API::Object> getInjectedBundleInitializationUserData(WebProcessPool&) override;
 };
 

--- a/Source/WebKit/UIProcess/WebFormClient.cpp
+++ b/Source/WebKit/UIProcess/WebFormClient.cpp
@@ -39,7 +39,7 @@ WebFormClient::WebFormClient(const WKPageFormClientBase* wkClient)
     initialize(wkClient);
 }
 
-void WebFormClient::willSubmitForm(WebPageProxy& page, WebFrameProxy& frame, WebFrameProxy& sourceFrame, const Vector<std::pair<String, String>>& textFieldValues, API::Object* userData, WTF::Function<void(void)>&& completionHandler)
+void WebFormClient::willSubmitForm(WebPageProxy& page, WebFrameProxy& frame, WebFrameProxy& sourceFrame, const Vector<std::pair<String, String>>& textFieldValues, const RefPtr<API::Object>& userData, WTF::Function<void(void)>&& completionHandler)
 {
     if (!m_client.willSubmitForm) {
         completionHandler();
@@ -51,7 +51,7 @@ void WebFormClient::willSubmitForm(WebPageProxy& page, WebFrameProxy& frame, Web
         map.set(textFieldValues[i].first, API::String::create(textFieldValues[i].second));
     auto textFieldsMap = API::Dictionary::create(WTFMove(map));
     auto listener = WebFormSubmissionListenerProxy::create(WTFMove(completionHandler));
-    m_client.willSubmitForm(toAPI(&page), toAPI(&frame), toAPI(&sourceFrame), toAPI(textFieldsMap.ptr()), toAPI(userData), toAPI(listener.ptr()), m_client.base.clientInfo);
+    m_client.willSubmitForm(toAPI(&page), toAPI(&frame), toAPI(&sourceFrame), toAPI(textFieldsMap.ptr()), toAPI(userData.get()), toAPI(listener.ptr()), m_client.base.clientInfo);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFormClient.h
+++ b/Source/WebKit/UIProcess/WebFormClient.h
@@ -42,7 +42,7 @@ class WebFormClient : public API::FormClient, API::Client<WKPageFormClientBase> 
 public:
     explicit WebFormClient(const WKPageFormClientBase*);
 
-    void willSubmitForm(WebPageProxy&, WebFrameProxy&, WebFrameProxy&, const Vector<std::pair<String, String>>& textFieldValues, API::Object* userData, WTF::Function<void(void)>&&) override;
+    void willSubmitForm(WebPageProxy&, WebFrameProxy&, WebFrameProxy&, const Vector<std::pair<String, String>>& textFieldValues, const RefPtr<API::Object>& userData, WTF::Function<void(void)>&&) override;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
@@ -35,15 +35,15 @@
 namespace WebKit {
 using namespace WebCore;
 
-void WebPageInjectedBundleClient::didReceiveMessageFromInjectedBundle(WebPageProxy* page, const String& messageName, API::Object* messageBody)
+void WebPageInjectedBundleClient::didReceiveMessageFromInjectedBundle(WebPageProxy* page, const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     if (!m_client.didReceiveMessageFromInjectedBundle)
         return;
 
-    m_client.didReceiveMessageFromInjectedBundle(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), m_client.base.clientInfo);
+    m_client.didReceiveMessageFromInjectedBundle(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody.get()), m_client.base.clientInfo);
 }
 
-void WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy* page, const String& messageName, API::Object* messageBody, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler)
+void WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy* page, const String& messageName, const RefPtr<API::Object>& messageBody, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler)
 {
     if (!m_client.didReceiveSynchronousMessageFromInjectedBundle
         && !m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener)
@@ -51,11 +51,11 @@ void WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle
 
     if (m_client.didReceiveSynchronousMessageFromInjectedBundle) {
         WKTypeRef returnDataRef = nullptr;
-        m_client.didReceiveSynchronousMessageFromInjectedBundle(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), &returnDataRef, m_client.base.clientInfo);
+        m_client.didReceiveSynchronousMessageFromInjectedBundle(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody.get()), &returnDataRef, m_client.base.clientInfo);
         return completionHandler(adoptRef(toImpl(returnDataRef)));
     }
 
-    m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), toAPI(API::MessageListener::create(WTFMove(completionHandler)).ptr()), m_client.base.clientInfo);
+    m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody.get()), toAPI(API::MessageListener::create(WTFMove(completionHandler)).ptr()), m_client.base.clientInfo);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.h
@@ -44,8 +44,8 @@ class WebPageProxy;
 class WebPageInjectedBundleClient : public API::Client<WKPageInjectedBundleClientBase> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    void didReceiveMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*);
-    void didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*, CompletionHandler<void(RefPtr<API::Object>)>&&);
+    void didReceiveMessageFromInjectedBundle(WebPageProxy*, const String&, const RefPtr<API::Object>&);
+    void didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy*, const String&, const RefPtr<API::Object>&, CompletionHandler<void(RefPtr<API::Object>)>&&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1435,7 +1435,7 @@ WebProcessProxy& WebPageProxy::ensureRunningProcess()
     return m_process;
 }
 
-RefPtr<API::Navigation> WebPageProxy::loadRequest(ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, API::Object* userData)
+RefPtr<API::Navigation> WebPageProxy::loadRequest(ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, const RefPtr<API::Object>& userData)
 {
     if (m_isClosed)
         return nullptr;
@@ -1458,7 +1458,7 @@ RefPtr<API::Navigation> WebPageProxy::loadRequest(ResourceRequest&& request, Sho
     return navigation;
 }
 
-void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& process, WebCore::PageIdentifier webPageID, API::Navigation& navigation, ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, API::Object* userData, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, std::optional<WebsitePoliciesData>&& websitePolicies, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume)
+void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& process, WebCore::PageIdentifier webPageID, API::Navigation& navigation, ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, const RefPtr<API::Object>& userData, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, std::optional<WebsitePoliciesData>&& websitePolicies, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume)
 {
     ASSERT(!m_isClosed);
 
@@ -1506,7 +1506,7 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     process->startResponsivenessTimer();
 }
 
-RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, const String& resourceDirectoryURLString, bool isAppInitiated, API::Object* userData)
+RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, const String& resourceDirectoryURLString, bool isAppInitiated, const RefPtr<API::Object>& userData)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "loadFile:");
 
@@ -1577,7 +1577,7 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
     return navigation;
 }
 
-RefPtr<API::Navigation> WebPageProxy::loadData(const IPC::DataReference& data, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy)
+RefPtr<API::Navigation> WebPageProxy::loadData(const IPC::DataReference& data, const String& MIMEType, const String& encoding, const String& baseURL, const RefPtr<API::Object>& userData, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "loadData:");
 
@@ -1603,7 +1603,7 @@ RefPtr<API::Navigation> WebPageProxy::loadData(const IPC::DataReference& data, c
     return navigation;
 }
 
-void WebPageProxy::loadDataWithNavigationShared(Ref<WebProcessProxy>&& process, WebCore::PageIdentifier webPageID, API::Navigation& navigation, const IPC::DataReference& data, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, std::optional<WebsitePoliciesData>&& websitePolicies, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility)
+void WebPageProxy::loadDataWithNavigationShared(Ref<WebProcessProxy>&& process, WebCore::PageIdentifier webPageID, API::Navigation& navigation, const IPC::DataReference& data, const String& MIMEType, const String& encoding, const String& baseURL, const RefPtr<API::Object>& userData, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, std::optional<WebsitePoliciesData>&& websitePolicies, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "loadDataWithNavigation");
 
@@ -1695,7 +1695,7 @@ RefPtr<API::Navigation> WebPageProxy::loadSimulatedRequest(WebCore::ResourceRequ
     return navigation;
 }
 
-void WebPageProxy::loadAlternateHTML(Ref<WebCore::DataSegment>&& htmlData, const String& encoding, const URL& baseURL, const URL& unreachableURL, API::Object* userData)
+void WebPageProxy::loadAlternateHTML(Ref<WebCore::DataSegment>&& htmlData, const String& encoding, const URL& baseURL, const URL& unreachableURL, const RefPtr<API::Object>& userData)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "loadAlternateHTML");
 
@@ -1745,7 +1745,7 @@ void WebPageProxy::loadAlternateHTML(Ref<WebCore::DataSegment>&& htmlData, const
     });
 }
 
-void WebPageProxy::loadWebArchiveData(API::Data* webArchiveData, API::Object* userData)
+void WebPageProxy::loadWebArchiveData(API::Data* webArchiveData, const RefPtr<API::Object>& userData)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "loadWebArchiveData:");
 
@@ -7306,7 +7306,7 @@ NativeWebMouseEvent* WebPageProxy::currentlyProcessedMouseDownEvent()
     return &event;
 }
 
-void WebPageProxy::postMessageToInjectedBundle(const String& messageName, API::Object* messageBody)
+void WebPageProxy::postMessageToInjectedBundle(const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     if (!hasRunningProcess()) {
         m_pendingInjectedBundleMessages.append(InjectedBundleMessage { messageName, messageBody });
@@ -10322,7 +10322,7 @@ void WebPageProxy::didPerformImmediateActionHitTest(const WebHitTestResultData& 
     pageClient().didPerformImmediateActionHitTest(result, contentPreventsDefault, m_process->transformHandlesToObjects(userData.object()).get());
 }
 
-NSObject *WebPageProxy::immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult> hitTestResult, uint64_t type, RefPtr<API::Object> userData)
+NSObject* WebPageProxy::immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult> hitTestResult, uint64_t type, const RefPtr<API::Object>& userData)
 {
     return pageClient().immediateActionAnimationControllerForHitTestResult(hitTestResult, type, userData);
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -704,12 +704,12 @@ public:
     void closePage();
 
     void addPlatformLoadParameters(WebProcessProxy&, LoadParameters&);
-    RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, API::Object* userData = nullptr);
-    RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
-    RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
+    RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks, const RefPtr<API::Object>& userData = nullptr);
+    RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, const RefPtr<API::Object>& userData = nullptr);
+    RefPtr<API::Navigation> loadData(const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, const RefPtr<API::Object>& userData = nullptr, WebCore::ShouldOpenExternalURLsPolicy = WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow);
     RefPtr<API::Navigation> loadSimulatedRequest(WebCore::ResourceRequest&&, WebCore::ResourceResponse&&, const IPC::DataReference&);
-    void loadAlternateHTML(Ref<WebCore::DataSegment>&&, const String& encoding, const URL& baseURL, const URL& unreachableURL, API::Object* userData = nullptr);
-    void loadWebArchiveData(API::Data*, API::Object* userData = nullptr);
+    void loadAlternateHTML(Ref<WebCore::DataSegment>&&, const String& encoding, const URL& baseURL, const URL& unreachableURL, const RefPtr<API::Object>& userData = nullptr);
+    void loadWebArchiveData(API::Data*, const RefPtr<API::Object>& userData = nullptr);
     void navigateToPDFLinkWithSimulatedClick(const String& url, WebCore::IntPoint documentPoint, WebCore::IntPoint screenPoint);
 
     void simulateDeviceOrientationChange(double alpha, double beta, double gamma);
@@ -1564,7 +1564,7 @@ public:
     void setIsShowingInputViewForFocusedElement(bool);
 #endif
 
-    void postMessageToInjectedBundle(const String& messageName, API::Object* messageBody);
+    void postMessageToInjectedBundle(const String& messageName, const RefPtr<API::Object>& messageBody);
 
 #if ENABLE(INPUT_TYPE_COLOR)
     void setColorPickerColor(const WebCore::Color&);
@@ -1671,7 +1671,7 @@ public:
     void immediateActionDidCancel();
     void immediateActionDidComplete();
 
-    NSObject *immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult>, uint64_t, RefPtr<API::Object>);
+    NSObject *immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult>, uint64_t, const RefPtr<API::Object>&);
 
     void handleAcceptedCandidate(WebCore::TextCheckingResult);
     void didHandleAcceptedCandidate();
@@ -1890,8 +1890,8 @@ public:
     void decidePolicyForNavigationActionAsyncShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::PolicyCheckIdentifier, uint64_t navigationID, NavigationActionData&&, FrameInfoData&& originatingFrameInfo, std::optional<WebPageProxyIdentifier> originatingPageID, const WebCore::ResourceRequest& originalRequest, WebCore::ResourceRequest&&, IPC::FormDataReference&& requestBody, WebCore::ResourceResponse&& redirectResponse, uint64_t listenerID);
     void decidePolicyForResponseShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::PolicyCheckIdentifier, uint64_t navigationID, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, const String& downloadAttribute, uint64_t listenerID);
     void startURLSchemeTaskShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, URLSchemeTaskParameters&&);
-    void loadDataWithNavigationShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, API::Navigation&, const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::SubstituteData::SessionHistoryVisibility);
-    void loadRequestWithNavigationShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, API::Navigation&, WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, API::Object* userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&& = std::nullopt, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume = std::nullopt);
+    void loadDataWithNavigationShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, API::Navigation&, const IPC::DataReference&, const String& MIMEType, const String& encoding, const String& baseURL, const RefPtr<API::Object>& userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::SubstituteData::SessionHistoryVisibility);
+    void loadRequestWithNavigationShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, API::Navigation&, WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, const RefPtr<API::Object>& userData, WebCore::ShouldTreatAsContinuingLoad, std::optional<NavigatingToAppBoundDomain>, std::optional<WebsitePoliciesData>&& = std::nullopt, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume = std::nullopt);
     void backForwardAddItemShared(Ref<WebProcessProxy>&&, BackForwardListItemState&&);
     void backForwardGoToItemShared(Ref<WebProcessProxy>&&, const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void decidePolicyForNavigationActionSyncShared(Ref<WebProcessProxy>&&, WebCore::PageIdentifier, WebCore::FrameIdentifier, bool isMainFrame, FrameInfoData&&, WebCore::PolicyCheckIdentifier, uint64_t navigationID, NavigationActionData&&, FrameInfoData&& originatingFrameInfo, std::optional<WebPageProxyIdentifier> originatingPageID, const WebCore::ResourceRequest& originalRequest, WebCore::ResourceRequest&&, IPC::FormDataReference&& requestBody, WebCore::ResourceResponse&& redirectResponse, CompletionHandler<void(PolicyDecision&&)>&&);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1211,7 +1211,7 @@ DownloadProxy& WebProcessPool::resumeDownload(WebsiteDataStore& dataStore, WebPa
     return downloadProxy;
 }
 
-void WebProcessPool::postMessageToInjectedBundle(const String& messageName, API::Object* messageBody)
+void WebProcessPool::postMessageToInjectedBundle(const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     for (auto& process : m_processes) {
         // FIXME: Return early if the message body contains any references to WKPageRefs/WKFrameRefs etc. since they're local to a process.

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -231,7 +231,7 @@ public:
 
     void setInjectedBundleInitializationUserData(RefPtr<API::Object>&& userData) { m_injectedBundleInitializationUserData = WTFMove(userData); }
 
-    void postMessageToInjectedBundle(const String&, API::Object*);
+    void postMessageToInjectedBundle(const String&, const RefPtr<API::Object>&);
 
     void populateVisitedLinks();
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1492,7 +1492,7 @@ void WebProcessProxy::disableSuddenTermination()
     ++m_numberOfTimesSuddenTerminationWasDisabled;
 }
 
-RefPtr<API::Object> WebProcessProxy::transformHandlesToObjects(API::Object* object)
+RefPtr<API::Object> WebProcessProxy::transformHandlesToObjects(const RefPtr<API::Object>& object)
 {
     struct Transformer final : UserData::Transformer {
         Transformer(WebProcessProxy& webProcessProxy)
@@ -1542,10 +1542,10 @@ RefPtr<API::Object> WebProcessProxy::transformHandlesToObjects(API::Object* obje
         WebProcessProxy& m_webProcessProxy;
     };
 
-    return UserData::transform(object, Transformer(*this));
+    return UserData::transform(object.get(), Transformer(*this));
 }
 
-RefPtr<API::Object> WebProcessProxy::transformObjectsToHandles(API::Object* object)
+RefPtr<API::Object> WebProcessProxy::transformObjectsToHandles(const RefPtr<API::Object>& object)
 {
     struct Transformer final : UserData::Transformer {
         bool shouldTransformObject(const API::Object& object) const override
@@ -1584,7 +1584,7 @@ RefPtr<API::Object> WebProcessProxy::transformObjectsToHandles(API::Object* obje
         }
     };
 
-    return UserData::transform(object, Transformer());
+    return UserData::transform(object.get(), Transformer());
 }
 
 void WebProcessProxy::sendPrepareToSuspend(IsSuspensionImminent isSuspensionImminent, double remainingRunTime, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -290,8 +290,8 @@ public:
 
     void requestTermination(ProcessTerminationReason);
 
-    RefPtr<API::Object> transformHandlesToObjects(API::Object*);
-    static RefPtr<API::Object> transformObjectsToHandles(API::Object*);
+    RefPtr<API::Object> transformHandlesToObjects(const RefPtr<API::Object>&);
+    static RefPtr<API::Object> transformObjectsToHandles(const RefPtr<API::Object>&);
 
 #if PLATFORM(COCOA)
     RefPtr<ObjCObjectGraph> transformHandlesToObjects(ObjCObjectGraph&);

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -177,7 +177,7 @@ private:
     void restorePageState(std::optional<WebCore::FloatPoint>, const WebCore::FloatPoint&, const WebCore::FloatBoxExtent&, double) override;
     void restorePageCenterAndScale(std::optional<WebCore::FloatPoint>, double) override;
 
-    void elementDidFocus(const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState::Flag> activityStateChanges, API::Object* userData) override;
+    void elementDidFocus(const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState::Flag> activityStateChanges, const RefPtr<API::Object>& userData) override;
     void updateInputContextAfterBlurringAndRefocusingElement() final;
     void elementDidBlur() override;
     void focusedElementDidChangeInputMode(WebCore::InputMode) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -608,12 +608,12 @@ void PageClientImpl::restorePageCenterAndScale(std::optional<WebCore::FloatPoint
     [m_webView _restorePageStateToUnobscuredCenter:center scale:scale];
 }
 
-void PageClientImpl::elementDidFocus(const FocusedElementInformation& nodeInformation, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState::Flag> activityStateChanges, API::Object* userData)
+void PageClientImpl::elementDidFocus(const FocusedElementInformation& nodeInformation, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState::Flag> activityStateChanges, const RefPtr<API::Object>& userData)
 {
     MESSAGE_CHECK(!userData || userData->type() == API::Object::Type::Data);
 
     NSObject <NSSecureCoding> *userObject = nil;
-    if (API::Data* data = static_cast<API::Data*>(userData)) {
+    if (API::Data* data = static_cast<API::Data*>(userData.get())) {
         auto nsData = adoptNS([[NSData alloc] initWithBytesNoCopy:const_cast<unsigned char*>(data->bytes()) length:data->size() freeWhenDone:NO]);
         auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:nsData.get() error:nullptr]);
         unarchiver.get().decodingFailurePolicy = NSDecodingFailurePolicyRaiseException;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -249,8 +249,8 @@ private:
     void didSameDocumentNavigationForMainFrame(SameDocumentNavigationType) override;
     void handleControlledElementIDResponse(const String&) override;
 
-    void didPerformImmediateActionHitTest(const WebHitTestResultData&, bool contentPreventsDefault, API::Object*) override;
-    NSObject *immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult>, uint64_t, RefPtr<API::Object>) override;
+    void didPerformImmediateActionHitTest(const WebHitTestResultData&, bool contentPreventsDefault, const RefPtr<API::Object>&) override;
+    NSObject *immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult>, uint64_t, const RefPtr<API::Object>&) override;
 
     void didHandleAcceptedCandidate() override;
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -907,12 +907,12 @@ CGRect PageClientImpl::boundsOfLayerInLayerBackedWindowCoordinates(CALayer *laye
     return [windowContentLayer convertRect:layer.bounds fromLayer:layer];
 }
 
-void PageClientImpl::didPerformImmediateActionHitTest(const WebHitTestResultData& result, bool contentPreventsDefault, API::Object* userData)
+void PageClientImpl::didPerformImmediateActionHitTest(const WebHitTestResultData& result, bool contentPreventsDefault, const RefPtr<API::Object>& userData)
 {
-    m_impl->didPerformImmediateActionHitTest(result, contentPreventsDefault, userData);
+    m_impl->didPerformImmediateActionHitTest(result, contentPreventsDefault, userData.get());
 }
 
-NSObject *PageClientImpl::immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult> hitTestResult, uint64_t type, RefPtr<API::Object> userData)
+NSObject *PageClientImpl::immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult> hitTestResult, uint64_t type, const RefPtr<API::Object>& userData)
 {
     return m_impl->immediateActionAnimationControllerForHitTestResult(hitTestResult.get(), type, userData.get());
 }

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -679,7 +679,7 @@ static RetainPtr<NSMenuItem> createMenuActionItem(const WebContextMenuItemData& 
     [menuItem setIdentifier:menuItemIdentifier(item.action())];
 
     if (item.userData())
-        [menuItem setRepresentedObject:adoptNS([[WKUserDataWrapper alloc] initWithUserData:item.userData()]).get()];
+        [menuItem setRepresentedObject:adoptNS([[WKUserDataWrapper alloc] initWithUserData:item.userData().get()]).get()];
 
     return menuItem;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleBundleClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleBundleClient.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/RefPtr.h>
 
 namespace WebKit {
 class InjectedBundle;
@@ -45,8 +46,8 @@ public:
 
     virtual void didCreatePage(WebKit::InjectedBundle&, WebKit::WebPage&) { }
     virtual void willDestroyPage(WebKit::InjectedBundle&, WebKit::WebPage&) { }
-    virtual void didReceiveMessage(WebKit::InjectedBundle&, const WTF::String&, API::Object*) { }
-    virtual void didReceiveMessageToPage(WebKit::InjectedBundle&, WebKit::WebPage&, const WTF::String&, API::Object*) { }
+    virtual void didReceiveMessage(WebKit::InjectedBundle&, const WTF::String&, const RefPtr<API::Object>&) { }
+    virtual void didReceiveMessageToPage(WebKit::InjectedBundle&, WebKit::WebPage&, const WTF::String&, const RefPtr<API::Object>&) { }
 };
 
 } // namespace InjectedBundle

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageLoaderClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageLoaderClient.h
@@ -55,8 +55,8 @@ class PageLoaderClient {
 public:
     virtual ~PageLoaderClient() = default;
 
-    virtual void willLoadURLRequest(WebKit::WebPage&, const WebCore::ResourceRequest&, API::Object*) { }
-    virtual void willLoadDataRequest(WebKit::WebPage&, const WebCore::ResourceRequest&, RefPtr<WebCore::FragmentedSharedBuffer>, const WTF::String&, const WTF::String&, const WTF::URL&, API::Object*) { }
+    virtual void willLoadURLRequest(WebKit::WebPage&, const WebCore::ResourceRequest&, const RefPtr<API::Object>&) { }
+    virtual void willLoadDataRequest(WebKit::WebPage&, const WebCore::ResourceRequest&, RefPtr<WebCore::FragmentedSharedBuffer>, const WTF::String&, const WTF::String&, const WTF::URL&, const RefPtr<API::Object>&) { }
 
     virtual void didStartProvisionalLoadForFrame(WebKit::WebPage&, WebKit::WebFrame&, RefPtr<API::Object>&) { }
     virtual void didReceiveServerRedirectForProvisionalLoadForFrame(WebKit::WebPage&, WebKit::WebFrame&, RefPtr<API::Object>&) { }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.cpp
@@ -48,11 +48,11 @@ void WebProcessExtensionManager::scanModules(const String& webProcessExtensionsD
     }
 }
 
-static void parseUserData(API::Object* userData, String& webProcessExtensionsDirectory, GRefPtr<GVariant>& initializationUserData)
+static void parseUserData(const RefPtr<API::Object>& userData, String& webProcessExtensionsDirectory, GRefPtr<GVariant>& initializationUserData)
 {
     ASSERT(userData->type() == API::Object::Type::String);
 
-    CString userDataString = static_cast<API::String*>(userData)->string().utf8();
+    CString userDataString = static_cast<API::String*>(userData.get())->string().utf8();
     GRefPtr<GVariant> variant = g_variant_parse(nullptr, userDataString.data(),
         userDataString.data() + userDataString.length(), nullptr, nullptr);
 
@@ -96,7 +96,7 @@ bool WebProcessExtensionManager::initializeWebProcessExtension(Module* extension
     return false;
 }
 
-void WebProcessExtensionManager::initialize(InjectedBundle* bundle, API::Object* userDataObject)
+void WebProcessExtensionManager::initialize(InjectedBundle* bundle, const RefPtr<API::Object>& userDataObject)
 {
     ASSERT(bundle);
     ASSERT(userDataObject);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.h
@@ -45,7 +45,7 @@ class WebProcessExtensionManager {
 public:
     __attribute__((visibility("default"))) static WebProcessExtensionManager& singleton();
 
-    __attribute__((visibility("default"))) void initialize(InjectedBundle*, API::Object*);
+    __attribute__((visibility("default"))) void initialize(InjectedBundle*, const RefPtr<API::Object>&);
 
     WebKitWebProcessExtension* extension() const { return m_extension.get(); }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -91,7 +91,7 @@ namespace WebKit {
 using namespace WebCore;
 using namespace JSC;
 
-RefPtr<InjectedBundle> InjectedBundle::create(WebProcessCreationParameters& parameters, API::Object* initializationUserData)
+RefPtr<InjectedBundle> InjectedBundle::create(WebProcessCreationParameters& parameters, const RefPtr<API::Object>& initializationUserData)
 {
     TraceScope scope(TracePointCode::CreateInjectedBundleStart, TracePointCode::CreateInjectedBundleEnd);
     
@@ -130,13 +130,13 @@ void InjectedBundle::setServiceWorkerProxyCreationCallback(void (*callback)(uint
 #endif
 }
 
-void InjectedBundle::postMessage(const String& messageName, API::Object* messageBody)
+void InjectedBundle::postMessage(const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     auto& webProcess = WebProcess::singleton();
     webProcess.parentProcessConnection()->send(Messages::WebProcessPool::HandleMessage(messageName, UserData(webProcess.transformObjectsToHandles(messageBody))), 0);
 }
 
-void InjectedBundle::postSynchronousMessage(const String& messageName, API::Object* messageBody, RefPtr<API::Object>& returnData)
+void InjectedBundle::postSynchronousMessage(const String& messageName, const RefPtr<API::Object>& messageBody, RefPtr<API::Object>& returnData)
 {
     auto& webProcess = WebProcess::singleton();
     auto sendResult = webProcess.parentProcessConnection()->sendSync(Messages::WebProcessPool::HandleSynchronousMessage(messageName, UserData(webProcess.transformObjectsToHandles(messageBody))), 0);
@@ -272,12 +272,12 @@ void InjectedBundle::willDestroyPage(WebPage* page)
     m_client->willDestroyPage(*this, *page);
 }
 
-void InjectedBundle::didReceiveMessage(const String& messageName, API::Object* messageBody)
+void InjectedBundle::didReceiveMessage(const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     m_client->didReceiveMessage(*this, messageName, messageBody);
 }
 
-void InjectedBundle::didReceiveMessageToPage(WebPage* page, const String& messageName, API::Object* messageBody)
+void InjectedBundle::didReceiveMessageToPage(WebPage* page, const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     m_client->didReceiveMessageToPage(*this, *page, messageName, messageBody);
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
@@ -77,19 +77,19 @@ struct WebProcessCreationParameters;
 
 class InjectedBundle : public API::ObjectImpl<API::Object::Type::Bundle> {
 public:
-    static RefPtr<InjectedBundle> create(WebProcessCreationParameters&, API::Object* initializationUserData);
+    static RefPtr<InjectedBundle> create(WebProcessCreationParameters&, const RefPtr<API::Object>& initializationUserData);
 
     ~InjectedBundle();
 
-    bool initialize(const WebProcessCreationParameters&, API::Object* initializationUserData);
+    bool initialize(const WebProcessCreationParameters&, const RefPtr<API::Object>& initializationUserData);
 
     void setBundleParameter(const String&, const IPC::DataReference&);
     void setBundleParameters(const IPC::DataReference&);
 
     // API
     void setClient(std::unique_ptr<API::InjectedBundle::Client>&&);
-    void postMessage(const String&, API::Object*);
-    void postSynchronousMessage(const String&, API::Object*, RefPtr<API::Object>& returnData);
+    void postMessage(const String&, const RefPtr<API::Object>&);
+    void postSynchronousMessage(const String&, const RefPtr<API::Object>&, RefPtr<API::Object>& returnData);
     void setServiceWorkerProxyCreationCallback(void (*)(uint64_t));
 
     WebConnection* webConnectionToUIProcess() const;
@@ -120,8 +120,8 @@ public:
     // Callback hooks
     void didCreatePage(WebPage*);
     void willDestroyPage(WebPage*);
-    void didReceiveMessage(const String&, API::Object*);
-    void didReceiveMessageToPage(WebPage*, const String&, API::Object*);
+    void didReceiveMessage(const String&, const RefPtr<API::Object>&);
+    void didReceiveMessageToPage(WebPage*, const String&, const RefPtr<API::Object>&);
 
     static void reportException(JSContextRef, JSValueRef exception);
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.cpp
@@ -54,20 +54,20 @@ void InjectedBundleClient::willDestroyPage(InjectedBundle& bundle, WebPage& page
     m_client.willDestroyPage(toAPI(&bundle), toAPI(&page), m_client.base.clientInfo);
 }
 
-void InjectedBundleClient::didReceiveMessage(InjectedBundle& bundle, const String& messageName, API::Object* messageBody)
+void InjectedBundleClient::didReceiveMessage(InjectedBundle& bundle, const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     if (!m_client.didReceiveMessage)
         return;
 
-    m_client.didReceiveMessage(toAPI(&bundle), toAPI(messageName.impl()), toAPI(messageBody), m_client.base.clientInfo);
+    m_client.didReceiveMessage(toAPI(&bundle), toAPI(messageName.impl()), toAPI(messageBody.get()), m_client.base.clientInfo);
 }
 
-void InjectedBundleClient::didReceiveMessageToPage(InjectedBundle& bundle, WebPage& page, const String& messageName, API::Object* messageBody)
+void InjectedBundleClient::didReceiveMessageToPage(InjectedBundle& bundle, WebPage& page, const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     if (!m_client.didReceiveMessageToPage)
         return;
 
-    m_client.didReceiveMessageToPage(toAPI(&bundle), toAPI(&page), toAPI(messageName.impl()), toAPI(messageBody), m_client.base.clientInfo);
+    m_client.didReceiveMessageToPage(toAPI(&bundle), toAPI(&page), toAPI(messageName.impl()), toAPI(messageBody.get()), m_client.base.clientInfo);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.h
@@ -51,8 +51,8 @@ public:
 
     void didCreatePage(InjectedBundle&, WebPage&) override;
     void willDestroyPage(InjectedBundle&, WebPage&) override;
-    void didReceiveMessage(InjectedBundle&, const WTF::String&, API::Object*) override;
-    void didReceiveMessageToPage(InjectedBundle&, WebPage&, const WTF::String&, API::Object*) override;
+    void didReceiveMessage(InjectedBundle&, const WTF::String&, const RefPtr<API::Object>&) override;
+    void didReceiveMessageToPage(InjectedBundle&, WebPage&, const WTF::String&, const RefPtr<API::Object>&) override;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.cpp
@@ -51,12 +51,12 @@ InjectedBundlePageLoaderClient::InjectedBundlePageLoaderClient(const WKBundlePag
     ASSERT(!m_client.shouldGoToBackForwardListItem);
 }
 
-void InjectedBundlePageLoaderClient::willLoadURLRequest(WebPage& page, const ResourceRequest& request, API::Object* userData)
+void InjectedBundlePageLoaderClient::willLoadURLRequest(WebPage& page, const ResourceRequest& request, const RefPtr<API::Object>& userData)
 {
     if (!m_client.willLoadURLRequest)
         return;
 
-    m_client.willLoadURLRequest(toAPI(&page), toAPI(request), toAPI(userData), m_client.base.clientInfo);
+    m_client.willLoadURLRequest(toAPI(&page), toAPI(request), toAPI(userData.get()), m_client.base.clientInfo);
 }
 
 static void releaseSharedBuffer(unsigned char*, const void* data)
@@ -65,7 +65,7 @@ static void releaseSharedBuffer(unsigned char*, const void* data)
     static_cast<const SharedBuffer*>(data)->deref();
 }
 
-void InjectedBundlePageLoaderClient::willLoadDataRequest(WebPage& page, const ResourceRequest& request, RefPtr<FragmentedSharedBuffer> sharedBuffer, const String& MIMEType, const String& encodingName, const URL& unreachableURL, API::Object* userData)
+void InjectedBundlePageLoaderClient::willLoadDataRequest(WebPage& page, const ResourceRequest& request, RefPtr<FragmentedSharedBuffer> sharedBuffer, const String& MIMEType, const String& encodingName, const URL& unreachableURL, const RefPtr<API::Object>& userData)
 {
     if (!m_client.willLoadDataRequest)
         return;
@@ -77,7 +77,7 @@ void InjectedBundlePageLoaderClient::willLoadDataRequest(WebPage& page, const Re
         data = API::Data::createWithoutCopying(contiguousBuffer->data(), contiguousBuffer->size(), releaseSharedBuffer, contiguousBuffer.ptr());
     }
 
-    m_client.willLoadDataRequest(toAPI(&page), toAPI(request), toAPI(data.get()), toAPI(MIMEType.impl()), toAPI(encodingName.impl()), toURLRef(unreachableURL.string().impl()), toAPI(userData), m_client.base.clientInfo);
+    m_client.willLoadDataRequest(toAPI(&page), toAPI(request), toAPI(data.get()), toAPI(MIMEType.impl()), toAPI(encodingName.impl()), toURLRef(unreachableURL.string().impl()), toAPI(userData.get()), m_client.base.clientInfo);
 }
 
 void InjectedBundlePageLoaderClient::didStartProvisionalLoadForFrame(WebPage& page, WebFrame& frame, RefPtr<API::Object>& userData)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.h
@@ -46,8 +46,8 @@ class InjectedBundlePageLoaderClient : public API::Client<WKBundlePageLoaderClie
 public:
     explicit InjectedBundlePageLoaderClient(const WKBundlePageLoaderClientBase*);
 
-    void willLoadURLRequest(WebPage&, const WebCore::ResourceRequest&, API::Object*) override;
-    void willLoadDataRequest(WebPage&, const WebCore::ResourceRequest&, RefPtr<WebCore::FragmentedSharedBuffer>, const WTF::String&, const WTF::String&, const URL&, API::Object*) override;
+    void willLoadURLRequest(WebPage&, const WebCore::ResourceRequest&, const RefPtr<API::Object>&) override;
+    void willLoadDataRequest(WebPage&, const WebCore::ResourceRequest&, RefPtr<WebCore::FragmentedSharedBuffer>, const WTF::String&, const WTF::String&, const URL&, const RefPtr<API::Object>&) override;
 
     void didStartProvisionalLoadForFrame(WebPage&, WebFrame&, RefPtr<API::Object>&) override;
     void didReceiveServerRedirectForProvisionalLoadForFrame(WebPage&, WebFrame&, RefPtr<API::Object>&) override;

--- a/Source/WebKit/WebProcess/InjectedBundle/glib/InjectedBundleGlib.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/glib/InjectedBundleGlib.cpp
@@ -34,7 +34,7 @@
 
 namespace WebKit {
 
-bool InjectedBundle::initialize(const WebProcessCreationParameters&, API::Object* initializationUserData)
+bool InjectedBundle::initialize(const WebProcessCreationParameters&, const RefPtr<API::Object>& initializationUserData)
 {
     m_platformBundle = g_module_open(FileSystem::fileSystemRepresentation(m_path).data(), G_MODULE_BIND_LOCAL);
     if (!m_platformBundle) {
@@ -48,7 +48,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters&, API::Object
         return false;
     }
 
-    initializeFunction(toAPI(this), toAPI(initializationUserData));
+    initializeFunction(toAPI(this), toAPI(initializationUserData.get()));
     return true;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -115,7 +115,7 @@ bool InjectedBundle::decodeBundleParameters(API::Data* bundleParameterDataPtr)
     return true;
 }
 
-bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, API::Object* initializationUserData)
+bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, const RefPtr<API::Object>& initializationUserData)
 {
     if (auto sandboxExtension = std::exchange(m_sandboxExtension, nullptr)) {
         if (!sandboxExtension->consumePermanently()) {
@@ -160,7 +160,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, 
 
     // Update list of valid classes for the parameter coder
     if (additionalClassesForParameterCoderFunction)
-        additionalClassesForParameterCoderFunction(toAPI(this), toAPI(initializationUserData));
+        additionalClassesForParameterCoderFunction(toAPI(this), toAPI(initializationUserData.get()));
 
 #if PLATFORM(MAC)
     // Swizzle [NSEvent modiferFlags], since it always returns 0 when the WindowServer is blocked.
@@ -172,7 +172,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, 
     if (initializeFunction) {
         if (!decodeBundleParameters(parameters.bundleParameterData.get()))
             return false;
-        initializeFunction(toAPI(this), toAPI(initializationUserData));
+        initializeFunction(toAPI(this), toAPI(initializationUserData.get()));
         return true;
     }
 
@@ -206,7 +206,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, 
     if ([instance respondsToSelector:@selector(webProcessPlugIn:initializeWithObject:)]) {
         RetainPtr<id> objCInitializationUserData;
         if (initializationUserData && initializationUserData->type() == API::Object::Type::ObjCObjectGraph)
-            objCInitializationUserData = static_cast<ObjCObjectGraph*>(initializationUserData)->rootObject();
+            objCInitializationUserData = static_cast<ObjCObjectGraph*>(initializationUserData.get())->rootObject();
         [instance webProcessPlugIn:plugInController initializeWithObject:objCInitializationUserData.get()];
     }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/playstation/InjectedBundlePlayStation.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/playstation/InjectedBundlePlayStation.cpp
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, API::Object* initializationUserData)
+bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, const RefPtr<API::Object>& initializationUserData)
 {
     auto bundle = LibraryBundle::create(m_path.utf8().data());
     m_platformBundle = bundle;
@@ -45,7 +45,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters& parameters, 
         printf("PlayStation::Bundle::resolve failed\n");
         return false;
     }
-    initializeFunction(toAPI(this), toAPI(initializationUserData));
+    initializeFunction(toAPI(this), toAPI(initializationUserData.get()));
     return true;
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/win/InjectedBundleWin.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/win/InjectedBundleWin.cpp
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-bool InjectedBundle::initialize(const WebProcessCreationParameters&, API::Object* initializationUserData)
+bool InjectedBundle::initialize(const WebProcessCreationParameters&, const RefPtr<API::Object>& initializationUserData)
 {
     HMODULE lib = ::LoadLibrary(m_path.wideCharacters().data());
     if (!lib)
@@ -41,7 +41,7 @@ bool InjectedBundle::initialize(const WebProcessCreationParameters&, API::Object
     if (!proc)
         return false;
 
-    proc(toAPI(this), toAPI(initializationUserData));
+    proc(toAPI(this), toAPI(initializationUserData.get()));
     return true;
 }
 

--- a/Source/WebKit/WebProcess/WebConnectionToUIProcess.cpp
+++ b/Source/WebKit/WebProcess/WebConnectionToUIProcess.cpp
@@ -51,12 +51,12 @@ void WebConnectionToUIProcess::invalidate()
 
 // WebConnection
 
-RefPtr<API::Object> WebConnectionToUIProcess::transformHandlesToObjects(API::Object* object)
+RefPtr<API::Object> WebConnectionToUIProcess::transformHandlesToObjects(const RefPtr<API::Object>& object)
 {
     return m_process->transformHandlesToObjects(object);
 }
 
-RefPtr<API::Object> WebConnectionToUIProcess::transformObjectsToHandles(API::Object* object)
+RefPtr<API::Object> WebConnectionToUIProcess::transformObjectsToHandles(const RefPtr<API::Object>& object)
 {
     return m_process->transformObjectsToHandles(object);
 }

--- a/Source/WebKit/WebProcess/WebConnectionToUIProcess.h
+++ b/Source/WebKit/WebProcess/WebConnectionToUIProcess.h
@@ -41,8 +41,8 @@ private:
     WebConnectionToUIProcess(WebProcess*);
 
     // WebConnection
-    RefPtr<API::Object> transformHandlesToObjects(API::Object*) override;
-    RefPtr<API::Object> transformObjectsToHandles(API::Object*) override;
+    RefPtr<API::Object> transformHandlesToObjects(const RefPtr<API::Object>&) override;
+    RefPtr<API::Object> transformObjectsToHandles(const RefPtr<API::Object>&) override;
     bool hasValidConnection() const override;
 
     // IPC::MessageSender

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7349,17 +7349,17 @@ void WebPage::didChangeScrollOffsetForFrame(LocalFrame* frame)
     updateMainFrameScrollOffsetPinning();
 }
 
-void WebPage::postMessage(const String& messageName, API::Object* messageBody)
+void WebPage::postMessage(const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     send(Messages::WebPageProxy::HandleMessage(messageName, UserData(WebProcess::singleton().transformObjectsToHandles(messageBody))));
 }
 
-void WebPage::postMessageIgnoringFullySynchronousMode(const String& messageName, API::Object* messageBody)
+void WebPage::postMessageIgnoringFullySynchronousMode(const String& messageName, const RefPtr<API::Object>& messageBody)
 {
     send(Messages::WebPageProxy::HandleMessage(messageName, UserData(WebProcess::singleton().transformObjectsToHandles(messageBody))), IPC::SendOption::IgnoreFullySynchronousMode);
 }
 
-void WebPage::postSynchronousMessageForTesting(const String& messageName, API::Object* messageBody, RefPtr<API::Object>& returnData)
+void WebPage::postSynchronousMessageForTesting(const String& messageName, const RefPtr<API::Object>& messageBody, RefPtr<API::Object>& returnData)
 {
     auto& webProcess = WebProcess::singleton();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1290,9 +1290,9 @@ public:
     void setMainFrameProgressCompleted(bool completed) { m_mainFrameProgressCompleted = completed; }
     bool shouldDispatchFakeMouseMoveEvents() const { return m_shouldDispatchFakeMouseMoveEvents; }
 
-    void postMessage(const String& messageName, API::Object* messageBody);
-    void postSynchronousMessageForTesting(const String& messageName, API::Object* messageBody, RefPtr<API::Object>& returnData);
-    void postMessageIgnoringFullySynchronousMode(const String& messageName, API::Object* messageBody);
+    void postMessage(const String& messageName, const RefPtr<API::Object>& messageBody);
+    void postSynchronousMessageForTesting(const String& messageName, const RefPtr<API::Object>& messageBody, RefPtr<API::Object>& returnData);
+    void postMessageIgnoringFullySynchronousMode(const String& messageName, const RefPtr<API::Object>& messageBody);
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     void setInputMethodState(WebCore::Element*);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1760,7 +1760,7 @@ void WebProcess::seedResourceLoadStatisticsForTesting(const RegistrableDomain& f
     completionHandler();
 }
 
-RefPtr<API::Object> WebProcess::transformHandlesToObjects(API::Object* object)
+RefPtr<API::Object> WebProcess::transformHandlesToObjects(const RefPtr<API::Object>& object)
 {
     struct Transformer final : UserData::Transformer {
         Transformer(WebProcess& webProcess)
@@ -1811,7 +1811,7 @@ RefPtr<API::Object> WebProcess::transformHandlesToObjects(API::Object* object)
     return UserData::transform(object, Transformer(*this));
 }
 
-RefPtr<API::Object> WebProcess::transformObjectsToHandles(API::Object* object)
+RefPtr<API::Object> WebProcess::transformObjectsToHandles(const RefPtr<API::Object>& object)
 {
     struct Transformer final : UserData::Transformer {
         bool shouldTransformObject(const API::Object& object) const override

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -297,8 +297,8 @@ public:
 
     void isJITEnabled(CompletionHandler<void(bool)>&&);
 
-    RefPtr<API::Object> transformHandlesToObjects(API::Object*);
-    static RefPtr<API::Object> transformObjectsToHandles(API::Object*);
+    RefPtr<API::Object> transformHandlesToObjects(const RefPtr<API::Object>&);
+    static RefPtr<API::Object> transformObjectsToHandles(const RefPtr<API::Object>&);
 
 #if PLATFORM(COCOA)
     RefPtr<ObjCObjectGraph> transformHandlesToObjects(ObjCObjectGraph&);


### PR DESCRIPTION
#### 5943a13bf1c86d36246122c1cb8391be15f87eb8
<pre>
Use RefPtr when operating on API::Object*
<a href="https://bugs.webkit.org/show_bug.cgi?id=253905">https://bugs.webkit.org/show_bug.cgi?id=253905</a>
rdar://106458642

Reviewed by NOBODY (OOPS!).

This change adopts smart pointer for API::Object for security hardening.

* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry _callReplyWithID:blockInvocation:]):
* Source/WebKit/Shared/API/c/WKContextMenuItem.cpp:
(WKContextMenuItemGetUserData):
* Source/WebKit/Shared/UserData.cpp:
(WebKit::UserData::transform):
(WebKit::UserData::encode):
* Source/WebKit/Shared/UserData.h:
(WebKit::UserData::object const):
* Source/WebKit/Shared/WebConnection.cpp:
(WebKit::WebConnection::postMessage):
* Source/WebKit/Shared/WebConnection.h:
* Source/WebKit/Shared/WebConnectionClient.cpp:
(WebKit::WebConnectionClient::didReceiveMessage):
* Source/WebKit/Shared/WebConnectionClient.h:
* Source/WebKit/Shared/WebContextMenuItem.cpp:
(WebKit::WebContextMenuItem::userData const):
(WebKit::WebContextMenuItem::setUserData):
* Source/WebKit/Shared/WebContextMenuItem.h:
* Source/WebKit/Shared/WebContextMenuItemData.cpp:
(WebKit::WebContextMenuItemData::userData const):
(WebKit::WebContextMenuItemData::setUserData):
* Source/WebKit/Shared/WebContextMenuItemData.h:
* Source/WebKit/UIProcess/API/APIContextMenuClient.h:
(API::ContextMenuClient::getContextMenuFromProposedMenu):
(API::ContextMenuClient::menuFromProposedMenu):
* Source/WebKit/UIProcess/API/APIFormClient.h:
(API::FormClient::willSubmitForm):
* Source/WebKit/UIProcess/API/APIInjectedBundleClient.h:
(API::InjectedBundleClient::didReceiveMessageFromInjectedBundle):
(API::InjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle):
* Source/WebKit/UIProcess/API/APILoaderClient.h:
(API::LoaderClient::didStartProvisionalLoadForFrame):
(API::LoaderClient::didReceiveServerRedirectForProvisionalLoadForFrame):
(API::LoaderClient::didFailProvisionalLoadWithErrorForFrame):
(API::LoaderClient::didFinishLoadForFrame):
(API::LoaderClient::didFailLoadWithErrorForFrame):
(API::LoaderClient::didFirstVisuallyNonEmptyLayoutForFrame):
(API::LoaderClient::didCommitLoadForFrame):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::SubstituteData::SubstituteData):
* Source/WebKit/UIProcess/API/APINavigationClient.h:
(API::NavigationClient::didStartProvisionalNavigation):
(API::NavigationClient::didReceiveServerRedirectForProvisionalNavigation):
(API::NavigationClient::didFailProvisionalNavigationWithError):
(API::NavigationClient::didCommitNavigation):
(API::NavigationClient::didFinishDocumentLoad):
(API::NavigationClient::didFinishNavigation):
(API::NavigationClient::didFailNavigationWithError):
(API::NavigationClient::didSameDocumentNavigation):
(API::NavigationClient::didDisplayInsecureContent):
(API::NavigationClient::didRunInsecureContent):
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::mouseDidMoveOverElement):
(API::UIClient::didClickAutoFillButton):
(API::UIClient::didResignInputElementStrongPasswordAppearance):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageContextMenuClient):
(WKPageSetPageLoaderClient):
(WKPageSetPageUIClient):
(WKPageSetPageNavigationClient):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setInputDelegate:]):
* Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitFormClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp:
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::didStartProvisionalNavigation):
(WebKit::NavigationState::NavigationClient::didReceiveServerRedirectForProvisionalNavigation):
(WebKit::NavigationState::NavigationClient::didFailProvisionalNavigationWithError):
(WebKit::NavigationState::NavigationClient::didCommitNavigation):
(WebKit::NavigationState::NavigationClient::didFinishDocumentLoad):
(WebKit::NavigationState::NavigationClient::didFinishNavigation):
(WebKit::NavigationState::NavigationClient::didFailNavigationWithError):
(WebKit::NavigationState::NavigationClient::didSameDocumentNavigation):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::ContextMenuClient::menuFromProposedMenu):
(WebKit::UIDelegate::UIClient::mouseDidMoveOverElement):
(WebKit::UIDelegate::UIClient::didResignInputElementStrongPasswordAppearance):
(WebKit::UIDelegate::UIClient::didClickAutoFillButton):
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::loadData):
(WebKit::ProvisionalPageProxy::loadRequest):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/WebConnectionToWebProcess.cpp:
(WebKit::WebConnectionToWebProcess::transformHandlesToObjects):
(WebKit::WebConnectionToWebProcess::transformObjectsToHandles):
* Source/WebKit/UIProcess/WebConnectionToWebProcess.h:
* Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp:
(WebKit::WebContextInjectedBundleClient::didReceiveMessageFromInjectedBundle):
(WebKit::WebContextInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle):
* Source/WebKit/UIProcess/WebContextInjectedBundleClient.h:
* Source/WebKit/UIProcess/WebFormClient.cpp:
(WebKit::WebFormClient::willSubmitForm):
* Source/WebKit/UIProcess/WebFormClient.h:
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp:
(WebKit::WebPageInjectedBundleClient::didReceiveMessageFromInjectedBundle):
(WebKit::WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle):
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadData):
(WebKit::WebPageProxy::loadDataWithNavigationShared):
(WebKit::WebPageProxy::loadAlternateHTML):
(WebKit::WebPageProxy::loadWebArchiveData):
(WebKit::WebPageProxy::postMessageToInjectedBundle):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::postMessageToInjectedBundle):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::transformHandlesToObjects):
(WebKit::WebProcessProxy::transformObjectsToHandles):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didPerformImmediateActionHitTest):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::createMenuActionItem):
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundleBundleClient.h:
(API::InjectedBundle::Client::didReceiveMessage):
(API::InjectedBundle::Client::didReceiveMessageToPage):
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageLoaderClient.h:
(API::InjectedBundle::PageLoaderClient::willLoadURLRequest):
(API::InjectedBundle::PageLoaderClient::willLoadDataRequest):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.cpp:
(WebKit::parseUserData):
(WebKit::WebProcessExtensionManager::initialize):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::create):
(WebKit::InjectedBundle::postMessage):
(WebKit::InjectedBundle::postSynchronousMessage):
(WebKit::InjectedBundle::didReceiveMessage):
(WebKit::InjectedBundle::didReceiveMessageToPage):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.cpp:
(WebKit::InjectedBundleClient::didReceiveMessage):
(WebKit::InjectedBundleClient::didReceiveMessageToPage):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.cpp:
(WebKit::InjectedBundlePageLoaderClient::willLoadURLRequest):
(WebKit::InjectedBundlePageLoaderClient::willLoadDataRequest):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.h:
* Source/WebKit/WebProcess/InjectedBundle/glib/InjectedBundleGlib.cpp:
(WebKit::InjectedBundle::initialize):
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::InjectedBundle::initialize):
* Source/WebKit/WebProcess/InjectedBundle/playstation/InjectedBundlePlayStation.cpp:
(WebKit::InjectedBundle::initialize):
* Source/WebKit/WebProcess/InjectedBundle/win/InjectedBundleWin.cpp:
(WebKit::InjectedBundle::initialize):
* Source/WebKit/WebProcess/WebConnectionToUIProcess.cpp:
(WebKit::WebConnectionToUIProcess::transformHandlesToObjects):
(WebKit::WebConnectionToUIProcess::transformObjectsToHandles):
* Source/WebKit/WebProcess/WebConnectionToUIProcess.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::postMessage):
(WebKit::WebPage::postMessageIgnoringFullySynchronousMode):
(WebKit::WebPage::postSynchronousMessageForTesting):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::transformHandlesToObjects):
(WebKit::WebProcess::transformObjectsToHandles):
* Source/WebKit/WebProcess/WebProcess.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32ed549cea24bf442587c76e1220507fd7aede0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112666 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121193 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5588 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105742 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46224 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14143 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1019 "1 flakes 6 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/95427 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14829 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10371 "1 flakes 2 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53016 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16673 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->