### PR TITLE
10X tests need pixel tolerance adjustments for running in simulators on arm64 Macs

### DIFF
--- a/LayoutTests/css3/blending/background-blend-mode-body-image.html
+++ b/LayoutTests/css3/blending/background-blend-mode-body-image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=130500-153000" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=130500-168000" />
 <style>
 body {
 	background-image: linear-gradient(green, green);

--- a/LayoutTests/css3/blending/background-blend-mode-body-transparent-color-and-image.html
+++ b/LayoutTests/css3/blending/background-blend-mode-body-transparent-color-and-image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<meta name="fuzzy" content="maxDifference=0-2;totalPixels=240000-252000" />
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=240000-273000" />
 <style>
 body {
 	background-image: linear-gradient(green, green);

--- a/LayoutTests/css3/blending/background-blend-mode-body-transparent-image.html
+++ b/LayoutTests/css3/blending/background-blend-mode-body-transparent-image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<meta name="fuzzy" content="maxDifference=0-2;totalPixels=234000-244000" />
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=234000-254000" />
 <style>
 body {
 	background-image: linear-gradient(transparent, transparent 10%, green 10%, green 90%, transparent 90%, transparent);

--- a/LayoutTests/css3/filters/effect-grayscale-hw.html
+++ b/LayoutTests/css3/filters/effect-grayscale-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-32600">
+    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-33000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/fast/images/sprite-sheet-image-draw.html
+++ b/LayoutTests/fast/images/sprite-sheet-image-draw.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=14200-14600" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=14200-16000" />
 <style>
     .box {
         width: 200px;

--- a/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-right.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-right.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://compat.spec.whatwg.org/#css-gradients-webkit-linear-gradient">
 <meta name="assert" content="'right' in -webkit-linear-gradient is equivalent to 'to left' in modern syntax">
 <link rel="match" href="green-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
 <style>
   #outer {
     width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-top.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-top.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://compat.spec.whatwg.org/#css-gradients-webkit-linear-gradient">
 <meta name="assert" content="'top' in -webkit-linear-gradient is equivalent to 'to bottom' in modern syntax">
 <link rel="match" href="green-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4000">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4400">
 <style>
   #outer {
     width: 100px;

--- a/LayoutTests/svg/css/invalid-color-cascade.svg
+++ b/LayoutTests/svg/css/invalid-color-cascade.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=184000-190500" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=184000-208000" />
     <defs>
         <linearGradient id="gradient">
             <stop offset="0" stop-color="green" style="stop-color: invalid" />

--- a/LayoutTests/svg/gradients/spreadMethodDiagonal3.svg
+++ b/LayoutTests/svg/gradients/spreadMethodDiagonal3.svg
@@ -1,5 +1,5 @@
 <html><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="2000px" height="2000px">
-    <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-68000" />
+    <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-70000" />
     <linearGradient id="base-grad" x1="-100%" y1="-100%" x2="-50%" y2="-50%">
         <stop stop-color="green" offset="0"/>
         <stop stop-color="green" offset="0.5"/>

--- a/LayoutTests/svg/gradients/spreadMethodDiagonal4.svg
+++ b/LayoutTests/svg/gradients/spreadMethodDiagonal4.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="2000px" height="2000px">
-    <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-67000" />
+    <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-69000" />
     <linearGradient id="base-grad" x1="0" y1="0" x2="50%" y2="50%">
         <stop stop-color="green" offset="0"/>
         <stop stop-color="green" offset="0.5"/>


### PR DESCRIPTION
#### 8519e6435f57496445d1fd2b8f423269e4520994
<pre>
10X tests need pixel tolerance adjustments for running in simulators on arm64 Macs
<a href="https://bugs.webkit.org/show_bug.cgi?id=253918">https://bugs.webkit.org/show_bug.cgi?id=253918</a>
rdar://106725307

Unreviewed test gardening.

Adjusting pixel tolerances to account for failures seen after upgrading macos version on bots from Monterey to Ventura.

* LayoutTests/css3/blending/background-blend-mode-body-image.html:
* LayoutTests/css3/blending/background-blend-mode-body-transparent-color-and-image.html:
* LayoutTests/css3/blending/background-blend-mode-body-transparent-image.html:
* LayoutTests/css3/filters/effect-grayscale-hw.html:
* LayoutTests/fast/images/sprite-sheet-image-draw.html:
* LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-right.html:
* LayoutTests/imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-top.html:
* LayoutTests/svg/css/invalid-color-cascade.svg:
* LayoutTests/svg/gradients/spreadMethodDiagonal3.svg:
* LayoutTests/svg/gradients/spreadMethodDiagonal4.svg:

Canonical link: <a href="https://commits.webkit.org/261695@main">https://commits.webkit.org/261695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5b72291594ff25f746c0482f9cc1a08483b8725

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4266 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121062 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5399 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118255 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17062 "5 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105543 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46068 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13981 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/843 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14673 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52848 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16497 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4459 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->