### PR TITLE
[GTK] Enable the async clipboard API

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -849,21 +849,17 @@ fast/forms/range/input-appearance-range-rtl.html [ ImageOnlyFailure ]
 
 # Service-workers tests that fail, time out or crash.
 
-# GTK ought to support async clipboard
-webkit.org/b/211979 editing/async-clipboard/clipboard-change-data-while-writing.html [ Failure ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-read-text-from-platform.html [ Failure ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-change-data-while-getting-type.html [ Timeout ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-change-data-while-reading.html [ Timeout ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-get-type-with-old-items.html [ Timeout ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-read-basic.html [ Timeout ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-read-text-same-origin.html [ Timeout ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-write-basic.html [ Timeout ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-write-items-twice.html [ Timeout ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-write-text.html [ Timeout ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-item-get-type-basic.html [ Failure ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-read-text.html [ Failure ]
-webkit.org/b/211979 editing/async-clipboard/clipboard-read-write-images.html [ Failure ]
-webkit.org/b/211979 editing/async-clipboard/sanitize-when-reading-markup.html [ Failure ]
+# GTK doesn't support multiple items in the clipboard
+# FIXME: add platform specific tests equivalent to these but using single item.
+editing/async-clipboard/clipboard-read-write-images.html [ Skip ]
+editing/async-clipboard/clipboard-write-basic.html [ Skip ]
+editing/async-clipboard/sanitize-when-reading-markup.html [ Skip ]
+
+# These tests are intended to exercise programmatic paste mechanism specific to Apple ports.
+editing/async-clipboard/clipboard-change-data-while-reading.html [ Skip ]
+editing/async-clipboard/clipboard-read-text-from-platform.html [ Skip ]
+editing/async-clipboard/clipboard-read-text-same-origin.html [ Skip ]
+editing/async-clipboard/clipboard-read-while-pasting.html [ Skip ]
 
 webkit.org/b/180062 fast/text/user-installed-fonts [ Skip ]
 
@@ -1069,8 +1065,6 @@ webkit.org/b/120839 animations/cross-fade-background-image.html [ ImageOnlyFailu
 
 webkit.org/b/207605 [ Debug ] http/tests/workers/service/registration-clear-redundant-worker.html [ Crash ]
 webkit.org/b/207605 [ Debug ] http/tests/websocket/tests/hybi/no-subprotocol.html [ Crash ]
-
-webkit.org/b/212232 editing/async-clipboard/clipboard-read-while-pasting.html [ Crash ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Crashing tests

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -571,7 +571,7 @@ AsyncClipboardAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(COCOA)" : true
+      "PLATFORM(COCOA) || PLATFORM(GTK)" : true
       default: false
     WebCore:
       default: false

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -318,9 +318,7 @@ void Clipboard::ItemWriter::write(const Vector<RefPtr<ClipboardItem>>& items)
 {
     ASSERT(m_promise);
     ASSERT(m_clipboard);
-#if PLATFORM(COCOA)
     m_changeCountAtStart = m_pasteboard->changeCount();
-#endif
     m_dataToWrite.fill(std::nullopt, items.size());
     m_pendingItemCount = items.size();
     for (size_t index = 0; index < items.size(); ++index) {
@@ -355,7 +353,6 @@ void Clipboard::ItemWriter::didSetAllData()
     if (!m_promise)
         return;
 
-#if PLATFORM(COCOA)
     auto newChangeCount = m_pasteboard->changeCount();
     if (m_changeCountAtStart != newChangeCount) {
         // FIXME: Instead of checking the changeCount here, send it over to the client (e.g. the UI process
@@ -363,7 +360,7 @@ void Clipboard::ItemWriter::didSetAllData()
         reject();
         return;
     }
-#endif // PLATFORM(COCOA)
+
     auto dataToWrite = std::exchange(m_dataToWrite, { });
     Vector<PasteboardCustomData> customData;
     customData.reserveInitialCapacity(dataToWrite.size());

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.h
@@ -103,9 +103,7 @@ private:
         RefPtr<DeferredPromise> m_promise;
         unsigned m_pendingItemCount;
         std::unique_ptr<Pasteboard> m_pasteboard;
-#if PLATFORM(COCOA)
         int64_t m_changeCountAtStart { 0 };
-#endif
     };
 
     void didResolveOrReject(ItemWriter&);

--- a/Source/WebCore/Modules/async-clipboard/ClipboardImageReader.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardImageReader.cpp
@@ -27,15 +27,16 @@
 #include "ClipboardImageReader.h"
 
 #include "Document.h"
-#include "NotImplemented.h"
+#include "SharedBuffer.h"
 
 namespace WebCore {
 
 #if !PLATFORM(COCOA)
 
-void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBuffer>&&)
+void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBuffer>&& buffer)
 {
-    notImplemented();
+    if (m_mimeType == "image/png"_s)
+        m_result = Blob::create(m_document.get(), buffer->extractData(), m_mimeType);
 }
 
 #endif // !PLATFORM(COCOA)

--- a/Source/WebCore/platform/Pasteboard.cpp
+++ b/Source/WebCore/platform/Pasteboard.cpp
@@ -61,7 +61,7 @@ Vector<String> Pasteboard::readAllStrings(const String& type)
 
 std::optional<Vector<PasteboardItemInfo>> Pasteboard::allPasteboardItemInfo() const
 {
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || PLATFORM(GTK)
     if (auto* strategy = platformStrategies()->pasteboardStrategy())
         return strategy->allPasteboardItemInfo(name(), m_changeCount, context());
 #endif
@@ -70,7 +70,7 @@ std::optional<Vector<PasteboardItemInfo>> Pasteboard::allPasteboardItemInfo() co
 
 std::optional<PasteboardItemInfo> Pasteboard::pasteboardItemInfo(size_t index) const
 {
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || PLATFORM(GTK)
     if (auto* strategy = platformStrategies()->pasteboardStrategy())
         return strategy->informationForItemAtIndex(index, name(), m_changeCount, context());
 #else

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -257,6 +257,7 @@ public:
 #if PLATFORM(GTK)
     const SelectionData& selectionData() const;
     static std::unique_ptr<Pasteboard> createForGlobalSelection(std::unique_ptr<PasteboardContext>&&);
+    int64_t changeCount() const;
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -279,12 +280,14 @@ public:
     WEBCORE_EXPORT static NSArray *supportedFileUploadPasteboardTypes();
     int64_t changeCount() const;
     const PasteboardCustomData& readCustomData();
-#else
+#elif !PLATFORM(GTK)
     int64_t changeCount() const { return 0; }
 #endif
 
 #if PLATFORM(COCOA)
     const String& name() const { return m_pasteboardName; }
+#elif PLATFORM(GTK)
+    const String& name() const { return m_name; }
 #else
     const String& name() const { return emptyString(); }
 #endif
@@ -342,6 +345,7 @@ private:
 #if PLATFORM(GTK)
     std::optional<SelectionData> m_selectionData;
     String m_name;
+    int64_t m_changeCount { 0 };
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/PasteboardStrategy.h
+++ b/Source/WebCore/platform/PasteboardStrategy.h
@@ -89,6 +89,7 @@ public:
     virtual RefPtr<SharedBuffer> readBufferFromClipboard(const String& pasteboardName, const String& pasteboardType) = 0;
     virtual void writeToClipboard(const String& pasteboardName, SelectionData&&) = 0;
     virtual void clearClipboard(const String& pasteboardName) = 0;
+    virtual int64_t changeCount(const String& pasteboardName) = 0;
 #endif // PLATFORM(GTK)
 
 #if USE(LIBWPE)

--- a/Source/WebCore/platform/gtk/SelectionData.cpp
+++ b/Source/WebCore/platform/gtk/SelectionData.cpp
@@ -120,6 +120,7 @@ void SelectionData::clearAllExceptFilenames()
     clearURL();
     clearImage();
     clearCustomData();
+    clearBuffers();
 
     m_canSmartReplace = false;
 }

--- a/Source/WebCore/platform/gtk/SelectionData.h
+++ b/Source/WebCore/platform/gtk/SelectionData.h
@@ -60,6 +60,11 @@ public:
     void setCanSmartReplace(bool canSmartReplace) { m_canSmartReplace = canSmartReplace; }
     bool canSmartReplace() const { return m_canSmartReplace; }
 
+    void addBuffer(const String& type, const Ref<SharedBuffer>& buffer) { m_buffers.add(type, buffer.get()); }
+    const HashMap<String, Ref<SharedBuffer>>& buffers() const { return m_buffers; }
+    SharedBuffer* buffer(const String& type) { return m_buffers.get(type); }
+    void clearBuffers() { m_buffers.clear(); }
+
     void setCustomData(Ref<SharedBuffer>&& buffer) { m_customData = WTFMove(buffer); }
     SharedBuffer* customData() const { return m_customData.get(); }
     bool hasCustomData() const { return !!m_customData; }
@@ -77,6 +82,7 @@ private:
     RefPtr<Image> m_image;
     bool m_canSmartReplace { false };
     RefPtr<SharedBuffer> m_customData;
+    HashMap<String, Ref<SharedBuffer>> m_buffers;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.cpp
@@ -89,7 +89,6 @@ void WebPasteboardProxy::writeCustomData(IPC::Connection&, const Vector<WebCore:
 {
     completionHandler(0);
 }
-#endif
 
 void WebPasteboardProxy::allPasteboardItemInfo(IPC::Connection&, const String&, int64_t, std::optional<WebCore::PageIdentifier>, CompletionHandler<void(std::optional<Vector<WebCore::PasteboardItemInfo>>&&)>&& completionHandler)
 {
@@ -115,6 +114,7 @@ void WebPasteboardProxy::readBufferFromPasteboard(IPC::Connection&, std::optiona
 {
     completionHandler({ });
 }
+#endif
 
 #if !USE(LIBWPE)
 

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -133,6 +133,7 @@ private:
     void readBuffer(const String& pasteboardName, const String& pasteboardType, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
     void writeToClipboard(const String& pasteboardName, WebCore::SelectionData&&);
     void clearClipboard(const String& pasteboardName);
+    void getPasteboardChangeCount(IPC::Connection&, const String& pasteboardName, CompletionHandler<void(int64_t)>&&);
 
     WebFrameProxy* m_primarySelectionOwner { nullptr };
 #endif // PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -72,6 +72,7 @@ messages -> WebPasteboardProxy NotRefCounted {
     ReadBuffer(String pasteboardName, String pasteboardType) -> (RefPtr<WebCore::SharedBuffer> buffer) Synchronous
     WriteToClipboard(String pasteboardName, WebCore::SelectionData pasteboardContent)
     ClearClipboard(String pasteboardName)
+    GetPasteboardChangeCount(String pasteboardName) -> (int64_t changeCount) Synchronous
 #endif
 
 #if USE(LIBWPE)

--- a/Source/WebKit/UIProcess/gtk/Clipboard.h
+++ b/Source/WebKit/UIProcess/gtk/Clipboard.h
@@ -50,14 +50,18 @@ public:
 
     enum class Type { Clipboard, Primary };
     explicit Clipboard(Type);
+    ~Clipboard();
 
     Type type() const;
     void formats(CompletionHandler<void(Vector<String>&&)>&&);
     void readText(CompletionHandler<void(String&&)>&&);
     void readFilePaths(CompletionHandler<void(Vector<String>&&)>&&);
+    void readURL(CompletionHandler<void(String&& url, String&& title)>&&);
     void readBuffer(const char*, CompletionHandler<void(Ref<WebCore::SharedBuffer>&&)>&&);
-    void write(WebCore::SelectionData&&);
+    void write(WebCore::SelectionData&&, CompletionHandler<void(int64_t)>&&);
     void clear();
+
+    int64_t changeCount() const { return m_changeCount; }
 
 private:
 #if USE(GTK4)
@@ -66,6 +70,7 @@ private:
     GtkClipboard* m_clipboard { nullptr };
     WebFrameProxy* m_frameWritingToClipboard { nullptr };
 #endif
+    int64_t m_changeCount { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
@@ -42,6 +42,15 @@ namespace WebKit {
 Clipboard::Clipboard(Type type)
     : m_clipboard(gtk_clipboard_get_for_display(gdk_display_get_default(), type == Type::Clipboard ? GDK_SELECTION_CLIPBOARD : GDK_SELECTION_PRIMARY))
 {
+    g_signal_connect(m_clipboard, "owner-change", G_CALLBACK(+[](GtkClipboard*, GdkEvent*, gpointer userData) {
+        auto& clipboard = *static_cast<Clipboard*>(userData);
+        clipboard.m_changeCount++;
+    }), this);
+}
+
+Clipboard::~Clipboard()
+{
+    g_signal_handlers_disconnect_by_data(m_clipboard, this);
 }
 
 static bool isPrimaryClipboard(GtkClipboard* clipboard)
@@ -134,6 +143,25 @@ struct ReadBufferAsyncData {
     CompletionHandler<void(Ref<WebCore::SharedBuffer>&&)> completionHandler;
 };
 
+struct ReadURLAsyncData {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    explicit ReadURLAsyncData(CompletionHandler<void(String&& url, String&& title)>&& handler)
+        : completionHandler(WTFMove(handler))
+    {
+    }
+
+    CompletionHandler<void(String&& url, String&& title)> completionHandler;
+};
+
+void Clipboard::readURL(CompletionHandler<void(String&& url, String&& title)>&& completionHandler)
+{
+    gtk_clipboard_request_uris(m_clipboard, [](GtkClipboard*, char** uris, gpointer userData) {
+        std::unique_ptr<ReadURLAsyncData> data(static_cast<ReadURLAsyncData*>(userData));
+        data->completionHandler(uris && uris[0] ? String::fromUTF8(uris[0]) : String(), { });
+    }, new ReadURLAsyncData(WTFMove(completionHandler)));
+}
+
 void Clipboard::readBuffer(const char* format, CompletionHandler<void(Ref<WebCore::SharedBuffer>&&)>&& completionHandler)
 {
     gtk_clipboard_request_contents(m_clipboard, gdk_atom_intern(format, TRUE), [](GtkClipboard*, GtkSelectionData* selection, gpointer userData) {
@@ -157,9 +185,9 @@ struct WriteAsyncData {
     Clipboard& clipboard;
 };
 
-enum ClipboardTargetType { Markup, Text, Image, URIList, SmartPaste, Custom };
+enum ClipboardTargetType { Markup, Text, Image, URIList, SmartPaste, Custom, Buffer };
 
-void Clipboard::write(WebCore::SelectionData&& selectionData)
+void Clipboard::write(WebCore::SelectionData&& selectionData, CompletionHandler<void(int64_t)>&& completionHandler)
 {
     SetForScope frameWritingToClipboard(m_frameWritingToClipboard, WebPasteboardProxy::singleton().primarySelectionOwner());
 
@@ -176,11 +204,14 @@ void Clipboard::write(WebCore::SelectionData&& selectionData)
         gtk_target_list_add(list.get(), gdk_atom_intern_static_string("application/vnd.webkitgtk.smartpaste"), 0, ClipboardTargetType::SmartPaste);
     if (selectionData.hasCustomData())
         gtk_target_list_add(list.get(), gdk_atom_intern_static_string(WebCore::PasteboardCustomData::gtkType().characters()), 0, ClipboardTargetType::Custom);
+    for (const auto& type : selectionData.buffers().keys())
+        gtk_target_list_add(list.get(), gdk_atom_intern(type.utf8().data(), FALSE), 0, ClipboardTargetType::Buffer);
 
     int numberOfTargets;
     GtkTargetEntry* table = gtk_target_table_new_from_list(list.get(), &numberOfTargets);
     if (!numberOfTargets) {
         gtk_clipboard_clear(m_clipboard);
+        completionHandler(m_changeCount + 1);
         return;
     }
 
@@ -218,6 +249,13 @@ void Clipboard::write(WebCore::SelectionData&& selectionData)
                     gtk_selection_data_set(selection, gdk_atom_intern_static_string(WebCore::PasteboardCustomData::gtkType().characters()), 8, reinterpret_cast<const guchar*>(buffer->data()), buffer->size());
                 }
                 break;
+            case ClipboardTargetType::Buffer: {
+                auto* atom = gtk_selection_data_get_target(selection);
+                GUniquePtr<char> type(gdk_atom_name(atom));
+                if (auto* buffer = data.selectionData.buffer(String::fromUTF8(type.get())))
+                    gtk_selection_data_set(selection, atom, 8, reinterpret_cast<const guchar*>(buffer->data()), buffer->size());
+                break;
+            }
             }
         },
         [](GtkClipboard* clipboard, gpointer userData) {
@@ -233,6 +271,7 @@ void Clipboard::write(WebCore::SelectionData&& selectionData)
         gtk_clipboard_set_can_store(m_clipboard, nullptr, 0);
     }
     gtk_target_table_free(table, numberOfTargets);
+    completionHandler(succeeded ? m_changeCount + 1 : m_changeCount);
 }
 
 void Clipboard::clear()

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
@@ -47,6 +47,15 @@ Clipboard::Clipboard(Type type)
                 WebPasteboardProxy::singleton().setPrimarySelectionOwner(nullptr);
         }), nullptr);
     }
+    g_signal_connect(m_clipboard, "changed", G_CALLBACK(+[](GdkClipboard*, gpointer userData) {
+        auto& clipboard = *static_cast<Clipboard*>(userData);
+        clipboard.m_changeCount++;
+    }), this);
+}
+
+Clipboard::~Clipboard()
+{
+    g_signal_handlers_disconnect_by_data(m_clipboard, this);
 }
 
 Clipboard::Type Clipboard::type() const
@@ -157,7 +166,30 @@ void Clipboard::readBuffer(const char* format, CompletionHandler<void(Ref<WebCor
     }, new ReadBufferAsyncData(WTFMove(completionHandler)));
 }
 
-void Clipboard::write(WebCore::SelectionData&& selectionData)
+struct ReadURLAsyncData {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    explicit ReadURLAsyncData(CompletionHandler<void(String&& url, String&& title)>&& handler)
+        : completionHandler(WTFMove(handler))
+    {
+    }
+
+    CompletionHandler<void(String&& url, String&& title)> completionHandler;
+};
+
+void Clipboard::readURL(CompletionHandler<void(String&& url, String&& title)>&& completionHandler)
+{
+    gdk_clipboard_read_value_async(m_clipboard, GDK_TYPE_FILE_LIST, G_PRIORITY_DEFAULT, nullptr, [](GObject* clipboard, GAsyncResult* result, gpointer userData) {
+        std::unique_ptr<ReadURLAsyncData> data(static_cast<ReadURLAsyncData*>(userData));
+        const GValue* value = gdk_clipboard_read_value_finish(GDK_CLIPBOARD(clipboard), result, nullptr);
+        auto* list = static_cast<GSList*>(g_value_get_boxed(value));
+        auto* file = list && list->data ? G_FILE(list->data) : nullptr;
+        GUniquePtr<char> uri(g_file_get_uri(file));
+        data->completionHandler(uri ? String::fromUTF8(uri.get()) : String(), { });
+    }, new ReadURLAsyncData(WTFMove(completionHandler)));
+}
+
+void Clipboard::write(WebCore::SelectionData&& selectionData, CompletionHandler<void(int64_t)>&& completionHandler)
 {
     Vector<GdkContentProvider*> providers;
     if (selectionData.hasMarkup()) {
@@ -190,13 +222,20 @@ void Clipboard::write(WebCore::SelectionData&& selectionData)
         providers.append(gdk_content_provider_new_for_bytes(WebCore::PasteboardCustomData::gtkType().characters(), bytes.get()));
     }
 
+    for (const auto& it : selectionData.buffers()) {
+        GRefPtr<GBytes> bytes = it.value->createGBytes();
+        providers.append(gdk_content_provider_new_for_bytes(it.key.utf8().data(), bytes.get()));
+    }
+
     if (providers.isEmpty()) {
         clear();
+        completionHandler(m_changeCount);
         return;
     }
 
     GRefPtr<GdkContentProvider> provider = adoptGRef(gdk_content_provider_new_union(providers.data(), providers.size()));
     gdk_clipboard_set_content(m_clipboard, provider.get());
+    completionHandler(m_changeCount);
 }
 
 void Clipboard::clear()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -336,6 +336,13 @@ void WebPlatformStrategies::clearClipboard(const String& pasteboardName)
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebPasteboardProxy::ClearClipboard(pasteboardName), 0);
 }
 
+int64_t WebPlatformStrategies::changeCount(const String& pasteboardName)
+{
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardChangeCount(pasteboardName), 0);
+    auto [changeCount] = sendResult.takeReplyOr(0);
+    return changeCount;
+}
+
 #endif // PLATFORM(GTK)
 
 #if USE(LIBWPE)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
@@ -81,6 +81,7 @@ private:
     RefPtr<WebCore::SharedBuffer> readBufferFromClipboard(const String& pasteboardName, const String& pasteboardType) override;
     void writeToClipboard(const String& pasteboardName, WebCore::SelectionData&&) override;
     void clearClipboard(const String& pasteboardName) override;
+    int64_t changeCount(const String& pasteboardName) override;
 #endif
 #if USE(LIBWPE)
     void getTypes(Vector<String>& types) override;


### PR DESCRIPTION
#### ec3dd91419a8c035ddb2c79bbd85a93619bab1e9
<pre>
[GTK] Enable the async clipboard API
<a href="https://bugs.webkit.org/show_bug.cgi?id=211979">https://bugs.webkit.org/show_bug.cgi?id=211979</a>

Reviewed by Wenson Hsieh.

Enable async clipboard API and implement the required platform strategy
functions.

* LayoutTests/platform/gtk/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::Clipboard::ItemWriter::write):
(WebCore::Clipboard::ItemWriter::didSetAllData):
* Source/WebCore/Modules/async-clipboard/Clipboard.h:
* Source/WebCore/Modules/async-clipboard/ClipboardImageReader.cpp:
(WebCore::ClipboardImageReader::readBuffer):
* Source/WebCore/platform/Pasteboard.cpp:
(WebCore::Pasteboard::allPasteboardItemInfo const):
(WebCore::Pasteboard::pasteboardItemInfo const):
* Source/WebCore/platform/Pasteboard.h:
(WebCore::Pasteboard::name const):
* Source/WebCore/platform/PasteboardStrategy.h:
* Source/WebCore/platform/gtk/PasteboardGtk.cpp:
(WebCore::Pasteboard::Pasteboard):
(WebCore::Pasteboard::read):
(WebCore::Pasteboard::writeCustomData):
(WebCore::Pasteboard::changeCount const):
* Source/WebCore/platform/gtk/SelectionData.cpp:
(WebCore::SelectionData::clearAllExceptFilenames):
* Source/WebCore/platform/gtk/SelectionData.h:
(WebCore::SelectionData::addBuffer):
(WebCore::SelectionData::buffers const):
(WebCore::SelectionData::buffer):
(WebCore::SelectionData::clearBuffers):
* Source/WebKit/UIProcess/WebPasteboardProxy.cpp:
(WebKit::WebPasteboardProxy::writeCustomData):
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.messages.in:
* Source/WebKit/UIProcess/gtk/Clipboard.h:
(WebKit::Clipboard::changeCount const):
* Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp:
(WebKit::Clipboard::Clipboard):
(WebKit::Clipboard::~Clipboard):
(WebKit::ReadURLAsyncData::ReadURLAsyncData):
(WebKit::Clipboard::readURL):
(WebKit::Clipboard::write):
* Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp:
(WebKit::Clipboard::write):
* Source/WebKit/UIProcess/gtk/WebPasteboardProxyGtk.cpp:
(WebKit::WebPasteboardProxy::writeToClipboard):
(WebKit::WebPasteboardProxy::writeCustomData):
(WebKit::pasteboardIemInfoFromFormats):
(WebKit::WebPasteboardProxy::allPasteboardItemInfo):
(WebKit::WebPasteboardProxy::informationForItemAtIndex):
(WebKit::WebPasteboardProxy::getPasteboardItemsCount):
(WebKit::WebPasteboardProxy::readURLFromPasteboard):
(WebKit::WebPasteboardProxy::readBufferFromPasteboard):
(WebKit::WebPasteboardProxy::getPasteboardChangeCount):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::changeCount):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h:

Canonical link: <a href="https://commits.webkit.org/261740@main">https://commits.webkit.org/261740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e58dafc2b0939a31e86e5d9b59bfad874c054cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/112699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121225 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/116768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5634 "Passed tests") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/118468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105779 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46249 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/100987 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14176 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1052 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12297 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14863 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102488 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53044 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/31994 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8190 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16708 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110530 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27296 "Passed tests") | 
<!--EWS-Status-Bubble-End-->