### PR TITLE
Simplify treeScope handling logic in CSSStyleSheetObservableArray

### DIFF
--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -48,6 +48,14 @@
 
 namespace WebCore {
 
+static Style::Scope& styleScopeFor(ContainerNode& treeScope)
+{
+    ASSERT(is<Document>(treeScope) || is<ShadowRoot>(treeScope));
+    if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(treeScope))
+        return shadowRoot->styleScope();
+    return downcast<Document>(treeScope).styleScope();
+}
+
 class StyleSheetCSSRuleList final : public CSSRuleList {
 public:
     StyleSheetCSSRuleList(CSSStyleSheet* sheet) : m_styleSheet(sheet) { }
@@ -239,10 +247,8 @@ void CSSStyleSheet::forEachStyleScope(const Function<void(Style::Scope&)>& apply
         apply(*scope);
         return;
     }
-    for (auto& shadowRoot : m_adoptingShadowRoots)
-        apply(shadowRoot.styleScope());
-    for (auto& document : m_adoptingDocuments)
-        apply(document.styleScope());
+    for (auto& treeScope : m_adoptingTreeScopes)
+        apply(styleScopeFor(treeScope));
 }
 
 void CSSStyleSheet::clearOwnerNode()
@@ -484,28 +490,18 @@ Document* CSSStyleSheet::constructorDocument() const
     return m_constructorDocument.get();
 }
 
-void CSSStyleSheet::addAdoptingTreeScope(Document& document)
+void CSSStyleSheet::addAdoptingTreeScope(ContainerNode& treeScope)
 {
-    m_adoptingDocuments.add(document);
-    document.styleScope().didChangeActiveStyleSheetCandidates();
+    ASSERT(is<Document>(treeScope) || is<ShadowRoot>(treeScope));
+    m_adoptingTreeScopes.add(treeScope);
+    styleScopeFor(treeScope).didChangeActiveStyleSheetCandidates();
 }
 
-void CSSStyleSheet::addAdoptingTreeScope(ShadowRoot& shadowRoot)
+void CSSStyleSheet::removeAdoptingTreeScope(ContainerNode& treeScope)
 {
-    m_adoptingShadowRoots.add(shadowRoot);
-    shadowRoot.styleScope().didChangeActiveStyleSheetCandidates();
-}
-
-void CSSStyleSheet::removeAdoptingTreeScope(Document& document)
-{
-    m_adoptingDocuments.remove(document);
-    document.styleScope().didChangeStyleSheetContents();
-}
-
-void CSSStyleSheet::removeAdoptingTreeScope(ShadowRoot& shadowRoot)
-{
-    m_adoptingShadowRoots.remove(shadowRoot);
-    shadowRoot.styleScope().didChangeStyleSheetContents();
+    ASSERT(is<Document>(treeScope) || is<ShadowRoot>(treeScope));
+    m_adoptingTreeScopes.remove(treeScope);
+    styleScopeFor(treeScope).didChangeStyleSheetContents();
 }
 
 CSSStyleSheet::RuleMutationScope::RuleMutationScope(CSSStyleSheet* sheet, RuleMutationType mutationType, StyleRuleKeyframes* insertedKeyframesRule)

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -42,14 +42,13 @@ class CSSParser;
 class CSSRule;
 class CSSStyleSheet;
 class CachedCSSStyleSheet;
+class ContainerNode;
 class DeferredPromise;
 class Document;
 class Element;
 class WeakPtrImplWithEventTargetData;
-class ShadowRoot;
 class StyleRuleKeyframes;
 class StyleSheetContents;
