### PR TITLE
Implement prefers-reduced-transparency media feature

### DIFF
--- a/LayoutTests/fast/media/mq-prefers-reduced-transparency-expected.html
+++ b/LayoutTests/fast/media/mq-prefers-reduced-transparency-expected.html
@@ -1,0 +1,32 @@
+<html>
+<head>
+<title>CSS5 media query test: prefers-reduced-transparency.</title>
+<style type="text/css">
+#a { color: black; }
+#b { color: black; }
+#c { color: black; }
+#d { color: black; }
+</style>
+<script>
+window.addEventListener("load", function () {
+
+    if (!window.internals) {
+        ["a", "b", "c", "d"].forEach(id => { document.getElementById(id).textContent = "This expected result requires DRT/WKTR."; });
+        return;
+    }
+
+    if (window.internals.userPrefersReducedTransparency())
+        ["a", "b", "c"].forEach(id => { document.getElementById(id).style.color = "green"; });
+    else
+        document.getElementById("d").style.color = "green";
+
+}, false);
+</script>
+</head>
+<body>
+  <p id="a">This text should be green if the user requested reduced transparency. Black otherwise.</p>
+  <p id="b">This text should be green if the user requested reduced transparency. Black otherwise.</p>
+  <p id="c">This text should be green if the user requested reduced transparency. Black otherwise.</p>
+  <p id="d">This text should be green if the user has not requested reduced transparency. Black otherwise.</p>
+</body>
+</html>

--- a/LayoutTests/fast/media/mq-prefers-reduced-transparency-forced-value-expected.html
+++ b/LayoutTests/fast/media/mq-prefers-reduced-transparency-forced-value-expected.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<title>CSS5 media query test: prefers-reduced-transparency.</title>
+<style type="text/css">
+p { color: green; }
+</style>
+</head>
+<body>
+  <p id="a">This text should be green.</p>
+  <p id="b">This text should be green.</p>
+  <p id="c">This text should be green.</p>
+  <p id="d">This text should be green.</p>
+</body>
+</html>

--- a/LayoutTests/fast/media/mq-prefers-reduced-transparency-forced-value.html
+++ b/LayoutTests/fast/media/mq-prefers-reduced-transparency-forced-value.html
@@ -1,0 +1,32 @@
+<html>
+<head>
+<title>CSS5 media query test: prefers-reduced-transparency.</title>
+<style type="text/css">
+p { color: black; }
+</style>
+<script>
+window.addEventListener("load", function () {
+    if (!window.internals)
+        return;
+
+    window.internals.settings.forcedPrefersReducedTransparencyAccessibilityValue = "on";
+    if (window.matchMedia("(prefers-reduced-transparency)").matches)
+        document.getElementById("a").style.color = "green";
+    if (window.matchMedia("(prefers-reduced-transparency: reduce)").matches)
+        document.getElementById("b").style.color = "green";
+
+    window.internals.settings.forcedPrefersReducedTransparencyAccessibilityValue = "off";
+    if (!window.matchMedia("(prefers-reduced-transparency)").matches)
+        document.getElementById("c").style.color = "green";
+    if (window.matchMedia("(prefers-reduced-transparency: no-preference)").matches)
+        document.getElementById("d").style.color = "green";
+}, false);
+</script>
+</head>
+<body>
+  <p id="a">This text should be green.</p>
+  <p id="b">This text should be green.</p>
+  <p id="c">This text should be green.</p>
+  <p id="d">This text should be green.</p>
+</body>
+</html>

--- a/LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update-expected.html
+++ b/LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update-expected.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<title>CSS5 media query test: prefers-reduced-transparency.</title>
+<style type="text/css">
+p { color: black; }
+#a { color: green; }
+</style>
+</head>
+<body>
+  <p id="a"></p>
+  <p>Before was: rgb(0, 0, 0) - should be rgb(0, 0, 0)</p>
+  <p>After was: rgb(0, 128, 0) - should be rgb(0, 128, 0)</p>
+</body>
+</html>

