### PR TITLE
[JSC] Add more tests for RegExp V flag and fix issues found

### DIFF
--- a/JSTests/stress/regexp-vflag-property-of-strings.js
+++ b/JSTests/stress/regexp-vflag-property-of-strings.js
@@ -149,6 +149,7 @@ function testRegExpSyntaxError(reString, flags, expError)
 
     try {
         let re = new RegExp(reString, flags);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError);
     } catch (e) {
         if (e != expError)
             print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
@@ -158,55 +159,119 @@ function testRegExpSyntaxError(reString, flags, expError)
 }
 
 // Test 1
-testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/, "a", ["a"]);
 testRegExpSyntaxError("[\\p{RGI_Emoji_Tag_Sequence}a]", "u", "SyntaxError: Invalid regular expression: invalid property expression");
-testRegExpSyntaxError("\\P{Emoji_Keycap_Sequence}", "v", "SyntaxError: Invalid regular expression: Negated class set may contain strings");
-testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "a", ["a"]);
-testRegExp(/(?:\u{1f3f4}\u{e0067}\u{e0062}\u{e0065}\u{e006e}\u{e0067}\u{e007F}|\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}|\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006C}\u{e0073}\u{e007F}|[a])/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
+testRegExpSyntaxError("\\P{Emoji_Keycap_Sequence}", "v", "SyntaxError: Invalid regular expression: negated class set may contain strings");
+testRegExpSyntaxError("[a1&&\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z1&&\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a1-3&&\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 6
-testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
-testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "a", ["a"]);
-testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
-testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
-testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "a", null);
+testRegExpSyntaxError("[a-z1-3&&\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z1-3&&\\p{White_Space}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a1--\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z1--\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a1-3--\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 11
+testRegExpSyntaxError("[a-z1-3--\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z1-3--\\p{White_Space}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--x1]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--\\q{k}1]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z--\\q{k}1]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+
+// Test 16
+testRegExpSyntaxError("[\w--\\q{k}1]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[\w--\\q{k}\\p{White_Space}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--x&&1]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--\\q{k}&&1]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z--\\q{k}&&1]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+
+// Test 21
+testRegExpSyntaxError("[\w--\\q{k}&&1]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[\w--\\q{k}&&\\p{White_Space}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&1\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z&&1\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[1-3&&a\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+
+// Test 26
+testRegExpSyntaxError("[a-z&&1\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z&&1\\p{White_Space}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&1--\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z&&1--\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[1-3&&a--\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+
+// Test 31
+testRegExpSyntaxError("[a-z&&1--\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z&&1--\\p{White_Space}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&&\\p{White_Space}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&&]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&-]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+
+// Test 36
+testRegExpSyntaxError("[a&&b-c]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&bc]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--b-c]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--bc]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-z--k]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+
+// Test 41
+testRegExpSyntaxError("[a-z&&k]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a---]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExp(/[\p{ASCII}&&\&]/v, "a&b", ["&"]);
+testRegExp(/[\p{ASCII}&&\-]/v, "a-b", ["-"]);
+testRegExp(/[\p{ASCII}--\&]/v, "&b", ["b"]);
+
+// Test 46
+testRegExp(/[\p{ASCII}--&]/v, "&b", ["b"]);
+testRegExp(/[\p{ASCII}--\-]/v, "-b", ["b"]);
+testRegExp(/[\p{ASCII}---]/v, "-b", ["b"]);
+testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/, "a", ["a"]);
+testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "a", ["a"]);
+
+// Test 51
+testRegExp(/(?:\u{1f3f4}\u{e0067}\u{e0062}\u{e0065}\u{e006e}\u{e0067}\u{e007F}|\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}|\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006C}\u{e0073}\u{e007F}|[a])/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
+testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
+testRegExp(/[a\p{RGI_Emoji_Tag_Sequence}]/v, "a", ["a"]);
+testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
+testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
+
+// Test 56
+testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "a", null);
 testRegExp(/[\q{\u{1f1fa}\u{1f1f8}}a]/v, "a", ["a"]);
 testRegExp(/[\q{\u{1f1fa}\u{1f1f8}}a]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\q{\u{1f1fa}}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}}\p{RGI_Emoji_Tag_Sequence}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
-testRegExp(/[\p{RGI_Emoji_Tag_Sequence}[\q{\u{1f1fa}\u{1f1f8}}a]]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 
-// Test 16
+// Test 61
+testRegExp(/[\p{RGI_Emoji_Tag_Sequence}[\q{\u{1f1fa}\u{1f1f8}}a]]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}[\q{\u{1f1fa}\u{1f1f8}}a]]/v, "a", ["a"]);
 testRegExp(/[b-z[a]]/v, "a", ["a"]);
-testRegExp(/[a-z--k]/v, "a", ["a"]);
+testRegExp(/[[a-z]--k]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1F3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
-testRegExp(/[a-z\q{X}]/v, "X", ["X"]);
 
-// Test 21
-testRegExp(/[a-z--\q{k}]/v, "a", ["a"]);
+// Test 66
+testRegExp(/[a-z\q{X}]/v, "X", ["X"]);
+testRegExp(/[[a-z]--\q{k}]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}|abc|a|\u{1f1fa}}]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", null);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}"]);
-testRegExp(/[\p{RGI_Emoji_Tag_Sequence}&&\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 
-// Test 26
+// Test 71
+testRegExp(/[\p{RGI_Emoji_Tag_Sequence}&&\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}&&\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}", null);
-testRegExp(/[a-z&&\q{a|e|i|o|u|X|Y|Z}]/v, "a", ["a"]);
+testRegExp(/[[a-z]&&\q{a|e|i|o|u|X|Y|Z}]/v, "a", ["a"]);
 testRegExp(/[\p{White_Space}&&\p{ASCII}]/v, " ", [" "]);
 testRegExp(/[\p{White_Space}&&\p{ASCII}]/v, "\u2028", null);
-testRegExp(/[\p{White_Space}--\p{ASCII}]/v, " ", null);
 
-// Test 31
+// Test 76
+testRegExp(/[\p{White_Space}--\p{ASCII}]/v, " ", null);
 testRegExp(/[\p{White_Space}--\p{ASCII}]/v, "\u2028", ["\u2028"]);
 testRegExp(/^[[0-9]&&\d]+$/v, "0", ["0"]);
 testRegExp(/^[_--[0-9]]+$/v, "_", ["_"]);
 testRegExp(/[[a-z]--[a]]/v, "a", null);
-testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1F1E6}\u{1F1E8}", ["\u{1F1E6}\u{1F1E8}"]);
 
-// Test 36
+// Test 81
+testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1F1E6}\u{1F1E8}", ["\u{1F1E6}\u{1F1E8}"]);
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1F1E6}\u{1F1E8}\u{1f1e7}\u{1f1f1}", ["\u{1f1e6}\u{1f1e8}\u{1f1e7}\u{1f1f1}"]);
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1f1f9}\u{1f1ef}\u{1F1E6}\u{1F1E8}\u{1f1f9}\u{1f1f7}", ["\u{1f1f9}\u{1f1ef}\u{1F1E6}\u{1F1E8}\u{1f1f9}\u{1f1f7}"]);
 testRegExp(/^\p{Emoji_Keycap_Sequence}+$/v, "#\u{fe0f}\u{20e3}", ["#\u{fe0f}\u{20e3}"]);

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
@@ -51,7 +51,7 @@ ASCIILiteral errorMessage(ErrorCode error)
         REGEXP_ERROR_PREFIX "missing terminating ] for character class"_s,            // CharacterClassUnmatched
         REGEXP_ERROR_PREFIX "range out of order in character class"_s,                // CharacterClassRangeOutOfOrder
         REGEXP_ERROR_PREFIX "invalid range in character class for Unicode pattern"_s, // CharacterClassRangeInvalid
