### PR TITLE
Rename ListStyleType::Type::CustomCounterStyle to CounterStyle

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3243,7 +3243,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyListStyleType:
         if (style.listStyleType().type == ListStyleType::Type::String)
             return CSSPrimitiveValue::create(style.listStyleType().identifier);
-        if (style.listStyleType().type == ListStyleType::Type::CustomCounterStyle)
+        if (style.listStyleType().type == ListStyleType::Type::CounterStyle)
             return CSSPrimitiveValue::createCustomIdent(style.listStyleType().identifier);
         return createConvertingToCSSValueID(style.listStyleType().type);
     case CSSPropertyWebkitLocale:

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -304,7 +304,7 @@ static ListStyleType::Type effectiveListMarkerType(ListStyleType::Type type, int
 {
     // Note, the following switch statement has been explicitly grouped by list-style-type ordinal range.
     switch (type) {
-    case ListStyleType::Type::CustomCounterStyle:
+    case ListStyleType::Type::CounterStyle:
     case ListStyleType::Type::ArabicIndic:
     case ListStyleType::Type::Bengali:
     case ListStyleType::Type::Binary:
@@ -421,7 +421,7 @@ static ListStyleType::Type effectiveListMarkerType(ListStyleType::Type type, int
 static StringView listMarkerSuffix(ListStyleType::Type type)
 {
     switch (type) {
-    case ListStyleType::Type::CustomCounterStyle:
+    case ListStyleType::Type::CounterStyle:
         return { };
     case ListStyleType::Type::Asterisks:
     case ListStyleType::Type::Circle:
@@ -565,7 +565,7 @@ String listMarkerText(ListStyleType::Type type, int value, CSSCounterStyle* coun
     case ListStyleType::Type::DisclosureOpen:
         return { &blackDownPointingSmallTriangle, 1 };
 
-    case ListStyleType::Type::CustomCounterStyle:
+    case ListStyleType::Type::CounterStyle:
         if (!counterStyle)
             return String::number(value);
         return counterStyle->text(value);
@@ -1845,7 +1845,7 @@ void RenderListMarker::updateContent()
         // FIXME: Depending on the string value, we may need the real bidi algorithm. (rdar://106139180)
         m_textIsLeftToRightDirection = u_charDirection(m_textWithSuffix[0]) != U_RIGHT_TO_LEFT;
         break;
-    case ListStyleType::Type::CustomCounterStyle: {
+    case ListStyleType::Type::CounterStyle: {
         auto* counter = counterStyle();
         ASSERT(counter);
         auto text = makeString(counter->prefix(), counter->text(m_listItem->value()));

--- a/Source/WebCore/rendering/style/ListStyleType.cpp
+++ b/Source/WebCore/rendering/style/ListStyleType.cpp
@@ -38,7 +38,7 @@ TextStream& operator<<(TextStream& ts, ListStyleType::Type styleType)
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, ListStyleType listStyle)
 {
-    if (listStyle.type == ListStyleType::Type::CustomCounterStyle)
+    if (listStyle.type == ListStyleType::Type::CounterStyle)
         ts << listStyle.identifier;
     else if (listStyle.type == ListStyleType::Type::String)
         ts << "\"" << listStyle.identifier << "\"";

--- a/Source/WebCore/rendering/style/ListStyleType.h
+++ b/Source/WebCore/rendering/style/ListStyleType.h
@@ -128,13 +128,13 @@ struct ListStyleType {
         TraditionalChineseInformal,
         TraditionalChineseFormal,
         EthiopicNumeric,
-        CustomCounterStyle,
+        CounterStyle,
         String,
         None
     };
 
     Type type { Type::None };
-    // The identifier serve as string value when the Type is String and as a counter-style name (identifier) when the type is CounterStyle.
+    // The identifier is the string when the type is String and is the @counter-style name when the type is CounterStyle.
     AtomString identifier;
     bool operator==(const ListStyleType& other) const { return type == other.type && identifier == other.identifier; }
 };
@@ -244,7 +244,7 @@ template<> struct EnumTraits<WebCore::ListStyleType::Type> {
         WebCore::ListStyleType::Type::TraditionalChineseInformal,
         WebCore::ListStyleType::Type::TraditionalChineseFormal,
         WebCore::ListStyleType::Type::EthiopicNumeric,
-        WebCore::ListStyleType::Type::CustomCounterStyle,
+        WebCore::ListStyleType::Type::CounterStyle,
         WebCore::ListStyleType::Type::String,
         WebCore::ListStyleType::Type::None
     >;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -293,7 +293,7 @@ inline ListStyleType BuilderConverter::convertListStyleType(const BuilderState&,
     if (primitiveValue.isValueID())
         return { fromCSSValue<ListStyleType::Type>(primitiveValue), nullAtom() };
     if (primitiveValue.isCustomIdent())
-        return { ListStyleType::Type::CustomCounterStyle, makeAtomString(primitiveValue.stringValue()) };
+        return { ListStyleType::Type::CounterStyle, makeAtomString(primitiveValue.stringValue()) };
     return { ListStyleType::Type::String, makeAtomString(primitiveValue.stringValue()) };
 }
 


### PR DESCRIPTION
#### 2c2726ff90d9d3ec95f1516b0c42c2de33668e6e
<pre>
Rename ListStyleType::Type::CustomCounterStyle to CounterStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=253932">https://bugs.webkit.org/show_bug.cgi?id=253932</a>
rdar://106736501

Reviewed by Antti Koivisto.

UA styles will also be handled through this `CustomCounterStyle` type, so the `Custom` part isn&apos;t relevant.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::effectiveListMarkerType):
(WebCore::listMarkerSuffix):
(WebCore::listMarkerText):
(WebCore::RenderListMarker::updateContent):
* Source/WebCore/rendering/style/ListStyleType.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/ListStyleType.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertListStyleType):

Canonical link: <a href="https://commits.webkit.org/261676@main">https://commits.webkit.org/261676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b3f3ef5641c5aec779c9817a40f17ae643920e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4310 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12846 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118303 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105595 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/849 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14024 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/886 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14706 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52891 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8134 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16542 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->