### PR TITLE
[Cocoa] Setting to drop all assertions immediately

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5789,6 +5789,19 @@ ShouldDisplayTextDescriptions:
     WebCore:
       default: false
 
+ShouldDropSuspendedAssertionAfterDelay:
+  type: bool
+  status: internal
+  humanReadableName: "Drop Suspended Assertion After Delay"
+  humanReadableDescription: "Causes processes to fully suspend after a delay"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: WebKit::defaultShouldDropSuspendedAssertionAfterDelay()
+    WebCore:
+      default: false
+
 ShouldEnableTextAutosizingBoost:
   type: bool
   status: embedder
@@ -5875,7 +5888,7 @@ ShouldTakeSuspendedAssertions:
     WebKitLegacy:
       default: true
     WebKit:
-      default: WebKit::defaultShouldTakeSuspendedAssertions()
+      default: true
     WebCore:
       default: true
 

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -206,13 +206,13 @@ bool defaultRunningBoardThrottlingEnabled()
 #endif
 }
 
-bool defaultShouldTakeSuspendedAssertions()
+bool defaultShouldDropSuspendedAssertionAfterDelay()
 {
 #if PLATFORM(COCOA)
     static bool newSDK = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::FullySuspendsBackgroundContent);
-    return !newSDK;
+    return newSDK;
 #else
-    return true;
+    return false;
 #endif
 }
 

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -95,7 +95,7 @@ bool defaultGamepadVibrationActuatorEnabled();
 #endif
 
 bool defaultRunningBoardThrottlingEnabled();
-bool defaultShouldTakeSuspendedAssertions();
+bool defaultShouldDropSuspendedAssertionAfterDelay();
 bool defaultShowModalDialogEnabled();
 
 bool defaultShouldEnableScreenOrientationAPI();

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -50,7 +50,7 @@ static uint64_t generatePrepareToSuspendRequestID()
 ProcessThrottler::ProcessThrottler(ProcessThrottlerClient& process, bool shouldTakeUIBackgroundAssertion)
     : m_process(process)
     , m_prepareToSuspendTimeoutTimer(RunLoop::main(), this, &ProcessThrottler::prepareToSuspendTimeoutTimerFired)
-    , m_removeAllAssertionsTimer(RunLoop::main(), this, &ProcessThrottler::removeAllAssertionsTimerFired)
+    , m_dropSuspendedAssertionTimer(RunLoop::main(), this, &ProcessThrottler::dropSuspendedAssertionTimerFired)
     , m_shouldTakeUIBackgroundAssertion(shouldTakeUIBackgroundAssertion)
 {
 }
@@ -191,10 +191,13 @@ void ProcessThrottler::setThrottleState(ProcessThrottleState newState)
             weakThis->assertionWasInvalidated();
     });
 
-    if (m_assertion->type() == ProcessAssertionType::Suspended)
-        m_removeAllAssertionsTimer.startOneShot(removeAllAssertionsTimeout);
-    else
-        m_removeAllAssertionsTimer.stop();
+    if (m_assertion->type() == ProcessAssertionType::Suspended) {
+        if (!m_shouldTakeSuspendedAssertion)
+            m_assertion = nullptr;
+        else
+            m_dropSuspendedAssertionTimer.startOneShot(removeAllAssertionsTimeout);
+    } else
+        m_dropSuspendedAssertionTimer.stop();
 
     m_process.didChangeThrottleState(newState);
 }
@@ -244,12 +247,11 @@ void ProcessThrottler::prepareToSuspendTimeoutTimerFired()
     updateThrottleStateNow();
 }
 
-void ProcessThrottler::removeAllAssertionsTimerFired()
+void ProcessThrottler::dropSuspendedAssertionTimerFired()
 {
-    PROCESSTHROTTLER_RELEASE_LOG("removeAllAssertionsTimerFired: Removing all process assertions");
+    PROCESSTHROTTLER_RELEASE_LOG("dropSuspendedAssertionTimerFired: Removing suspended process assertion");
     RELEASE_ASSERT(m_assertion && m_assertion->type() == ProcessAssertionType::Suspended);
-    if (!m_shouldTakeSuspendedAssertion)
-        m_assertion = nullptr;
+    m_assertion = nullptr;
 }
     
 void ProcessThrottler::processReadyToSuspend()