-        REGEXP_ERROR_PREFIX "Missing terminating } for class string disjunction"_s,   // ClassStringDIsjunctionUnmatched
+        REGEXP_ERROR_PREFIX "missing terminating } for class string disjunction"_s,   // ClassStringDIsjunctionUnmatched
         REGEXP_ERROR_PREFIX "\\ at end of pattern"_s,                                 // EscapeUnterminated
         REGEXP_ERROR_PREFIX "invalid Unicode \\u escape"_s,                           // InvalidUnicodeEscape
         REGEXP_ERROR_PREFIX "invalid Unicode code point \\u{} escape"_s,              // InvalidUnicodeCodePointEscape
@@ -64,8 +64,9 @@ ASCIILiteral errorMessage(ErrorCode error)
         REGEXP_ERROR_PREFIX "too many nested disjunctions"_s,                         // TooManyDisjunctions
         REGEXP_ERROR_PREFIX "pattern exceeds string length limits"_s,                 // OffsetTooLarge
         REGEXP_ERROR_PREFIX "invalid flags"_s,                                        // InvalidRegularExpressionFlags
-        REGEXP_ERROR_PREFIX "Invalid operation in class set"_s,                       // InvalidClassSetOperation
-        REGEXP_ERROR_PREFIX "Negated class set may contain strings"_s                 // NegatedClassSetMayContainStrings
+        REGEXP_ERROR_PREFIX "invalid operation in class set"_s,                       // InvalidClassSetOperation
+        REGEXP_ERROR_PREFIX "negated class set may contain strings"_s,                // NegatedClassSetMayContainStrings
+        REGEXP_ERROR_PREFIX "invalid class set character"_s                           // InvalidClassSetCharacter
     };
 
     return errorMessages[static_cast<unsigned>(error)];
