### PR TITLE
Rename AbstractFrameView to FrameView

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1235,7 +1235,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/cache/KeepaliveRequestTracker.h
     loader/cache/MemoryCache.h
 
-    page/AbstractFrameView.h
     page/ActivityState.h
     page/ActivityStateChangeObserver.h
     page/AdjustViewSizeOrNot.h
@@ -1282,6 +1281,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/FrameIdentifier.h
     page/FrameSnapshotting.h
     page/FrameTree.h
+    page/FrameView.h
     page/FrameViewLayoutContext.h
     page/GlobalFrameIdentifier.h
     page/GlobalWindowIdentifier.h

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -33,8 +33,8 @@
 
 namespace WebCore {
 
-class AbstractFrameView;
 class DOMWindow;
+class FrameView;
 class HTMLFrameOwnerElement;
 class Page;
 class Settings;
@@ -71,7 +71,7 @@ protected:
 
 private:
     virtual DOMWindow* virtualWindow() const = 0;
-    virtual AbstractFrameView* virtualView() const = 0;
+    virtual FrameView* virtualView() const = 0;
 
     WeakPtr<Page> m_page;
     const FrameIdentifier m_frameID;

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -29,10 +29,10 @@
 
 namespace WebCore {
 
-class AbstractFrameView : public ScrollView {
+class FrameView : public ScrollView {
 public:
-    enum class FrameViewType : bool { Local, Remote };
-    virtual FrameViewType viewType() const = 0;
+    enum class Type : bool { Local, Remote };
+    virtual Type viewType() const = 0;
 };
 
 }

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -914,7 +914,7 @@ DOMWindow* LocalFrame::virtualWindow() const
     return window();
 }
 
-AbstractFrameView* LocalFrame::virtualView() const
+FrameView* LocalFrame::virtualView() const
 {
     return m_view.get();
 }

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -300,7 +300,7 @@ private:
     void frameDetached() final;
     bool preventsParentFromBeingComplete() const final;
 
-    AbstractFrameView* virtualView() const final;
+    FrameView* virtualView() const final;
     DOMWindow* virtualWindow() const final;
 
     HashSet<FrameDestructionObserver*> m_destructionObservers;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -146,7 +146,7 @@
 
 #define PAGE_ID valueOrDefault(m_frame->pageID()).toUInt64()
 #define FRAME_ID m_frame->frameID().object().toUInt64()
-#define FRAMEVIEW_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] FrameView::" fmt, this, PAGE_ID, FRAME_ID, m_frame->isMainFrame(), ##__VA_ARGS__)
+#define FRAMEVIEW_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] LocalFrameView::" fmt, this, PAGE_ID, FRAME_ID, m_frame->isMainFrame(), ##__VA_ARGS__)
 
 namespace WebCore {
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -24,9 +24,9 @@
 
 #pragma once
 
-#include "AbstractFrameView.h"
 #include "AdjustViewSizeOrNot.h"
 #include "Color.h"
+#include "FrameView.h"
 #include "FrameViewLayoutContext.h"
 #include "LayoutMilestone.h"
 #include "LayoutRect.h"
@@ -88,7 +88,7 @@ class View;
 
 Pagination::Mode paginationModeForRenderStyle(const RenderStyle&);
 
-class LocalFrameView final : public AbstractFrameView {
+class LocalFrameView final : public FrameView {
     WTF_MAKE_ISO_ALLOCATED(LocalFrameView);
 public:
     friend class RenderView;
@@ -104,7 +104,7 @@ public:
     
     WEBCORE_EXPORT void invalidateRect(const IntRect&) final;
     void setFrameRect(const IntRect&) final;
-    FrameViewType viewType() const final { return FrameViewType::Local; }
+    Type viewType() const final { return Type::Local; }
 
     // FIXME: This should return Frame. If it were a RemoteFrame, we would have a RemoteFrameView.
     WEBCORE_EXPORT Frame& frame() const;
@@ -1073,6 +1073,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, const LocalFrameView&);
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LocalFrameView)
-static bool isType(const WebCore::AbstractFrameView& view) { return view.viewType() == WebCore::AbstractFrameView::FrameViewType::Local; }
+static bool isType(const WebCore::FrameView& view) { return view.viewType() == WebCore::FrameView::Type::Local; }
 static bool isType(const WebCore::Widget& widget) { return widget.isFrameView(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -83,7 +83,7 @@ bool RemoteFrame::preventsParentFromBeingComplete() const
     return m_preventsParentFromBeingComplete;
 }
 
-AbstractFrameView* RemoteFrame::virtualView() const
+FrameView* RemoteFrame::virtualView() const
 {
     return m_view.get();
 }

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -66,7 +66,7 @@ private:
     void frameDetached() final;
     bool preventsParentFromBeingComplete() const final;
 
-    AbstractFrameView* virtualView() const final;
+    FrameView* virtualView() const final;
     DOMWindow* virtualWindow() const final;
 
     Ref<RemoteDOMWindow> m_window;

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -41,7 +41,7 @@ void RemoteFrameView::setFrameRect(const IntRect& newRect)
     IntRect oldRect = frameRect();
     if (newRect.size() != oldRect.size())
         m_frame->client().sizeDidChange(newRect.size());
-    AbstractFrameView::setFrameRect(newRect);
+    FrameView::setFrameRect(newRect);
 }
 
 // FIXME: Implement all the stubs below.

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -25,17 +25,17 @@
 
 #pragma once
 
-#include "AbstractFrameView.h"
+#include "FrameView.h"
 
 namespace WebCore {
 
 class RemoteFrame;
 
-class RemoteFrameView final : public AbstractFrameView {
+class RemoteFrameView final : public FrameView {
 public:
     static Ref<RemoteFrameView> create(RemoteFrame& frame) { return adoptRef(*new RemoteFrameView(frame)); }
 
-    FrameViewType viewType() const final { return FrameViewType::Remote; }
+    Type viewType() const final { return Type::Remote; }
 private:
     WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);
 
@@ -74,6 +74,6 @@ private:
 }
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::RemoteFrameView)
-static bool isType(const WebCore::AbstractFrameView& view) { return view.viewType() == WebCore::AbstractFrameView::FrameViewType::Remote; }
+static bool isType(const WebCore::FrameView& view) { return view.viewType() == WebCore::FrameView::Type::Remote; }
 static bool isType(const WebCore::Widget& widget) { return widget.isRemoteFrameView(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6229,7 +6229,7 @@ Frame* WebPage::mainFrame() const
     return m_page ? &m_page->mainFrame() : nullptr;
 }
 
-// FIXME: This should return an AbstractFrameView.
+// FIXME: This should return an FrameView.
 LocalFrameView* WebPage::mainFrameView() const
 {
     if (auto* frame = dynamicDowncast<LocalFrame>(mainFrame()))


### PR DESCRIPTION
#### c97ae74f40fd9f8f66734fef57a5972aa18cc695
<pre>
Rename AbstractFrameView to FrameView
<a href="https://bugs.webkit.org/show_bug.cgi?id=253968">https://bugs.webkit.org/show_bug.cgi?id=253968</a>

Reviewed by Darin Adler.

Rename AbstractFrameView to FrameView, now that FrameView was renamed to
LocalFrameView.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameView.h: Renamed from Source/WebCore/page/AbstractFrameView.h.
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::virtualView const):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/page/LocalFrameView.h:
(isType):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::virtualView const):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::setFrameRect):
* Source/WebCore/page/RemoteFrameView.h:
(isType):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:

Canonical link: <a href="https://commits.webkit.org/261701@main">https://commits.webkit.org/261701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ead31f4a093619004d92c9d206fb480e785474a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4384 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12919 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118372 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105680 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/917 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14089 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/963 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14771 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52958 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16611 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4462 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27275 "Passed tests") | 
<!--EWS-Status-Bubble-End-->