### PR TITLE
[JSC] Remove `swap` for FPRegisterID

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -3201,13 +3201,17 @@ public:
 
     void swap(RegisterID reg1, RegisterID reg2)
     {
+        if (reg1 == reg2)
+            return;
         move(reg1, getCachedDataTempRegisterIDAndInvalidate());
         move(reg2, reg1);
         move(dataTempRegister, reg2);
     }
 
-    void swap(FPRegisterID reg1, FPRegisterID reg2)
+    void swapDouble(FPRegisterID reg1, FPRegisterID reg2)
     {
+        if (reg1 == reg2)
+            return;
         moveDouble(reg1, fpTempRegister);
         moveDouble(reg2, reg1);
         moveDouble(fpTempRegister, reg2);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -2051,8 +2051,10 @@ public:
         move(dataTempRegister, reg2);
     }
 
-    void swap(FPRegisterID fr1, FPRegisterID fr2)
+    void swapDouble(FPRegisterID fr1, FPRegisterID fr2)
     {
+        if (fr1 == fr2)
+            return;
         moveDouble(fr1, fpTempRegister);
         moveDouble(fr2, fr1);
         moveDouble(fpTempRegister, fr2);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h
@@ -3329,8 +3329,10 @@ public:
         convertInt32ToDouble(MIPSRegisters::zero, reg);
     }
 
-    void swap(FPRegisterID fr1, FPRegisterID fr2)
+    void swapDouble(FPRegisterID fr1, FPRegisterID fr2)
     {
+        if (fr1 == fr2)
+            return;
         moveDouble(fr1, fpTempRegister);
         moveDouble(fr2, fr1);
         moveDouble(fpTempRegister, fr2);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -1751,8 +1751,10 @@ public:
         move(temp.data(), reg2);
     }
 
-    void swap(FPRegisterID reg1, FPRegisterID reg2)
+    void swapDouble(FPRegisterID reg1, FPRegisterID reg2)
     {
+        if (reg1 == reg2)
+            return;
         moveDouble(reg1, fpTempRegister);
         moveDouble(reg2, reg1);
         moveDouble(fpTempRegister, reg2);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -2560,19 +2560,6 @@ public:
             m_assembler.xchgq_rr(reg1, reg2);
     }
 
-    void swap(FPRegisterID reg1, FPRegisterID reg2)
-    {
-        if (reg1 == reg2)
-            return;
-
-        // FIXME: This is kinda a hack since we don't use xmm7 as a temp.
-        ASSERT(reg1 != FPRegisterID::xmm7);
-        ASSERT(reg2 != FPRegisterID::xmm7);
-        moveDouble(reg1, FPRegisterID::xmm7);
-        moveDouble(reg2, reg1);
-        moveDouble(FPRegisterID::xmm7, reg2);
-    }
-
     void signExtend32To64(TrustedImm32 imm, RegisterID dest)
     {
         if (!imm.m_value)
@@ -2673,7 +2660,7 @@ public:
             m_assembler.xchgl_rr(reg1, reg2);
     }
 
-    void swap(FPRegisterID reg1, FPRegisterID reg2)
+    void swapDouble(FPRegisterID reg1, FPRegisterID reg2)
     {
         if (reg1 == reg2)
             return;

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -1247,6 +1247,19 @@ public:
         m_assembler.xchgq_rm(src, dest.offset, dest.base);
     }
 
+    void swapDouble(FPRegisterID reg1, FPRegisterID reg2)
+    {
+        if (reg1 == reg2)
+            return;
+
+        // FIXME: This is kinda a hack since we don't use xmm7 as a temp.
+        ASSERT(reg1 != FPRegisterID::xmm7);
+        ASSERT(reg2 != FPRegisterID::xmm7);
+        moveDouble(reg1, FPRegisterID::xmm7);
+        moveDouble(reg2, reg1);
+        moveDouble(FPRegisterID::xmm7, reg2);
+    }
+
     void move32ToFloat(RegisterID src, FPRegisterID dest)
     {
         if (supportsAVX())

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -177,7 +177,10 @@ private:
 
             RegType source = pairs[0].first;
             RegType dest = pairs[0].second;
-            swap(source, dest);
+            if constexpr (std::is_same_v<RegType, FPRReg>)
+                swapDouble(source, dest);
+            else
+                swap(source, dest);
             pairs.remove(0);
 
             RegType newSource = source;


### PR DESCRIPTION
#### 1a72ae381c3ed28603e582fd42cbff65c0d7c46a
<pre>
[JSC] Remove `swap` for FPRegisterID
<a href="https://bugs.webkit.org/show_bug.cgi?id=253930">https://bugs.webkit.org/show_bug.cgi?id=253930</a>
rdar://106734188

Reviewed by Mark Lam.

As the same to 261040@main, we should not have swap(FPRegisterID, FPRegisterID) since
there is a Vector register usage. We rename it swapDouble.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::swap):
(JSC::MacroAssemblerARM64::swapDouble):
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::swapDouble):
* Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h:
(JSC::MacroAssemblerMIPS::swapDouble):
* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h:
(JSC::MacroAssemblerRISCV64::swapDouble):
* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::swapDouble):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::swapDouble):
* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::setupStubArgs):

Canonical link: <a href="https://commits.webkit.org/261674@main">https://commits.webkit.org/261674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8803021479554e1d567af8cf5f7fca48cf4de17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4300 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12834 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118292 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105579 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/839 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/100835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14015 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/876 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12118 "Built successfully and passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/14700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102303 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52881 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31961 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16533 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110342 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4455 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27261 "Passed tests") | 
<!--EWS-Status-Bubble-End-->