### PR TITLE
webkitpy: Use WinCairoPort by default on Windows

### DIFF
--- a/Tools/Scripts/webkitpy/common/config/ports.py
+++ b/Tools/Scripts/webkitpy/common/config/ports.py
@@ -68,12 +68,11 @@ class DeprecatedPort(object):
             "jsc-only": JscOnlyPort,
             "mac": MacPort,
             "mac-wk2": MacWK2Port,
-            "win": WinPort,
             "wincairo": WinCairoPort,
             "wpe": WpePort,
         }
         default_port = {
-            "Windows": WinPort,
+            "Windows": WinCairoPort,
             "Darwin": MacPort,
         }
         # Do we really need MacPort as the ultimate default?
@@ -166,15 +165,6 @@ class MacPort(DeprecatedPort):
 
 class MacWK2Port(DeprecatedPort):
     port_flag_name = "mac-wk2"
-
-
-class WinPort(DeprecatedPort):
-    port_flag_name = "win"
-
-    def run_webkit_tests_command(self, build_style=None):
-        command = super(WinPort, self).run_webkit_tests_command(build_style)
-        command.append("--dump-render-tree")
-        return command
 
 
 class WinCairoPort(DeprecatedPort):

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -492,10 +492,6 @@ def _set_up_derived_options(port, options):
     if options.platform in ["gtk", "wpe"]:
         options.webkit_test_runner = True
 
-    # Don't maintain render tree dump results for Apple Windows port.
-    if port.port_name == "win":
-        options.ignore_render_tree_dump_results = True
-
 def run(port, options, args, logging_stream):
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG if options.debug_rwt_logging else logging.INFO)

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -114,7 +114,6 @@ class PortFactory(object):
         'mac.MacPort',
         'test.TestPort',
         'win.WinCairoPort',
-        'win.WinPort',
         'wpe.WPEPort',
     )
 
@@ -128,7 +127,7 @@ class PortFactory(object):
         elif platform.is_mac():
             return 'mac'
         elif platform.is_win():
-            return 'win'
+            return 'wincairo'
         raise NotImplementedError('unknown platform: %s' % platform)
 
     def get(self, port_name=None, options=None, **kwargs):

--- a/Tools/Scripts/webkitpy/port/factory_unittest.py
+++ b/Tools/Scripts/webkitpy/port/factory_unittest.py
@@ -60,11 +60,11 @@ class FactoryTest(unittest.TestCase):
         self.assert_port(port_name=None,  os_name='mac', os_version=Version.from_name('Lion'), cls=mac.MacPort)
 
     def test_win(self):
-        self.assert_port(port_name='win-xp', cls=win.WinPort)
-        self.assert_port(port_name='win-xp-wk2', cls=win.WinPort)
-        self.assert_port(port_name='win', os_name='win', os_version=Version.from_name('XP'), cls=win.WinPort)
-        self.assert_port(port_name=None, os_name='win', os_version=Version.from_name('XP'), cls=win.WinPort)
-        self.assert_port(port_name=None, os_name='win', os_version=Version.from_name('XP'), options=self.webkit_options, cls=win.WinPort)
+        self.assert_port(port_name='wincairo-win10', cls=win.WinCairoPort)
+        self.assert_port(port_name='wincairo-win10-wk2', cls=win.WinCairoPort)
+        self.assert_port(port_name='wincairo', os_name='win', os_version=Version.from_name('Win10'), cls=win.WinCairoPort)
+        self.assert_port(port_name=None, os_name='win', os_version=Version.from_name('Win10'), cls=win.WinCairoPort)
+        self.assert_port(port_name=None, os_name='win', os_version=Version.from_name('Win10'), options=self.webkit_options, cls=win.WinCairoPort)
 
     def test_gtk(self):
         self.assert_port(port_name='gtk', cls=gtk.GtkPort)


### PR DESCRIPTION
#### 4075f39b99867ed031472f80da844bc2cead2069
<pre>
webkitpy: Use WinCairoPort by default on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=253912">https://bugs.webkit.org/show_bug.cgi?id=253912</a>

Reviewed by Jonathan Bedard.

With this change, we can invoke run-webkit-tests without --wincairo
switch on Windows. However, we can&apos;t remove --wincairo switch yet
because buildbot is still using it. I&apos;ll rename WinCairoPort to
WinPort in the future. However, there are some remaining tasks. I keep
the name WinCairoPort at the moment.

* Tools/Scripts/webkitpy/common/config/ports.py:
(DeprecatedPort.port):
(MacWK2Port):
(WinPort): Deleted.
(WinPort.run_webkit_tests_command): Deleted.
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(_set_up_derived_options):
* Tools/Scripts/webkitpy/port/factory.py:
(PortFactory):
(PortFactory._default_port):
* Tools/Scripts/webkitpy/port/factory_unittest.py:
(FactoryTest.test_win):

Canonical link: <a href="https://commits.webkit.org/261712@main">https://commits.webkit.org/261712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f17710912f737db21a23363236183304c780a26f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4302 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121088 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5435 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118294 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105582 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/115947 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14017 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/877 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14701 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52882 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8168 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16535 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->