@@ -106,6 +107,7 @@ JSObject* errorToThrow(JSGlobalObject* globalObject, ErrorCode error)
     case ErrorCode::InvalidRegularExpressionFlags:
     case ErrorCode::InvalidClassSetOperation:
     case ErrorCode::NegatedClassSetMayContainStrings:
+    case ErrorCode::InvalidClassSetCharacter:
         return createSyntaxError(globalObject, errorMessage(error));
     case ErrorCode::TooManyDisjunctions:
         return createOutOfMemoryError(globalObject, errorMessage(error));

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.h
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.h
@@ -67,6 +67,7 @@ enum class ErrorCode : uint8_t {
     InvalidRegularExpressionFlags,
     InvalidClassSetOperation,
     NegatedClassSetMayContainStrings,
+    InvalidClassSetCharacter,
 };
 
 JS_EXPORT_PRIVATE ASCIILiteral errorMessage(ErrorCode);

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -305,14 +305,26 @@ private:
      * to perform the parsing of escape characters in character sets.
      */
     class ClassSetParserDelegate {
+    private:
+        struct NestingState {
+        public:
+            NestingState(CharacterClassSetOp setOp, bool inverted)
+                : m_setOp(setOp)
+                , m_inverted(inverted)
+            { }
+
+            CharacterClassSetOp m_setOp;
+            bool m_inverted;
+        };
+
     public:
         ClassSetParserDelegate(Delegate& delegate, ErrorCode& err)
             : m_delegate(delegate)
             , m_errorCode(err)
-            , m_state(CharacterClassConstructionState::Empty)
+            , m_state(ClassSetConstructionState::Empty)
             , m_setOp(CharacterClassSetOp::Default)
             , m_inverted(false)
-            , m_classNestingLevel(0)
+            , m_processingEscape(false)
             , m_character(0)
         {
         }
@@ -330,20 +342,25 @@ private:
 
         void nestedClassBegin()
         {
-            ++m_classNestingLevel;
             m_delegate.atomCharacterClassPushNested();
+            nestedParseState.append(NestingState(m_setOp, m_inverted));
+            m_setOp = CharacterClassSetOp::Default;
+            m_inverted = false;
         }
 
-        bool doneAfterCharacterClassEnd()
+        bool nestedClassEnd()
         {
             flushCachedCharacterIfNeeded();
 
-            if (!m_classNestingLevel) {
+            if (nestedParseState.isEmpty()) {
                 end();
                 return true;
             }
 
-            --m_classNestingLevel;
+            NestingState lastState = nestedParseState.takeLast();
+            m_setOp = lastState.m_setOp;
+            m_inverted = lastState.m_inverted;
+
             m_delegate.atomCharacterClassPopNested();
             return false;
         }
@@ -360,6 +377,14 @@ private:
             m_delegate.atomCharacterClassSetOp(m_setOp);
         }
 
+        void switchFromDefaultOpToUnionOpIfNeeded()
+        {
+            if (m_setOp == CharacterClassSetOp::Default) {
+                m_setOp = CharacterClassSetOp::Union;
+                m_delegate.atomCharacterClassSetOp(m_setOp);
+            }
+        }
+
         void setSubtractOp()
         {
             if (m_setOp != CharacterClassSetOp::Default && m_setOp != CharacterClassSetOp::Subtraction) {
@@ -370,6 +395,7 @@ private:
             flushCachedCharacterIfNeeded();
             m_setOp = CharacterClassSetOp::Subtraction;
             m_delegate.atomCharacterClassSetOp(m_setOp);
+            m_state = ClassSetConstructionState::Empty;
         }
 
         void setIntersectionOp()
@@ -382,14 +408,61 @@ private:
             flushCachedCharacterIfNeeded();
             m_setOp = CharacterClassSetOp::Intersection;
             m_delegate.atomCharacterClassSetOp(m_setOp);
+            m_state = ClassSetConstructionState::Empty;
         }
 
         void flushCachedCharacterIfNeeded()
         {
-            if (m_state == CharacterClassConstructionState::CachedCharacter) {
+            if (m_state == ClassSetConstructionState::CachedCharacter) {
                 m_delegate.atomCharacterClassAtom(m_character);
-                m_state = CharacterClassConstructionState::Empty;
+                m_state = ClassSetConstructionState::Empty;
             }
+        }
+
+        void afterOperand()
+        {
+            if (m_setOp == CharacterClassSetOp::Default || m_setOp == CharacterClassSetOp::Union)
+                return;
+
+            flushCachedCharacterIfNeeded();
+
+            if (m_state != ClassSetConstructionState::Empty && m_state != ClassSetConstructionState::AfterCharacterClass) {
+                m_errorCode = ErrorCode::InvalidClassSetOperation;
+                return;
+            }
+
+            m_state = ClassSetConstructionState::AfterSetOperand;
+        }
+
+        bool canTakeSetOperand()
+        {
+            bool unionOpActive = m_setOp == CharacterClassSetOp::Default || m_setOp == CharacterClassSetOp::Union;
+
+            switch (m_state) {
+            case ClassSetConstructionState::Empty:
+                return true;
+
+            case ClassSetConstructionState::CachedCharacter:
+                if (!unionOpActive)
+                    return false;
+
+                flushCachedCharacterIfNeeded();
+                return true;
+
+            case ClassSetConstructionState::CachedCharacterHyphen:
+            case ClassSetConstructionState::AfterCharacterClassHyphen:
+            case ClassSetConstructionState::AfterCharacterClass:
+            case ClassSetConstructionState::AfterSetRange:
+            case ClassSetConstructionState::AfterSetOperand:
+                return unionOpActive;
+            }
+
+            return false;
+        }
+
+        void setProcessingEscape()
+        {
+            m_processingEscape = true;
         }
 
         /*
@@ -401,10 +474,14 @@ private:
          * mode we will allow a hypen to be treated as indicating a range (i.e. /[a-z]/
          * is different to /[a\-z]/).
          */
-        void atomPatternCharacter(UChar32 ch, bool hyphenIsRange = false)
+        void atomPatternCharacter(UChar32 ch)
         {
+            bool unionOpActive = m_setOp == CharacterClassSetOp::Default || m_setOp == CharacterClassSetOp::Union;
+            bool processingEscape = m_processingEscape;
+            m_processingEscape = false;
+
             switch (m_state) {
-            case CharacterClassConstructionState::AfterCharacterClass:
+            case ClassSetConstructionState::AfterCharacterClass:
                 // Following a built-in character class we need look out for a hyphen.
                 // We're looking for invalid ranges, such as /[\d-x]/ or /[\d-\d]/.
                 // If we see a hyphen following a character class then unlike usual
@@ -413,41 +490,65 @@ private:
                 // another character or character class will result in syntax error.
                 // A hypen following a character class is itself valid, but only at
                 // the end of a regex.
-                if (hyphenIsRange && ch == '-') {
+                if (unionOpActive && ch == '-') {
                     m_delegate.atomCharacterClassAtom('-');
-                    m_state = CharacterClassConstructionState::AfterCharacterClassHyphen;
+                    m_state = ClassSetConstructionState::AfterCharacterClassHyphen;
                     return;
                 }
-                // Otherwise just fall through - cached character so treat this as CharacterClassConstructionState::Empty.
+                // Otherwise just fall through - cached character so treat this as ClassSetConstructionState::Empty.
                 FALLTHROUGH;
 
-            case CharacterClassConstructionState::Empty:
+            case ClassSetConstructionState::AfterSetRange:
+                switchFromDefaultOpToUnionOpIfNeeded();
+
+                // Continue processing the current character.
+                FALLTHROUGH;
+
+            case ClassSetConstructionState::Empty:
+                if (!processingEscape && ch == '-') {
+                    m_errorCode = ErrorCode::InvalidClassSetCharacter;
+                    return;
+                }
+
                 m_character = ch;
-                m_state = CharacterClassConstructionState::CachedCharacter;
+                m_state = ClassSetConstructionState::CachedCharacter;
                 return;
 
-            case CharacterClassConstructionState::CachedCharacter:
-                if (hyphenIsRange && ch == '-')
-                    m_state = CharacterClassConstructionState::CachedCharacterHyphen;
+            case ClassSetConstructionState::CachedCharacter:
+                if (!unionOpActive) {
+                    m_errorCode = ErrorCode::InvalidClassSetOperation;
+                    return;
+                }
+
+                if (ch == '-')
+                    m_state = ClassSetConstructionState::CachedCharacterHyphen;
                 else {
                     m_delegate.atomCharacterClassAtom(m_character);
+                    switchFromDefaultOpToUnionOpIfNeeded();
                     m_character = ch;
                 }
                 return;
 
-            case CharacterClassConstructionState::CachedCharacterHyphen:
+            case ClassSetConstructionState::CachedCharacterHyphen:
                 if (ch < m_character) {
                     m_errorCode = ErrorCode::CharacterClassRangeOutOfOrder;
                     return;
                 }
+
                 m_delegate.atomCharacterClassRange(m_character, ch);
-                m_state = CharacterClassConstructionState::Empty;
+                switchFromDefaultOpToUnionOpIfNeeded();
+                m_state = ClassSetConstructionState::AfterSetRange;
                 return;
 
                 // If we hit this case, we have an invalid range like /[\d-a]/.
                 // See coment in atomBuiltInCharacterClass() below.
-            case CharacterClassConstructionState::AfterCharacterClassHyphen:
+            case ClassSetConstructionState::AfterCharacterClassHyphen:
                 m_errorCode = ErrorCode::CharacterClassRangeInvalid;
+                return;
+
+                // The only thing valid at this point is s repeat of the current operator.
+            case ClassSetConstructionState::AfterSetOperand:
+                m_errorCode = ErrorCode::InvalidClassSetOperation;
                 return;
             }
         }
@@ -459,19 +560,36 @@ private:
          */
         void atomBuiltInCharacterClass(BuiltInCharacterClassID classID, bool invert)
         {
+            bool unionOpActive = m_setOp == CharacterClassSetOp::Default || m_setOp == CharacterClassSetOp::Union;
+
             switch (m_state) {
-            case CharacterClassConstructionState::CachedCharacter:
+            case ClassSetConstructionState::CachedCharacter:
+                if (!unionOpActive) {
+                    m_errorCode = ErrorCode::InvalidClassSetOperation;
+                    return;
+                }
+
                 // Flush the currently cached character, then fall through.
                 m_delegate.atomCharacterClassAtom(m_character);
+
+                // Yes, we really want to fall through to the AfterSetRange case to switch from Default to Union op
+                // and then handle the built in class by falling through again.
                 FALLTHROUGH;
-            case CharacterClassConstructionState::Empty:
-            case CharacterClassConstructionState::AfterCharacterClass:
+
+            case ClassSetConstructionState::AfterSetRange:
+                switchFromDefaultOpToUnionOpIfNeeded();
+
+                // Continue processing the current character.
+                FALLTHROUGH;
+
+            case ClassSetConstructionState::Empty:
+            case ClassSetConstructionState::AfterCharacterClass:
                 if ((invert || m_inverted) && characterClassMayContainStrings(classID)) {
                     m_errorCode = ErrorCode::NegatedClassSetMayContainStrings;
                     return;
                 }
                 m_delegate.atomCharacterClassBuiltIn(classID, invert);
-                m_state = CharacterClassConstructionState::AfterCharacterClass;
+                m_state = ClassSetConstructionState::AfterCharacterClass;
                 return;
 
                 // If we hit either of these cases, we have an invalid range that
@@ -482,12 +600,17 @@ private:
                 // e.g. /[\d-a-z]/ is treated as /[\d\-a\-z]/.
                 // See usages of CharacterRangeOrUnion abstract op in
                 // https://tc39.es/ecma262/#sec-regular-expression-patterns-semantics
-            case CharacterClassConstructionState::CachedCharacterHyphen:
+            case ClassSetConstructionState::CachedCharacterHyphen:
                 m_delegate.atomCharacterClassAtom(m_character);
                 m_delegate.atomCharacterClassAtom('-');
                 FALLTHROUGH;
-            case CharacterClassConstructionState::AfterCharacterClassHyphen:
+            case ClassSetConstructionState::AfterCharacterClassHyphen:
                 m_errorCode = ErrorCode::CharacterClassRangeInvalid;
+                return;
+
+                // The only thing valid at this point is s repeat of the current operator.
+            case ClassSetConstructionState::AfterSetOperand:
+                m_errorCode = ErrorCode::InvalidClassSetOperation;
                 return;
             }
         }
@@ -499,9 +622,9 @@ private:
          */
         void end()
         {
-            if (m_state == CharacterClassConstructionState::CachedCharacter)
+            if (m_state == ClassSetConstructionState::CachedCharacter)
                 m_delegate.atomCharacterClassAtom(m_character);
-            else if (m_state == CharacterClassConstructionState::CachedCharacterHyphen) {
+            else if (m_state == ClassSetConstructionState::CachedCharacterHyphen) {
                 m_delegate.atomCharacterClassAtom(m_character);
                 m_delegate.atomCharacterClassAtom('-');
             }
@@ -520,18 +643,21 @@ private:
     private:
         Delegate& m_delegate;
         ErrorCode& m_errorCode;
-        enum class CharacterClassConstructionState {
+        enum class ClassSetConstructionState {
             Empty,
             CachedCharacter,
             CachedCharacterHyphen,
             AfterCharacterClass,
             AfterCharacterClassHyphen,
+            AfterSetRange,
+            AfterSetOperand,
         };
-        CharacterClassConstructionState m_state;
+        ClassSetConstructionState m_state;
         CharacterClassSetOp m_setOp;
         bool m_inverted;
-        unsigned m_classNestingLevel;
+        bool m_processingEscape;
         UChar32 m_character;
+        Vector<NestingState> nestedParseState;
     };
 
     /*
@@ -595,12 +721,15 @@ private:
     {
     }
 
-    // The handling of IdentityEscapes is different depending on the unicode flag.
+    // The handling of IdentityEscapes is different depending on which unicode flag if any is active.
     // For Unicode patterns, IdentityEscapes only include SyntaxCharacters or '/'.
+    // For UnicodeSet patterns, adds to the UnicodePatterns IdentityEscapes
+    // ClassSetReservedPunctionation which includes &-!#%,:;<=>@`~
     // For non-unicode patterns, most any character can be escaped.
     bool isIdentityEscapeAnError(int ch)
     {
-        if (isEitherUnicodeCompilation() && (!strchr("^$\\.*+?()[]{}|/", ch) || !ch)) {
+        if (isEitherUnicodeCompilation()
+            && ((isASCII(ch) && !strchr(isUnicodeCompilation() ? "^$\\.*+?()[]{}|/" : "^$\\.*+?()[]{}|/&-!#%,:;<=>@`~" , ch)) || !ch)) {
             m_errorCode = ErrorCode::InvalidIdentityEscape;
             return true;
         }
@@ -989,9 +1118,9 @@ private:
         parseEscape<ParseEscapeMode::CharacterClass>(delegate);
     }
 
-    void parseClassSetEscape(ClassSetParserDelegate& delegate)
+    TokenType parseClassSetEscape(ClassSetParserDelegate& delegate)
     {
-        parseEscape<ParseEscapeMode::CharacterClass>(delegate);
+        return parseEscape<ParseEscapeMode::CharacterClass>(delegate);
     }
 
     void parseClassStringDisjunctionEscape(ClassStringDisjunctionParserDelegate& delegate)
@@ -1056,14 +1185,23 @@ private:
         classSetConstructor.begin(tryConsume('^'));
 
         auto processCharacterNormally = [&] () {
-            classSetConstructor.atomPatternCharacter(consumePossibleSurrogatePair<UnicodeParseContext::PatternCodePoint>(), true);
+            UChar32 ch = consumePossibleSurrogatePair<UnicodeParseContext::PatternCodePoint>();
+
+            // Check if the character is part of ClassSetSyntaxCharacter, except the characters
+            // explicitly handled below or in classSetConstructor.atomPatternCharacter().
+            if ((isASCII(ch) && strchr("(){}/|)", ch)) || !ch) {
+                m_errorCode = ErrorCode::InvalidClassSetCharacter;
+                return;
+            }
+
+            classSetConstructor.atomPatternCharacter(ch);
         };
 
         while (!atEndOfPattern()) {
             switch (peek()) {
             case ']':
                 consume();
-                if (classSetConstructor.doneAfterCharacterClassEnd())
+                if (classSetConstructor.nestedClassEnd())
                     return;
                 break;
 
@@ -1074,7 +1212,14 @@ private:
             }
 
             case '\\':
+                if (!classSetConstructor.canTakeSetOperand()) {
+                    m_errorCode = ErrorCode::InvalidClassSetOperation;
+                    return;
+                }
+
+                classSetConstructor.setProcessingEscape();
                 parseClassSetEscape(classSetConstructor);
+                classSetConstructor.afterOperand();
                 break;
 
             case '-': {
@@ -1095,6 +1240,10 @@ private:
                 consume();
                 if (peek() == '&') {
                     consume();
+                    if (peek() == '&') {
+                        m_errorCode = ErrorCode::InvalidClassSetOperation;
+                        return;
+                    }
                     classSetConstructor.setIntersectionOp();
                     break;
                 }


### PR DESCRIPTION
#### 30c8a2c9c4a8874d97236588a3241ca247e8fe36
<pre>
[JSC] Add more tests for RegExp V flag and fix issues found
<a href="https://bugs.webkit.org/show_bug.cgi?id=253915">https://bugs.webkit.org/show_bug.cgi?id=253915</a>
rdar://106724836

Reviewed by Yusuke Suzuki.

Added over 40 tests for RegExp V flag, organizing the syntax error tests ahead of the operational tests.

This change doesn&apos;t impact the results of the test262 RegExp V flag related tests.  Rather it fills in
the missing syntax checks from test262.

Almost all of the issues found with these new tests impact the ClassSetParserDelegate processing.
These changes include:
 * Saving and restoring the current parsing state when nesting class sets.  That change allowed
   eliminating the nesting class level and using the size of the nested parse state vector.
 * Implicitly change the opcode type from Default to Union when we have a construct that is only
   allowed for the ClassUnion production.  For example, a simple unnested rangecl like a-z cannot appear
   as part of a ClassIntersection or ClassSubtraction production.  This is done with the new method
   switchFromDefaultOpToUnionOpIfNeeded().
 * Added explicit state handling for set operands.  This facilitates the proper processing of
   ClassSetOperands per the spec.
 * Added syntax checking for the ClassSetSyntaxCharacter and ClassSetReservedPunctuator rules
   according to the spec.
 * Renamed the CharacterClassConstructionState enum in ClassSetParserDelegate to ClassSetConstructionState.
 * Renamed doneAfterCharacterClassEnd() to nestedClassEnd() to match nestedClassBegin().

Since the return value of parseClassSetEscape() wasn&apos;t used, changed the type to void.

Updated CharacterClassConstructor::putChar(UChar32) with a new helper to handle adding characters
as part of the right hand side of a intersection or subtraction set operation.

Added a new error, InvalidClassSetCharacter, and changed the spelling of all the errors added with the
RegExp V flag initial checkin to have an initial lower case letter like all the other RegExp error strings.

* JSTests/stress/regexp-vflag-property-of-strings.js:
(testRegExpSyntaxError):
* Source/JavaScriptCore/yarr/YarrErrorCode.cpp:
(JSC::Yarr::errorMessage):
(JSC::Yarr::errorToThrow):
* Source/JavaScriptCore/yarr/YarrErrorCode.h:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::ClassSetParserDelegate::NestingState::NestingState):
(JSC::Yarr::Parser::ClassSetParserDelegate::ClassSetParserDelegate):
(JSC::Yarr::Parser::ClassSetParserDelegate::nestedClassBegin):
(JSC::Yarr::Parser::ClassSetParserDelegate::nestedClassEnd):
(JSC::Yarr::Parser::ClassSetParserDelegate::switchFromDefaultOpToUnionOpIfNeeded):
(JSC::Yarr::Parser::ClassSetParserDelegate::setSubtractOp):
(JSC::Yarr::Parser::ClassSetParserDelegate::setIntersectionOp):
(JSC::Yarr::Parser::ClassSetParserDelegate::flushCachedCharacterIfNeeded):
(JSC::Yarr::Parser::ClassSetParserDelegate::afterOperand):
(JSC::Yarr::Parser::ClassSetParserDelegate::canTakeSetOperand):
(JSC::Yarr::Parser::ClassSetParserDelegate::setProcessingEscape):
(JSC::Yarr::Parser::ClassSetParserDelegate::atomPatternCharacter):
(JSC::Yarr::Parser::ClassSetParserDelegate::atomBuiltInCharacterClass):
(JSC::Yarr::Parser::ClassSetParserDelegate::end):
(JSC::Yarr::Parser::isIdentityEscapeAnError):
(JSC::Yarr::Parser::parseClassSetEscape):
(JSC::Yarr::Parser::parseClassSet):
(JSC::Yarr::Parser::ClassSetParserDelegate::doneAfterCharacterClassEnd): Deleted.
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::putChar):
(JSC::Yarr::CharacterClassConstructor::putCharNonUnion):
(JSC::Yarr::CharacterClassConstructor::isUnionSetOp):

Canonical link: <a href="https://commits.webkit.org/261714@main">https://commits.webkit.org/261714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a2d5f2adb8f532478b2f463307c057b89635a55

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8171 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->