@@ -336,8 +338,8 @@ void ProcessThrottler::setShouldTakeSuspendedAssertion(bool shouldTakeSuspendedA
 void ProcessThrottler::delaySuspension()
 {
     PROCESSTHROTTLER_RELEASE_LOG("delaySuspension");
-    if (m_removeAllAssertionsTimer.isActive())
-        m_removeAllAssertionsTimer.startOneShot(removeAllAssertionsTimeout);
+    if (m_dropSuspendedAssertionTimer.isActive())
+        m_dropSuspendedAssertionTimer.startOneShot(removeAllAssertionsTimeout);
 }
 
 ProcessThrottler::TimedActivity::TimedActivity(Seconds timeout, ProcessThrottler::ActivityVariant&& activity)

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -141,6 +141,7 @@ public:
     void didConnectToProcess(ProcessID);
     bool shouldBeRunnable() const { return m_foregroundActivities.size() || m_backgroundActivities.size(); }
     void setAllowsActivities(bool);
+    void setShouldDropSuspendedAssertionAfterDelay(bool shouldDropAfterDelay) { m_shouldDropSuspendedAssertionAfterDelay = shouldDropAfterDelay; }
     void setShouldTakeSuspendedAssertion(bool);
     void delaySuspension();
     bool isSuspended() const { return !m_assertion; }
@@ -154,7 +155,7 @@ private:
     void setAssertionType(ProcessAssertionType);
     void setThrottleState(ProcessThrottleState);
     void prepareToSuspendTimeoutTimerFired();
-    void removeAllAssertionsTimerFired();
+    void dropSuspendedAssertionTimerFired();
     void sendPrepareToSuspendIPC(IsSuspensionImminent);
     void processReadyToSuspend();
 
@@ -175,11 +176,12 @@ private:
     ProcessID m_processIdentifier { 0 };
     RefPtr<ProcessAssertion> m_assertion;
     RunLoop::Timer m_prepareToSuspendTimeoutTimer;
-    RunLoop::Timer m_removeAllAssertionsTimer;
+    RunLoop::Timer m_dropSuspendedAssertionTimer;
     HashSet<ForegroundActivity*> m_foregroundActivities;
     HashSet<BackgroundActivity*> m_backgroundActivities;
     std::optional<uint64_t> m_pendingRequestToSuspendID;
     ProcessThrottleState m_state { ProcessThrottleState::Suspended };
+    bool m_shouldDropSuspendedAssertionAfterDelay { false };
     bool m_shouldTakeUIBackgroundAssertion;
     bool m_shouldTakeSuspendedAssertion { true };
     bool m_allowsActivities { true };

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -691,6 +691,11 @@ bool WebProcessProxy::shouldTakeSuspendedAssertion() const
     return false;
 }
 
+bool WebProcessProxy::shouldDropSuspendedAssertionAfterDelay() const
+{
+    return WTF::anyOf(m_pageMap.values(), [](auto& page) { return page->preferences().shouldDropSuspendedAssertionAfterDelay(); });
+}
+
 void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataStore beginsUsingDataStore)
 {
     WEBPROCESSPROXY_RELEASE_LOG(Process, "addExistingWebPage: webPage=%p, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64, &webPage, webPage.identifier().toUInt64(), webPage.webPageID().toUInt64());
@@ -714,6 +719,7 @@ void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataS
     globalPageMap().set(webPage.identifier(), WeakPtr { webPage });
 
     m_throttler.setShouldTakeSuspendedAssertion(shouldTakeSuspendedAssertion());
+    m_throttler.setShouldDropSuspendedAssertionAfterDelay(shouldDropSuspendedAssertionAfterDelay());
 
     updateRegistrationWithDataStore();
     updateBackgroundResponsivenessTimer();
@@ -1210,6 +1216,7 @@ void WebProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
 #endif // USE(RUNNINGBOARD)
 
     m_throttler.setShouldTakeSuspendedAssertion(shouldTakeSuspendedAssertion());
+    m_throttler.setShouldDropSuspendedAssertionAfterDelay(shouldDropSuspendedAssertionAfterDelay());
 
 #if PLATFORM(COCOA)
     unblockAccessibilityServerIfNeeded();

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -604,6 +604,7 @@ private:
 #endif
 
     bool shouldTakeSuspendedAssertion() const;
+    bool shouldDropSuspendedAssertionAfterDelay() const;
 
     enum class IsWeak { No, Yes };
     template<typename T> class WeakOrStrongPtr {


### PR DESCRIPTION
#### a5486e6679b8f6ca940f78aa8ec427f5607fc64c
<pre>
[Cocoa] Setting to drop all assertions immediately
<a href="https://bugs.webkit.org/show_bug.cgi?id=253910">https://bugs.webkit.org/show_bug.cgi?id=253910</a>
rdar://problem/106722788

Reviewed by Chris Dumez.

Having an option to quickly remove all assertions would really help
with testing background process suspension

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultShouldDropSuspendedAssertionAfterDelay):
(WebKit::defaultShouldTakeSuspendedAssertions): Deleted.
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::ProcessThrottler):
(WebKit::ProcessThrottler::setThrottleState):
(WebKit::ProcessThrottler::dropSuspendedAssertionTimerFired):
(WebKit::ProcessThrottler::delaySuspension):
(WebKit::ProcessThrottler::removeAllAssertionsTimerFired): Deleted.
* Source/WebKit/UIProcess/ProcessThrottler.h:
(WebKit::ProcessThrottler::setShouldDropSuspendedAssertionAfterDelay):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldDropSuspendedAssertionAfterDelay const):
(WebKit::WebProcessProxy::addExistingWebPage):
(WebKit::WebProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/261886@main">https://commits.webkit.org/261886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/133efe0d8685d3886280c62139c6b0cb26c5fd78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112750 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4559 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121294 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5726 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105865 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1077 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46315 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/101056 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14245 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1118 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12379 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10466 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102573 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53110 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/32018 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8302 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16790 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110616 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27320 "Passed tests") | 
<!--EWS-Status-Bubble-End-->