### PR TITLE
Unreviewed, more test gardening

### DIFF
--- a/JSTests/stress/elidable-new-object-roflcopter-then-exit.js
+++ b/JSTests/stress/elidable-new-object-roflcopter-then-exit.js
@@ -1,4 +1,5 @@
 //@ skip if $architecture != "arm64" and $architecture != "x86_64" and $architecture != "mips" and $architecture != "arm"
+//@ $skipModes << :lockdown if ($buildType == "debug")
 
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;

--- a/JSTests/stress/proxy-set-failure-inline-cache.js
+++ b/JSTests/stress/proxy-set-failure-inline-cache.js
@@ -1,3 +1,4 @@
+//@ $skipModes << :lockdown if ($buildType == "debug")
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`Bad value: ${actual}!`);

--- a/JSTests/wasm/stress/simd-tail-calls-throw.js
+++ b/JSTests/wasm/stress/simd-tail-calls-throw.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useWebAssemblySIMD=1","--useWebAssemblyTailCalls=1")
-//@ skip if !$isSIMDPlatform
+//@ skip
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/v8/many-memories-no-trap-handler.js
+++ b/JSTests/wasm/v8/many-memories-no-trap-handler.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1", "--useWebAssemblyFastMemory=0")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.


### PR DESCRIPTION
#### b0ea3a9090d18fc7d797138efc0f110c41756a7f
<pre>
Unreviewed, more test gardening
<a href="https://bugs.webkit.org/show_bug.cgi?id=253923">https://bugs.webkit.org/show_bug.cgi?id=253923</a>
rdar://106729268

Skip super slow tests for lockdown mode in Debug builds.
Skip wasm tail-calls completely since they are not supported.
Use non-fast-memory for V8 test which expects non-fast-memory.

* JSTests/stress/elidable-new-object-roflcopter-then-exit.js:
* JSTests/stress/proxy-set-failure-inline-cache.js:
* JSTests/wasm/stress/simd-tail-calls-throw.js:
* JSTests/wasm/v8/many-memories-no-trap-handler.js:

Canonical link: <a href="https://commits.webkit.org/261664@main">https://commits.webkit.org/261664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38b266dbb6b9a8e4907305c253188d829d142bb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1152 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/4278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22986 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/12806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/4278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118267 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/100269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/105555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/105555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/100818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/13993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/105555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/83/builds/12098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/12806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102277 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/52857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/31948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/16509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110316 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4450 "Built successfully and passed tests") | | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/27249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->