### PR TITLE
Revert [261690@main] [WGSL] Remove m_ prefix from public struct members

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -36,9 +36,9 @@ namespace WGSL::AST {
 
 struct Indent {
     Indent(StringDumper& dumper)
-        : scope(dumper.m_indent, dumper.m_indent + "    ")
+        : m_scope(dumper.m_indent, dumper.m_indent + "    ")
     { }
-    SetForScope<String> scope;
+    SetForScope<String> m_scope;
 };
 
 static Indent bumpIndent(StringDumper& dumper)

--- a/Source/WebGPU/WGSL/CallGraph.h
+++ b/Source/WebGPU/WGSL/CallGraph.h
@@ -40,13 +40,13 @@ class CallGraph {
 
 public:
     struct Callee {
-        AST::Function* target;
-        Vector<AST::CallExpression*> callSites;
+        AST::Function* m_target;
+        Vector<AST::CallExpression*> m_callSites;
     };
 
     struct EntryPoint {
-        AST::Function& function;
-        AST::StageAttribute::Stage stage;
+        AST::Function& m_function;
+        AST::StageAttribute::Stage m_stage;
     };
 
     ShaderModule& ast() const { return m_ast; }

--- a/Source/WebGPU/WGSL/CompilationMessage.cpp
+++ b/Source/WebGPU/WGSL/CompilationMessage.cpp
@@ -32,7 +32,7 @@ namespace WGSL {
 
 void CompilationMessage::dump(PrintStream& out) const
 {
-    out.print(m_span.line, ":", m_span.lineOffset, ": ", m_message);
+    out.print(m_span.m_line, ":", m_span.m_lineOffset, ": ", m_message);
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/CompilationMessage.h
+++ b/Source/WebGPU/WGSL/CompilationMessage.h
@@ -43,10 +43,10 @@ public:
     void dump(PrintStream& out) const;
 
     const String& message() const { return m_message; }
-    unsigned lineNumber() const { return m_span.line; }
-    unsigned lineOffset() const { return m_span.lineOffset; }
-    unsigned offset() const { return m_span.offset; }
-    unsigned length() const { return m_span.length; }
+    unsigned lineNumber() const { return m_span.m_line; }
+    unsigned lineOffset() const { return m_span.m_lineOffset; }
+    unsigned offset() const { return m_span.m_offset; }
+    unsigned length() const { return m_span.m_length; }
 
 private:
     String m_message;

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -44,9 +44,9 @@ public:
 
 private:
     struct MemberOrParameter {
-        AST::Identifier name;
-        AST::TypeName::Ref type;
-        AST::Attribute::List attributes;
+        AST::Identifier m_name;
+        AST::TypeName::Ref m_type;
+        AST::Attribute::List m_attributes;
     };
 
     enum class IsBuiltin {
@@ -156,9 +156,9 @@ void EntryPointRewriter::constructInputStruct()
     for (auto& parameter : m_parameters) {
         structMembers.append(makeUniqueRef<AST::StructureMember>(
             SourceSpan::empty(),
-            WTFMove(parameter.name),
-            WTFMove(parameter.type),
-            WTFMove(parameter.attributes)
+            WTFMove(parameter.m_name),
+            WTFMove(parameter.m_type),
+            WTFMove(parameter.m_attributes)
         ));
     }
 
@@ -188,12 +188,12 @@ void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& da
 {
     std::unique_ptr<AST::Expression> rhs;
     if (isBuiltin == IsBuiltin::Yes)
-        rhs = makeUnique<AST::IdentifierExpression>(SourceSpan::empty(), AST::Identifier::make(data.name));
+        rhs = makeUnique<AST::IdentifierExpression>(SourceSpan::empty(), AST::Identifier::make(data.m_name));
     else {
         rhs = makeUnique<AST::FieldAccessExpression>(
             SourceSpan::empty(),
             makeUniqueRef<AST::IdentifierExpression>(SourceSpan::empty(), AST::Identifier::make(m_structParameterName)),
-            AST::Identifier::make(data.name)
+            AST::Identifier::make(data.m_name)
         );
     }
 
@@ -203,9 +203,9 @@ void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& da
             makeUniqueRef<AST::Variable>(
                 SourceSpan::empty(),
                 AST::VariableFlavor::Var,
-                AST::Identifier::make(data.name),
+                AST::Identifier::make(data.m_name),
                 nullptr, // TODO: do we need a VariableQualifier?
-                data.type.copyRef(),
+                data.m_type.copyRef(),
                 WTFMove(rhs),
                 AST::Attribute::List { }
             )
@@ -213,7 +213,7 @@ void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& da
         return;
     }
 
-    path.append(data.name);
+    path.append(data.m_name);
     unsigned i = 0;
     UniqueRef<AST::Expression> lhs = makeUniqueRef<AST::IdentifierExpression>(SourceSpan::empty(), AST::Identifier::make(path[i++]));
     while (i < path.size()) {
@@ -233,20 +233,20 @@ void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& da
 
 void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
 {
-    if (auto* structType = std::get_if<Types::Struct>(data.type->resolvedType())) {
+    if (auto* structType = std::get_if<Types::Struct>(data.m_type->resolvedType())) {
         m_materializations.append(makeUniqueRef<AST::VariableStatement>(
             SourceSpan::empty(),
             makeUniqueRef<AST::Variable>(
                 SourceSpan::empty(),
                 AST::VariableFlavor::Var,
-                AST::Identifier::make(data.name),
+                AST::Identifier::make(data.m_name),
                 nullptr,
-                data.type.copyRef(),
+                data.m_type.copyRef(),
                 nullptr,
                 AST::Attribute::List { }
             )
         ));
-        path.append(data.name);
+        path.append(data.m_name);
         for (auto& member : structType->structure.members())
             visit(path, MemberOrParameter { member.name(), member.type(), member.attributes() });
         path.removeLast();
@@ -254,7 +254,7 @@ void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
     }
 
     bool isBuiltin = false;
-    for (auto& attribute : data.attributes) {
+    for (auto& attribute : data.m_attributes) {
         if (is<AST::BuiltinAttribute>(attribute)) {
             isBuiltin = true;
             break;
@@ -267,13 +267,13 @@ void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
             materialize(path, data, IsBuiltin::Yes);
 
         // builtin was hoisted from a struct into a parameter, we need to reconstruct the struct
-        // ${path}.${data.name} = ${data.name}
+        // ${path}.${data.m_name} = ${data.name}
         m_builtins.append(WTFMove(data));
         return;
     }
 
     // parameter was moved into a struct, so we need to reload it
-    // ${path}.${data.name} = ${struct}.${data.name}
+    // ${path}.${data.m_name} = ${struct}.${data.name}
     materialize(path, data, IsBuiltin::No);
     m_parameters.append(WTFMove(data));
 }
@@ -283,9 +283,9 @@ void EntryPointRewriter::appendBuiltins()
     for (auto& data : m_builtins) {
         m_function.parameters().append(makeUniqueRef<AST::Parameter>(
             SourceSpan::empty(),
-            AST::Identifier::make(data.name),
-            WTFMove(data.type),
-            WTFMove(data.attributes),
+            AST::Identifier::make(data.m_name),
+            WTFMove(data.m_type),
+            WTFMove(data.m_attributes),
             AST::ParameterRole::UserDefined
         ));
     }
@@ -294,9 +294,9 @@ void EntryPointRewriter::appendBuiltins()
 void rewriteEntryPoints(CallGraph& callGraph, PrepareResult& result)
 {
     for (auto& entryPoint : callGraph.entrypoints()) {
-        EntryPointRewriter rewriter(callGraph.ast(), entryPoint.function, entryPoint.stage);
+        EntryPointRewriter rewriter(callGraph.ast(), entryPoint.m_function, entryPoint.m_stage);
         rewriter.rewrite();
-        auto addResult = result.entryPoints.add(entryPoint.function.name().id(), rewriter.takeEntryPointInformation());
+        auto addResult = result.entryPoints.add(entryPoint.m_function.name().id(), rewriter.takeEntryPointInformation());
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
     }
 }

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -337,8 +337,8 @@ T Lexer<T>::shift(unsigned i)
     // At one point timing showed that setting m_current to 0 unconditionally was faster than an if-else sequence.
     m_current = 0;
     m_code += i;
-    m_currentPosition.offset += i;
-    m_currentPosition.lineOffset += i;
+    m_currentPosition.m_offset += i;
+    m_currentPosition.m_lineOffset += i;
     if (LIKELY(m_code < m_codeEnd))
         m_current = *m_code;
     return last;
@@ -355,8 +355,8 @@ T Lexer<T>::peek(unsigned i)
 template <typename T>
 void Lexer<T>::newLine()
 {
-    m_currentPosition.line += 1;
-    m_currentPosition.lineOffset = 0;
+    m_currentPosition.m_line += 1;
+    m_currentPosition.m_lineOffset = 0;
 }
 
 template <typename T>

--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -55,8 +55,8 @@ public:
     SourcePosition currentPosition() const { return m_currentPosition; }
 
 private:
-    unsigned currentOffset() const { return m_currentPosition.offset; }
-    unsigned currentTokenLength() const { return currentOffset() - m_tokenStartingPosition.offset; }
+    unsigned currentOffset() const { return m_currentPosition.m_offset; }
+    unsigned currentTokenLength() const { return currentOffset() - m_tokenStartingPosition.m_offset; }
 
     Token makeToken(TokenType type)
     {

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -105,11 +105,11 @@ private:
 void NameManglerVisitor::run()
 {
     for (const auto& entrypoint : m_callGraph.entrypoints()) {
-        String originalName = entrypoint.function.name();
-        introduceVariable(entrypoint.function.name(), MangledName::Function);
+        String originalName = entrypoint.m_function.name();
+        introduceVariable(entrypoint.m_function.name(), MangledName::Function);
         auto it = m_result.entryPoints.find(originalName);
         RELEASE_ASSERT(it != m_result.entryPoints.end());
-        it->value.mangledName = entrypoint.function.name();
+        it->value.mangledName = entrypoint.m_function.name();
     }
 
     auto& module = m_callGraph.ast();

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -105,7 +105,7 @@ void FunctionDefinitionWriter::write()
     for (auto& structure : m_callGraph.ast().structures())
         visit(structure);
     for (auto& entryPoint : m_callGraph.entrypoints())
-        visit(entryPoint.function);
+        visit(entryPoint.m_function);
 }
 
 void FunctionDefinitionWriter::visit(AST::Function& functionDefinition)

--- a/Source/WebGPU/WGSL/SourceSpan.h
+++ b/Source/WebGPU/WGSL/SourceSpan.h
@@ -28,38 +28,38 @@
 namespace WGSL {
 
 struct SourcePosition {
-    unsigned line;
-    unsigned lineOffset;
-    unsigned offset;
+    unsigned m_line;
+    unsigned m_lineOffset;
+    unsigned m_offset;
 };
 
 struct SourceSpan {
-    // FIXME: we could possibly skip lineOffset and recompute it only when trying to show an error
+    // FIXME: we could possibly skip m_lineOffset and recompute it only when trying to show an error
     // This would shrink the AST size by 32 bits per AST node, at the cost of a bit of code complexity in the error toString function.
-    unsigned line;
-    unsigned lineOffset;
-    unsigned offset;
-    unsigned length;
+    unsigned m_line;
+    unsigned m_lineOffset;
+    unsigned m_offset;
+    unsigned m_length;
 
     static constexpr SourceSpan empty() { return { 0, 0, 0, 0 }; }
 
     constexpr SourceSpan(unsigned line, unsigned lineOffset, unsigned offset, unsigned length)
-        : line(line)
-        , lineOffset(lineOffset)
-        , offset(offset)
-        , length(length)
+        : m_line(line)
+        , m_lineOffset(lineOffset)
+        , m_offset(offset)
+        , m_length(length)
     { }
 
     constexpr SourceSpan(SourcePosition start, SourcePosition end)
-        : SourceSpan(start.line, start.lineOffset, start.offset, end.offset - start.offset)
+        : SourceSpan(start.m_line, start.m_lineOffset, start.m_offset, end.m_offset - start.m_offset)
     { }
 
     constexpr bool operator==(const SourceSpan& other) const
     {
-        return (line == other.line
-            && lineOffset == other.lineOffset
-            && offset == other.offset
-            && length == other.length);
+        return (m_line == other.m_line
+            && m_lineOffset == other.m_lineOffset
+            && m_offset == other.m_offset
+            && m_length == other.m_length);
     }
 
     constexpr bool operator!=(const SourceSpan& other) const

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -114,16 +114,16 @@ enum class TokenType: uint32_t {
 String toString(TokenType);
 
 struct Token {
-    TokenType type;
-    SourceSpan span;
+    TokenType m_type;
+    SourceSpan m_span;
     union {
-        double literalValue;
-        String ident;
+        double m_literalValue;
+        String m_ident;
     };
 
     Token(TokenType type, SourcePosition position, unsigned length)
-        : type(type)
-        , span(position.line, position.lineOffset, position.offset, length)
+        : m_type(type)
+        , m_span(position.m_line, position.m_lineOffset, position.m_offset, length)
     {
         ASSERT(type != TokenType::Identifier);
         ASSERT(type != TokenType::IntegerLiteral);
@@ -134,9 +134,9 @@ struct Token {
     }
 
     Token(TokenType type, SourcePosition position, unsigned length, double literalValue)
-        : type(type)
-        , span(position.line, position.lineOffset, position.offset, length)
-        , literalValue(literalValue)
+        : m_type(type)
+        , m_span(position.m_line, position.m_lineOffset, position.m_offset, length)
+        , m_literalValue(literalValue)
     {
         ASSERT(type == TokenType::IntegerLiteral
             || type == TokenType::IntegerLiteralSigned
@@ -146,33 +146,33 @@ struct Token {
     }
 
     Token(TokenType type, SourcePosition position, unsigned length, String&& ident)
-        : type(type)
-        , span(position.line, position.lineOffset, position.offset, length)
-        , ident(WTFMove(ident))
+        : m_type(type)
+        , m_span(position.m_line, position.m_lineOffset, position.m_offset, length)
+        , m_ident(WTFMove(ident))
     {
-        ASSERT(ident.impl() && ident.impl()->bufferOwnership() == StringImpl::BufferInternal);
+        ASSERT(m_ident.impl() && m_ident.impl()->bufferOwnership() == StringImpl::BufferInternal);
         ASSERT(type == TokenType::Identifier);
     }
 
     Token& operator=(Token&& other)
     {
-        if (type == TokenType::Identifier)
-            ident.~String();
+        if (m_type == TokenType::Identifier)
+            m_ident.~String();
 
-        type = other.type;
-        span = other.span;
+        m_type = other.m_type;
+        m_span = other.m_span;
 
-        switch (other.type) {
+        switch (other.m_type) {
         case TokenType::Identifier:
-            new (NotNull, &ident) String();
-            ident = other.ident;
+            new (NotNull, &m_ident) String();
+            m_ident = other.m_ident;
             break;
         case TokenType::IntegerLiteral:
         case TokenType::IntegerLiteralSigned:
         case TokenType::IntegerLiteralUnsigned:
         case TokenType::DecimalFloatLiteral:
         case TokenType::HexFloatLiteral:
-            literalValue = other.literalValue;
+            m_literalValue = other.m_literalValue;
             break;
         default:
             break;
@@ -182,20 +182,20 @@ struct Token {
     }
 
     Token(const Token& other)
-        : type(other.type)
-        , span(other.span)
+        : m_type(other.m_type)
+        , m_span(other.m_span)
     {
-        switch (other.type) {
+        switch (other.m_type) {
         case TokenType::Identifier:
-            new (NotNull, &ident) String();
-            ident = other.ident;
+            new (NotNull, &m_ident) String();
+            m_ident = other.m_ident;
             break;
         case TokenType::IntegerLiteral:
         case TokenType::IntegerLiteralSigned:
         case TokenType::IntegerLiteralUnsigned:
         case TokenType::DecimalFloatLiteral:
         case TokenType::HexFloatLiteral:
-            literalValue = other.literalValue;
+            m_literalValue = other.m_literalValue;
             break;
         default:
             break;
@@ -204,8 +204,8 @@ struct Token {
 
     ~Token()
     {
-        if (type == TokenType::Identifier)
-            (&ident)->~String();
+        if (m_type == TokenType::Identifier)
+            (&m_ident)->~String();
     }
 };
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -32,22 +32,22 @@ static WGSL::Token checkSingleToken(const String& string, WGSL::TokenType type)
 {
     WGSL::Lexer<LChar> lexer(string);
     WGSL::Token result = lexer.lex();
-    EXPECT_EQ(result.type, type);
+    EXPECT_EQ(result.m_type, type);
     return result;
 }
 
 static void checkSingleLiteral(const String& string, WGSL::TokenType type, double literalValue)
 {
     WGSL::Token result = checkSingleToken(string, type);
-    EXPECT_EQ(result.literalValue, literalValue);
+    EXPECT_EQ(result.m_literalValue, literalValue);
 }
 
 template<typename T>
 static WGSL::Token checkNextTokenIs(WGSL::Lexer<T>& lexer, WGSL::TokenType type, unsigned lineNumber)
 {
     WGSL::Token result = lexer.lex();
-    EXPECT_EQ(result.type, type);
-    EXPECT_EQ(result.span.line, lineNumber);
+    EXPECT_EQ(result.m_type, type);
+    EXPECT_EQ(result.m_span.m_line, lineNumber);
     return result;
 }
 
@@ -55,14 +55,14 @@ template<typename T>
 static void checkNextTokenIsIdentifier(WGSL::Lexer<T>& lexer, const String& ident, unsigned lineNumber)
 {
     WGSL::Token result = checkNextTokenIs(lexer, WGSL::TokenType::Identifier, lineNumber);
-    EXPECT_EQ(result.ident, ident);
+    EXPECT_EQ(result.m_ident, ident);
 }
 
 template<typename T>
 static void checkNextTokenIsLiteral(WGSL::Lexer<T>& lexer, WGSL::TokenType type, double literalValue, unsigned lineNumber)
 {
     WGSL::Token result = checkNextTokenIs(lexer, type, lineNumber);
-    EXPECT_EQ(result.literalValue, literalValue);
+    EXPECT_EQ(result.m_literalValue, literalValue);
 }
 
 template<typename T>


### PR DESCRIPTION
#### a48e91ce4ab51138a9c6f01a2289c5429f11be21
<pre>
Revert [261690@main] [WGSL] Remove m_ prefix from public struct members
<a href="https://bugs.webkit.org/show_bug.cgi?id=253665">https://bugs.webkit.org/show_bug.cgi?id=253665</a>
rdar://106512980

Unreviewed revert.

Rverting commit that cause multiple API test failures.

* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::Indent::Indent):
* Source/WebGPU/WGSL/CallGraph.h:
* Source/WebGPU/WGSL/CompilationMessage.cpp:
(WGSL::CompilationMessage::dump const):
* Source/WebGPU/WGSL/CompilationMessage.h:
(WGSL::CompilationMessage::lineNumber const):
(WGSL::CompilationMessage::lineOffset const):
(WGSL::CompilationMessage::offset const):
(WGSL::CompilationMessage::length const):
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::constructInputStruct):
(WGSL::EntryPointRewriter::materialize):
(WGSL::EntryPointRewriter::visit):
(WGSL::EntryPointRewriter::appendBuiltins):
(WGSL::rewriteEntryPoints):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::run):
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::requiredGroups):
(WGSL::RewriteGlobalVariables::insertStructs):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::shift):
(WGSL::Lexer&lt;T&gt;::newLine):
* Source/WebGPU/WGSL/Lexer.h:
(WGSL::Lexer::currentOffset const):
(WGSL::Lexer::currentTokenLength const):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::run):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::write):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::canBeginUnaryExpression):
(WGSL::canContinueMultiplicativeExpression):
(WGSL::canContinueAdditiveExpression):
(WGSL::canContinueBitwiseExpression):
(WGSL::canContinueRelationalExpression):
(WGSL::canContinueShortCircuitAndExpression):
(WGSL::canContinueShortCircuitOrExpression):
(WGSL::toBinaryOperation):
(WGSL::toUnaryOperation):
(WGSL::Parser&lt;Lexer&gt;::consumeType):
(WGSL::Parser&lt;Lexer&gt;::consumeTypes):
(WGSL::Parser&lt;Lexer&gt;::parseIdentifier):
(WGSL::Parser&lt;Lexer&gt;::parseGlobalDecl):
(WGSL::Parser&lt;Lexer&gt;::parseAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
(WGSL::Parser&lt;Lexer&gt;::parseStructure):
(WGSL::Parser&lt;Lexer&gt;::parseTypeName):
(WGSL::Parser&lt;Lexer&gt;::parseTypeNameAfterIdentifier):
(WGSL::Parser&lt;Lexer&gt;::parseArrayType):
(WGSL::Parser&lt;Lexer&gt;::parseVariableWithAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseVariableQualifier):
(WGSL::Parser&lt;Lexer&gt;::parseStorageClass):
(WGSL::Parser&lt;Lexer&gt;::parseAccessMode):
(WGSL::Parser&lt;Lexer&gt;::parseFunction):
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseCompoundStatement):
(WGSL::Parser&lt;Lexer&gt;::parseReturnStatement):
(WGSL::Parser&lt;Lexer&gt;::parseShortCircuitExpression):
(WGSL::Parser&lt;Lexer&gt;::parseShiftExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseAdditiveExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseBitwiseExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseMultiplicativeExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parsePostfixExpression):
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
(WGSL::Parser&lt;Lexer&gt;::parseCoreLHSExpression):
(WGSL::Parser&lt;Lexer&gt;::parseArgumentExpressionList):
* Source/WebGPU/WGSL/SourceSpan.h:
(WGSL::SourceSpan::SourceSpan):
(WGSL::SourceSpan::operator== const):
* Source/WebGPU/WGSL/Token.h:
(WGSL::Token::Token):
(WGSL::Token::operator=):
(WGSL::Token::~Token):
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::checkSingleToken):
(TestWGSLAPI::checkSingleLiteral):
(TestWGSLAPI::checkNextTokenIs):
(TestWGSLAPI::checkNextTokenIsIdentifier):
(TestWGSLAPI::checkNextTokenIsLiteral):

Canonical link: <a href="https://commits.webkit.org/261722@main">https://commits.webkit.org/261722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db88760dc3c9fe85711ada60229d803d1f3f2fb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112664 "Failed to checkout and rebase branch from PR 11580") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/21817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/4438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/116731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12982 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/4438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/118432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/105739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/105739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/14142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/105739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14827 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16671 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4476 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->