### PR TITLE
Revert "[GPU Process] Update pixel tolerance for fast/" for tests that were affected by display list state management bug

### DIFF
--- a/LayoutTests/fast/gradients/conic-from-angle.html
+++ b/LayoutTests/fast/gradients/conic-from-angle.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-200;totalPixels=10900-33000" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=10900-33000" />
     <style>
         div {
             width: 200px;

--- a/LayoutTests/fast/gradients/conic-gradient-alpha-unpremultiplied.html
+++ b/LayoutTests/fast/gradients/conic-gradient-alpha-unpremultiplied.html
@@ -1,6 +1,6 @@
 <html><!-- webkit-test-runner [ CSSGradientPremultipliedAlphaInterpolationEnabled=false ] -->
 <head>
-<meta name="fuzzy" content="maxDifference=0-200; totalPixels=0-9000" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-7455" />
 <style>
     svg {
         width: 800px;

--- a/LayoutTests/fast/gradients/conic-gradient-alpha.html
+++ b/LayoutTests/fast/gradients/conic-gradient-alpha.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-130; totalPixels=0-600" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-163" />
 <style>
     svg {
         width: 800px;

--- a/LayoutTests/fast/gradients/conic-gradient-extended-stops.html
+++ b/LayoutTests/fast/gradients/conic-gradient-extended-stops.html
@@ -1,6 +1,5 @@
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-26000" />
 <style>
     svg {
         width: 800px;

--- a/LayoutTests/fast/gradients/conic-gradient.html
+++ b/LayoutTests/fast/gradients/conic-gradient.html
@@ -1,6 +1,5 @@
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-130; totalPixels=0-26000" />
 <style>
     svg {
         width: 800px;

--- a/LayoutTests/fast/gradients/linear-two-hints-angle.html
+++ b/LayoutTests/fast/gradients/linear-two-hints-angle.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-140;totalPixels=12300-14000" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=12300-12700" />
     <style>
     	div {
             width: 200px;


### PR DESCRIPTION
#### 8ea4af0de03afc276a9190c42c69b2b67339c5ad
<pre>
Revert &quot;[GPU Process] Update pixel tolerance for fast/&quot; for tests that were affected by display list state management bug
<a href="https://bugs.webkit.org/show_bug.cgi?id=253948">https://bugs.webkit.org/show_bug.cgi?id=253948</a>
rdar://problem/106744103

Reviewed by Simon Fraser.

Revert the parts that pass after fixing the display list drawing issues
in
261618@main (b9e5c9199441) DisplayListRecorder fails to record state change before multiple commands <a href="https://bugs.webkit.org/show_bug.cgi?id=253693">https://bugs.webkit.org/show_bug.cgi?id=253693</a> rdar://problem/106542943
261451@main (0ccc458e8461) [UI-side compositing] css3/masking/clip-path-overflow-hidden-bounds.html fails <a href="https://bugs.webkit.org/show_bug.cgi?id=253575">https://bugs.webkit.org/show_bug.cgi?id=253575</a> rdar://106115074

Tests that still have pixel tolerance due to GPU Process:
LayoutTests/fast/layers/overflow-scroll-transform-border-radius.html
LayoutTests/fast/masking/clip-path-inset-large-radii.html

* LayoutTests/fast/gradients/conic-from-angle.html:
* LayoutTests/fast/gradients/conic-gradient-alpha-unpremultiplied.html:
* LayoutTests/fast/gradients/conic-gradient-alpha.html:
* LayoutTests/fast/gradients/conic-gradient-extended-stops.html:
* LayoutTests/fast/gradients/conic-gradient.html:
* LayoutTests/fast/gradients/linear-two-hints-angle.html:

Canonical link: <a href="https://commits.webkit.org/261862@main">https://commits.webkit.org/261862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c7c330ac212741127357c270ddced22bd894ba5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4321 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121103 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5461 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118314 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17115 "5 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105608 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99059 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46115 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14035 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/95221 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14717 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10275 "1 flakes 3 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8280 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16553 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->