### PR TITLE
REGRESSION(257515@main): breaks build with -flto=auto

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -206,4 +206,8 @@ void SpeechRecognition::didEnd()
     queueTaskToDispatchEvent(*this, TaskSource::Speech, Event::create(eventNames().endEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
+SpeechRecognition::~SpeechRecognition()
+{
+}
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechRecognition.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.h
@@ -64,6 +64,8 @@ public:
     using RefCounted::ref;
     using RefCounted::deref;
 
+    virtual ~SpeechRecognition();
+
 private:
     enum class State {
         Inactive,

--- a/Source/WebCore/Modules/speech/SpeechRecognitionConnectionClient.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionConnectionClient.h
@@ -40,7 +40,7 @@ public:
     {
     }
 
-    virtual ~SpeechRecognitionConnectionClient() = default;
+    virtual ~SpeechRecognitionConnectionClient() { }
 
     virtual void didStart() = 0;
     virtual void didStartCapturingAudio() = 0;


### PR DESCRIPTION
#### ee58c2ab83717762d360197159639854543a3c24
<pre>
REGRESSION(257515@main): breaks build with -flto=auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=249368">https://bugs.webkit.org/show_bug.cgi?id=249368</a>

Reviewed by Philippe Normand.

Workaround compiler/linker issue with LTO enabled with certain versions
of GCC and Binutils on Linux. Tested using a Yocto build targeting
AArch64 (Raspberry Pi 4), with LTO enabled, which uses GCC 11.3.0 and
Binutils 2.38.

* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
(WebCore::SpeechRecognition::~SpeechRecognition): Define an empty
virtual destructor.
* Source/WebCore/Modules/speech/SpeechRecognition.h: Declare a virtual
destructor for the class.
* Source/WebCore/Modules/speech/SpeechRecognitionConnectionClient.h:
(WebCore::SpeechRecognitionConnectionClient::~SpeechRecognitionConnectionClient):
Once the complaint about the missing SpeechRecognition vtable was fixed,
the linker started complaning about a missing virtual destructor for
SpeechRecognitionConnectionClient, which is definitely a compiler bug
given that it was defaulted; but using an empty inline destructor in the
header workarounds the issue.

Canonical link: <a href="https://commits.webkit.org/261724@main">https://commits.webkit.org/261724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44225e14b96f2f95d7cf3ce51a8c3d27aeec214b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4389 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116679 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5542 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118380 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105685 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46181 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14097 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/967 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14777 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52962 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16619 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4478 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->