--- a/LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update-for-listener-expected.txt
+++ b/LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update-for-listener-expected.txt
@@ -1,0 +1,11 @@
+This tests listeners on MediaQueryList get called when reduce transparency is turned on when there are no relevant style rules
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didCallListener is true
+PASS matchMedia("(prefers-reduced-transparency)").matches is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update-for-listener.html
+++ b/LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update-for-listener.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests listeners on MediaQueryList get called when reduce transparency is turned on when there are no relevant style rules');
+
+jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+let didCallListener = false;
+let timer;
+
+window.onload = () => {
+    window.matchMedia('(prefers-reduced-transparency)').addListener((e) => {
+        didCallListener = true;
+    });
+
+    if (!window.internals || !testRunner.runUIScript) {
+        testFailed('This test requires runUIScript');
+        finishJSTest();
+        return;
+    }
+
+    requestAnimationFrame(async () => {
+        window.internals.settings.forcedPrefersReducedTransparencyAccessibilityValue = "on";
+        await new Promise(resolve => {
+            testRunner.runUIScript(`
+                uiController.simulateAccessibilitySettingsChangeNotification(() => {
+                    uiController.uiScriptComplete();
+                });`, resolve);
+        });
+
+        if (didCallListener)
+            finalize();
+        else
+            timer = setTimeout(finalize, 1000);
+    });
+}
+
+function finalize() {
+    if (timer)
+        clearTimeout(timer);
+
+    shouldBeTrue('didCallListener');
+    shouldBeTrue('matchMedia("(prefers-reduced-transparency)").matches');
+    finishJSTest();
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update.html
+++ b/LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update.html
@@ -1,0 +1,50 @@
+<html>
+<head>
+<title>CSS5 media query test: prefers-reduced-transparency.</title>
+<style type="text/css">
+p { color: black; }
+
+@media (prefers-reduced-transparency) {
+    #a { color: green; }
+}
+</style>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function getUIScript()
+{
+    return `
+    (function() {
+        uiController.simulateAccessibilitySettingsChangeNotification(function() {
+            uiController.uiScriptComplete("Done");
+        });
+    })();`
+}
+
+function runTest()
+{
+    if (!window.internals)
+        return;
+
+    var element = document.getElementById("a");
+
+    window.internals.settings.forcedPrefersReducedTransparencyAccessibilityValue = "on";
+    document.getElementById("before").textContent = window.getComputedStyle(element).color;
+    if (testRunner.runUIScript) {
+        testRunner.runUIScript(getUIScript(), function(result) {
+            document.getElementById("after").textContent = window.getComputedStyle(element).color;
+            testRunner.notifyDone();
+        });
+    }
+}
+
+window.addEventListener("load", runTest, false);
+</script>
+</head>
+<body>
+  <p id="a"></p>
+  <p>Before was: <span id="before"></span> - should be rgb(0, 0, 0)</p>
+  <p>After was: <span id="after"></span> - should be rgb(0, 128, 0)</p>
+</body>
+</html>

--- a/LayoutTests/fast/media/mq-prefers-reduced-transparency-matchMedia-expected.txt
+++ b/LayoutTests/fast/media/mq-prefers-reduced-transparency-matchMedia-expected.txt
@@ -1,0 +1,5 @@
+Initial value of transparencyQuery.matches: false - should be false
+
+Updated value of transparencyQuery.matches: true - should be true
+
+Note the updated value will only be filled if the listener fires.

--- a/LayoutTests/fast/media/mq-prefers-reduced-transparency-matchMedia.html
+++ b/LayoutTests/fast/media/mq-prefers-reduced-transparency-matchMedia.html
@@ -1,0 +1,51 @@
+<html>
+<head>
+<title>CSS5 media query test: prefers-reduced-transparency using matchMedia and addListener.</title>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function runTest()
+{
+    if (!window.internals)
+        return;
+
+    var transparencyQuery = window.matchMedia("(prefers-reduced-transparency)");
+    transparencyQuery.addListener(() => {
+        document.getElementById("after").textContent = transparencyQuery.matches ? "true" : "false";
+        queryFired = true;
+        checkDone();
+    });
+
+    document.getElementById("before").textContent = transparencyQuery.matches ? "true" : "false";
+    window.internals.settings.forcedPrefersReducedTransparencyAccessibilityValue = "on";
+    testRunner.runUIScript(`
+        (function() {
+            uiController.simulateAccessibilitySettingsChangeNotification(function() {
+                uiController.uiScriptComplete("Done");
+            });
+        })();`, function (result) {
+            scriptRan = true;
+            checkDone();
+        });
+}
+
+let queryFired = false;
+let scriptRan = false;
+
+function checkDone() {
+    if (queryFired && scriptRan)
+        testRunner.notifyDone();
+}
+
+window.addEventListener("load", runTest, false);
+</script>
+</head>
+<body>
+  <p>Initial value of transparencyQuery.matches: <span id="before">unknown</span> - should be false</p>
+  <p>Updated value of transparencyQuery.matches: <span id="after">unknown</span> - should be true</p>
+  <p>Note the updated value will only be filled if the listener fires.</p>
+</body>
+</html>

--- a/LayoutTests/fast/media/mq-prefers-reduced-transparency.html
+++ b/LayoutTests/fast/media/mq-prefers-reduced-transparency.html
@@ -1,0 +1,35 @@
+<html>
+<head>
+<title>CSS5 media query test: prefers-reduced-transparency.</title>
+<style type="text/css">
+#a { color: black; }
+#b { color: black; }
+#c { color: black; }
+#d { color: black; }
+
+@media (prefers-reduced-transparency) {
+#a { color: green; }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+#b { color: green; }
+}
+
+@media (prefers-reduced-transparency: no-preference) {
+#d { color: green; }
+}
+</style>
+<script>
+window.addEventListener("load", function () {
+    if (window.matchMedia("(prefers-reduced-transparency)").matches)
+        document.getElementById("c").style.color = "green";
+}, false);
+</script>
+</head>
+<body>
+  <p id="a">This text should be green if the user requested reduced transparency. Black otherwise.</p>
+  <p id="b">This text should be green if the user requested reduced transparency. Black otherwise.</p>
+  <p id="c">This text should be green if the user requested reduced transparency. Black otherwise.</p>
+  <p id="d">This text should be green if the user has not requested reduced transparency. Black otherwise.</p>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-reduced-transparency-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-reduced-transparency-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Should be known: '(prefers-reduced-transparency)' assert_true: expected true got false
-FAIL Should be known: '(prefers-reduced-transparency: no-preference)' assert_true: expected true got false
-FAIL Should be known: '(prefers-reduced-transparency: reduce)' assert_true: expected true got false
+PASS Should be known: '(prefers-reduced-transparency)'
+PASS Should be known: '(prefers-reduced-transparency: no-preference)'
+PASS Should be known: '(prefers-reduced-transparency: reduce)'
 PASS Should be parseable: '(prefers-reduced-transparency: 0)'
 PASS Should be unknown: '(prefers-reduced-transparency: 0)'
 PASS Should be parseable: '(prefers-reduced-transparency: none)'
@@ -14,6 +14,6 @@ PASS Should be parseable: '(prefers-reduced-transparency: reduced)'
 PASS Should be unknown: '(prefers-reduced-transparency: reduced)'
 PASS Should be parseable: '(prefers-reduced-transparency: no-preference/reduce)'
 PASS Should be unknown: '(prefers-reduced-transparency: no-preference/reduce)'
-FAIL Check that no-preference evaluates to false in the boolean context assert_equals: expected true but got false
+PASS Check that no-preference evaluates to false in the boolean context
 PASS Check that invalid evaluates to false
 

--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -35,7 +35,7 @@
         {
             "id": "UserPreferenceName",
             "type": "string",
-            "enum": ["PrefersReducedMotion", "PrefersContrast", "PrefersColorScheme"],
+            "enum": ["PrefersReducedMotion", "PrefersContrast", "PrefersColorScheme", "PrefersReducedTransparency"],
             "description": "User preference name."
         },
         {

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1196,6 +1196,20 @@ CSSPaintingAPIEnabled:
     WebCore:
       default: false
 
+CSSPrefersReducedTransparencyEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS prefers-reduced-transparency media query"
+  humanReadableDescription: "Enable the CSS prefers-reduced-transparency media query"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSRelativeColorSyntaxEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/PAL/pal/ios/UIKitSoftLink.h
+++ b/Source/WebCore/PAL/pal/ios/UIKitSoftLink.h
@@ -75,6 +75,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityIsReduceMotionEnabled, 
 #define UIAccessibilityIsReduceMotionEnabled PAL::softLink_UIKit_UIAccessibilityIsReduceMotionEnabled
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityDarkerSystemColorsEnabled, BOOL, (void), ())
 #define UIAccessibilityDarkerSystemColorsEnabled PAL::softLink_UIKit_UIAccessibilityDarkerSystemColorsEnabled
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityIsReduceTransparencyEnabled, BOOL, (void), ())
+#define UIAccessibilityIsReduceTransparencyEnabled PAL::softLink_UIKit_UIAccessibilityIsReduceTransparencyEnabled
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIAccessibilityPostNotification, void, (UIAccessibilityNotifications n, id argument), (n, argument))
 #define UIAccessibilityPostNotification PAL::softLink_UIKit_UIAccessibilityPostNotification
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, UIKit, UIGraphicsGetCurrentContext, CGContextRef, (void), ())

