### PR TITLE
Clients should not be informed about inner image-only attachments

### DIFF
--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4326,6 +4326,9 @@ void Editor::cloneAttachmentData(const String& fromIdentifier, const String& toI
 
 void Editor::didInsertAttachmentElement(HTMLAttachmentElement& attachment)
 {
+    if (attachment.isImageOnly())
+        return;
+
     auto identifier = attachment.uniqueIdentifier();
     if (identifier.isEmpty())
         return;


### PR DESCRIPTION
#### cec6fc7f82ae6257abaf901496865dfb106ae82b
<pre>
Clients should not be informed about inner image-only attachments
<a href="https://bugs.webkit.org/show_bug.cgi?id=253924">https://bugs.webkit.org/show_bug.cgi?id=253924</a>
rdar://106567546

Reviewed by Tim Horton and Aditya Keerthi.

Image-only attachments are an implementation detail of the new wide-layout attachments. (This will eventually be removed, see rdar://105252742 )

Because clients (like Mail) knew about this image-only attachment, they could confusingly give information (about the referenced file) only to this inner attachment, so when the outer attachment brick would get dropped elsewhere it wouldn&apos;t know what information to provide, which resulted in drag-and-drops doing nothing.

The solution is to not inform clients about image-only attachments.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::didInsertAttachmentElement):

Canonical link: <a href="https://commits.webkit.org/261720@main">https://commits.webkit.org/261720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/101837a6a6a4b9c3e3b3ce889f27d70cea6c3604

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4281 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/22991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5416 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118272 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17074 "5 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46097 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/13996 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/857 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10243 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52862 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16514 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4474 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->