### PR TITLE
[GStreamer][WebRTC] Improve DataChannel logs

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
@@ -84,6 +84,8 @@ private:
 
     std::optional<size_t> m_cachedBufferedAmount;
     bool m_closing { false };
+
+    String m_channelId;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 758056c72f5c38f86397703d87f764069d876e55
<pre>
[GStreamer][WebRTC] Improve DataChannel logs
<a href="https://bugs.webkit.org/show_bug.cgi?id=253954">https://bugs.webkit.org/show_bug.cgi?id=253954</a>

Reviewed by Xabier Rodriguez-Calvar.

The logs now mention one unique identifier per data-channel. This works only when building against
GStreamer 1.22 though because it requires new macros.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::GStreamerDataChannelHandler):
(WebCore::GStreamerDataChannelHandler::~GStreamerDataChannelHandler):
(WebCore::GStreamerDataChannelHandler::setClient):
(WebCore::GStreamerDataChannelHandler::sendStringData):
(WebCore::GStreamerDataChannelHandler::sendRawData):
(WebCore::GStreamerDataChannelHandler::close):
(WebCore::GStreamerDataChannelHandler::checkState):
(WebCore::GStreamerDataChannelHandler::bufferedAmountChanged):
(WebCore::GStreamerDataChannelHandler::onMessageData):
(WebCore::GStreamerDataChannelHandler::onMessageString):
(WebCore::GStreamerDataChannelHandler::onError):
(WebCore::GStreamerDataChannelHandler::onClose):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h:

Canonical link: <a href="https://commits.webkit.org/261683@main">https://commits.webkit.org/261683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c16dc70684396e6663f9d1d98addd7faca9b6878

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4334 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12871 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118326 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105621 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/870 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14047 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/907 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14729 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52912 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8141 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16566 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->