--- a/Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm
+++ b/Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm
@@ -70,6 +70,7 @@ SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIAccessibilityIsGrayscaleEnabled, BOO
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIAccessibilityIsInvertColorsEnabled, BOOL, (void), ())
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, UIKit, UIAccessibilityIsReduceMotionEnabled, BOOL, (void), (), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, UIKit, UIAccessibilityDarkerSystemColorsEnabled, BOOL, (void), (), PAL_EXPORT)
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, UIKit, UIAccessibilityIsReduceTransparencyEnabled, BOOL, (void), (), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIAccessibilityPostNotification, void, (UIAccessibilityNotifications n, id argument), (n, argument))
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIGraphicsGetCurrentContext, CGContextRef, (void), ())
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, UIKit, UIGraphicsPopContext, void, (void), ())

--- a/Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h
@@ -149,6 +149,8 @@ void _AXSetClientIdentificationOverride(AXClientType);
 
 extern CFStringRef kAXInterfaceReduceMotionKey;
 extern CFStringRef kAXInterfaceReduceMotionStatusDidChangeNotification;
+extern CFStringRef kAXInterfaceReduceTransparencyKey;
+extern CFStringRef kAXInterfaceReduceTransparencyStatusDidChangeNotification;
 
 extern CFStringRef kAXInterfaceIncreaseContrastKey;
 

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1586,6 +1586,7 @@ prefers
 // no-preference
 
 // prefers-reduced-motion
+// prefers-reduced-transparency
 reduce
 no-preference
 

--- a/Source/WebCore/css/MediaQueryParserContext.cpp
+++ b/Source/WebCore/css/MediaQueryParserContext.cpp
@@ -34,12 +34,14 @@ namespace WebCore {
     
 MediaQueryParserContext::MediaQueryParserContext(const CSSParserContext& context)
     : useSystemAppearance(context.useSystemAppearance)
+    , cssPrefersReducedTransparencyEnabled(context.cssPrefersReducedTransparencyEnabled)
     , mode(context.mode)
 {
 }
 
 MediaQueryParserContext::MediaQueryParserContext(const Document& document)
     : useSystemAppearance(document.page() && document.page()->useSystemAppearance())
+    , cssPrefersReducedTransparencyEnabled(document.settings().cssPrefersReducedTransparencyEnabled())
 {
 }
 

--- a/Source/WebCore/css/MediaQueryParserContext.h
+++ b/Source/WebCore/css/MediaQueryParserContext.h
@@ -39,6 +39,7 @@ public:
     WEBCORE_EXPORT MediaQueryParserContext(const Document&);
 
     bool useSystemAppearance { false };
+    bool cssPrefersReducedTransparencyEnabled { false };
     CSSParserMode mode { HTMLStandardMode };
 };
     

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -101,6 +101,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
 #if ENABLE(CSS_PAINTING_API)
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
 #endif
