### PR TITLE
Allow setting a storage limit for all origins

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -112,7 +112,7 @@ static Ref<NetworkStorageManager> createNetworkStorageManager(IPC::Connection* c
     IPC::Connection::UniqueID connectionID;
     if (connection)
         connectionID = connection->uniqueID();
-    return NetworkStorageManager::create(parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, parameters.perOriginStorageQuota, parameters.perThirdPartyOriginStorageQuota, parameters.originQuotaRatio, parameters.unifiedOriginStorageLevel);
+    return NetworkStorageManager::create(parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, parameters.perOriginStorageQuota, parameters.perThirdPartyOriginStorageQuota, parameters.originQuotaRatio, parameters.totalQuotaRatio, parameters.volumeCapacityOverride, parameters.unifiedOriginStorageLevel);
 }
 
 NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
@@ -100,7 +100,7 @@ void NetworkSessionCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << isBlobRegistryTopOriginPartitioningEnabled;
 
     encoder << unifiedOriginStorageLevel;
-    encoder << perOriginStorageQuota << perThirdPartyOriginStorageQuota << originQuotaRatio;
+    encoder << perOriginStorageQuota << perThirdPartyOriginStorageQuota << originQuotaRatio << totalQuotaRatio << volumeCapacityOverride;
     encoder << localStorageDirectory << localStorageDirectoryExtensionHandle;
     encoder << indexedDBDirectory << indexedDBDirectoryExtensionHandle;
     encoder << cacheStorageDirectory << cacheStorageDirectoryExtensionHandle;
@@ -382,6 +382,16 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
     if (!originQuotaRatio)
         return std::nullopt;
 
+    std::optional<std::optional<double>> totalQuotaRatio;
+    decoder >> totalQuotaRatio;
+    if (!totalQuotaRatio)
+        return std::nullopt;
+
+    std::optional<std::optional<uint64_t>> volumeCapacityOverride;
+    decoder >> volumeCapacityOverride;
+    if (!volumeCapacityOverride)
+        return std::nullopt;
+
     std::optional<String> localStorageDirectory;
     decoder >> localStorageDirectory;
     if (!localStorageDirectory)
@@ -507,6 +517,8 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
         , WTFMove(*perOriginStorageQuota)
         , WTFMove(*perThirdPartyOriginStorageQuota)
         , WTFMove(*originQuotaRatio)
