### PR TITLE
In results.html's imageResultLinks(), don't add extra dot before already-dotted testExtension

### DIFF
--- a/LayoutTests/fast/harness/full_results.json
+++ b/LayoutTests/fast/harness/full_results.json
@@ -166,6 +166,20 @@ ADD_RESULTS({
                     }
                 }
             }
+        },
+        "fast": {
+            "attachment": {
+                "attachment-uti.html": {
+                    "expected": "PASS",
+                    "actual": "IMAGE",
+                    "reftest_type": ["=="]
+                },
+                "attachment-wrapping-action.html": {
+                    "expected": "PASS",
+                    "actual": "IMAGE",
+                    "reftest_type": ["!="]
+                }
+            }
         }
     },
     "skipped": 5367,

--- a/LayoutTests/fast/harness/results-expected.txt
+++ b/LayoutTests/fast/harness/results-expected.txt
@@ -10,10 +10,12 @@ Other crashes (2): flag all
 
 +DumpRenderTree-54888	crash log
 +DumpRenderTree-56804	crash log
-Tests that failed text/pixel/audio diff (7): flag all
+Tests that failed text/pixel/audio diff (9): flag all
 
  test 	results	image results	actual failure	expected failure	history
 +css1/font_properties/font_family.html	expected actual diff pretty diff	images	text missing		history
++fast/attachment/attachment-uti.html		reference images diff (nan%)	image	pass	history
++fast/attachment/attachment-wrapping-action.html		ref mismatch actual	image	pass	history
 +http/tests/storageAccess/request-storage-access-top-frame.html	expected actual diff pretty diff		text	pass timeout	history
 +http/wpt/cache-storage/cache-put-keys.https.any.worker.html	expected actual diff pretty diff		text	pass	history
 +http/wpt/cache-storage/image-fail-with-leak.html		images diff (0.26%)	image leak	pass	history

--- a/LayoutTests/fast/harness/results.html
+++ b/LayoutTests/fast/harness/results.html
@@ -1457,11 +1457,11 @@ class FailuresSectionBuilder extends SectionBuilder {
             let testExtension = Utils.splitExtension(testResult.name)[1];
 
             if (testResult.isMismatchRefTest()) {
-                result += TestResultsController.resultLink(this._resultsController.layoutTestsBasePath() + testPrefix, '-expected-mismatch.' + testExtension, 'ref mismatch');
+                result += TestResultsController.resultLink(this._resultsController.layoutTestsBasePath() + testPrefix, '-expected-mismatch' + testExtension, 'ref mismatch');
                 result += TestResultsController.resultLink(testPrefix, '-actual.png', 'actual');
             } else {
                 if (testResult.isMatchRefTest())
-                    result += TestResultsController.resultLink(this._resultsController.layoutTestsBasePath() + testPrefix, '-expected.' + testExtension, 'reference');
+                    result += TestResultsController.resultLink(this._resultsController.layoutTestsBasePath() + testPrefix, '-expected' + testExtension, 'reference');
 
                 if (this._resultsController.shouldToggleImages)
                     result += TestResultsController.resultLink(testPrefix, '-diffs.html', 'images');


### PR DESCRIPTION
#### 9872023d5aed892954ffa8ae8fb352c87f95b5ac
<pre>
In results.html&apos;s imageResultLinks(), don&apos;t add extra dot before already-dotted testExtension
<a href="https://bugs.webkit.org/show_bug.cgi?id=254000">https://bugs.webkit.org/show_bug.cgi?id=254000</a>
rdar://106785429

Reviewed by Simon Fraser.

`testExtension` already contains a dot, e.g. &quot;.html&quot;, so we don&apos;t need to add a dot before it.

Note: The added test cases in full_results.json covers this code path, but the verification only looks at the text context of results.html, so it won&apos;t actually catch regressions in links.

* LayoutTests/fast/harness/results.html:

Canonical link: <a href="https://commits.webkit.org/261791@main">https://commits.webkit.org/261791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/996ae941b3763c98bee2829c0e60aee804f3198a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4614 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121340 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5784 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118573 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105923 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14293 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1169 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10514 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20310 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53162 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8225 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16844 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->