+    , cssPrefersReducedTransparencyEnabled { document.settings().cssPrefersReducedTransparencyEnabled() }
     , cssTextUnderlinePositionLeftRightEnabled { document.settings().cssTextUnderlinePositionLeftRightEnabled() }
     , cssTextWrapNewValuesEnabled { document.settings().cssTextWrapNewValuesEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
@@ -139,6 +140,7 @@ bool operator==(const CSSParserContext& a, const CSSParserContext& b)
         && a.masonryEnabled == b.masonryEnabled
         && a.cssNestingEnabled == b.cssNestingEnabled
         && a.cssPaintingAPIEnabled == b.cssPaintingAPIEnabled
+        && a.cssPrefersReducedTransparencyEnabled == b.cssPrefersReducedTransparencyEnabled
         && a.cssTextUnderlinePositionLeftRightEnabled == b.cssTextUnderlinePositionLeftRightEnabled
         && a.cssTextWrapNewValuesEnabled == b.cssTextWrapNewValuesEnabled
         && a.propertySettings == b.propertySettings
@@ -171,9 +173,10 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.masonryEnabled                            << 19
         | context.cssNestingEnabled                         << 20
         | context.cssPaintingAPIEnabled                     << 21
-        | context.cssTextUnderlinePositionLeftRightEnabled  << 22
-        | context.cssTextWrapNewValuesEnabled               << 23
-        | (uint64_t)context.mode                            << 24; // This is multiple bits, so keep it last.
+        | context.cssPrefersReducedTransparencyEnabled      << 22
+        | context.cssTextUnderlinePositionLeftRightEnabled  << 23
+        | context.cssTextWrapNewValuesEnabled               << 24
+        | (uint64_t)context.mode                            << 25; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -93,6 +93,7 @@ struct CSSParserContext {
     bool masonryEnabled { false };
     bool cssNestingEnabled { false };
     bool cssPaintingAPIEnabled { false };
+    bool cssPrefersReducedTransparencyEnabled { false };
     bool cssTextUnderlinePositionLeftRightEnabled { false };
     bool cssTextWrapNewValuesEnabled { false };
 

--- a/Source/WebCore/css/query/MediaQueryFeatures.h
+++ b/Source/WebCore/css/query/MediaQueryFeatures.h
@@ -55,6 +55,7 @@ const FeatureSchema& pointer();
 const FeatureSchema& prefersContrast();
 const FeatureSchema& prefersDarkInterface();
 const FeatureSchema& prefersReducedMotion();
+const FeatureSchema& prefersReducedTransparency();
 const FeatureSchema& resolution();
 const FeatureSchema& scan();
 const FeatureSchema& scripting();

--- a/Source/WebCore/css/query/MediaQueryParser.cpp
+++ b/Source/WebCore/css/query/MediaQueryParser.cpp
@@ -190,6 +190,9 @@ const FeatureSchema* MediaQueryParser::schemaForFeatureName(const AtomString& na
     if (schema == &Features::prefersDarkInterface()) {
         if (!m_context.useSystemAppearance && !isUASheetBehavior(m_context.mode))
             return nullptr;
+    } else if (schema == &Features::prefersReducedTransparency()) {
+        if (!m_context.cssPrefersReducedTransparencyEnabled)
+            return nullptr;
     }
     
     return schema;

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -159,6 +159,7 @@ private:
     static bool dataContent(const uint8_t* data, unsigned size, const String& textEncodingName, bool withBase64Encode, String* result);
 
     void overridePrefersReducedMotion(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
+    void overridePrefersReducedTransparency(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersContrast(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersColorScheme(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
 

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -172,6 +172,13 @@ ForcedPrefersReducedMotionAccessibilityValue:
     WebCore:
       default: ForcedAccessibilityValue::System
 
+ForcedPrefersReducedTransparencyAccessibilityValue:
+  type: uint32_t
+  refinedType: ForcedAccessibilityValue
+  defaultValue:
+    WebCore:
+      default: ForcedAccessibilityValue::System
+
 ForcedSupportsHighDynamicRangeValue:
   type: uint32_t
   refinedType: ForcedAccessibilityValue

--- a/Source/WebCore/platform/Theme.cpp
+++ b/Source/WebCore/platform/Theme.cpp
@@ -89,6 +89,10 @@ bool Theme::userPrefersContrast() const
     return false;
 }
 
+bool Theme::userPrefersReducedTransparency() const
+{
+    return false;
+}
 
 LengthBox Theme::controlBorder(StyleAppearance appearance, const FontCascade&, const LengthBox& zoomedBox, float) const
 {

--- a/Source/WebCore/platform/Theme.h
+++ b/Source/WebCore/platform/Theme.h
@@ -83,6 +83,7 @@ public:
 
     virtual bool userPrefersContrast() const;
     virtual bool userPrefersReducedMotion() const;
+    virtual bool userPrefersReducedTransparency() const;
 
 protected:
     Theme() = default;

--- a/Source/WebCore/platform/ios/ThemeIOS.h
+++ b/Source/WebCore/platform/ios/ThemeIOS.h
@@ -35,6 +35,7 @@ class ThemeIOS final : public ThemeCocoa {
 private:
     bool userPrefersReducedMotion() const final;
     bool userPrefersContrast() const final;
+    bool userPrefersReducedTransparency() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/ThemeIOS.mm
+++ b/Source/WebCore/platform/ios/ThemeIOS.mm
@@ -49,6 +49,11 @@ bool ThemeIOS::userPrefersContrast() const
     return PAL::softLink_UIKit_UIAccessibilityDarkerSystemColorsEnabled();
 }
 
+bool ThemeIOS::userPrefersReducedTransparency() const
+{
+    return PAL::softLink_UIKit_UIAccessibilityIsReduceTransparencyEnabled();
+}
+
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/mac/ThemeMac.h
+++ b/Source/WebCore/platform/mac/ThemeMac.h
@@ -60,6 +60,7 @@ private:
 
     bool userPrefersReducedMotion() const final;
     bool userPrefersContrast() const final;
+    bool userPrefersReducedTransparency() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -676,6 +676,11 @@ bool ThemeMac::userPrefersContrast() const
     return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast];
 }
 
+bool ThemeMac::userPrefersReducedTransparency() const
+{
+    return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceTransparency];
+}
+
 bool ThemeMac::supportsLargeFormControls()
 {
     static bool hasSupport = [[NSAppearance currentDrawingAppearance] _usesMetricsAppearance];

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -58,6 +58,7 @@ InternalSettings::Backup::Backup(Settings& settings)
     , m_forcedDisplayIsMonochromeAccessibilityValue(settings.forcedDisplayIsMonochromeAccessibilityValue())
     , m_forcedPrefersContrastAccessibilityValue(settings.forcedPrefersContrastAccessibilityValue())
     , m_forcedPrefersReducedMotionAccessibilityValue(settings.forcedPrefersReducedMotionAccessibilityValue())
+    , m_forcedPrefersReducedTransparencyAccessibilityValue(settings.forcedPrefersReducedTransparencyAccessibilityValue())
     , m_fontLoadTimingOverride(settings.fontLoadTimingOverride())
     , m_fetchAPIKeepAliveAPIEnabled(DeprecatedGlobalSettings::fetchAPIKeepAliveEnabled())
     , m_customPasteboardDataEnabled(DeprecatedGlobalSettings::customPasteboardDataEnabled())
@@ -111,6 +112,7 @@ void InternalSettings::Backup::restoreTo(Settings& settings)
     settings.setForcedDisplayIsMonochromeAccessibilityValue(m_forcedDisplayIsMonochromeAccessibilityValue);
     settings.setForcedPrefersContrastAccessibilityValue(m_forcedPrefersContrastAccessibilityValue);
     settings.setForcedPrefersReducedMotionAccessibilityValue(m_forcedPrefersReducedMotionAccessibilityValue);
+    settings.setForcedPrefersReducedTransparencyAccessibilityValue(m_forcedPrefersReducedTransparencyAccessibilityValue);
     settings.setFontLoadTimingOverride(m_fontLoadTimingOverride);
 
     DeprecatedGlobalSettings::setFetchAPIKeepAliveEnabled(m_fetchAPIKeepAliveAPIEnabled);
@@ -395,6 +397,16 @@ InternalSettings::ForcedAccessibilityValue InternalSettings::forcedPrefersReduce
 void InternalSettings::setForcedPrefersReducedMotionAccessibilityValue(InternalSettings::ForcedAccessibilityValue value)
 {
     settings().setForcedPrefersReducedMotionAccessibilityValue(value);
+}
+
+InternalSettings::ForcedAccessibilityValue InternalSettings::forcedPrefersReducedTransparencyAccessibilityValue() const
+{
+    return settings().forcedPrefersReducedTransparencyAccessibilityValue();
+}
+
+void InternalSettings::setForcedPrefersReducedTransparencyAccessibilityValue(InternalSettings::ForcedAccessibilityValue value)
+{
+    settings().setForcedPrefersReducedTransparencyAccessibilityValue(value);
 }
 
 InternalSettings::ForcedAccessibilityValue InternalSettings::forcedSupportsHighDynamicRangeValue() const

--- a/Source/WebCore/testing/InternalSettings.h
+++ b/Source/WebCore/testing/InternalSettings.h
@@ -80,6 +80,8 @@ public:
     void setForcedPrefersContrastAccessibilityValue(ForcedAccessibilityValue);
     ForcedAccessibilityValue forcedPrefersReducedMotionAccessibilityValue() const;
     void setForcedPrefersReducedMotionAccessibilityValue(ForcedAccessibilityValue);
+    ForcedAccessibilityValue forcedPrefersReducedTransparencyAccessibilityValue() const;
+    void setForcedPrefersReducedTransparencyAccessibilityValue(ForcedAccessibilityValue);
     ForcedAccessibilityValue forcedSupportsHighDynamicRangeValue() const;
     void setForcedSupportsHighDynamicRangeValue(ForcedAccessibilityValue);
 
@@ -153,6 +155,7 @@ private:
         WebCore::ForcedAccessibilityValue m_forcedDisplayIsMonochromeAccessibilityValue;
         WebCore::ForcedAccessibilityValue m_forcedPrefersContrastAccessibilityValue;
         WebCore::ForcedAccessibilityValue m_forcedPrefersReducedMotionAccessibilityValue;
+        WebCore::ForcedAccessibilityValue m_forcedPrefersReducedTransparencyAccessibilityValue;
         WebCore::FontLoadTimingOverride m_fontLoadTimingOverride;
 
         // DeprecatedGlobalSettings

--- a/Source/WebCore/testing/InternalSettings.idl
+++ b/Source/WebCore/testing/InternalSettings.idl
@@ -58,6 +58,7 @@ enum UserInterfaceDirectionPolicy { "Content", "System" };
     attribute ForcedAccessibilityValue forcedDisplayIsMonochromeAccessibilityValue;
     attribute ForcedAccessibilityValue forcedPrefersContrastAccessibilityValue;
     attribute ForcedAccessibilityValue forcedPrefersReducedMotionAccessibilityValue;
+    attribute ForcedAccessibilityValue forcedPrefersReducedTransparencyAccessibilityValue;
     attribute ForcedAccessibilityValue forcedSupportsHighDynamicRangeValue;
 
     // DeprecatedGlobalSettings.

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5428,6 +5428,11 @@ bool Internals::userPrefersReducedMotion() const
     return false;
 }
 
+bool Internals::userPrefersReducedTransparency() const
+{
+    return false;
+}
+
 bool Internals::userPrefersContrast() const
 {
     return false;

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -872,6 +872,7 @@ public:
 
     bool userPrefersContrast() const;
     bool userPrefersReducedMotion() const;
+    bool userPrefersReducedTransparency() const;
 
     void reportBacktrace();
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -945,6 +945,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     boolean userPrefersContrast();
     boolean userPrefersReducedMotion();
+    boolean userPrefersReducedTransparency();
 
     undefined reportBacktrace();
 

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -116,6 +116,15 @@ bool Internals::userPrefersReducedMotion() const
 #endif
 }
 
+bool Internals::userPrefersReducedTransparency() const
+{
+#if PLATFORM(IOS_FAMILY)
+    return PAL::softLink_UIKit_UIAccessibilityIsReduceTransparencyEnabled();
+#else
+    return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceTransparency];
+#endif
+}
+
 #if PLATFORM(MAC)
 
 ExceptionOr<RefPtr<Range>> Internals::rangeForDictionaryLookupAtLocation(int x, int y)

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1291,6 +1291,8 @@ localizedStrings["Redirect Response"] = "Redirect Response";
 localizedStrings["Redirects"] = "Redirects";
 /* Label for input to override the preference for reduced motion. */
 localizedStrings["Reduce motion @ User Preferences Overrides"] = "Reduce motion";
+/* Label for input to override the preference for reduced transparency. */
+localizedStrings["Reduce transparency @ User Preferences Overrides"] = "Reduce transparency";
 localizedStrings["Reduction"] = "Reduction";
 localizedStrings["Reference Issue"] = "Reference Issue";
 localizedStrings["Reflection"] = "Reflection";

--- a/Source/WebInspectorUI/UserInterface/Views/CodeMirrorAdditions.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CodeMirrorAdditions.js
@@ -281,6 +281,9 @@
                     case "prefers-reduced-motion":
                     case     "reduce":
                     case     "no-preference":
+                    case "prefers-reduced-transparency":
+                    case     "reduce":
+                    case     "no-preference":
                     case "inverted-colors":
                     case     "inverted":
                     case "color-gamut":

--- a/Source/WebInspectorUI/UserInterface/Views/OverrideUserPreferencesPopover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OverrideUserPreferencesPopover.js
@@ -86,7 +86,7 @@ WI.OverrideUserPreferencesPopover = class OverrideUserPreferencesPopover extends
             });
         }
 
