### PR TITLE
[WPE] Enable threaded rendering by default using one paint thread

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
@@ -36,8 +36,7 @@ namespace Nicosia {
 
 std::unique_ptr<PaintingEngine> PaintingEngine::create()
 {
-#if (ENABLE(DEVELOPER_MODE) && PLATFORM(WPE)) || USE(GTK4)
-#if USE(GTK4)
+#if PLATFORM(WPE) || USE(GTK4)
     unsigned numThreads = 1;
 #else
     unsigned numThreads = 0;
@@ -53,7 +52,6 @@ std::unique_ptr<PaintingEngine> PaintingEngine::create()
 
     if (numThreads)
         return std::unique_ptr<PaintingEngine>(new PaintingEngineThreaded(numThreads));
-#endif
 
     return std::unique_ptr<PaintingEngine>(new PaintingEngineBasic);
 }

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -73,6 +73,7 @@ class GtkPort(GLibPort):
     def setup_environ_for_server(self, server_name=None):
         environment = super(GtkPort, self).setup_environ_for_server(server_name)
         environment['LIBOVERLAY_SCROLLBAR'] = '0'
+        environment['WEBKIT_NICOSIA_PAINTING_THREADS'] = '0'
 
         # Configure the software libgl renderer if jhbuild ready and we test inside a virtualized window system
         if self._driver_class() in [XvfbDriver, WestonDriver] and (self._should_use_jhbuild() or self._is_flatpak()):

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -59,6 +59,7 @@ class WPEPort(GLibPort):
 
     def setup_environ_for_server(self, server_name=None):
         environment = super(WPEPort, self).setup_environ_for_server(server_name)
+        environment['WEBKIT_NICOSIA_PAINTING_THREADS'] = '0'
         self._copy_value_from_environ_if_set(environment, 'XR_RUNTIME_JSON')
         self._copy_value_from_environ_if_set(environment, 'BREAKPAD_MINIDUMP_DIR')
         return environment


### PR DESCRIPTION
#### 88ee43d6411f1d3ffb0c7f5f6f0c81629813d5a9
<pre>
[WPE] Enable threaded rendering by default using one paint thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=253953">https://bugs.webkit.org/show_bug.cgi?id=253953</a>

Reviewed by Carlos Garcia Campos.

Enable threaded rendering, following suit after GTK4 which enabled it
in 260059@main after some back and forth which involved landing fixes
to propertly synchronize access to global resources.

* Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp:
(Nicosia::PaintingEngine::create): Use one paint thread also for WPE by
default and remove the developer mode guard, which was already being
ignored for GTK4.
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.setup_environ_for_server): Disable threaded rendering when
running layout tests.
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.setup_environ_for_server): Ditto.

Canonical link: <a href="https://commits.webkit.org/263365@main">https://commits.webkit.org/263365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a12e2cd6fbec5b7a7abb2a0a7dd3dd69e22ce58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4566 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4801 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5823 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/4407 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3892 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/7192 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5494 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3548 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3890 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7941 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/503 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->