### PR TITLE
CSSOM should transform all StyleRule to StyleRuleWithNesting

### DIFF
--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -44,10 +44,16 @@ static SelectorTextCache& selectorTextCache()
 
 CSSStyleRule::CSSStyleRule(StyleRule& styleRule, CSSStyleSheet* parent)
     : CSSRule(parent)
-    , m_styleRule(styleRule)
+    , m_styleRule(StyleRuleWithNesting::create(WTFMove(styleRule)))
     , m_styleMap(DeclaredStylePropertyMap::create(*this))
     , m_childRuleCSSOMWrappers(0)
 {
+    /*
+    volatile int x = 9;
+    if (x)
+        //ASSERT_NOT_REACHED();
+    //return;
+    */
 }
 
 CSSStyleRule::CSSStyleRule(StyleRuleWithNesting& styleRule, CSSStyleSheet* parent)
@@ -130,7 +136,9 @@ void CSSStyleRule::setSelectorText(const String& selectorText)
 Vector<Ref<StyleRuleBase>> CSSStyleRule::nestedRules() const
 {
     if (m_styleRule->isStyleRuleWithNesting())
-        return downcast<StyleRuleWithNesting>(m_styleRule.get()).nestedRules();
+        return m_styleRule->nestedRules();
+
+        //return downcast<StyleRuleWithNesting>(m_styleRule.get()).nestedRules();
 
     return { };
 }
@@ -164,7 +172,13 @@ String CSSStyleRule::cssText() const
 
 void CSSStyleRule::reattach(StyleRuleBase& rule)
 {
-    m_styleRule = downcast<StyleRule>(rule);
+    m_styleRule = downcast<StyleRuleWithNesting>(rule);
+    /*
+    if (rule.isStyleRuleWithNesting())
+    else
+        m_styleRule = downcast<StyleRule>(rule);
+    */
+
     if (m_propertiesCSSOMWrapper)
         m_propertiesCSSOMWrapper->reattach(m_styleRule->mutableProperties());
 }

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -47,7 +47,7 @@ public:
     WEBCORE_EXPORT CSSStyleDeclaration& style();
 
     // FIXME: Not CSSOM. Remove.
-    StyleRule& styleRule() const { return m_styleRule.get(); }
+    StyleRuleWithNesting& styleRule() const { return m_styleRule.get(); }
 
     CSSRuleList& cssRules() const;
     unsigned length() const;
@@ -66,7 +66,7 @@ private:
     String generateSelectorText() const;
     Vector<Ref<StyleRuleBase>> nestedRules() const;
 
