### PR TITLE
[git pre-push] Treat a 'None' security source level as the maximum level

### DIFF
--- a/Tools/Scripts/hooks/pre-push
+++ b/Tools/Scripts/hooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env {{ python }}
-VERSION = '1.0'
+VERSION = '1.1'
 
 import io
 import os
@@ -295,7 +295,7 @@ def main(name, remote):
             print_error("'{}' comes from an uncategorized remote, it's not safe to push it publically".format(commit))
             return 1
         # Security level of source exceeds security level of target
-        if categorization_class == 1 and security_level > (target_security_level or 0):
+        if categorization_class == 1 and (MAX_LEVEL if security_level is None else security_level) > (target_security_level or 0):
             print_error("'{}' comes from a more secure remote than '{}'".format(commit, name))
             if MODE == PUBLISH_MODE:
                 prompt_for.append(commit)
@@ -307,7 +307,7 @@ def main(name, remote):
             print_error("'{}' cherry-picks a change from an uncategorized remote, it's not safe to push it publically".format(commit))
             return 1
         # Security level of original of a cherry-pick exceeds security level of target
-        if categorization_class == 2 and security_level > (target_security_level or 0):
+        if categorization_class == 2 and (MAX_LEVEL if security_level is None else security_level) > (target_security_level or 0):
             print_error("'{}' cherry-picks a change from a more secure remote than '{}'".format(commit, name))
             if MODE == DEFAULT_MODE:
                 prompt_for.append(commit)


### PR DESCRIPTION
#### 7db47f286675e177952d3a75904712f951d29df8
<pre>
[git pre-push] Treat a &apos;None&apos; security source level as the maximum level
<a href="https://bugs.webkit.org/show_bug.cgi?id=254008">https://bugs.webkit.org/show_bug.cgi?id=254008</a>
rdar://106790367

Reviewed by Aakash Jain.

If the source of a commit has an unknown security level, we must treat that source
as having the maximum possible security level.

* Tools/Scripts/hooks/pre-push:

Canonical link: <a href="https://commits.webkit.org/261753@main">https://commits.webkit.org/261753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea5a52d6564b7f5c9c6385c27993675205e8bfcd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4468 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5622 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118461 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17226 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46243 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14169 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1043 "6 failures") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14856 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10392 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53038 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16700 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4493 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->