### PR TITLE
[UI-side compositing] Add lock for accessing NSScrollerImpPair in ScrollerPairMac

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -328,6 +328,7 @@ ScrollerMac::~ScrollerMac()
 
 void ScrollerMac::attach()
 {
+    Locker locker { m_pair.scrollerImpPairLock() };
     m_scrollerImpDelegate = adoptNS([[WebScrollerImpDelegateMac alloc] initWithScroller:this]);
 
     NSScrollerStyle newStyle = [m_pair.scrollerImpPair() scrollerStyle];
@@ -339,6 +340,8 @@ void ScrollerMac::setHostLayer(CALayer *layer)
 {
     if (m_hostLayer == layer)
         return;
+    
+    Locker locker { m_pair.scrollerImpPairLock() };
 
     m_hostLayer = layer;
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -86,8 +86,9 @@ private:
 
     NSScrollerImp *scrollerImpHorizontal() { return horizontalScroller().scrollerImp(); }
     NSScrollerImp *scrollerImpVertical() { return verticalScroller().scrollerImp(); }
-
-    NSScrollerImpPair *scrollerImpPair() { return m_scrollerImpPair.get(); }
+    
+    NSScrollerImpPair *scrollerImpPair() WTF_REQUIRES_LOCK(m_scrollerImpPairLock) { return m_scrollerImpPair.get(); }
+    Lock& scrollerImpPairLock() WTF_RETURNS_LOCK(m_scrollerImpPairLock) { return m_scrollerImpPairLock; }
 
     WebCore::ScrollingTreeScrollingNode& m_scrollingNode;
 
@@ -97,6 +98,7 @@ private:
     WebCore::IntPoint m_lastKnownMousePosition;
     std::optional<WebCore::FloatPoint> m_lastScrollOffset;
 
+    mutable Lock m_scrollerImpPairLock;
     RetainPtr<NSScrollerImpPair> m_scrollerImpPair;
     RetainPtr<WebScrollerImpPairDelegateMac> m_scrollerImpPairDelegate;
     

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -128,6 +128,8 @@ ScrollerPairMac::ScrollerPairMac(WebCore::ScrollingTreeScrollingNode& node)
 
 void ScrollerPairMac::init()
 {
+    Locker locker { m_scrollerImpPairLock };
+
     m_scrollerImpPairDelegate = adoptNS([[WebScrollerImpPairDelegateMac alloc] initWithScrollerPair:this]);
 
     m_scrollerImpPair = adoptNS([[NSScrollerImpPair alloc] init]);
@@ -140,12 +142,16 @@ void ScrollerPairMac::init()
 
 ScrollerPairMac::~ScrollerPairMac()
 {
+    Locker locker { m_scrollerImpPairLock };
+
     [m_scrollerImpPairDelegate invalidate];
     [m_scrollerImpPair setDelegate:nil];
 }
 
 void ScrollerPairMac::handleWheelEventPhase(PlatformWheelEventPhase phase)
 {
+    Locker locker { m_scrollerImpPairLock };
+
     switch (phase) {
     case WebCore::PlatformWheelEventPhase::Began:
         [m_scrollerImpPair beginScrollGesture];
@@ -167,6 +173,8 @@ bool ScrollerPairMac::handleMouseEvent(const WebCore::PlatformMouseEvent& event)
 {
     if (event.type() != WebCore::PlatformEvent::Type::MouseMoved)
         return false;
+    
+    Locker locker { m_scrollerImpPairLock };
 
     m_lastKnownMousePosition = event.position();
     [m_scrollerImpPair mouseMovedInContentArea];
@@ -193,6 +201,8 @@ void ScrollerPairMac::setVerticalScrollbarPresentationValue(float scrollbValue)
 
 void ScrollerPairMac::updateValues()
 {
+    Locker locker { m_scrollerImpPairLock };
+
     auto offset = m_scrollingNode.currentScrollOffset();
 
     if (offset != m_lastScrollOffset) {


### PR DESCRIPTION
#### c936c69128b0cb246f8faa4b7cbebd522c987dc1
<pre>
[UI-side compositing] Add lock for accessing NSScrollerImpPair in ScrollerPairMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=253984">https://bugs.webkit.org/show_bug.cgi?id=253984</a>
rdar://106652775

Reviewed by Simon Fraser.

Add locks for use when accessing the NSScrollerImpPair on ScrollerPairMac since
NSScrollerImpPair is not thread safe.

* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::attach):
(WebCore::ScrollerMac::setHostLayer):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
(WebCore::ScrollerPairMac::WTF_REQUIRES_LOCK):
(WebCore::ScrollerPairMac::WTF_RETURNS_LOCK):
(WebCore::ScrollerPairMac::scrollerImpPair): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::init):
(WebCore::ScrollerPairMac::~ScrollerPairMac):
(WebCore::ScrollerPairMac::handleWheelEventPhase):
(WebCore::ScrollerPairMac::handleMouseEvent):
(WebCore::ScrollerPairMac::updateValues):

Canonical link: <a href="https://commits.webkit.org/261759@main">https://commits.webkit.org/261759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6137e39fae4ad6b9c5031f018c4abbde24ee6c87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4419 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121176 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5571 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118412 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17186 "4 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100412 "2 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105718 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46204 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14126 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/997 "6 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/95311 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14808 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10351 "1 flakes 3 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52992 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16651 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4495 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->