### PR TITLE
Web Inspector: New CSS property unexpectedly dropped from empty CSS rule when tabbing through or editing selector

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js
@@ -43,6 +43,7 @@ WI.SpreadsheetCSSStyleDeclarationSection = class SpreadsheetCSSStyleDeclarationS
         this._filterText = null;
         this._shouldFocusSelectorElement = false;
         this._wasEditing = false;
+        this._setSelectorTextPromise = Promise.resolve();
 
         this._isMousePressed = false;
         this._mouseDownIndex = NaN;
@@ -761,7 +762,7 @@ WI.SpreadsheetCSSStyleDeclarationSection = class SpreadsheetCSSStyleDeclarationS
         let selectorText = this._selectorElement.textContent.trim();
         if (selectorText && changed) {
             this.dispatchEventToListeners(WI.SpreadsheetCSSStyleDeclarationSection.Event.SelectorOrGroupingWillChange);
-            this._style.ownerRule.setSelectorText(selectorText).finally(this._renderSelector.bind(this));
+            this._setSelectorTextPromise = this._style.ownerRule.setSelectorText(selectorText).finally(this._renderSelector.bind(this));
         } else
             this._discardSelectorChange();
     }
@@ -769,7 +770,7 @@ WI.SpreadsheetCSSStyleDeclarationSection = class SpreadsheetCSSStyleDeclarationS
     _handleSpreadsheetSelectorFieldWillNavigate(direction)
     {
         if (direction === "forward")
-            this._propertiesEditor.startEditingFirstProperty();
+            this._setSelectorTextPromise.then(() => this._propertiesEditor.startEditingFirstProperty());
         else if (direction === "backward") {
             for (let i = this._groupingElements.length - 1; i >= 0; ++i) {
                 let groupingElementTextField = this._groupingElements[i].associatedTextField;
@@ -782,7 +783,7 @@ WI.SpreadsheetCSSStyleDeclarationSection = class SpreadsheetCSSStyleDeclarationS
                 const delta = -1;
                 this._delegate.spreadsheetCSSStyleDeclarationSectionStartEditingAdjacentRule(this, delta);
             } else
-                this._propertiesEditor.startEditingLastProperty();
+                this._setSelectorTextPromise.then(() => this._propertiesEditor.startEditingLastProperty());
         }
     }
 


### PR DESCRIPTION
#### 84150ea85574551811c8802fe27fa252bc571d31
<pre>
Web Inspector: New CSS property unexpectedly dropped from empty CSS rule when tabbing through or editing selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=245768">https://bugs.webkit.org/show_bug.cgi?id=245768</a>

Reviewed by Patrick Angle.

There are two issues here:
1) changing the selector of an empty CSS rule causes the first added CSS property to be dropped.
2) tabbing through the editable text field for a CSS selector marks it as changed even when it&apos;s not.

The core problem is the order of operations.

Tabbing out of a CSS selector text field first calls
`SpreadsheetCSSStyleDeclarationSection.spreadsheetRuleHeaderFieldWillNavigate()`
from the `SpreadsheetRuleHeaderField._handleKeyDown` handler.

For an empty CSS rule, this creates a new blank CSS property with:
`SpreadsheetCSSStyleDeclarationEditor.startEditingFirstProperty()` -&gt; `CSSStyleDeclaration.newBlankProperty()`.

At this point, the frontend model for the CSS rule contains a `CSSStyleDeclaration` with one `CSSProperty`.

In quick succession, the second operation happens when the selector text field loses focus:
`SpreadsheetCSSStyleDeclarationSection.spreadsheetRuleHeaderFieldDidCommit()`
from the `SpreadsheetRuleHeaderField._handleBlur` handler.

If the selector text has changed, a request is sent to the backend via `DOMNodeStyles.changeRuleSelector()`.
A request is then made for the latest matching styles via `DOMNodeStyles.refresh()`.

For an empty CSS rule, there are no matching styles. As a result, the `CSSStyleDeclaration` of the corresponding
CSS rule is updated with an empty list of CSS properties in `DOMNodeStyles._parseStyleDeclarationPayload()`:

```
if (style) {
    style.update(text, properties, styleSheetTextRange);
    return style;
}
```

This has the effect of orphaning the new blank `CSSProperty` introduced earlier.

`CSSProperty._updateOwnerStyleText()` is called to persist the `CSSProperty` to the backend.
This calls `CSSStyleDeclaration.generateFormattedText()` to serialize the whole CSS declaration block.
But our `CSSStyleDeclaration` was just emptied of properties by the update in
`DOMNodeStyles._parseStyleDeclarationPayload()` so it falls back to returning an empty string:

```
let styleText = &quot;&quot;;
...
let properties = this._styleSheetTextRange ? this.visibleProperties : this._properties;
...
return styleText;
```

When the `CSSProperty` commits with an empty name and value, the matching styles obtained
in response to `DOMNodeStyles.refresh()` are empty, and the orphaned property is dropped.

Trying again with the newly created blank CSS property will work because this time
there&apos;s no race with `DOMNodeStyles.refresh()` from the selector change.

To fix the first issue, we must ensure that the operation to update the selector
and the style refresh it causes occurs before adding a new CSS property to avoid
the style refresh invalidating the models on the frontend.

To fix the second issue, we don&apos;t call `SpreadsheetRuleHeaderField.stopEditing()` in the
keydown handler for Tab or Enter  because that resets `_valueBeforeEditing` which causes
the check in  `SpreadsheetRuleHeaderField._handleBlur` to always consider the selector
as having been changed, thus triggering the operations described above.

* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js:
(WI.SpreadsheetCSSStyleDeclarationSection):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype._handleSpreadsheetSelectorFieldDidCommit):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype._handleSpreadsheetSelectorFieldWillNavigate):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetRuleHeaderField.js:
(WI.SpreadsheetRuleHeaderField):
(WI.SpreadsheetRuleHeaderField.prototype.stopEditing):
(WI.SpreadsheetRuleHeaderField.prototype._handleBlur):
(WI.SpreadsheetRuleHeaderField.prototype._handleKeyDown):

Canonical link: <a href="https://commits.webkit.org/261861@main">https://commits.webkit.org/261861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e3bd753a16a4129070a6acbc77ab4c216153434

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4695 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121416 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5883 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106008 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99355 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1188 "5 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46417 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14372 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1228 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10563 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53220 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8282 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16928 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->