### PR TITLE
REGRESSION (iOS 16.4): Chrome crashes in -[WKWebGeolocationPolicyDecider _executeNextChallenge]

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -36,6 +36,7 @@
 #import <pal/spi/cocoa/NSFileManagerSPI.h>
 #import <wtf/Deque.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/WeakObjCPtr.h>
 #import <wtf/spi/cf/CFBundleSPI.h>
 
 SOFT_LINK_FRAMEWORK(CoreLocation)
@@ -183,13 +184,13 @@ struct PermissionRequest {
 
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
         [alert _setTitleMaximumLineCount:0]; // No limit, we need to make sure the title doesn't get truncated.
-        UIAlertAction *denyAction = [UIAlertAction actionWithTitle:denyActionTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *) {
-            [self _addChallengeCount:-1 forToken:_activeChallenge->token.get() requestingURL:_activeChallenge->requestingURL.get()];
-            [self _finishActiveChallenge:NO];
+        UIAlertAction *denyAction = [UIAlertAction actionWithTitle:denyActionTitle style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
+            if (auto strongSelf = weakSelf.get())
+                [strongSelf _finishActiveChallenge:NO];
         }];
-        UIAlertAction *allowAction = [UIAlertAction actionWithTitle:allowActionTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *) {
-            [self _addChallengeCount:1 forToken:_activeChallenge->token.get() requestingURL:_activeChallenge->requestingURL.get()];
-            [self _finishActiveChallenge:YES];
+        UIAlertAction *allowAction = [UIAlertAction actionWithTitle:allowActionTitle style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
+            if (auto strongSelf = weakSelf.get())
+                [strongSelf _finishActiveChallenge:YES];
         }];
 
         [alert addAction:denyAction];
@@ -201,7 +202,10 @@ struct PermissionRequest {
 
 - (void)_finishActiveChallenge:(BOOL)allow
 {
-    ASSERT(_activeChallenge);
+    if (!_activeChallenge)
+        return;
+
+    [self _addChallengeCount:allow ? 1 : -1 forToken:_activeChallenge->token.get() requestingURL:_activeChallenge->requestingURL.get()];
     if (allow)
         [_activeChallenge->listener allow];
     else


### PR DESCRIPTION
#### 4429746eddd45f836344ec39a914d40d25b6c728
<pre>
REGRESSION (iOS 16.4): Chrome crashes in -[WKWebGeolocationPolicyDecider _executeNextChallenge]
<a href="https://bugs.webkit.org/show_bug.cgi?id=253965">https://bugs.webkit.org/show_bug.cgi?id=253965</a>
rdar://106767100

Reviewed by Wenson Hsieh.

When the UIAlertAction block gets called, make sure that `self` is still alive and that
`_activeChallenge` is non-null.

* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
(-[WKWebGeolocationPolicyDecider _executeNextChallenge]):
(-[WKWebGeolocationPolicyDecider _finishActiveChallenge:]):

Canonical link: <a href="https://commits.webkit.org/261728@main">https://commits.webkit.org/261728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bbae45ea12ae369037485dfeab1568b1b38b4b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4435 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121189 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5586 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118428 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105755 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/972 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14139 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1009 "1 flakes 6 failures") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14823 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53006 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/8183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16667 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4484 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->