-    Ref<StyleRule> m_styleRule;
+    Ref<StyleRuleWithNesting> m_styleRule;
     Ref<DeclaredStylePropertyMap> m_styleMap;
     RefPtr<StyleRuleCSSStyleDeclaration> m_propertiesCSSOMWrapper;
 

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -155,8 +155,9 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSRu
 {
     // FIXME: const_cast is required here because a wrapper for a style rule can be used to *modify* the style rule's selector; use of const in the style system is thus inaccurate.
     auto wrapper = const_cast<StyleRuleBase&>(*this).visitDerived(WTF::makeVisitor(
-        [&](StyleRule& rule) -> Ref<CSSRule> {
-            return CSSStyleRule::create(rule, parentSheet);
+        [&](StyleRule&) -> Ref<CSSRule> {
+            ASSERT_NOT_REACHED();
+            //return CSSStyleRule::create(rule, parentSheet);
         },
         [&](StyleRuleWithNesting& rule) -> Ref<CSSRule> {
             return CSSStyleRule::create(rule, parentSheet);
@@ -317,9 +318,20 @@ Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(Ref<StyleProperties>&& pr
     return adoptRef(* new StyleRuleWithNesting(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(selectors), WTFMove(nestedRules)));
 }
 
+Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(StyleRule&& styleRule)
+{ 
+    return adoptRef(* new StyleRuleWithNesting(WTFMove(styleRule)));
+}
+
 StyleRuleWithNesting::StyleRuleWithNesting(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)
     : StyleRule(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(selectors))
     , m_nestedRules(WTFMove(nestedRules))
+{ 
+    setType(StyleRuleType::StyleWithNesting);
+}
+
+StyleRuleWithNesting::StyleRuleWithNesting(StyleRule&& styleRule)
+    : StyleRule(WTFMove(styleRule))
 { 
     setType(StyleRuleType::StyleWithNesting);
 }
@@ -423,6 +435,11 @@ StyleRuleGroup::StyleRuleGroup(const StyleRuleGroup& other)
 }
 
 const Vector<RefPtr<StyleRuleBase>>& StyleRuleGroup::childRules() const
+{
+    return m_childRules;
+}
+
+Vector<RefPtr<StyleRuleBase>>& StyleRuleGroup::childRules()
 {
     return m_childRules;
 }

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -158,6 +158,7 @@ class StyleRuleWithNesting final : public StyleRule {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleWithNesting);
 public:
     static Ref<StyleRuleWithNesting> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+    static Ref<StyleRuleWithNesting> create(StyleRule&&);
 
     const Vector<Ref<StyleRuleBase>>& nestedRules() const { return m_nestedRules; }
     const CSSSelectorList& resolvedSelectorList() const { return m_resolvedSelectorList; }
@@ -166,6 +167,7 @@ public:
 
 private:
     StyleRuleWithNesting(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+    StyleRuleWithNesting(StyleRule&&);
 
     Vector<Ref<StyleRuleBase>> m_nestedRules;
     mutable CSSSelectorList m_resolvedSelectorList;
@@ -276,6 +278,7 @@ private:
 class StyleRuleGroup : public StyleRuleBase {
 public:
     const Vector<RefPtr<StyleRuleBase>>& childRules() const;
+    Vector<RefPtr<StyleRuleBase>>& childRules();
 
     void wrapperInsertRule(unsigned, Ref<StyleRuleBase>&&);
     void wrapperRemoveRule(unsigned);

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -90,6 +90,7 @@ public:
     bool traverseRules(const Function<bool(const StyleRuleBase&)>& handler) const;
     bool traverseSubresources(const Function<bool(const CachedResource&)>& handler) const;
 
+    void transformStyleRuleToNesting() ;
     void setIsUserStyleSheet(bool b) { m_isUserStyleSheet = b; }
     bool isUserStyleSheet() const { return m_isUserStyleSheet; }
     void setHasSyntacticallyValidCSSHeader(bool b) { m_hasSyntacticallyValidCSSHeader = b; }

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1052,6 +1052,7 @@ void InspectorStyleSheet::reparseStyleSheet(const String& text)
     {
         CSSStyleSheet::RuleMutationScope mutationScope(m_pageStyleSheet.get());
         m_pageStyleSheet->contents().parseString(text);
+        m_pageStyleSheet->contents().transformStyleRuleToNesting();
         m_pageStyleSheet->clearChildRuleCSSOMWrappers();
         fireStyleSheetChanged();
     }


### PR DESCRIPTION
#### 885308bf87be88a46369fedd2fe9f98e635ae5af
<pre>
CSSOM should transform all StyleRule to StyleRuleWithNesting

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::CSSStyleRule):
(WebCore::CSSStyleRule::nestedRules const):
(WebCore::CSSStyleRule::reattach):
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::CSSStyleSheet):
(WebCore::CSSStyleSheet::reattachChildRuleCSSOMWrappers):
(WebCore::CSSStyleSheet::item):
(WebCore::CSSStyleSheet::insertRule):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::createCSSOMWrapper const):
(WebCore::StyleRuleWithNesting::create):
(WebCore::StyleRuleWithNesting::StyleRuleWithNesting):
(WebCore::StyleRuleGroup::childRules):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::transformStyleRuleToNesting):
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheet::reparseStyleSheet):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/885308bf87be88a46369fedd2fe9f98e635ae5af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112600 "5 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21752 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1261 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4376 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121147 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116667 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23093 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12915 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/87/builds/4376 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118368 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/23093 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/90/builds/1261 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105679 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/23093 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/90/builds/1261 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/105679 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14086 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/90/builds/1261 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/105679 "Failed to compile WebKit") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14768 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10318 "1 flakes 2 failures") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20108 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/90/builds/1261 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16608 "Failed to compile WebKit") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->