-        if (InspectorBackend.Enum.Page?.UserPreferenceName?.PrefersReducedMotion || InspectorBackend.Enum.Page?.UserPreferenceName?.PrefersContrast) {
+        if (InspectorBackend.Enum.Page?.UserPreferenceName?.PrefersReducedMotion || InspectorBackend.Enum.Page?.UserPreferenceName?.PrefersContrast || InspectorBackend.Enum.Page?.UserPreferenceName?.PrefersReducedTransparency) {
             let accessibilityHeader = contentElement.appendChild(document.createElement("h1"));
             accessibilityHeader.textContent = WI.UIString("Accessibility", "Accessibility @ User Preferences Overrides", "Header for section with accessibility user preferences.");
         }
@@ -110,6 +110,17 @@ WI.OverrideUserPreferencesPopover = class OverrideUserPreferencesPopover extends
                 label: WI.UIString("Increase contrast", "Increase contrast @ User Preferences Overrides", "Label for input to override the preference for high contrast."),
                 preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.PrefersContrast,
                 preferenceValues: [InspectorBackend.Enum.Page.UserPreferenceValue.More, InspectorBackend.Enum.Page.UserPreferenceValue.NoPreference],
+                defaultValue: WI.CSSManager.UserPreferenceDefaultValue,
+            });
+
+        // COMPATIBILITY (macOS 13.0, iOS 16.0): `PrefersReducedTransparency` value for `Page.UserPreferenceName` did not exist yet.
+        if (InspectorBackend.Enum.Page?.UserPreferenceName?.PrefersReducedTransparency)
+            this._createSelectElement({
+                contentElement,
+                id: "override-prefers-reduced-transparency",
+                label: WI.UIString("Reduce transparency", "Reduce transparency @ User Preferences Overrides", "Label for input to override the preference for reduced transparency."),
+                preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.PrefersReducedTransparency,
+                preferenceValues: [InspectorBackend.Enum.Page.UserPreferenceValue.Reduce, InspectorBackend.Enum.Page.UserPreferenceValue.NoPreference],
                 defaultValue: WI.CSSManager.UserPreferenceDefaultValue,
             });
 

