### PR TITLE
Fix ASSERTION FAILED: lastDocument->fullscreenManager().fullscreenElement()

### DIFF
--- a/LayoutTests/fullscreen/webkit-exit-full-screen-crash-expected.txt
+++ b/LayoutTests/fullscreen/webkit-exit-full-screen-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fullscreen/webkit-exit-full-screen-crash.html
+++ b/LayoutTests/fullscreen/webkit-exit-full-screen-crash.html
@@ -1,0 +1,10 @@
+<script>
+function test() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    document.webkitExitFullscreen();
+    document.body.innerHTML = 'PASS if no crash';
+}
+</script>
+<body onload="test()">
+</body>

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -46,7 +46,8 @@ void DocumentFullscreen::exitFullscreen(Document& document, RefPtr<DeferredPromi
 
 void DocumentFullscreen::webkitExitFullscreen(Document& document)
 {
-    document.fullscreenManager().exitFullscreen(nullptr);
+    if (document.fullscreenManager().fullscreenElement())
+        document.fullscreenManager().exitFullscreen(nullptr);
 }
 
 // https://fullscreen.spec.whatwg.org/#dom-document-fullscreenenabled


### PR DESCRIPTION
#### cdf4725166dd5bc60b6bb881455e1f43094dc031
<pre>
Fix ASSERTION FAILED: lastDocument-&gt;fullscreenManager().fullscreenElement()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253987">https://bugs.webkit.org/show_bug.cgi?id=253987</a>
rdar://106776257

Reviewed by Tim Nguyen.

We don&apos;t handle document not being a fullScreenElement in
webkitExitFullscreen which causes a crash on debug builds. This change
fixes that.

* LayoutTests/fullscreen/webkit-exit-full-screen-crash-expected.txt: Added.
* LayoutTests/fullscreen/webkit-exit-full-screen-crash.html: Added.
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::webkitExitFullscreen):

Canonical link: <a href="https://commits.webkit.org/261735@main">https://commits.webkit.org/261735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d366e7591afcd7ac98912093112e8df7941301f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5575 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118419 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105772 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/961 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14131 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/999 "6 failures") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14815 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/52994 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8187 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16658 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->