+        , WTFMove(*totalQuotaRatio)
+        , WTFMove(*volumeCapacityOverride)
         , WTFMove(*localStorageDirectory)
         , WTFMove(*localStorageDirectoryExtensionHandle)
         , WTFMove(*indexedDBDirectory)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -121,6 +121,8 @@ struct NetworkSessionCreationParameters {
     uint64_t perOriginStorageQuota;
     uint64_t perThirdPartyOriginStorageQuota;
     std::optional<double> originQuotaRatio;
+    std::optional<double> totalQuotaRatio;
+    std::optional<uint64_t> volumeCapacityOverride;
     String localStorageDirectory;
     SandboxExtension::Handle localStorageDirectoryExtensionHandle;
     String indexedDBDirectory;

--- a/Source/WebKit/NetworkProcess/storage/NetworkQuotaManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkQuotaManager.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NetworkQuotaManager.h"
+
+#include "NetworkStorageManager.h"
+
+namespace WebKit {
+
+NetworkQuotaManager::NetworkQuotaManager(uint64_t quota, const Vector<std::pair<WebCore::ClientOrigin, uint64_t>>& usages, Function<bool(const WebCore::SecurityOriginData&)>&& function)
+    : m_quota(quota)
+    , m_evictDataFunction(WTFMove(function))
+{
+    for (auto [origin, usage] : usages) {
+        m_origins.appendOrMoveToLast(origin.topOrigin);
+        m_originUsageMap.ensure(origin.topOrigin, [] {
+            return HashMap<WebCore::SecurityOriginData, uint64_t> { };
+        }).iterator->value.add(origin.clientOrigin, usage);
+    }
+
+    performEvictionIfNeeded();
+}
+
+void NetworkQuotaManager::originUsageUpdated(const WebCore::ClientOrigin& origin, uint64_t usage)
+{
+    originVisited(origin);
+    auto& originUsage = m_originUsageMap.ensure(origin.topOrigin, [] {
+        return HashMap<WebCore::SecurityOriginData, uint64_t> { };
+    }).iterator->value;
+    auto iterator = originUsage.ensure(origin.clientOrigin, [] {
+        return 0;
+    }).iterator;
+    auto currentUsage = iterator->value;
+    iterator->value = usage;
+    if (usage <= currentUsage)
+        return;
+
+    performEvictionIfNeeded();
+}
+
+void NetworkQuotaManager::performEvictionIfNeeded()
+{
+    if (!m_evictDataFunction)
+        return;
+
+    uint64_t totalUsage = 0;
+    for (auto origin : m_origins) {
+        auto iterator = m_originUsageMap.find(origin);
+        if (iterator == m_originUsageMap.end())
+            continue;
+
+        for (auto usage : iterator->value.values())
+            totalUsage += usage;
+    }
+
+    while (totalUsage > m_quota) {
+        ASSERT(!m_origins.isEmpty());
+
+        auto topOrigin = m_origins.first();
+        if (!m_evictDataFunction(topOrigin))
+            break;
+
+        m_origins.removeFirst();
+        auto originUsage = m_originUsageMap.take(topOrigin);
+        for (auto& [origin, usage] : originUsage)
+            totalUsage -= usage;
+    }
+}
+
+void NetworkQuotaManager::originVisited(const WebCore::ClientOrigin& origin)
+{
+    m_origins.appendOrMoveToLast(origin.topOrigin);
+}
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -39,9 +39,10 @@
 #include "LocalStorageManager.h"
 #include "Logging.h"
 #include "NetworkProcessProxyMessages.h"
+#include "NetworkQuotaManager.h"
 #include "NetworkStorageManagerMessages.h"
+#include "OriginQuotaManager.h"
 #include "OriginStorageManager.h"
-#include "QuotaManager.h"
 #include "SessionStorageManager.h"
 #include "StorageAreaBase.h"
 #include "StorageAreaMapMessages.h"
@@ -49,7 +50,6 @@
 #include "StorageUtilities.h"
 #include "UnifiedOriginStorageLevel.h"
 #include "WebsiteDataType.h"
-#include <WebCore/ClientOrigin.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/UniqueIDBDatabaseConnection.h>
 #include <WebCore/UniqueIDBDatabaseTransaction.h>
@@ -130,18 +130,20 @@ static void deleteEmptyOriginDirectory(const String& directory)
     FileSystem::deleteEmptyDirectory(FileSystem::parentPath(directory));
 }
 
-Ref<NetworkStorageManager> NetworkStorageManager::create(PAL::SessionID sessionID, Markable<UUID> identifier, IPC::Connection::UniqueID connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, std::optional<double> originQuotaRatio, UnifiedOriginStorageLevel level)
+Ref<NetworkStorageManager> NetworkStorageManager::create(PAL::SessionID sessionID, Markable<UUID> identifier, IPC::Connection::UniqueID connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel level)
 {
-    return adoptRef(*new NetworkStorageManager(sessionID, identifier, connection, path, customLocalStoragePath, customIDBStoragePath, customCacheStoragePath, defaultOriginQuota, defaultThirdPartyOriginQuota, originQuotaRatio, level));
+    return adoptRef(*new NetworkStorageManager(sessionID, identifier, connection, path, customLocalStoragePath, customIDBStoragePath, customCacheStoragePath, defaultOriginQuota, defaultThirdPartyOriginQuota, originQuotaRatio, totalQuotaRatio, volumeCapacityOverride, level));
 }
 
-NetworkStorageManager::NetworkStorageManager(PAL::SessionID sessionID, Markable<UUID> identifier, IPC::Connection::UniqueID connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, std::optional<double> originQuotaRatio, UnifiedOriginStorageLevel level)
+NetworkStorageManager::NetworkStorageManager(PAL::SessionID sessionID, Markable<UUID> identifier, IPC::Connection::UniqueID connection, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel level)
     : m_sessionID(sessionID)
     , m_queueName(makeString("com.apple.WebKit.Storage.", sessionID.toUInt64(), ".", static_cast<uint64_t>(identifier->data() >> 64), static_cast<uint64_t>(identifier->data())))
     , m_queue(SuspendableWorkQueue::create(m_queueName.utf8().data(), SuspendableWorkQueue::QOS::Default, SuspendableWorkQueue::ShouldLog::Yes))
     , m_defaultOriginQuota(defaultOriginQuota)
     , m_defaultThirdPartyOriginQuota(defaultThirdPartyOriginQuota)
     , m_originQuotaRatio(originQuotaRatio)
+    , m_totalQuotaRatio(totalQuotaRatio)
+    , m_volumeCapacityOverride(volumeCapacityOverride)
     , m_parentConnection(connection)
 #if PLATFORM(IOS_FAMILY)
     , m_backupExclusionPeriod(defaultBackupExclusionPeriod)
@@ -191,11 +193,18 @@ NetworkStorageManager::~NetworkStorageManager()
 
 bool NetworkStorageManager::canHandleTypes(OptionSet<WebsiteDataType> types)
 {
-    return types.contains(WebsiteDataType::LocalStorage)
-        || types.contains(WebsiteDataType::SessionStorage)
-        || types.contains(WebsiteDataType::FileSystem)
-        || types.contains(WebsiteDataType::IndexedDBDatabases)
-        || types.contains(WebsiteDataType::DOMCache);
+    return allManagedTypes().containsAny(types);
+}
+
+OptionSet<WebsiteDataType> NetworkStorageManager::allManagedTypes()
+{
+    return {
+        WebsiteDataType::LocalStorage,
+        WebsiteDataType::SessionStorage,
+        WebsiteDataType::FileSystem,
+        WebsiteDataType::IndexedDBDatabases,
+        WebsiteDataType::DOMCache
+    };
 }
 
 void NetworkStorageManager::close(CompletionHandler<void()>&& completionHandler)
@@ -242,7 +251,7 @@ void NetworkStorageManager::stopReceivingMessageFromConnection(IPC::Connection& 
         m_originStorageManagers.removeIf([&](auto& entry) {
             auto& manager = entry.value;
             manager->connectionClosed(connection);
-            bool shouldRemove = !manager->isActive();
+            bool shouldRemove = !manager->isActive() && !manager->hasDataInMemory();
             if (shouldRemove) {
                 manager->deleteEmptyDirectory();
                 deleteEmptyOriginDirectory(manager->path());
@@ -284,6 +293,7 @@ void NetworkStorageManager::writeOriginToFileIfNecessary(const WebCore::ClientOr
 #if PLATFORM(IOS_FAMILY)
         includeOriginInBackupIfNecessary(*manager);
 #endif
+        updateOriginModificationTime(origin);
         return;
     }
 
@@ -306,6 +316,52 @@ void NetworkStorageManager::writeOriginToFileIfNecessary(const WebCore::ClientOr
 #else
     UNUSED_PARAM(didWrite);
 #endif
+
+    if (m_quotaManager)
+        m_quotaManager->originVisited(origin);
+}
+
+NetworkQuotaManager& NetworkStorageManager::quotaManager()
+{
+    if (!m_quotaManager) {
+        Vector<std::pair<WebCore::ClientOrigin, WallTime>> origins;
+        forEachOriginDirectory([&](auto directory) {
+            auto originFile = originFilePath(directory);
+            auto modificationTime = FileSystem::fileModificationTime(originFile);
+            if (modificationTime) {
+                if (auto origin = readOriginFromFile(originFile))
+                    origins.append({ *origin, *modificationTime });
+            }
+        });
+
+        std::sort(origins.begin(), origins.end(), [&](const auto& a, const auto& b) {
+            return a.second < b.second;
+        });
+
+        Vector<std::pair<WebCore::ClientOrigin, uint64_t>> usages;
+        for (auto& origin : origins) {
+            auto usage = originStorageManager(origin.first).quotaManager().usage();
+            usages.append({ origin.first, usage });
+            removeOriginStorageManagerIfPossible(origin.first);
+        }
+
+        uint64_t quota = std::numeric_limits<uint64_t>::max();
+        if (m_totalQuotaRatio) {
+            if (m_volumeCapacityOverride)
+                quota = m_totalQuotaRatio.value() * m_volumeCapacityOverride.value();
+            else if (auto capacity = FileSystem::volumeCapacity(m_path))
+                quota = m_totalQuotaRatio.value() * capacity.value();
+        }
+        m_quotaManager = makeUnique<NetworkQuotaManager>(quota, usages, [weakThis = ThreadSafeWeakPtr { *this }](auto origin) {
+            if (auto strongThis = weakThis.get()) {
+                strongThis->evictDataByTopOrigin(origin);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    return *m_quotaManager;
 }
 
 OriginStorageManager& NetworkStorageManager::originStorageManager(const WebCore::ClientOrigin& origin, ShouldWriteOriginFile shouldWriteOriginFile)
@@ -318,19 +374,26 @@ OriginStorageManager& NetworkStorageManager::originStorageManager(const WebCore:
         auto idbStoragePath = IDBStorageManager::idbStorageOriginDirectory(m_customIDBStoragePath, origin);
         auto cacheStoragePath = CacheStorageManager::cacheStorageOriginDirectory(m_customCacheStoragePath, origin);
         CacheStorageManager::copySaltFileToOriginDirectory(m_customCacheStoragePath, cacheStoragePath);
-        QuotaManager::IncreaseQuotaFunction increaseQuotaFunction = [sessionID = m_sessionID, origin, connection = m_parentConnection] (auto identifier, auto currentQuota, auto currentUsage, auto requestedIncrease) mutable {
+        OriginQuotaManager::IncreaseQuotaFunction increaseQuotaFunction = [sessionID = m_sessionID, origin, connection = m_parentConnection] (auto identifier, auto currentQuota, auto currentUsage, auto requestedIncrease) mutable {
             IPC::Connection::send(connection, Messages::NetworkProcessProxy::IncreaseQuota(sessionID, origin, identifier, currentQuota, currentUsage, requestedIncrease), 0);
         };
         uint64_t quota = m_defaultOriginQuota;
         if (m_originQuotaRatio) {
-            if (auto capacity = FileSystem::volumeCapacity(m_path)) {
+            if (m_volumeCapacityOverride) {
+                quota = m_originQuotaRatio.value() * m_volumeCapacityOverride.value();
+                increaseQuotaFunction = { };
+            } else if (auto capacity = FileSystem::volumeCapacity(m_path)) {
                 quota = m_originQuotaRatio.value() * capacity.value();
                 increaseQuotaFunction = { };
             }
         }
         if (origin.topOrigin != origin.clientOrigin)
             quota = quota / m_defaultOriginQuota * m_defaultThirdPartyOriginQuota;
-        return makeUnique<OriginStorageManager>(quota, WTFMove(increaseQuotaFunction), WTFMove(originDirectory), WTFMove(localStoragePath), WTFMove(idbStoragePath), WTFMove(cacheStoragePath), m_unifiedOriginStorageLevel);
+        OriginQuotaManager::NotifyUsageUpdateFunction notifyUsageUpdateFunction = [weakThis = ThreadSafeWeakPtr { *this }, origin](uint64_t usage) {
+            if (auto strongThis = weakThis.get())
+                strongThis->quotaManager().originUsageUpdated(origin, usage);
+        };
+        return makeUnique<OriginStorageManager>(quota, WTFMove(increaseQuotaFunction), WTFMove(notifyUsageUpdateFunction), WTFMove(originDirectory), WTFMove(localStoragePath), WTFMove(idbStoragePath), WTFMove(cacheStoragePath), m_unifiedOriginStorageLevel);
     }).iterator->value;
 
     if (shouldWriteOriginFile == ShouldWriteOriginFile::Yes)
@@ -348,7 +411,7 @@ bool NetworkStorageManager::removeOriginStorageManagerIfPossible(const WebCore::
         return true;
 
     auto& manager = iterator->value;
-    if (manager->isActive())
+    if (manager->isActive() || manager->hasDataInMemory())
         return false;
 
     manager->deleteEmptyDirectory();
@@ -356,6 +419,24 @@ bool NetworkStorageManager::removeOriginStorageManagerIfPossible(const WebCore::
 
     m_originStorageManagers.remove(iterator);
     return true;
+}
+
+void NetworkStorageManager::updateOriginModificationTime(const WebCore::ClientOrigin& origin)
+{
+    assertIsCurrent(workQueue());
+    // This function should be called when origin is in use, i.e. OriginStorageManager exists.
+    auto* manager = m_originStorageManagers.get(origin);
+    if (!manager)
+        return;
+
+    auto originDirectory = manager->path();
+    if (originDirectory.isEmpty())
+        return;
+
+    auto originFile = originFilePath(originDirectory);
+    FileSystem::updateFileModificationTime(originFile);
+    if (m_quotaManager)
+        m_quotaManager->originVisited(origin);
 }
 
 void NetworkStorageManager::persisted(const WebCore::ClientOrigin& origin, CompletionHandler<void(bool)>&& completionHandler)
@@ -786,13 +867,37 @@ void NetworkStorageManager::moveData(OptionSet<WebsiteDataType> types, WebCore::
     });
 }
 
+bool NetworkStorageManager::evictDataByTopOrigin(const WebCore::SecurityOriginData& topOrigin)
+{
+    ASSERT(!RunLoop::isMain());
+    assertIsCurrent(workQueue());
+
+    Vector<WebCore::ClientOrigin> originsToEvict;
+    for (auto& origin : getAllOrigins()) {
+        if (origin.topOrigin != topOrigin)
+            continue;
+
+        if (auto* originManager = m_originStorageManagers.get(origin)) {
+            if (originManager->isActive())
+                return false;
+        }
+        originsToEvict.append(origin);
+    }
+
+    for (auto& origin : originsToEvict) {
+        originStorageManager(origin, ShouldWriteOriginFile::No).deleteData(allManagedTypes(), -WallTime::infinity());
+        removeOriginStorageManagerIfPossible(origin);
+    }
+    return true;
+}
+
 void NetworkStorageManager::getOriginDirectory(WebCore::ClientOrigin&& origin, WebsiteDataType type, CompletionHandler<void(const String&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
     ASSERT(!m_closed);
 
     m_queue->dispatch([this, protectedThis = Ref { *this }, type, origin = crossThreadCopy(WTFMove(origin)), completionHandler = WTFMove(completionHandler)]() mutable {
-        RunLoop::main().dispatch([completionHandler = WTFMove(completionHandler), directory = crossThreadCopy(originStorageManager(origin).resolvedPath(type))]() mutable {
+        RunLoop::main().dispatch([completionHandler = WTFMove(completionHandler), directory = crossThreadCopy(originStorageManager(origin, ShouldWriteOriginFile::No).resolvedPath(type))]() mutable {
             completionHandler(WTFMove(directory));
         });
         removeOriginStorageManagerIfPossible(origin);
@@ -883,7 +988,7 @@ void NetworkStorageManager::requestSpace(const WebCore::ClientOrigin& origin, ui
     m_queue->dispatch([this, protectedThis = Ref { *this }, origin = crossThreadCopy(origin), size, completionHandler = WTFMove(completionHandler)]() mutable {
         originStorageManager(origin).quotaManager().requestSpace(size, [completionHandler = WTFMove(completionHandler)](auto decision) mutable {
             RunLoop::main().dispatch([completionHandler = WTFMove(completionHandler), decision]() mutable {
-                completionHandler(decision == QuotaManager::Decision::Grant);
+                completionHandler(decision == OriginQuotaManager::Decision::Grant);
             });
         });
     });

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -74,13 +74,15 @@ enum class BackgroundFetchChange : uint8_t;
 enum class UnifiedOriginStorageLevel : uint8_t;
 class FileSystemStorageHandleRegistry;
 class IDBStorageRegistry;
+class NetworkQuotaManager;
 class StorageAreaBase;
 class StorageAreaRegistry;
 
 class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver {
 public:
-    static Ref<NetworkStorageManager> create(PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, std::optional<double> originQuotaRatio, UnifiedOriginStorageLevel);
+    static Ref<NetworkStorageManager> create(PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);
+    static OptionSet<WebsiteDataType> allManagedTypes();
 
     void startReceivingMessageFromConnection(IPC::Connection&);
     void stopReceivingMessageFromConnection(IPC::Connection&);
@@ -117,17 +119,20 @@ public:
 #endif // ENABLE(SERVICE_WORKER)
 
 private:
-    NetworkStorageManager(PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, std::optional<double> originQuotaRatio, UnifiedOriginStorageLevel);
+    NetworkStorageManager(PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     ~NetworkStorageManager();
+    NetworkQuotaManager& quotaManager();
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
     OriginStorageManager& originStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);
     bool removeOriginStorageManagerIfPossible(const WebCore::ClientOrigin&);
+    void updateOriginModificationTime(const WebCore::ClientOrigin&);
 
     void forEachOriginDirectory(const Function<void(const String&)>&);
     HashSet<WebCore::ClientOrigin> getAllOrigins();
     Vector<WebsiteData::Entry> fetchDataFromDisk(OptionSet<WebsiteDataType>, ShouldComputeSize);
     HashSet<WebCore::ClientOrigin> deleteDataOnDisk(OptionSet<WebsiteDataType>, WallTime, const Function<bool(const WebCore::ClientOrigin&)>&);
+    bool evictDataByTopOrigin(const WebCore::SecurityOriginData&);
 #if PLATFORM(IOS_FAMILY)
     void includeOriginInBackupIfNecessary(OriginStorageManager&);
 #endif
@@ -225,6 +230,9 @@ private:
     uint64_t m_defaultOriginQuota;
     uint64_t m_defaultThirdPartyOriginQuota;
     std::optional<double> m_originQuotaRatio;
+    std::optional<double> m_totalQuotaRatio;
+    std::optional<uint64_t> m_volumeCapacityOverride;
+    std::unique_ptr<NetworkQuotaManager> m_quotaManager;
     UnifiedOriginStorageLevel m_unifiedOriginStorageLevel;
     IPC::Connection::UniqueID m_parentConnection;
     HashMap<IPC::Connection::UniqueID, HashSet<String>> m_temporaryBlobPathsByConnection WTF_GUARDED_BY_CAPABILITY(workQueue());

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
@@ -32,12 +32,13 @@
 
 namespace WebKit {
 
-class QuotaManager : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<QuotaManager> {
+class OriginQuotaManager : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<OriginQuotaManager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using GetUsageFunction = Function<uint64_t()>;
     using IncreaseQuotaFunction = Function<void(QuotaIncreaseRequestIdentifier, uint64_t currentQuota, uint64_t currentUsage, uint64_t requestedIncrease)>;
-    static Ref<QuotaManager> create(uint64_t quota, GetUsageFunction&&, IncreaseQuotaFunction&& = { });
+    using NotifyUsageUpdateFunction = Function<void(uint64_t)>;
+    static Ref<OriginQuotaManager> create(uint64_t quota, GetUsageFunction&&, IncreaseQuotaFunction&& = { }, NotifyUsageUpdateFunction&& = { });
     uint64_t reportedQuota() const;
     uint64_t usage();
     enum class Decision : bool { Deny, Grant };
@@ -49,10 +50,11 @@ public:
     void resetQuotaForTesting();
 
 private:
-    QuotaManager(uint64_t quota, GetUsageFunction&&, IncreaseQuotaFunction&&);
+    OriginQuotaManager(uint64_t quota, GetUsageFunction&&, IncreaseQuotaFunction&&, NotifyUsageUpdateFunction&&);
     void handleRequests();
     bool grantWithCurrentQuota(uint64_t spaceRequested);
     bool grantFastPath(uint64_t spaceRequested);
+    void usageUpdated(uint64_t newUsage);
 
     struct Request {
         uint64_t spaceRequested;
@@ -68,6 +70,7 @@ private:
     std::optional<uint64_t> m_usage;
     GetUsageFunction m_getUsageFunction;
     IncreaseQuotaFunction m_increaseQuotaFunction;
+    NotifyUsageUpdateFunction m_notifyUsageUpdateFunction;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "Connection.h"
-#include "QuotaManager.h"
+#include "OriginQuotaManager.h"
 #include "WebsiteDataType.h"
 #include <wtf/text/WTFString.h>
 
@@ -57,7 +57,7 @@ class OriginStorageManager : public CanMakeWeakPtr<OriginStorageManager> {
 public:
     static String originFileIdentifier();
 
-    OriginStorageManager(uint64_t quota, QuotaManager::IncreaseQuotaFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel);
+    OriginStorageManager(uint64_t quota, OriginQuotaManager::IncreaseQuotaFunction&&, OriginQuotaManager::NotifyUsageUpdateFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel);
     ~OriginStorageManager();
 
     void connectionClosed(IPC::Connection::UniqueID);
@@ -65,7 +65,7 @@ public:
     void setPersisted(bool value);
     WebCore::StorageEstimate estimate();
     const String& path() const { return m_path; }
-    QuotaManager& quotaManager();
+    OriginQuotaManager& quotaManager();
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&);
     FileSystemStorageManager* existingFileSystemStorageManager();
     LocalStorageManager& localStorageManager(StorageAreaRegistry&);
@@ -83,6 +83,7 @@ public:
     void closeCacheStorageManager();
     String resolvedPath(WebsiteDataType);
     bool isActive();
+    bool hasDataInMemory();
     bool isEmpty();
     using DataTypeSizeMap = HashMap<WebsiteDataType, uint64_t, IntHash<WebsiteDataType>, WTF::StrongEnumHashTraits<WebsiteDataType>>;
     DataTypeSizeMap fetchDataTypesInList(OptionSet<WebsiteDataType>, bool shouldComputeSize);
@@ -97,7 +98,7 @@ public:
 #endif
 
 private:
-    Ref<QuotaManager> createQuotaManager();
+    Ref<OriginQuotaManager> createQuotaManager();
     enum class StorageBucketMode : bool;
     class StorageBucket;
     StorageBucket& defaultBucket();
@@ -108,8 +109,9 @@ private:
     String m_customIDBStoragePath;
     String m_customCacheStoragePath;
     uint64_t m_quota;
-    QuotaManager::IncreaseQuotaFunction m_increaseQuotaFunction;
-    RefPtr<QuotaManager> m_quotaManager;
+    OriginQuotaManager::IncreaseQuotaFunction m_increaseQuotaFunction;
+    OriginQuotaManager::NotifyUsageUpdateFunction m_notifyUsageUpdateFunction;
+    RefPtr<OriginQuotaManager> m_quotaManager;
     bool m_persisted { false };
     UnifiedOriginStorageLevel m_level;
     Markable<WallTime> m_originFileCreationTimestamp;

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -166,9 +166,10 @@ NetworkProcess/storage/IDBStorageManager.cpp
 NetworkProcess/storage/IDBStorageRegistry.cpp
 NetworkProcess/storage/LocalStorageManager.cpp
 NetworkProcess/storage/MemoryStorageArea.cpp
+NetworkProcess/storage/NetworkQuotaManager.cpp
 NetworkProcess/storage/NetworkStorageManager.cpp
+NetworkProcess/storage/OriginQuotaManager.cpp
 NetworkProcess/storage/OriginStorageManager.cpp
-NetworkProcess/storage/QuotaManager.cpp
 NetworkProcess/storage/SQLiteStorageArea.cpp
 NetworkProcess/storage/SessionStorageManager.cpp
 NetworkProcess/storage/StorageAreaBase.cpp

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -53,6 +53,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic) BOOL fastServerTrustEvaluationEnabled WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic) NSUInteger perOriginStorageQuota WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic, nullable, copy) NSNumber *originQuotaRatio WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, nullable, copy) NSNumber *totalQuotaRatio WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, nullable, copy) NSString *boundInterfaceIdentifier WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic) BOOL allowsCellularAccess WK_API_AVAILABLE(macos(10.15.4), ios(14.0));
 @property (nonatomic) BOOL legacyTLSEnabled WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
@@ -98,6 +99,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic, nullable, copy) NSURL *generalStorageDirectory WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic, nullable, copy, setter=setWebPushPartitionString:) NSString *webPushPartitionString WK_API_AVAILABLE(macos(13.3), ios(16.4));
 @property (nonatomic) _WKUnifiedOriginStorageLevel unifiedOriginStorageLevel WK_API_AVAILABLE(macos(13.3), ios(16.4));
+@property (nonatomic, nullable, copy) NSNumber *volumeCapacityOverride WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 // Testing only.
 @property (nonatomic) BOOL allLoadsBlockedByDeviceManagementRestrictionsForTesting WK_API_AVAILABLE(macos(10.15), ios(13.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -523,6 +523,45 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
     _configuration->setOriginQuotaRatio(ratio);
 }
 
+- (NSNumber *)totalQuotaRatio
+{
+    auto ratio = _configuration->totalQuotaRatio();
+    if (!ratio)
+        return nil;
+
+    return [NSNumber numberWithFloat:*ratio];
+}
+
+- (void)setTotalQuotaRatio:(NSNumber *)totalQuotaRatio
+{
+    std::optional<double> ratio = std::nullopt;
+    if (totalQuotaRatio) {
+        ratio = [totalQuotaRatio doubleValue];
+        if (!ratio.value())
+            [NSException raise:NSInvalidArgumentException format:@"totalQuotaRatio is 0.0"];
+    }
+
+    _configuration->setTotalQuotaRatio(ratio);
+}
+
+- (NSNumber *)volumeCapacityOverride
+{
+    auto capacity = _configuration->volumeCapacityOverride();
+    if (!capacity)
+        return nil;
+
+    return [NSNumber numberWithUnsignedLongLong:*capacity];
+}
+
+- (void)setVolumeCapacityOverride:(NSNumber *)mockVolumeCapactiy
+{
+    std::optional<uint64_t> capacity = std::nullopt;
+    if (mockVolumeCapactiy)
+        capacity = [mockVolumeCapactiy unsignedLongLongValue];
+
+    _configuration->setVolumeCapacityOverride(capacity);
+}
+
 - (NSUInteger)testSpeedMultiplier
 {
     return _configuration->testSpeedMultiplier();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1921,6 +1921,8 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     networkSessionParameters.perOriginStorageQuota = perOriginStorageQuota();
     networkSessionParameters.perThirdPartyOriginStorageQuota = perThirdPartyOriginStorageQuota();
     networkSessionParameters.originQuotaRatio = originQuotaRatio();
+    networkSessionParameters.totalQuotaRatio = m_configuration->totalQuotaRatio();
+    networkSessionParameters.volumeCapacityOverride = m_configuration->volumeCapacityOverride();
     networkSessionParameters.localStorageDirectory = resolvedLocalStorageDirectory();
     createHandleFromResolvedPathIfPossible(networkSessionParameters.localStorageDirectory, networkSessionParameters.localStorageDirectoryExtensionHandle);
     networkSessionParameters.indexedDBDirectory = resolvedIndexedDBDatabaseDirectory();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -127,6 +127,8 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     copy->m_unifiedOriginStorageLevel = this->m_unifiedOriginStorageLevel;
     copy->m_perOriginStorageQuota = this->m_perOriginStorageQuota;
     copy->m_originQuotaRatio = this->m_originQuotaRatio;
+    copy->m_totalQuotaRatio = this->m_totalQuotaRatio;
+    copy->m_volumeCapacityOverride = this->m_volumeCapacityOverride;
     copy->m_networkCacheDirectory = this->m_networkCacheDirectory;
     copy->m_applicationCacheDirectory = this->m_applicationCacheDirectory;
     copy->m_applicationCacheFlatFileSubdirectoryName = this->m_applicationCacheFlatFileSubdirectoryName;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -69,6 +69,12 @@ public:
     std::optional<double> originQuotaRatio() const { return m_originQuotaRatio; }
     void setOriginQuotaRatio(std::optional<double> ratio) { m_originQuotaRatio = ratio; }
 
+    std::optional<double> totalQuotaRatio() const { return m_totalQuotaRatio; }
+    void setTotalQuotaRatio(std::optional<double> ratio) { m_totalQuotaRatio = ratio; }
+
+    std::optional<uint64_t> volumeCapacityOverride() const { return m_volumeCapacityOverride; }
+    void setVolumeCapacityOverride(std::optional<uint64_t> capacity) { m_volumeCapacityOverride = capacity; }
+
     const String& applicationCacheDirectory() const { return m_applicationCacheDirectory; }
     void setApplicationCacheDirectory(String&& directory) { m_applicationCacheDirectory = WTFMove(directory); }
     
@@ -251,6 +257,8 @@ private:
     String m_generalStorageDirectory;
     uint64_t m_perOriginStorageQuota;
     std::optional<double> m_originQuotaRatio;
+    std::optional<double> m_totalQuotaRatio;
+    std::optional<uint64_t> m_volumeCapacityOverride;
     String m_networkCacheDirectory;
     String m_applicationCacheDirectory;
     String m_applicationCacheFlatFileSubdirectoryName { "Files"_s };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -879,6 +879,8 @@
 		37F623B812A57B6200E3FDF6 /* WKFindOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 37F623B712A57B6200E3FDF6 /* WKFindOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37FC19471850FBF2008CFA47 /* WKBrowsingContextLoadDelegatePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 37FC19461850FBF2008CFA47 /* WKBrowsingContextLoadDelegatePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37FC194B18510D6A008CFA47 /* WKNSURLAuthenticationChallenge.h in Headers */ = {isa = PBXBuildFile; fileRef = 37FC194918510D6A008CFA47 /* WKNSURLAuthenticationChallenge.h */; };
+		3AB0C59429C8162300141B5E /* NetworkQuotaManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB0C59229C8162200141B5E /* NetworkQuotaManager.h */; };
+		3AE104C029CBC8BB00661165 /* OriginQuotaManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE104BE29CBC8BB00661165 /* OriginQuotaManager.h */; };
 		3CAECB6627465AE400AB78D0 /* UnifiedSource113.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */; };
 		3F418EF91887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F418EF51887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp */; };
 		3F418EFB1887BD97002795FD /* VideoFullscreenManagerProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F418EF71887BD97002795FD /* VideoFullscreenManagerProxyMessageReceiver.cpp */; };
@@ -4399,6 +4401,10 @@
 		37FC194918510D6A008CFA47 /* WKNSURLAuthenticationChallenge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKNSURLAuthenticationChallenge.h; sourceTree = "<group>"; };
 		3A8997E029B25E8E00AB88B6 /* WebCookieCacheCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCookieCacheCocoa.mm; sourceTree = "<group>"; };
 		3AA50E2C28D37F8700D024E4 /* ProcessAssertionCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ProcessAssertionCocoa.mm; sourceTree = "<group>"; };
+		3AB0C59129C8162200141B5E /* NetworkQuotaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkQuotaManager.cpp; sourceTree = "<group>"; };
+		3AB0C59229C8162200141B5E /* NetworkQuotaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkQuotaManager.h; sourceTree = "<group>"; };
+		3AE104BD29CBC8BA00661165 /* OriginQuotaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OriginQuotaManager.cpp; sourceTree = "<group>"; };
+		3AE104BE29CBC8BB00661165 /* OriginQuotaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OriginQuotaManager.h; sourceTree = "<group>"; };
 		3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource113.cpp; sourceTree = "<group>"; };
 		3F418EF51887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoFullscreenManagerMessageReceiver.cpp; sourceTree = "<group>"; };
 		3F418EF61887BD97002795FD /* VideoFullscreenManagerMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoFullscreenManagerMessages.h; sourceTree = "<group>"; };
@@ -7585,6 +7591,7 @@
 				0867D69AFE84028FC02AAC07 /* External Frameworks and Libraries */,
 				034768DFFF38A50411DB9C8B /* Products */,
 				5750F3292032D4E300389347 /* Frameworks */,
+				3AE104BB29CAAEDB00661165 /* Recovered References */,
 			);
 			name = WebKit2;
 			sourceTree = "<group>";
@@ -10233,6 +10240,14 @@
 			path = Cocoa;
 			sourceTree = "<group>";
 		};
+		3AE104BB29CAAEDB00661165 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				7A830B2D29B7F3EB00848075 /* WebPageInlines.h */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		413075971DE84ED70039EC69 /* webrtc */ = {
 			isa = PBXGroup;
 			children = (
@@ -11555,9 +11570,13 @@
 				93E799CB2760497A0074008A /* LocalStorageManager.h */,
 				93E799D8276121080074008A /* MemoryStorageArea.cpp */,
 				93E799D5276121070074008A /* MemoryStorageArea.h */,
+				3AB0C59129C8162200141B5E /* NetworkQuotaManager.cpp */,
+				3AB0C59229C8162200141B5E /* NetworkQuotaManager.h */,
 				93085DC326E1BBBD000EC6A7 /* NetworkStorageManager.cpp */,
 				93085DC426E1BBBD000EC6A7 /* NetworkStorageManager.h */,
 				93085DC726E1C6EE000EC6A7 /* NetworkStorageManager.messages.in */,
+				3AE104BD29CBC8BA00661165 /* OriginQuotaManager.cpp */,
+				3AE104BE29CBC8BB00661165 /* OriginQuotaManager.h */,
 				93085DC526E1C6CF000EC6A7 /* OriginStorageManager.cpp */,
 				93085DC626E1C6CF000EC6A7 /* OriginStorageManager.h */,
 				93B631EE27ABACA800443A44 /* QuotaManager.cpp */,
@@ -14385,6 +14404,7 @@
 				5179556E162877B300FA43B6 /* NetworkProcessProxy.h in Headers */,
 				513A163D163088F6005D7D22 /* NetworkProcessProxyMessages.h in Headers */,
 				5C1426EE1C23F80900D41183 /* NetworkProcessSupplement.h in Headers */,
+				3AB0C59429C8162300141B5E /* NetworkQuotaManager.h in Headers */,
 				51FD18B61651FBAD00DBE1CE /* NetworkResourceLoader.h in Headers */,
 				E152551B17011819003D7ADB /* NetworkResourceLoaderMessages.h in Headers */,
 				51240EC0220B694C005CFC63 /* NetworkResourceLoadMap.h in Headers */,
@@ -14407,6 +14427,7 @@
 				3754D5451B3A29FD003A4C7F /* NSInvocationSPI.h in Headers */,
 				41DD72AB2682167300A90C71 /* NWSPI.h in Headers */,
 				BC8ACA1316670D89004C1941 /* ObjCObjectGraph.h in Headers */,
+				3AE104C029CBC8BB00661165 /* OriginQuotaManager.h in Headers */,
 				93085DCA26E29775000EC6A7 /* OriginStorageManager.h in Headers */,
 				F4EB4AFD269CD7F300D297AE /* OSStateSPI.h in Headers */,
 				7CF47FFB17275C57008ACB91 /* PageBanner.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
@@ -750,4 +750,82 @@ TEST(WKWebsiteDataStoreConfiguration, OriginQuotaRatio)
     EXPECT_WK_STREQ(@"QuotaExceededError", [lastScriptMessage body]);
 }
 
+TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatio)
+{
+    done = false;
+    receivedScriptMessage = false;
+    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    // Clear existing data.
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        done = true;
+        EXPECT_NULL(error);
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    NSString *htmlString = @"<script> \
+        window.caches.open('test').then((cache) => { \
+            return cache.put('https://webkit.org/test', new Response(new ArrayBuffer(20000))); \
+        }).then(() => { \
+            window.webkit.messageHandlers.testHandler.postMessage('success'); \
+        }).catch(() => { \
+            window.webkit.messageHandlers.testHandler.postMessage('error'); \
+        }); \
+    </script>";
+    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    EXPECT_NULL([websiteDataStoreConfiguration.get() totalQuotaRatio]);
+    [websiteDataStoreConfiguration.get() setTotalQuotaRatio:[NSNumber numberWithFloat:0.5]];
+    [websiteDataStoreConfiguration.get() setVolumeCapacityOverride:[NSNumber numberWithFloat:100000]];
+    auto handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+    [configuration setWebsiteDataStore:websiteDataStore.get()];
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://first.com"]];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    receivedScriptMessage = false;
+    EXPECT_WK_STREQ(@"success", [lastScriptMessage body]);
+
+    [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://second.com"]];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    receivedScriptMessage = false;
+    EXPECT_WK_STREQ(@"success", [lastScriptMessage body]);
+
+    auto sortFunction = ^(WKWebsiteDataRecord *record1, WKWebsiteDataRecord *record2) {
+        return [record1.displayName compare:record2.displayName];
+    };
+    [websiteDataStore fetchDataRecordsOfTypes:[NSSet setWithObject:WKWebsiteDataTypeFetchCache] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        EXPECT_EQ(records.count, 2u);
+        auto sortedRecords = [records sortedArrayUsingComparator:sortFunction];
+        EXPECT_WK_STREQ(@"first.com", [[sortedRecords objectAtIndex:0] displayName]);
+        EXPECT_WK_STREQ(@"second.com", [[sortedRecords objectAtIndex:1] displayName]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    // Update recently used origin list.
+    [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://first.com"]];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    receivedScriptMessage = false;
+    EXPECT_WK_STREQ(@"success", [lastScriptMessage body]);
+
+    // Trigger eviction on example.com.
+    [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://third.com"]];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    receivedScriptMessage = false;
+    EXPECT_WK_STREQ(@"success", [lastScriptMessage body]);
+
+    [websiteDataStore fetchDataRecordsOfTypes:[NSSet setWithObject:WKWebsiteDataTypeFetchCache] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+        EXPECT_EQ(records.count, 2u);
+        auto sortedRecords = [records sortedArrayUsingComparator:sortFunction];
+        EXPECT_WK_STREQ(@"first.com", [[sortedRecords objectAtIndex:0] displayName]);
+        EXPECT_WK_STREQ(@"third.com", [[sortedRecords objectAtIndex:1] displayName]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### e9a1f73b15efbe97e1d3a5ea7a5d211c616215a9
<pre>
Allow setting a storage limit for all origins
<a href="https://bugs.webkit.org/show_bug.cgi?id=254011">https://bugs.webkit.org/show_bug.cgi?id=254011</a>
rdar://106792298

Reviewed by Youenn Fablet.

Make it possible to set a total quota of all origins based on disk space. This is implemented by adding a setting
totalQuotaRatio to WebsiteDataStoreConfiguration. The overall quota of a data store is calculated by:
totalDiskSpace * totalQuotaRatio. When this quota is exceeded, network process will evict data (only for data types that
are managed by NetworkStorageManager) based on LRU policy.

Test: WKWebsiteDataStoreConfiguration.TotalQuotaRatio

* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::createNetworkStorageManager):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp:
(WebKit::NetworkSessionCreationParameters::encode const):
(WebKit::NetworkSessionCreationParameters::decode):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/storage/NetworkQuotaManager.cpp: Added.
(WebKit::NetworkQuotaManager::NetworkQuotaManager):
(WebKit::NetworkQuotaManager::originUsageUpdated):
(WebKit::NetworkQuotaManager::performEvictionIfNeeded):
(WebKit::NetworkQuotaManager::originVisited):
* Source/WebKit/NetworkProcess/storage/NetworkQuotaManager.h: Copied from Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::create):
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::canHandleTypes):
(WebKit::NetworkStorageManager::allManagedTypes):
(WebKit::NetworkStorageManager::stopReceivingMessageFromConnection):
(WebKit::NetworkStorageManager::writeOriginToFileIfNecessary):
(WebKit::NetworkStorageManager::quotaManager):
(WebKit::NetworkStorageManager::originStorageManager):
(WebKit::NetworkStorageManager::removeOriginStorageManagerIfPossible):
(WebKit::NetworkStorageManager::updateOriginModificationTime):
(WebKit::NetworkStorageManager::evictDataByTopOrigin):
(WebKit::NetworkStorageManager::getOriginDirectory):
(WebKit::NetworkStorageManager::requestSpace):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp: Renamed from Source/WebKit/NetworkProcess/storage/QuotaManager.cpp.
(WebKit::OriginQuotaManager::create):
(WebKit::OriginQuotaManager::OriginQuotaManager):
(WebKit::OriginQuotaManager::usage):
(WebKit::OriginQuotaManager::requestSpace):
(WebKit::OriginQuotaManager::handleRequests):
(WebKit::OriginQuotaManager::grantWithCurrentQuota):
(WebKit::OriginQuotaManager::usageUpdated):
(WebKit::OriginQuotaManager::grantFastPath):
(WebKit::OriginQuotaManager::didIncreaseQuota):
(WebKit::OriginQuotaManager::resetQuotaUpdatedBasedOnUsageForTesting):
(WebKit::OriginQuotaManager::resetQuotaForTesting):
(WebKit::OriginQuotaManager::reportedQuota const):
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h: Renamed from Source/WebKit/NetworkProcess/storage/QuotaManager.h.
(WebKit::OriginQuotaManager::create):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::isActive const):
(WebKit::OriginStorageManager::StorageBucket::hasDataInMemory const):
(WebKit::OriginStorageManager::createQuotaManager):
(WebKit::OriginStorageManager::OriginStorageManager):
(WebKit::OriginStorageManager::quotaManager):
(WebKit::OriginStorageManager::fileSystemStorageManager):
(WebKit::OriginStorageManager::idbStorageManager):
(WebKit::OriginStorageManager::cacheStorageManager):
(WebKit::OriginStorageManager::backgroundFetchManager):
(WebKit::OriginStorageManager::hasDataInMemory):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/Platform/IPC/WorkQueueMessageReceiver.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration totalQuotaRatio]):
(-[_WKWebsiteDataStoreConfiguration setTotalQuotaRatio:]):
(-[_WKWebsiteDataStoreConfiguration volumeCapacityOverride]):
(-[_WKWebsiteDataStoreConfiguration setVolumeCapacityOverride:]):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::totalQuotaRatio const):
(WebKit::WebsiteDataStoreConfiguration::setTotalQuotaRatio):
(WebKit::WebsiteDataStoreConfiguration::volumeCapacityOverride const):
(WebKit::WebsiteDataStoreConfiguration::setVolumeCapacityOverride):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262196@main">https://commits.webkit.org/262196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7d2e955d48cb24e1577a4139bf4fc13ff6840ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/886 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/783 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/993 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1194 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/828 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/802 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1852 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/843 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/835 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/203 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/856 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->