### PR TITLE
[reporelaypy] Invoke command after cloning

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 8, 0)
+version = Version(0, 8, 1)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkout.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkout.py
@@ -65,7 +65,7 @@ class Checkout(object):
         return cls(**data, primary=False)
 
     @staticmethod
-    def clone(url, path, remotes, credentials, sentinal_file=None, checkout_data=None, disable_origin=True):
+    def clone(url, path, remotes, credentials, sentinal_file=None, checkout_data=None, disable_origin=True, post_clone_commands=None):
         run([local.Git.executable(), 'clone', url, path], cwd=os.path.dirname(path))
         run([local.Git.executable(), 'config', 'pull.ff', 'only'], cwd=path)
         if disable_origin:
@@ -73,6 +73,9 @@ class Checkout(object):
 
         Checkout.add_remotes(local.Git(path), remotes)
         Checkout.add_credentials(local.Git(path), credentials)
+
+        for command in post_clone_commands or []:
+            run(**command)
 
         if sentinal_file:
             with open(sentinal_file, 'w') as cloned:
@@ -116,6 +119,7 @@ class Checkout(object):
         sentinal=True, fallback_url=None, primary=True,
         remotes=None, credentials=None,
         forwarding=None, disable_origin=True,
+        post_clone_commands=None,
     ):
         self.sentinal = sentinal
         self.path = path
@@ -171,11 +175,11 @@ class Checkout(object):
         if self.sentinal:
             self._child_process = multiprocessing.Process(
                 target=self.clone,
-                args=(self.url, path, self.remotes, self.credentials, self.sentinal_file, checkout_data, disable_origin),
+                args=(self.url, path, self.remotes, self.credentials, self.sentinal_file, checkout_data, disable_origin, post_clone_commands),
             )
             self._child_process.start()
         else:
-            self.clone(self.url, path, self.remotes, self.credentials, checkout_data=checkout_data, disable_origin=disable_origin)
+            self.clone(self.url, path, self.remotes, self.credentials, checkout_data=checkout_data, disable_origin=disable_origin, post_clone_commands=post_clone_commands)
 
     @property
     def sentinal_file(self):

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.8.0',
+    version='0.8.1',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 17be066c97aff118b7793e8f1ee0e8575c7a1fe1
<pre>
[reporelaypy] Invoke command after cloning
<a href="https://bugs.webkit.org/show_bug.cgi?id=253989">https://bugs.webkit.org/show_bug.cgi?id=253989</a>
rdar://106778935

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Bump version.
* Tools/Scripts/libraries/reporelaypy/setup.py: Ditto.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/checkout.py:
(Checkout.clone): Treat post_clone_commands as a list of run() kwargs and invoke each of them.
(Checkout.__init__): Pass post_clone_commands list to clone function.

Canonical link: <a href="https://commits.webkit.org/261919@main">https://commits.webkit.org/261919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae18dd7ebfe19a459c2233955d5576c96b1c24bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/113282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/22415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/23783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/119069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/23783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/116711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/23783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/106380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/14715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/15423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/17278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4548 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->