### PR TITLE
REGRESSION (261597@main): [UI-side compositing] Many layout tests crash in RemoteScrollingCoordinatorProxy::topContentInset()

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -527,13 +527,13 @@ void ScrollingTree::clearLatchedNode()
 float ScrollingTree::mainFrameTopContentInset() const
 {
     Locker locker { m_treeStateLock };
-    return m_rootNode->topContentInset();
+    return m_rootNode ? m_rootNode->topContentInset() : 0;
 }
 
 FloatPoint ScrollingTree::mainFrameScrollPosition() const
 {
     Locker locker { m_treeStateLock };
-    return m_rootNode->currentScrollPosition();
+    return m_rootNode ? m_rootNode->currentScrollPosition() : FloatPoint { };
 }
 
 void ScrollingTree::setMainFrameScrollPosition(FloatPoint position)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -130,6 +130,11 @@ void RemoteLayerTreeDrawingAreaProxyMac::removeObserver(std::optional<DisplayLin
 
 void RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers(const RemoteLayerTreeTransaction& transaction)
 {
+    auto* headerBannerLayer = m_webPageProxy.headerBannerLayer();
+    auto* footerBannerLayer = m_webPageProxy.footerBannerLayer();
+    if (!headerBannerLayer && !footerBannerLayer)
+        return;
+
     float totalContentsHeight = transaction.contentsSize().height();
 
     auto layoutBannerLayer = [](CALayer *bannerLayer, float y, float width) {
@@ -145,14 +150,14 @@ void RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers(const RemoteLayerTre
     float topContentInset = m_webPageProxy.scrollingCoordinatorProxy()->topContentInset();
     auto scrollPosition = m_webPageProxy.scrollingCoordinatorProxy()->currentMainFrameScrollPosition();
     
-    if (auto* headerBannerLayer = m_webPageProxy.headerBannerLayer()) {
+    if (headerBannerLayer) {
         auto headerHeight = headerBannerLayer.frame.size.height;
         totalContentsHeight += headerHeight;
         auto y = LocalFrameView::yPositionForHeaderLayer(scrollPosition, topContentInset);
         layoutBannerLayer(headerBannerLayer, y, size().width());
     }
 
-    if (auto* footerBannerLayer = m_webPageProxy.footerBannerLayer()) {
+    if (footerBannerLayer) {
         auto footerHeight = footerBannerLayer.frame.size.height;
         totalContentsHeight += footerBannerLayer.frame.size.height;
         auto y = LocalFrameView::yPositionForFooterLayer(scrollPosition, topContentInset, totalContentsHeight, footerHeight);


### PR DESCRIPTION
#### 31e7627fb5554f0814f16edd24dac3a81b93c063
<pre>
REGRESSION (261597@main): [UI-side compositing] Many layout tests crash in RemoteScrollingCoordinatorProxy::topContentInset()
<a href="https://bugs.webkit.org/show_bug.cgi?id=253993">https://bugs.webkit.org/show_bug.cgi?id=253993</a>
rdar://106780096

Reviewed by Said Abou-Hallawa.

Some tests disable async scrolling with `[ useThreadedScrolling=false ]`, in which case we have no ScrollingCoordinator
in the web process. In this scenario we get a RemoteLayerTreeTransaction in the UI process with no scrolling tree,
so RemoteScrollingCoordinatorProxy::m_scrollingTree has no root node, so null-check it in `mainFrameTopContentInset()`
and `mainFrameScrollPosition()`.

Also refactor layoutBannerLayers() a little to avoid doing work when there are no banners.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::mainFrameTopContentInset const):
(WebCore::ScrollingTree::mainFrameScrollPosition const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers):

Canonical link: <a href="https://commits.webkit.org/261770@main">https://commits.webkit.org/261770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e496923ed527b2468c95404129809c90aca5bc3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4444 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121197 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12989 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5591 "112 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105746 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46222 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14147 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1016 "6 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/95424 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10373 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53013 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8203 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16677 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->