### PR TITLE
Not audible AudioContext prevents the audio session category to change from play-and-record after stopping capture

### DIFF
--- a/LayoutTests/fast/mediastream/audio-session-category-capture-audio-context-expected.txt
+++ b/LayoutTests/fast/mediastream/audio-session-category-capture-audio-context-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Check audio session state in case of stopped audio track and stopped audio context
+PASS Check audio session state in case of stopped audio track and not audible audio context
+

--- a/LayoutTests/fast/mediastream/audio-session-category-capture-audio-context.html
+++ b/LayoutTests/fast/mediastream/audio-session-category-capture-audio-context.html
@@ -1,0 +1,91 @@
+<body>
+<video id="localVideo" autoplay playsInline></video>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../webrtc/routines.js"></script>
+<script>
+
+promise_test(async() => {
+    if (!window.internals)
+       return Promise.reject("Test requires internals API");
+
+    if (!internals.supportsAudioSession)
+        return;
+
+    internals.settings.setShouldManageAudioSessionCategory(true);
+
+    const defaultCategory = internals.audioSessionCategory();
+    assert_not_equals(defaultCategory, "AmbientSound");
+
+    const audioContext = new AudioContext();
+    await audioContext.resume();
+
+    // Make sure that a not audible AudioContext is still setting the category to AmbientSound.
+    assert_equals(internals.audioSessionCategory(), "AmbientSound", "AmbientSound");
+
+    let stream = await navigator.mediaDevices.getUserMedia({audio : true});
+
+    assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "PlayAndRecord1");
+
+    const source = audioContext.createMediaStreamSource(stream);
+    source.connect(audioContext.destination);
+
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    const audioTrack = stream.getAudioTracks()[0];
+    audioTrack.stop();
+
+    await new Promise(resolve => setTimeout(resolve, 200));
+    assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "PlayAndRecord2");
+
+    audioContext.close();
+
+    const maxTries = 300;
+    let counter = 0;
+    while (++counter < maxTries) {
+        if (internals.audioSessionCategory() == defaultCategory)
+            break;
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    assert_less_than(counter, maxTries);
+    assert_equals(internals.audioSessionCategory(), defaultCategory);
+}, "Check audio session state in case of stopped audio track and stopped audio context");
+
+promise_test(async() => {
+    if (!window.internals)
+       return Promise.reject("Test requires internals API");
+
+    if (!internals.supportsAudioSession)
+        return;
+
+    internals.settings.setShouldManageAudioSessionCategory(true);
+
+    const defaultCategory = internals.audioSessionCategory();
+
+    const stream = await navigator.mediaDevices.getUserMedia({audio : true});
+
+    assert_equals(internals.audioSessionCategory(), "PlayAndRecord");
+
+    const context = new AudioContext();
+    analyseAudio(stream, 100, context);
+
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    const audioTrack = stream.getAudioTracks()[0];
+    audioTrack.stop();
+
+    const maxTries = 300;
+    let counter = 0;
+    while (++counter < maxTries) {
+        if (internals.audioSessionCategory() == "AmbientSound")
+            break;
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    assert_less_than(counter, maxTries);
+    assert_equals(internals.audioSessionCategory(), "AmbientSound");
+
+    context.close();
+}, "Check audio session state in case of stopped audio track and not audible audio context");
+
+</script>
+</body>

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -348,10 +348,12 @@ bool AudioContext::willPausePlayback()
 
 MediaProducerMediaStateFlags AudioContext::mediaState() const
 {
-    if (!isStopped() && destination().isPlayingAudio())
-        return MediaProducerMediaState::IsPlayingAudio;
+    return isAudible() ? MediaProducerMediaState::IsPlayingAudio : MediaProducer::IsNotPlaying;
+}
 
-    return MediaProducer::IsNotPlaying;
+bool AudioContext::isAudible() const
+{
+    return !isStopped() && destination().isPlayingAudio();
 }
 
 void AudioContext::mayResumePlayback(bool shouldResume)

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -131,6 +131,7 @@ private:
     bool canProduceAudio() const final { return true; }
     bool isSuspended() const final;
     bool isPlaying() const final;
+    bool isAudible() const final;
     MediaSessionGroupIdentifier mediaSessionGroupIdentifier() const final;
 
     // MediaCanStartListener.

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -955,6 +955,7 @@ private:
     bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType) const override;
     bool shouldOverrideBackgroundLoadingRestriction() const override;
     bool canProduceAudio() const final;
