### PR TITLE
[iOS] Unable to show the software keyboard when programmatically focusing a text field during `dblclick`

### DIFF
--- a/LayoutTests/fast/forms/ios/show-software-keyboard-on-programmatic-focus-during-dblclick-expected.txt
+++ b/LayoutTests/fast/forms/ios/show-software-keyboard-on-programmatic-focus-during-dblclick-expected.txt
@@ -1,0 +1,9 @@
+Tests that a software keyboard is shown when a text field is progammatically double clicked.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Double Click Me

--- a/LayoutTests/fast/forms/ios/show-software-keyboard-on-programmatic-focus-during-dblclick.html
+++ b/LayoutTests/fast/forms/ios/show-software-keyboard-on-programmatic-focus-during-dblclick.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="initial-scale=1, width=device-width">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Tests that a software keyboard is shown when a text field is progammatically double clicked.");
+
+    const input = document.querySelector("input");
+    const button = document.querySelector("button");
+    button.addEventListener("dblclick", () => {
+        input.focus();
+    });
+
+    if (!window.testRunner)
+        return;
+
+    const rect = button.getBoundingClientRect();
+    await UIHelper.setHardwareKeyboardAttached(false);
+    await UIHelper.doubleActivateAt(rect.left + (rect.width / 2), rect.top + (rect.height / 2));
+    await UIHelper.waitForKeyboardToShow();
+
+    input.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<button type="button">Double Click Me</button>
+<input>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -930,6 +930,8 @@ void WebPage::handleDoubleTapForDoubleClickAtPoint(const IntPoint& point, Option
     if (!frameRespondingToDoubleClick || lastLayerTreeTransactionId < WebFrame::fromCoreFrame(*frameRespondingToDoubleClick)->firstLayerTreeTransactionIDAfterDidCommitLoad())
         return;
 
+    SetForScope userIsInteractingChange { m_userIsInteracting, true };
+
     auto platformModifiers = platform(modifiers);
     auto roundedAdjustedPoint = roundedIntPoint(adjustedPoint);
     nodeRespondingToDoubleClick->document().frame()->eventHandler().handleMousePressEvent(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, LeftButton, PlatformEvent::Type::MousePressed, 2, platformModifiers, WallTime::now(), 0, WebCore::OneFingerTap));


### PR DESCRIPTION
#### 45fc397579fade6934aeab0bba233006f550580d
<pre>
[iOS] Unable to show the software keyboard when programmatically focusing a text field during `dblclick`
<a href="https://bugs.webkit.org/show_bug.cgi?id=253991">https://bugs.webkit.org/show_bug.cgi?id=253991</a>
rdar://104600783

Reviewed by Wenson Hsieh.

This commit adds the `dblclick` event to the set of events for which we
allow the software keyboard to be shown programmatically, which means
that programmatic focus now shows the software keyboard underneath a
user&apos;s double click interaction.

* LayoutTests/fast/forms/ios/show-software-keyboard-on-programmatic-focus-during-dblclick-expected.txt: Added.
* LayoutTests/fast/forms/ios/show-software-keyboard-on-programmatic-focus-during-dblclick.html: Added.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::handleDoubleTapForDoubleClickAtPoint):

Canonical link: <a href="https://commits.webkit.org/261751@main">https://commits.webkit.org/261751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14d54a8425571114d71c3d2cb970d4518877b94a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121194 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12986 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105743 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99157 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46218 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14144 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/95420 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14830 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10372 "2 flakes 4 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53012 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16674 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4491 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->