-class TreeScope;
 
 namespace Style {
 class Scope;
@@ -104,10 +103,8 @@ public:
 
     void clearOwnerRule() { m_ownerRule = nullptr; }
 
-    void removeAdoptingTreeScope(Document&);
-    void removeAdoptingTreeScope(ShadowRoot&);
-    void addAdoptingTreeScope(Document&);
-    void addAdoptingTreeScope(ShadowRoot&);
+    void removeAdoptingTreeScope(ContainerNode&);
+    void addAdoptingTreeScope(ContainerNode&);
 
     Document* ownerDocument() const;
     CSSStyleSheet& rootStyleSheet();
@@ -179,8 +176,7 @@ private:
     MQ::MediaQueryList m_mediaQueries;
     WeakPtr<Style::Scope> m_styleScope;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_constructorDocument;
-    WeakHashSet<ShadowRoot, WeakPtrImplWithEventTargetData> m_adoptingShadowRoots;
-    WeakHashSet<Document, WeakPtrImplWithEventTargetData> m_adoptingDocuments;
+    WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData> m_adoptingTreeScopes;
 
     WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
     WeakPtr<CSSImportRule> m_ownerRule;

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
@@ -34,24 +34,15 @@
 
 namespace WebCore {
 
-Ref<CSSStyleSheetObservableArray> CSSStyleSheetObservableArray::create(Document& document)
+Ref<CSSStyleSheetObservableArray> CSSStyleSheetObservableArray::create(ContainerNode& treeScope)
 {
-    return adoptRef(*new CSSStyleSheetObservableArray(document));
+    return adoptRef(*new CSSStyleSheetObservableArray(treeScope));
 }
 
-Ref<CSSStyleSheetObservableArray> CSSStyleSheetObservableArray::create(ShadowRoot& shadowRoot)
+CSSStyleSheetObservableArray::CSSStyleSheetObservableArray(ContainerNode& treeScope)
+    : m_treeScope(treeScope)
 {
-    return adoptRef(*new CSSStyleSheetObservableArray(shadowRoot));
-}
-
-CSSStyleSheetObservableArray::CSSStyleSheetObservableArray(Document& document)
-    : m_treeScope(WeakPtr { document })
-{
-}
-
-CSSStyleSheetObservableArray::CSSStyleSheetObservableArray(ShadowRoot& shadowRoot)
-    : m_treeScope(WeakPtr { shadowRoot })
-{
+    ASSERT(is<Document>(treeScope) || is<ShadowRoot>(treeScope));
 }
 
 bool CSSStyleSheetObservableArray::setValueAt(JSC::JSGlobalObject* lexicalGlobalObject, unsigned index, JSC::JSValue value)
@@ -126,35 +117,23 @@ std::optional<Exception> CSSStyleSheetObservableArray::shouldThrowWhenAddingShee
 
 TreeScope* CSSStyleSheetObservableArray::treeScope() const
 {
-    return WTF::switchOn(m_treeScope, [](const WeakPtr<Document, WeakPtrImplWithEventTargetData>& document) -> TreeScope* {
-        return document.get();
-    }, [](const WeakPtr<ShadowRoot, WeakPtrImplWithEventTargetData>& shadowRoot) -> TreeScope* {
-        return shadowRoot.get();
-    }, [](std::nullptr_t) -> TreeScope* {
+    if (!m_treeScope)
         return nullptr;
-    });
+    if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*m_treeScope))
+        return shadowRoot;
+    return &downcast<Document>(*m_treeScope);
 }
 
 void CSSStyleSheetObservableArray::didAddSheet(CSSStyleSheet& sheet)
 {
-    WTF::switchOn(m_treeScope, [&](const WeakPtr<Document, WeakPtrImplWithEventTargetData>& document) {
-        if (document)
-            sheet.addAdoptingTreeScope(*document);
-    }, [&](const WeakPtr<ShadowRoot, WeakPtrImplWithEventTargetData>& shadowRoot) {
-        if (shadowRoot)
-            sheet.addAdoptingTreeScope(*shadowRoot);
-    }, [](std::nullptr_t) { });
+    if (m_treeScope)
+        sheet.addAdoptingTreeScope(*m_treeScope);
 }
 
 void CSSStyleSheetObservableArray::willRemoveSheet(CSSStyleSheet& sheet)
 {
-    WTF::switchOn(m_treeScope, [&](const WeakPtr<Document, WeakPtrImplWithEventTargetData>& document) {
-        if (document)
-            sheet.removeAdoptingTreeScope(*document);
-    }, [&](const WeakPtr<ShadowRoot, WeakPtrImplWithEventTargetData>& shadowRoot) {
-        if (shadowRoot)
-            sheet.removeAdoptingTreeScope(*shadowRoot);
-    }, [](std::nullptr_t) { });
+    if (m_treeScope)
+        sheet.removeAdoptingTreeScope(*m_treeScope);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.h
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.h
@@ -31,21 +31,17 @@
 
 namespace WebCore {
 
-class Document;
-class ShadowRoot;
-class TreeScope;
+class ContainerNode;
 
 class CSSStyleSheetObservableArray : public JSC::ObservableArray {
 public:
-    static Ref<CSSStyleSheetObservableArray> create(Document&);
-    static Ref<CSSStyleSheetObservableArray> create(ShadowRoot&);
+    static Ref<CSSStyleSheetObservableArray> create(ContainerNode& treeScope);
 
     ExceptionOr<void> setSheets(Vector<RefPtr<CSSStyleSheet>>&&);
     const Vector<RefPtr<CSSStyleSheet>>& sheets() const { return m_sheets; }
 
 private:
-    explicit CSSStyleSheetObservableArray(Document&);
-    explicit CSSStyleSheetObservableArray(ShadowRoot&);
+    explicit CSSStyleSheetObservableArray(ContainerNode& treeScope);
 
     std::optional<Exception> shouldThrowWhenAddingSheet(const CSSStyleSheet&) const;
 
@@ -60,7 +56,7 @@ private:
     void didAddSheet(CSSStyleSheet&);
     void willRemoveSheet(CSSStyleSheet&);
 
-    std::variant<WeakPtr<Document, WeakPtrImplWithEventTargetData>, WeakPtr<ShadowRoot, WeakPtrImplWithEventTargetData>, std::nullptr_t> m_treeScope;
+    WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> m_treeScope;
     Vector<RefPtr<CSSStyleSheet>> m_sheets;
 };
 

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -550,12 +550,8 @@ RadioButtonGroups& TreeScope::radioButtonGroups()
 
 CSSStyleSheetObservableArray& TreeScope::ensureAdoptedStyleSheets()
 {
-    if (UNLIKELY(!m_adoptedStyleSheets)) {
-        if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(m_rootNode))
-            m_adoptedStyleSheets = CSSStyleSheetObservableArray::create(*shadowRoot);
-        else
-            m_adoptedStyleSheets = CSSStyleSheetObservableArray::create(downcast<Document>(m_rootNode));
-    }
+    if (UNLIKELY(!m_adoptedStyleSheets))
+        m_adoptedStyleSheets = CSSStyleSheetObservableArray::create(m_rootNode);
     return *m_adoptedStyleSheets;
 }
 


### PR DESCRIPTION
#### 5411d5fd0a7ab07fe04c33e6258101b2ab287d84
<pre>
Simplify treeScope handling logic in CSSStyleSheetObservableArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=253976">https://bugs.webkit.org/show_bug.cgi?id=253976</a>

Reviewed by Ryosuke Niwa.

Simplify treeScope handling logic in CSSStyleSheetObservableArray.
Use ContainerNode as common base type for Document and ShadowRoot to avoid
function overloading and std::variant use.

* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::styleScopeFor):
(WebCore::CSSStyleSheet::forEachStyleScope):
(WebCore::CSSStyleSheet::addAdoptingTreeScope):
(WebCore::CSSStyleSheet::removeAdoptingTreeScope):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/CSSStyleSheetObservableArray.cpp:
(WebCore::CSSStyleSheetObservableArray::create):
(WebCore::CSSStyleSheetObservableArray::CSSStyleSheetObservableArray):
(WebCore::CSSStyleSheetObservableArray::treeScope const):
(WebCore::CSSStyleSheetObservableArray::didAddSheet):
(WebCore::CSSStyleSheetObservableArray::willRemoveSheet):
* Source/WebCore/css/CSSStyleSheetObservableArray.h:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::ensureAdoptedStyleSheets):

Canonical link: <a href="https://commits.webkit.org/261733@main">https://commits.webkit.org/261733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cb83ee38632aaff3305e79cffd74a0b76f9d8ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13005 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118454 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105763 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/999 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14162 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1037 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14849 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53032 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8185 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16693 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->