+    bool isAudible() const final { return canProduceAudio(); };
     bool hasMediaStreamSource() const final;
     void processIsSuspendedChanged() final;
     bool shouldOverridePauseDuringRouteChange() const final;

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -326,6 +326,11 @@ bool PlatformMediaSession::isPlaying() const
     return m_client.isPlaying();
 }
 
+bool PlatformMediaSession::isAudible() const
+{
+    return m_client.isAudible();
+}
+
 bool PlatformMediaSession::shouldOverrideBackgroundLoadingRestriction() const
 {
     return m_client.shouldOverrideBackgroundLoadingRestriction();

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -159,6 +159,7 @@ public:
     bool isHidden() const;
     bool isSuspended() const;
     bool isPlaying() const;
+    bool isAudible() const;
 
     bool shouldOverrideBackgroundLoadingRestriction() const;
 
@@ -258,6 +259,7 @@ public:
     virtual bool canProduceAudio() const { return false; }
     virtual bool isSuspended() const { return false; };
     virtual bool isPlaying() const { return false; };
+    virtual bool isAudible() const { return false; };
 
     virtual bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType) const = 0;
     virtual bool shouldOverrideBackgroundLoadingRestriction() const { return false; }

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -139,7 +139,7 @@ void MediaSessionManagerCocoa::updateSessionState()
         case PlatformMediaSession::MediaType::WebAudio:
             if (session.canProduceAudio()) {
                 ++webAudioCount;
-                isPlayingAudio |= session.isPlaying();
+                isPlayingAudio |= session.isPlaying() && session.isAudible();
             }
             break;
         }
@@ -147,7 +147,7 @@ void MediaSessionManagerCocoa::updateSessionState()
         if (!hasAudibleAudioOrVideoMediaType) {
             bool isPotentiallyAudible = session.isPlayingToWirelessPlaybackTarget()
                 || ((type == PlatformMediaSession::MediaType::VideoAudio || type == PlatformMediaSession::MediaType::Audio)
-                    && session.canProduceAudio()
+                    && session.isAudible()
                     && (session.isPlaying() || session.preparingToPlay() || session.hasPlayedAudiblySinceLastInterruption()));
             if (isPotentiallyAudible) {
                 hasAudibleAudioOrVideoMediaType = true;


### PR DESCRIPTION
#### 6cee2aec2971066e4cee5fe286a55dbe5af6ad7c
<pre>
Not audible AudioContext prevents the audio session category to change from play-and-record after stopping capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=253951">https://bugs.webkit.org/show_bug.cgi?id=253951</a>
rdar://problem/106744687

Reviewed by Jer Noble.

We made PlayAndRecord audio session category sticky until audio playing ends.
This ensures that stopping microphone capture will not change the audio level on iOS.
This works well for HTMLMediaElement but not for AudioContext.
Some AudioContexts are used for analysis and are not producing any audio.
We should not delay changing the audio session category if those analytic AudioContexts are running.

For that reason, we introduce PlatformMediaSessionClient::isAudible() to introduce this.
It is somehow similar to canProduceAudio except it does not impact with interruptions.
We might want to merge both in a follow-up.

* LayoutTests/fast/mediastream/audio-session-category-capture-audio-context-expected.txt: Added.
* LayoutTests/fast/mediastream/audio-session-category-capture-audio-context.html: Added.
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::mediaState const):
(WebCore::AudioContext::isAudible const):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::isAudible const):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
(WebCore::PlatformMediaSessionClient::isAudible const):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):

Canonical link: <a href="https://commits.webkit.org/261908@main">https://commits.webkit.org/261908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12220c407bf53d753aebd2656dae7c3cbc57ad8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4645 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121364 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5822 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105954 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46376 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14321 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1194 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10531 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53187 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8324 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16873 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->