### PR TITLE
[ iOS x86_64 ] fast/scrolling/keyboard-scrolling-distance-pageDown.html is a near-constant crash

### DIFF
--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -862,8 +862,6 @@ imported/w3c/web-platform-tests/storage/ [ Pass ]
 
 fast/canvas/large-getImageData.html [ Pass ]
 
-webkit.org/b/253323 fast/scrolling/keyboard-scrolling-distance-pageDown.html [ Pass Crash ]
-
 webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.html [ Pass Failure ]
 webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.worker.html [ Pass Failure ]
 webkit.org/b/253533 imported/w3c/web-platform-tests/xhr/status.h2.window.html [ Pass Failure ]

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5268,6 +5268,8 @@ static void logTextInteractionAssistantSelectionChange(const char* methodName, U
 
 - (void)_didCommitLoadForMainFrame
 {
+    [_keyboardScrollingAnimator stopScrollingImmediately];
+
     _seenHardwareKeyDownInNonEditableElement = NO;
 
     [self _elementDidBlur];

--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.h
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.h
@@ -50,6 +50,8 @@ class FloatPoint;
 
 - (BOOL)scrollTriggeringKeyIsPressed;
 
+- (void)stopScrollingImmediately;
+
 @property (nonatomic, weak) id <WKKeyboardScrollViewAnimatorDelegate> delegate;
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
@@ -69,6 +69,8 @@
 - (BOOL)beginWithEvent:(::WebEvent *)event;
 - (void)handleKeyEvent:(::WebEvent *)event;
 
+- (void)stopScrollingImmediately;
+
 @end
 
 @implementation WKKeyboardScrollingAnimator {
@@ -393,6 +395,13 @@ static WebCore::FloatPoint farthestPointInDirection(WebCore::FloatPoint a, WebCo
     _displayLink = nil;
 }
 
+- (void)stopScrollingImmediately
+{
+    [_scrollable didFinishScrolling];
+    [self stopDisplayLink];
+    _velocity = { };
+}
+
 - (void)displayLinkFired:(CADisplayLink *)sender
 {
     WebCore::FloatSize force;
@@ -494,6 +503,11 @@ static WebCore::FloatPoint farthestPointInDirection(WebCore::FloatPoint a, WebCo
 
     [_animator invalidate];
     _animator = nil;
+}
+
+- (void)stopScrollingImmediately
+{
+    [_animator stopScrollingImmediately];
 }
 
 - (void)setDelegate:(id <WKKeyboardScrollViewAnimatorDelegate>)delegate


### PR DESCRIPTION
#### ec945fa4fae17e95471f50789b79fc0d89704fa7
<pre>
[ iOS x86_64 ] fast/scrolling/keyboard-scrolling-distance-pageDown.html is a near-constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=253323">https://bugs.webkit.org/show_bug.cgi?id=253323</a>
rdar://106199360

Reviewed by Simon Fraser.

This test was occasionally crashing as a consequence of the test that runs prior to it,
`keyboard-scrolling-distance-pageDown`. This prior test is implemented in such a way that it ends
as soon as a certain number of scroll events occur, and does not wait until the scroll itself
actually finishes.

As a result, by the time `keyboard-scrolling-distance-pageDown` is run, the scroll from the previous
test may still be running. Then, `-[WKWebView _didFinishScrolling:]` gets called at some point
during the second test, once the scroll from the first test finishes. The scrolling coordinator proxy
from the first test has been destroyed at this point, which causes the crash to happen when the proxy
tries to be dereferenced.

This is essentially the equivalent of going to a new page midway through a scroll and not halting the
scroll. This PR fixes this by always immediately stopping any keyboard scroll that may be in progress
whenever any new page is loaded.

* LayoutTests/platform/wk2/TestExpectations:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _didCommitLoadForMainFrame]):
* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.h:
* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm:
(-[WKKeyboardScrollingAnimator stopScrollingImmediately]):
(-[WKKeyboardScrollViewAnimator stopScrollingImmediately]):

Canonical link: <a href="https://commits.webkit.org/261757@main">https://commits.webkit.org/261757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a791c3fcf48929ce23919a2d58e55e38cd7323cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/112742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4544 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13089 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/118511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105849 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1064 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/14236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1105 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14928 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8202 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16775 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->