--- a/Source/WebKit/Platform/spi/Cocoa/AccessibilitySupportSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AccessibilitySupportSPI.h
@@ -41,6 +41,7 @@ typedef enum {
 WTF_EXTERN_C_BEGIN
 
 void _AXSSetReduceMotionEnabled(Boolean enabled);
+void _AXSSetReduceTransparencyEnabled(Boolean enabled);
 void _AXSSetDarkenSystemColors(Boolean enabled);
 Boolean _AXSKeyRepeatEnabled();
 Boolean _AXSApplicationAccessibilityEnabled();
@@ -48,14 +49,17 @@ void _AXSApplicationAccessibilitySetEnabled(Boolean enabled);
 extern CFStringRef kAXSApplicationAccessibilityEnabledNotification;
 
 extern CFStringRef kAXSReduceMotionPreference;
+extern CFStringRef kAXSReduceTransparencyPreference;
 
 extern CFStringRef kAXSReduceMotionChangedNotification;
+extern CFStringRef kAXSReduceTransparencyChangedNotification;
 extern CFStringRef kAXSIncreaseButtonLegibilityNotification;
 extern CFStringRef kAXSEnhanceTextLegibilityChangedNotification;
 extern CFStringRef kAXSDarkenSystemColorsEnabledNotification;
 extern CFStringRef kAXSInvertColorsEnabledNotification;
 
 AXValueState _AXSReduceMotionEnabledApp(CFStringRef appID);
+AXValueState _AXSReduceTransparencyEnabledApp(CFStringRef appID);
 AXValueState _AXSIncreaseButtonLegibilityApp(CFStringRef appID);
 AXValueState _AXSEnhanceTextLegibilityEnabledApp(CFStringRef appID);
 AXValueState _AXDarkenSystemColorsApp(CFStringRef appID);
@@ -63,6 +67,7 @@ AXValueState _AXSInvertColorsEnabledApp(CFStringRef appID);
 Boolean _AXSEnhanceTextLegibilityEnabled();
 
 void _AXSSetReduceMotionEnabledApp(AXValueState enabled, CFStringRef appID);
+void _AXSSetReduceTransparencyEnabledApp(AXValueState enabled, CFStringRef appID);
 void _AXSSetIncreaseButtonLegibilityApp(AXValueState enabled, CFStringRef appID);
 void _AXSSetEnhanceTextLegibilityEnabledApp(AXValueState enabled, CFStringRef appID);
 void _AXSSetDarkenSystemColorsApp(AXValueState enabled, CFStringRef appID);

--- a/Source/WebKit/Shared/AccessibilityPreferences.cpp
+++ b/Source/WebKit/Shared/AccessibilityPreferences.cpp
@@ -32,6 +32,7 @@ void ArgumentCoder<WebKit::AccessibilityPreferences>::encode(Encoder& encoder, c
 {
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
     encoder << preferences.reduceMotionEnabled;
+    encoder << preferences.reduceTransparencyEnabled;
     encoder << preferences.increaseButtonLegibility;
     encoder << preferences.enhanceTextLegibility;
     encoder << preferences.darkenSystemColors;
@@ -46,6 +47,8 @@ std::optional<WebKit::AccessibilityPreferences> ArgumentCoder<WebKit::Accessibil
     WebKit::AccessibilityPreferences preferences;
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
     if (!decoder.decode(preferences.reduceMotionEnabled))
+        return std::nullopt;
+    if (!decoder.decode(preferences.reduceTransparencyEnabled))
         return std::nullopt;
     if (!decoder.decode(preferences.increaseButtonLegibility))
         return std::nullopt;

--- a/Source/WebKit/Shared/AccessibilityPreferences.h
+++ b/Source/WebKit/Shared/AccessibilityPreferences.h
@@ -36,6 +36,7 @@ namespace WebKit {
 struct AccessibilityPreferences {
 #if HAVE(PER_APP_ACCESSIBILITY_PREFERENCES)
     AXValueState reduceMotionEnabled { AXValueStateEmpty };
+    AXValueState reduceTransparencyEnabled { AXValueStateEmpty };
     AXValueState increaseButtonLegibility { AXValueStateEmpty };
     AXValueState enhanceTextLegibility { AXValueStateEmpty };
     AXValueState darkenSystemColors { AXValueStateEmpty };

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -224,6 +224,10 @@ static void handleAXPreferenceChange(const String& domain, const String& key, id
         // these methods need to be called directly.
         if (CFEqual(key.createCFString().get(), kAXSReduceMotionPreference) && [value isKindOfClass:[NSNumber class]])
             _AXSSetReduceMotionEnabled([(NSNumber *)value boolValue]);
+#if PLATFORM(IOS)
+        else if (CFEqual(key.createCFString().get(), kAXSReduceTransparencyPreference) && [value isKindOfClass:[NSNumber class]])
+            _AXSSetReduceTransparencyEnabled([(NSNumber *)value boolValue]);
+#endif
         else if (CFEqual(key.createCFString().get(), increaseContrastPreferenceKey()) && [value isKindOfClass:[NSNumber class]])
             _AXSSetDarkenSystemColors([(NSNumber *)value boolValue]);
 #endif

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -216,6 +216,7 @@ static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfac
     [center addObserver:self selector:@selector(_accessibilitySettingsDidChange:) name:UIAccessibilityGrayscaleStatusDidChangeNotification object:nil];
     [center addObserver:self selector:@selector(_accessibilitySettingsDidChange:) name:UIAccessibilityInvertColorsStatusDidChangeNotification object:nil];
     [center addObserver:self selector:@selector(_accessibilitySettingsDidChange:) name:UIAccessibilityReduceMotionStatusDidChangeNotification object:nil];
+    [center addObserver:self selector:@selector(_accessibilitySettingsDidChange:) name:UIAccessibilityReduceTransparencyStatusDidChangeNotification object:nil];
 
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
     [center addObserver:self selector:@selector(_enhancedWindowingToggled:) name:_UIWindowSceneEnhancedWindowingModeChanged object:nil];

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -263,6 +263,9 @@ static AccessibilityPreferences accessibilityPreferences()
     preferences.enhanceTextLegibility = _AXSEnhanceTextLegibilityEnabledApp(appId.get());
     preferences.darkenSystemColors = _AXDarkenSystemColorsApp(appId.get());
     preferences.invertColorsEnabled = _AXSInvertColorsEnabledApp(appId.get());
+#if PLATFORM(MAC)
+    preferences.reduceTransparencyEnabled = _AXSReduceTransparencyEnabledApp(appId.get());
+#endif
 #endif
     preferences.enhanceTextLegibilityOverall = _AXSEnhanceTextLegibilityEnabled();
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
@@ -815,6 +818,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     addCFNotificationObserver(accessibilityPreferencesChangedCallback, kAXSEnhanceTextLegibilityChangedNotification);
     addCFNotificationObserver(accessibilityPreferencesChangedCallback, kAXSDarkenSystemColorsEnabledNotification);
     addCFNotificationObserver(accessibilityPreferencesChangedCallback, kAXSInvertColorsEnabledNotification);
+#if PLATFORM(MAC)
+    addCFNotificationObserver(accessibilityPreferencesChangedCallback, kAXSReduceTransparencyChangedNotification);
+#endif
 #endif
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     if (canLoadkAXSReduceMotionAutoplayAnimatedImagesChangedNotification())
@@ -875,6 +881,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     removeCFNotificationObserver(kAXSEnhanceTextLegibilityChangedNotification);
     removeCFNotificationObserver(kAXSDarkenSystemColorsEnabledNotification);
     removeCFNotificationObserver(kAXSInvertColorsEnabledNotification);
+#if PLATFORM(MAC)
+    removeCFNotificationObserver(kAXSReduceTransparencyChangedNotification);
+#endif
 #endif
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
     removeCFNotificationObserver(kMAXCaptionAppearanceSettingsChangedNotification);

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1194,6 +1194,11 @@ void WebProcess::accessibilityPreferencesDidChange(const AccessibilityPreference
     auto invertColorsEnabled = preferences.invertColorsEnabled;
     if (_AXSInvertColorsEnabledApp(appID) != invertColorsEnabled)
         _AXSInvertColorsSetEnabledApp(invertColorsEnabled, appID);
+#if PLATFORM(MAC)
+    auto reduceTransparencyEnabled = preferences.reduceTransparencyEnabled;
+    if (_AXSReduceTransparencyEnabledApp(appID) != reduceTransparencyEnabled)
+        _AXSSetReduceTransparencyEnabledApp(reduceTransparencyEnabled, appID);
+#endif
 #endif
     setOverrideEnhanceTextLegibility(preferences.enhanceTextLegibilityOverall);
     FontCache::invalidateAllFontCaches();
@@ -1304,7 +1309,7 @@ void WebProcess::handlePreferenceChange(const String& domain, const String& key,
 
 #if USE(APPKIT)
     auto cfKey = key.createCFString();
-    if (CFEqual(cfKey.get(), kAXInterfaceReduceMotionKey) || CFEqual(cfKey.get(), kAXInterfaceIncreaseContrastKey) || key == invertColorsPreferenceKey()) {
+    if (CFEqual(cfKey.get(), kAXInterfaceReduceMotionKey) || CFEqual(cfKey.get(), kAXInterfaceReduceTransparencyKey) || CFEqual(cfKey.get(), kAXInterfaceIncreaseContrastKey) || key == invertColorsPreferenceKey()) {
         [NSWorkspace _invalidateAccessibilityDisplayValues];
         for (auto& page : m_pageMap.values())
             page->accessibilitySettingsDidChange();


### PR DESCRIPTION
#### 4bf0c4741ebdf8df8ddb2b542a557cccad77a938
<pre>
Implement prefers-reduced-transparency media feature
<a href="https://bugs.webkit.org/show_bug.cgi?id=175497">https://bugs.webkit.org/show_bug.cgi?id=175497</a>

Reviewed by NOBODY (OOPS!).

Implements the prefers-reduced-transparency media feature for iOS and macOS.

This support is behind an off by default testable feature flag.

Also adds support for overriding this value within Web Inspector.

Spec: <a href="https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-transparency">https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-transparency</a>

* LayoutTests/fast/media/mq-prefers-reduced-transparency-expected.html: Added.
* LayoutTests/fast/media/mq-prefers-reduced-transparency-forced-value-expected.html: Added.
* LayoutTests/fast/media/mq-prefers-reduced-transparency-forced-value.html: Added.
* LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update-expected.html: Added.
* LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update-for-listener-expected.txt: Added.
* LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update-for-listener.html: Added.
* LayoutTests/fast/media/mq-prefers-reduced-transparency-live-update.html: Added.
* LayoutTests/fast/media/mq-prefers-reduced-transparency-matchMedia-expected.txt: Added.
* LayoutTests/fast/media/mq-prefers-reduced-transparency-matchMedia.html: Added.
* LayoutTests/fast/media/mq-prefers-reduced-transparency.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/prefers-reduced-transparency-expected.txt:
* Source/JavaScriptCore/inspector/protocol/Page.json:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/PAL/pal/ios/UIKitSoftLink.h:
* Source/WebCore/PAL/pal/ios/UIKitSoftLink.mm:
* Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/MediaQueryParserContext.cpp:
(WebCore::MediaQueryParserContext::MediaQueryParserContext):
* Source/WebCore/css/MediaQueryParserContext.h:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::operator==):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::prefersReducedTransparency):
(WebCore::MQ::Features::dynamicDependency):
* Source/WebCore/css/query/MediaQueryFeatures.h:
* Source/WebCore/css/query/MediaQueryParser.cpp:
(WebCore::MQ::MediaQueryParser::schemaForFeatureName const):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::disable):
(WebCore::InspectorPageAgent::overrideUserPreference):
(WebCore::InspectorPageAgent::overridePrefersReducedTransparency):
(WebCore::InspectorPageAgent::defaultUserPreferencesDidChange):
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/page/Settings.yaml:
* Source/WebCore/platform/Theme.cpp:
(WebCore::Theme::userPrefersReducedTransparency const):
* Source/WebCore/platform/Theme.h:
* Source/WebCore/platform/ios/ThemeIOS.h:
* Source/WebCore/platform/ios/ThemeIOS.mm:
(WebCore::ThemeIOS::userPrefersReducedTransparency const):
* Source/WebCore/platform/mac/ThemeMac.h:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::ThemeMac::userPrefersReducedTransparency const):
* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::Backup::Backup):
(WebCore::InternalSettings::Backup::restoreTo):
(WebCore::InternalSettings::forcedPrefersReducedTransparencyAccessibilityValue const):
(WebCore::InternalSettings::setForcedPrefersReducedTransparencyAccessibilityValue):
* Source/WebCore/testing/InternalSettings.h:
* Source/WebCore/testing/InternalSettings.idl:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::userPrefersReducedTransparency const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::userPrefersReducedTransparency const):
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/CodeMirrorAdditions.js:
* Source/WebInspectorUI/UserInterface/Views/OverrideUserPreferencesPopover.js:
(WI.OverrideUserPreferencesPopover.prototype.createContentElement):
* Source/WebKit/Platform/spi/Cocoa/AccessibilitySupportSPI.h:
* Source/WebKit/Shared/AccessibilityPreferences.cpp:
(IPC::ArgumentCoder&lt;WebKit::AccessibilityPreferences&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::AccessibilityPreferences&gt;::decode):
* Source/WebKit/Shared/AccessibilityPreferences.h:
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::handleAXPreferenceChange):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _registerForNotifications]):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::accessibilityPreferences):
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::unregisterNotificationObservers):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityPreferencesDidChange):
(WebKit::WebProcess::handlePreferenceChange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bf0c4741ebdf8df8ddb2b542a557cccad77a938

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13241 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13924 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13662 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9907 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10526 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17667 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9861 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13864 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11004 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9131 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11684 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10405 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3145 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14533 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12014 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10936 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2917 "Passed tests") | 
<!--EWS-Status-Bubble-End-->