### PR TITLE
It's too easy to open multiple ARQL previews by mistake

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
@@ -85,7 +85,7 @@ void LegacyDownloadClient::legacyDidStart(DownloadProxy& downloadProxy)
     if (downloadProxy.isSystemPreviewDownload()) {
         if (auto* webPage = downloadProxy.originatingPage()) {
             // FIXME: Update the MIME-type once it is known in the ResourceResponse.
-            webPage->systemPreviewController()->start(URL { webPage->currentURL() }, "application/octet-stream"_s, downloadProxy.systemPreviewDownloadInfo());
+            webPage->systemPreviewController()->start(downloadProxy.request().url(), URL { webPage->currentURL() }, "application/octet-stream"_s, downloadProxy.systemPreviewDownloadInfo());
         }
         takeActivityToken(downloadProxy);
         return;

--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -51,10 +51,10 @@ public:
 
     bool canPreview(const String& mimeType) const;
 
-    void start(URL originatingPageURL, const String& mimeType, const WebCore::SystemPreviewInfo&);
+    void start(URL downloadURL, URL originatingPageURL, const String& mimeType, const WebCore::SystemPreviewInfo&);
     void setDestinationURL(URL);
     void updateProgress(float);
-    void finish(URL);
+    void finish(URL); // Should be the same as the destination URL.
     void cancel();
     void fail(const WebCore::ResourceError&);
 
@@ -68,8 +68,9 @@ public:
 private:
     WebPageProxy& m_webPageProxy;
     WebCore::SystemPreviewInfo m_systemPreviewInfo;
-    URL m_destinationURL;
-    URL m_originatingPageURL;
+    URL m_destinationURL; // Where the download will be placed on disk.
+    URL m_downloadURL; // The URL that will be downloaded.
+    URL m_originatingPageURL; // The URL of the page that triggered the download.
 #if USE(QUICK_LOOK)
     RetainPtr<QLPreviewController> m_qlPreviewController;
     RetainPtr<_WKPreviewControllerDelegate> m_qlPreviewControllerDelegate;


### PR DESCRIPTION
#### b9d5cc284cd84904bce1101d360c16c8ab666a54
<pre>
It&apos;s too easy to open multiple ARQL previews by mistake
<a href="https://bugs.webkit.org/show_bug.cgi?id=253995">https://bugs.webkit.org/show_bug.cgi?id=253995</a>
rdar://106760359

Reviewed by NOBODY (OOPS!).

The new approach for opening ARQL means that if a user taps on a link multiple
times many previews will open. The idea here is to give ARQL a way to identify
the incoming URL without telling them exactly what it is (in this case, pass a
hash of the URL to ARQL). That way they can choose to not open a new instance.

* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm:
(WebKit::LegacyDownloadClient::legacyDidStart): Send the originating URL to
SystemPreviewController.
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm: Remove some
of the older SPI since they have long since been removed. Create a hash
of the URL and send it to ARQL.
* Source/WebKit/UIProcess/SystemPreviewController.h: Add a new parameter for
the download URL.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9d5cc284cd84904bce1101d360c16c8ab666a54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4447 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/12992 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118441 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105749 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/985 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14150 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/1022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14836 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53019 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16680 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->