### PR TITLE
ReleaseSerializedImageBuffer doesn't release the underlying IOSurface.

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -410,15 +410,15 @@ RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy(const WebCore
 {
     backend.remoteResourceCacheProxy().forgetImageBuffer(m_renderingResourceIdentifier);
     backend.moveToSerializedBuffer(m_renderingResourceIdentifier, m_referenceTracker.write());
-
-    // Record an implicit read, since we always do a read+write (to get+remove) as a single
-    // operation.
-    m_referenceTracker.read();
 }
 
 RefPtr<ImageBuffer> RemoteSerializedImageBufferProxy::sinkIntoImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy> buffer, RemoteRenderingBackendProxy& backend)
 {
     auto result = adoptRef(new RemoteImageBufferProxy(buffer->m_parameters, buffer->m_info, backend, nullptr, buffer->m_renderingResourceIdentifier));
+
+    // Record an implicit read, since we always do a read+write (to get+remove) as a single
+    // operation.
+    buffer->m_referenceTracker.read();
     backend.moveToImageBuffer(buffer->m_referenceTracker.write(), result->renderingResourceIdentifier());
     buffer->m_connection = nullptr;
     return result;


### PR DESCRIPTION
#### 284c71ac630f11ba5d7ac6c362691567865a6b7c
<pre>
ReleaseSerializedImageBuffer doesn&apos;t release the underlying IOSurface.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253927">https://bugs.webkit.org/show_bug.cgi?id=253927</a>

Reviewed by Kimmo Kinnunen.

We&apos;re adding a read reference in the RemoteSerializedImageBufferProxy constructor, and we never have any reads happen if we destroy the RemoteSerializedImageBufferProxy without transferring to an ImageBuffer.

This shouldn&apos;t happen often, but can happen if you draw to an OffscreenCanvas, call `commit()`, and then draw again quickly (not waiting for rAF).
Instead, only add the read reference when transferring to an ImageBuffer, since this both reads and writes (remove).

* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy):
(WebKit::RemoteSerializedImageBufferProxy::sinkIntoImageBuffer):

Canonical link: <a href="https://commits.webkit.org/261703@main">https://commits.webkit.org/261703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3d6295437a7d19f2dba9ef77fae8efc7550b5ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4291 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121080 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5426 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105570 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46092 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14006 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/865 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14693 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52870 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8165 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16524 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->