### PR TITLE
Clarify type for "integer degrees"

### DIFF
--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -46,6 +46,8 @@ struct LogArgument {
     template<typename U = T> static typename std::enable_if<std::is_same<U, long>::value, String>::type toString(long argument) { return String::number(argument); }
     template<typename U = T> static typename std::enable_if<std::is_same<U, unsigned long long>::value, String>::type toString(unsigned long long argument) { return String::number(argument); }
     template<typename U = T> static typename std::enable_if<std::is_same<U, long long>::value, String>::type toString(long long argument) { return String::number(argument); }
+    template<typename U = T> static typename std::enable_if<std::is_same<U, unsigned short>::value, String>::type toString(unsigned short argument) { return String::number(argument); }
+    template<typename U = T> static typename std::enable_if<std::is_same<U, short>::value, String>::type toString(short argument) { return String::number(argument); }
     template<typename U = T> static typename std::enable_if<std::is_enum<U>::value, String>::type toString(U argument) { return String::number(static_cast<typename std::underlying_type<U>::type>(argument)); }
     template<typename U = T> static typename std::enable_if<std::is_same<U, float>::value, String>::type toString(float argument) { return String::number(argument); }
     template<typename U = T> static typename std::enable_if<std::is_same<U, double>::value, String>::type toString(double argument) { return String::number(argument); }

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1723,6 +1723,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/InbandTextTrackPrivate.h
     platform/graphics/InbandTextTrackPrivateClient.h
     platform/graphics/InlinePathData.h
+    platform/graphics/IntDegrees.h
     platform/graphics/IntPoint.h
     platform/graphics/IntPointHash.h
     platform/graphics/IntRect.h

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -560,7 +560,7 @@ auto Document::allDocuments() -> DocumentsMap::ValuesIteratorRange
     return allDocumentsMap().values();
 }
 
-static inline int currentOrientation(LocalFrame* frame)
+static inline IntDegrees currentOrientation(LocalFrame* frame)
 {
 #if ENABLE(ORIENTATION_EVENTS)
     if (frame)
@@ -8615,7 +8615,7 @@ void Document::didRemoveInDocumentShadowRoot(ShadowRoot& shadowRoot)
     m_inDocumentShadowRoots.remove(shadowRoot);
 }
 
-void Document::orientationChanged(int orientation)
+void Document::orientationChanged(IntDegrees orientation)
 {
     LOG(Events, "Document %p orientationChanged - orientation %d", this, orientation);
     dispatchWindowEvent(Event::create(eventNames().orientationchangeEvent, Event::CanBubble::No, Event::IsCancelable::No));

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1578,7 +1578,7 @@ public:
 
     ConstantPropertyMap& constantProperties() const { return *m_constantPropertyMap; }
 
-    void orientationChanged(int orientation);
+    void orientationChanged(IntDegrees orientation);
     OrientationNotifier& orientationNotifier() { return m_orientationNotifier; }
 
     WEBCORE_EXPORT const AtomString& bgColor() const;

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -204,7 +204,7 @@ class EmptyChromeClient : public ChromeClient {
 #endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(ORIENTATION_EVENTS)
-    int deviceOrientation() const final { return 0; }
+    IntDegrees deviceOrientation() const final { return 0; }
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -319,7 +319,7 @@ public:
 #endif
 
 #if ENABLE(ORIENTATION_EVENTS)
-    virtual int deviceOrientation() const = 0;
+    virtual IntDegrees deviceOrientation() const = 0;
 #endif
 
 #if ENABLE(INPUT_TYPE_COLOR)

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -651,7 +651,7 @@ ExceptionOr<RefPtr<Element>> LocalDOMWindow::matchingElementInFlatTree(Node& sco
 }
 
 #if ENABLE(ORIENTATION_EVENTS)
-int LocalDOMWindow::orientation() const
+IntDegrees LocalDOMWindow::orientation() const
 {
     auto* frame = this->frame();
     if (!frame)

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -351,7 +351,7 @@ public:
     // This is the interface orientation in degrees. Some examples are:
     //  0 is straight up; -90 is when the device is rotated 90 clockwise;
     //  90 is when rotated counter clockwise.
-    int orientation() const;
+    IntDegrees orientation() const;
 #endif
 
     Performance& performance() const;

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -369,7 +369,7 @@ void LocalFrame::orientationChanged()
     });
 }
 
-int LocalFrame::orientation() const
+IntDegrees LocalFrame::orientation() const
 {
     if (auto* page = this->page())
         return page->chrome().client().deviceOrientation();

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -237,7 +237,7 @@ public:
     //  0 is straight up; -90 is when the device is rotated 90 clockwise;
     //  90 is when rotated counter clockwise.
     WEBCORE_EXPORT void orientationChanged();
-    int orientation() const;
+    IntDegrees orientation() const;
 #endif
 
     void clearTimers();

--- a/Source/WebCore/platform/OrientationNotifier.h
+++ b/Source/WebCore/platform/OrientationNotifier.h
@@ -25,21 +25,22 @@
 
 #pragma once
 
+#include "IntDegrees.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 class OrientationNotifier {
 public:
-    explicit OrientationNotifier(int orientation) { m_orientation = orientation; }
+    explicit OrientationNotifier(IntDegrees orientation) { m_orientation = orientation; }
     ~OrientationNotifier();
 
-    void orientationChanged(int orientation);
+    void orientationChanged(IntDegrees orientation);
 
     class Observer {
     public:
         virtual ~Observer();
-        virtual void orientationChanged(int orientation) = 0;
+        virtual void orientationChanged(IntDegrees orientation) = 0;
         void setNotifier(OrientationNotifier*);
 
     private:
@@ -48,11 +49,11 @@ public:
 
     void addObserver(Observer&);
     void removeObserver(Observer&);
-    int orientation() const { return m_orientation; }
+    IntDegrees orientation() const { return m_orientation; }
 
 private:
     Vector<std::reference_wrapper<Observer>> m_observers;
-    int m_orientation;
+    IntDegrees m_orientation;
 };
 
 inline OrientationNotifier::~OrientationNotifier()
@@ -79,7 +80,7 @@ inline void OrientationNotifier::Observer::setNotifier(OrientationNotifier* noti
     m_notifier = notifier;
 }
 
-inline void OrientationNotifier::orientationChanged(int orientation)
+inline void OrientationNotifier::orientationChanged(IntDegrees orientation)
 {
     m_orientation = orientation;
     for (Observer& observer : m_observers)

--- a/Source/WebCore/platform/graphics/IntDegrees.h
+++ b/Source/WebCore/platform/graphics/IntDegrees.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+typedef int32_t IntDegrees;
+
+}

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -105,7 +105,7 @@ private:
     AVFrameRateRange* frameDurationForFrameRate(double);
 
     // OrientationNotifier::Observer API
-    void orientationChanged(int orientation) final;
+    void orientationChanged(IntDegrees orientation) final;
 
     bool setFrameRateConstraint(double minFrameRate, double maxFrameRate);
 
@@ -124,8 +124,8 @@ private:
     RetainPtr<AVCaptureVideoDataOutput> m_videoOutput;
     std::unique_ptr<ImageTransferSessionVT> m_imageTransferSession;
 
-    int m_sensorOrientation { 0 };
-    int m_deviceOrientation { 0 };
+    IntDegrees m_sensorOrientation { 0 };
+    IntDegrees m_deviceOrientation { 0 };
     VideoFrameRotation m_videoFrameRotation { };
 
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -440,7 +440,7 @@ void AVVideoCaptureSource::setSessionSizeFrameRateAndZoom()
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-static inline int sensorOrientation(AVCaptureVideoOrientation videoOrientation)
+static inline IntDegrees sensorOrientation(AVCaptureVideoOrientation videoOrientation)
 {
 #if PLATFORM(IOS_FAMILY)
     switch (videoOrientation) {
@@ -468,7 +468,7 @@ static inline int sensorOrientation(AVCaptureVideoOrientation videoOrientation)
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-static inline int sensorOrientationFromVideoOutput(AVCaptureVideoDataOutput* videoOutput)
+static inline IntDegrees sensorOrientationFromVideoOutput(AVCaptureVideoDataOutput* videoOutput)
 {
     AVCaptureConnection* connection = [videoOutput connectionWithMediaType:AVMediaTypeVideo];
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -587,7 +587,7 @@ void AVVideoCaptureSource::monitorOrientation(OrientationNotifier& notifier)
 #endif
 }
 
-void AVVideoCaptureSource::orientationChanged(int orientation)
+void AVVideoCaptureSource::orientationChanged(IntDegrees orientation)
 {
     ASSERT(orientation == 0 || orientation == 90 || orientation == -90 || orientation == 180);
     m_deviceOrientation = orientation;

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -509,7 +509,7 @@ bool MockRealtimeVideoSource::mockDisplayType(CaptureDevice::DeviceType type) co
     return std::get<MockDisplayProperties>(m_device.properties).type == type;
 }
 
-void MockRealtimeVideoSource::orientationChanged(int orientation)
+void MockRealtimeVideoSource::orientationChanged(IntDegrees orientation)
 {
     auto deviceOrientation = m_deviceOrientation;
     switch (orientation) {

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -85,7 +85,7 @@ private:
     bool isMockSource() const final { return true; }
 
     // OrientationNotifier::Observer
-    void orientationChanged(int orientation) final;
+    void orientationChanged(IntDegrees orientation) final;
     void monitorOrientation(OrientationNotifier&) final;
 
     void drawAnimation(GraphicsContext&);

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -962,7 +962,7 @@ const String& GPUConnectionToWebProcess::mediaKeysStorageDirectory() const
 #endif
 
 #if ENABLE(MEDIA_STREAM)
-void GPUConnectionToWebProcess::setOrientationForMediaCapture(uint64_t orientation)
+void GPUConnectionToWebProcess::setOrientationForMediaCapture(IntDegrees orientation)
 {
 // FIXME: <https://bugs.webkit.org/show_bug.cgi?id=211085>
 #if PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -40,6 +40,7 @@
 #include "ScopedActiveMessageReceiveQueue.h"
 #include "ThreadSafeObjectHeap.h"
 #include "WebGPUIdentifier.h"
+#include <WebCore/IntDegrees.h>
 #include <WebCore/LibWebRTCEnumTraits.h>
 #include <WebCore/NowPlayingManager.h>
 #include <WebCore/PageIdentifier.h>
@@ -155,7 +156,7 @@ public:
 #endif
 
 #if ENABLE(MEDIA_STREAM)
-    void setOrientationForMediaCapture(uint64_t orientation);
+    void setOrientationForMediaCapture(WebCore::IntDegrees);
     void updateCaptureAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture);
     void updateCaptureOrigin(const WebCore::SecurityOriginData&);
     bool setCaptureAttributionString();

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -367,7 +367,7 @@ void GPUProcess::setUseSCContentSharingPicker(bool use)
 #endif
 }
 
-void GPUProcess::setOrientationForMediaCapture(uint64_t orientation)
+void GPUProcess::setOrientationForMediaCapture(IntDegrees orientation)
 {
     m_orientation = orientation;
     for (auto& connection : m_webProcessConnections.values())

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -32,6 +32,7 @@
 #include "SandboxExtension.h"
 #include "ShareableBitmap.h"
 #include "WebPageProxyIdentifier.h"
+#include <WebCore/IntDegrees.h>
 #include <WebCore/LibWebRTCEnumTraits.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/Timer.h>
@@ -156,7 +157,7 @@ private:
 #if ENABLE(MEDIA_STREAM)
     void setMockCaptureDevicesEnabled(bool);
     void setUseSCContentSharingPicker(bool);
-    void setOrientationForMediaCapture(uint64_t orientation);
+    void setOrientationForMediaCapture(WebCore::IntDegrees);
     void updateCaptureAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture, WebCore::ProcessIdentifier, CompletionHandler<void()>&&);
     void updateCaptureOrigin(const WebCore::SecurityOriginData&, WebCore::ProcessIdentifier);
     void updateSandboxAccess(const Vector<SandboxExtension::Handle>&);
@@ -209,7 +210,7 @@ private:
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
     RefPtr<WorkQueue> m_videoMediaStreamTrackRendererQueue;
 #endif
-    uint64_t m_orientation { 0 };
+    WebCore::IntDegrees m_orientation { 0 };
 #endif
 #if USE(LIBWEBRTC) && PLATFORM(COCOA)
     RefPtr<WorkQueue> m_libWebRTCCodecsQueue;

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -37,7 +37,7 @@ messages -> GPUProcess LegacyReceiver {
 
 #if ENABLE(MEDIA_STREAM)
     SetMockCaptureDevicesEnabled(bool isEnabled)
-    SetOrientationForMediaCapture(uint64_t orientation);
+    SetOrientationForMediaCapture(WebCore::IntDegrees orientation);
     UpdateSandboxAccess(Vector<WebKit::SandboxExtension::Handle> extensions);
     UpdateCaptureAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture, WebCore::ProcessIdentifier processID) -> ()
     UpdateCaptureOrigin(WebCore::SecurityOriginData originData, WebCore::ProcessIdentifier processID)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -341,6 +341,7 @@ def types_that_cannot_be_forward_declared():
         'WebCore::FrameIdentifier',
         'WebCore::GraphicsContextGLAttributes',
         'WebCore::GraphicsLayer::PlatformLayerID',
+        'WebCore::IntDegrees',
         'WebCore::ModalContainerControlType',
         'WebCore::NativeImageReference',
         'WebCore::PluginLoadClientPolicy',

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -43,6 +43,7 @@
 #include <WebCore/FloatSize.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/HighlightVisibility.h>
+#include <WebCore/IntDegrees.h>
 #include <WebCore/IntSize.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/LayoutMilestone.h>
@@ -180,7 +181,7 @@ struct WebPageCreationParameters {
     WebCore::FloatSize availableScreenSize;
     WebCore::FloatSize overrideScreenSize;
     float textAutosizingWidth;
-    int32_t deviceOrientation { 0 };
+    WebCore::IntDegrees deviceOrientation { 0 };
     bool keyboardIsAttached { false };
     bool canShowWhileLocked { false };
     bool isCapturingScreen { false };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -43,6 +43,7 @@
 #import "WKContentViewInteraction.h"
 #import "WKFullScreenWindowControllerIOS.h"
 #import <WebCore/FloatRect.h>
+#import <WebCore/IntDegrees.h>
 #import <WebCore/LengthBox.h>
 #import <WebCore/ViewportArguments.h>
 #endif
@@ -161,7 +162,7 @@ struct PerWebProcessState {
     BOOL viewportMetaTagCameFromImageDocument { NO };
 
     std::optional<WebCore::FloatSize> lastSentViewLayoutSize;
-    std::optional<int32_t> lastSentDeviceOrientation;
+    std::optional<WebCore::IntDegrees> lastSentDeviceOrientation;
     std::optional<CGFloat> lastSentMinimumEffectiveDeviceWidth;
 
     std::optional<CGRect> frozenVisibleContentRect;
@@ -260,7 +261,7 @@ struct PerWebProcessState {
     WebKit::DynamicViewportSizeUpdateID _currentDynamicViewportSizeUpdateID;
     CATransform3D _resizeAnimationTransformAdjustments;
     CGFloat _animatedResizeOldMinimumEffectiveDeviceWidth;
-    int32_t _animatedResizeOldOrientation;
+    WebCore::IntDegrees _animatedResizeOldOrientation;
     UIEdgeInsets _animatedResizeOldObscuredInsets;
     RetainPtr<UIView> _resizeAnimationView;
     CGFloat _lastAdjustmentForScroller;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -148,7 +148,7 @@ enum class TapHandlingResult : uint8_t;
 
 - (void)_setOpaqueInternal:(BOOL)opaque;
 - (NSString *)_contentSizeCategory;
-- (void)_dispatchSetDeviceOrientation:(int32_t)deviceOrientation;
+- (void)_dispatchSetDeviceOrientation:(WebCore::IntDegrees)deviceOrientation;
 - (WebCore::FloatSize)activeViewLayoutSize:(const CGRect&)bounds;
 - (void)_updateScrollViewInsetAdjustmentBehavior;
 
@@ -180,7 +180,7 @@ enum class TapHandlingResult : uint8_t;
 @property (nonatomic, readonly) UIEdgeInsets _computedObscuredInset;
 @property (nonatomic, readonly) UIEdgeInsets _computedUnobscuredSafeAreaInset;
 @property (nonatomic, readonly, getter=_isRetainingActiveFocusedState) BOOL _retainingActiveFocusedState;
-@property (nonatomic, readonly) int32_t _deviceOrientation;
+@property (nonatomic, readonly) WebCore::IntDegrees _deviceOrientation;
 
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
 @property (nonatomic, readonly) BOOL _isWindowResizingEnabled;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -99,7 +99,7 @@ static const Seconds delayBeforeNoVisibleContentsRectsLogging = 1_s;
 static const Seconds delayBeforeNoCommitsLogging = 5_s;
 static const unsigned highlightMargin = 5;
 
-static int32_t deviceOrientationForUIInterfaceOrientation(UIInterfaceOrientation orientation)
+static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfaceOrientation orientation)
 {
     switch (orientation) {
     case UIInterfaceOrientationUnknown:
@@ -267,7 +267,7 @@ static int32_t deviceOrientationForUIInterfaceOrientation(UIInterfaceOrientation
     return _focusPreservationCount || _activeFocusedStateRetainCount;
 }
 
-- (int32_t)_deviceOrientation
+- (WebCore::IntDegrees)_deviceOrientation
 {
     auto orientation = UIInterfaceOrientationUnknown;
     auto application = UIApplication.sharedApplication;
@@ -2110,7 +2110,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     _perProcessState.lastSentMinimumEffectiveDeviceWidth = newMinimumEffectiveDeviceWidth;
 }
 
-- (void)_dispatchSetDeviceOrientation:(int32_t)deviceOrientation
+- (void)_dispatchSetDeviceOrientation:(WebCore::IntDegrees)deviceOrientation
 {
     if (_perProcessState.lastSentDeviceOrientation && _perProcessState.lastSentDeviceOrientation.value() == deviceOrientation)
         return;
@@ -2587,7 +2587,7 @@ static WebCore::FloatSize activeMaximumUnobscuredSize(WKWebView *webView, const 
     return WebCore::FloatSize(webView->_maximumUnobscuredSizeOverride.value_or(bounds.size));
 }
 
-static int32_t activeOrientation(WKWebView *webView)
+static WebCore::IntDegrees activeOrientation(WKWebView *webView)
 {
     return webView->_overridesInterfaceOrientation ? deviceOrientationForUIInterfaceOrientation(webView->_interfaceOrientationOverride) : webView->_page->deviceOrientation();
 }
@@ -2698,7 +2698,7 @@ static int32_t activeOrientation(WKWebView *webView)
     auto newViewLayoutSize = [self activeViewLayoutSize:newBounds];
     auto newMinimumUnobscuredSize = activeMinimumUnobscuredSize(self, newBounds);
     auto newMaximumUnobscuredSize = activeMaximumUnobscuredSize(self, newBounds);
-    int32_t newOrientation = activeOrientation(self);
+    auto newOrientation = activeOrientation(self);
     auto newMinimumEffectiveDeviceWidth = [self _minimumEffectiveDeviceWidth];
 
     if (!_perProcessState.lastSentViewLayoutSize || newViewLayoutSize != _perProcessState.lastSentViewLayoutSize.value() || newMinimumEffectiveDeviceWidth != _perProcessState.lastSentMinimumEffectiveDeviceWidth.value())
@@ -3588,7 +3588,7 @@ static bool isLockdownModeWarningNeeded()
     _perProcessState.dynamicViewportUpdateMode = WebKit::DynamicViewportUpdateMode::ResizingWithAnimation;
 
     CGFloat oldMinimumEffectiveDeviceWidth;
-    int32_t oldOrientation;
+    WebCore::IntDegrees oldOrientation;
     UIEdgeInsets oldObscuredInsets;
     if (!CGRectIsEmpty(_perProcessState.animatedResizeOldBounds)) {
         oldBounds = _perProcessState.animatedResizeOldBounds;
@@ -3612,7 +3612,7 @@ static bool isLockdownModeWarningNeeded()
     auto newViewLayoutSize = [self activeViewLayoutSize:newBounds];
     auto newMinimumUnobscuredSize = activeMinimumUnobscuredSize(self, newBounds);
     auto newMaximumUnobscuredSize = activeMaximumUnobscuredSize(self, newBounds);
-    int32_t newOrientation = activeOrientation(self);
+    auto newOrientation = activeOrientation(self);
     UIEdgeInsets newObscuredInsets = _obscuredInsets;
     CGRect futureUnobscuredRectInSelfCoordinates = UIEdgeInsetsInsetRect(newBounds, _obscuredInsets);
     CGRect contentViewBounds = [_contentView bounds];

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -466,7 +466,7 @@ void UserMediaCaptureManagerProxy::clear()
     m_proxies.clear();
 }
 
-void UserMediaCaptureManagerProxy::setOrientation(uint64_t orientation)
+void UserMediaCaptureManagerProxy::setOrientation(WebCore::IntDegrees orientation)
 {
     m_orientationNotifier.orientationChanged(orientation);
 }

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -32,6 +32,7 @@
 #include "RemoteVideoFrameObjectHeap.h"
 #include "UserMediaCaptureManager.h"
 #include <WebCore/CaptureDevice.h>
+#include <WebCore/IntDegrees.h>
 #include <WebCore/OrientationNotifier.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/RealtimeMediaSource.h>
@@ -73,7 +74,7 @@ public:
 
     void clear();
 
-    void setOrientation(uint64_t);
+    void setOrientation(WebCore::IntDegrees);
 
     void didReceiveMessageFromGPUProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -205,7 +205,7 @@ void GPUProcessProxy::setUseSCContentSharingPicker(bool use)
 #endif
 }
 
-void GPUProcessProxy::setOrientationForMediaCapture(uint64_t orientation)
+void GPUProcessProxy::setOrientationForMediaCapture(WebCore::IntDegrees orientation)
 {
     if (m_orientation == orientation)
         return;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -34,6 +34,7 @@
 #include "ProcessThrottlerClient.h"
 #include "ShareableBitmap.h"
 #include "WebPageProxyIdentifier.h"
+#include <WebCore/IntDegrees.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <memory>
@@ -79,7 +80,7 @@ public:
 #if ENABLE(MEDIA_STREAM)
     void setUseMockCaptureDevices(bool);
     void setUseSCContentSharingPicker(bool);
-    void setOrientationForMediaCapture(uint64_t orientation);
+    void setOrientationForMediaCapture(WebCore::IntDegrees);
     void updateCaptureAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture, WebCore::ProcessIdentifier, CompletionHandler<void()>&&);
     void updateCaptureOrigin(const WebCore::SecurityOriginData&, WebCore::ProcessIdentifier);
     void addMockMediaDevice(const WebCore::MockMediaDevice&);
@@ -171,7 +172,7 @@ private:
     ProcessThrottler::ActivityVariant m_activityFromWebProcesses;
 #if ENABLE(MEDIA_STREAM)
     bool m_useMockCaptureDevices { false };
-    uint64_t m_orientation { 0 };
+    WebCore::IntDegrees m_orientation { 0 };
 #endif
 #if HAVE(SC_CONTENT_SHARING_PICKER)
     bool m_useSCContentSharingPicker { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11461,7 +11461,7 @@ void WebPageProxy::getProcessDisplayName(CompletionHandler<void(String&&)>&& com
     sendWithAsyncReply(Messages::WebPage::GetProcessDisplayName(), WTFMove(completionHandler));
 }
 
-void WebPageProxy::setOrientationForMediaCapture(uint64_t orientation)
+void WebPageProxy::setOrientationForMediaCapture(WebCore::IntDegrees orientation)
 {
 #if ENABLE(MEDIA_STREAM)
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -877,11 +877,11 @@ public:
 
     WebCore::FloatSize overrideScreenSize();
 
-    void dynamicViewportSizeUpdate(const WebCore::FloatSize& viewLayoutSize, const WebCore::FloatSize& minimumUnobscuredSize, const WebCore::FloatSize& maximumUnobscuredSize, const WebCore::FloatRect& targetExposedContentRect, const WebCore::FloatRect& targetUnobscuredRect, const WebCore::FloatRect& targetUnobscuredRectInScrollViewCoordinates, const WebCore::FloatBoxExtent& unobscuredSafeAreaInsets, double targetScale, int32_t deviceOrientation, double minimumEffectiveDeviceWidth, DynamicViewportSizeUpdateID);
+    void dynamicViewportSizeUpdate(const WebCore::FloatSize& viewLayoutSize, const WebCore::FloatSize& minimumUnobscuredSize, const WebCore::FloatSize& maximumUnobscuredSize, const WebCore::FloatRect& targetExposedContentRect, const WebCore::FloatRect& targetUnobscuredRect, const WebCore::FloatRect& targetUnobscuredRectInScrollViewCoordinates, const WebCore::FloatBoxExtent& unobscuredSafeAreaInsets, double targetScale, WebCore::IntDegrees deviceOrientation, double minimumEffectiveDeviceWidth, DynamicViewportSizeUpdateID);
 
     void setViewportConfigurationViewLayoutSize(const WebCore::FloatSize&, double scaleFactor, double minimumEffectiveDeviceWidth);
-    void setDeviceOrientation(int32_t);
-    int32_t deviceOrientation() const { return m_deviceOrientation; }
+    void setDeviceOrientation(WebCore::IntDegrees);
+    WebCore::IntDegrees deviceOrientation() const { return m_deviceOrientation; }
     void setOverrideViewportArguments(const std::optional<WebCore::ViewportArguments>&);
     void willCommitLayerTree(TransactionID);
 
@@ -1971,7 +1971,7 @@ public:
 
     void getProcessDisplayName(CompletionHandler<void(String&&)>&&);
 
-    void setOrientationForMediaCapture(uint64_t);
+    void setOrientationForMediaCapture(WebCore::IntDegrees);
 
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
     void setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted);
@@ -2891,7 +2891,7 @@ private:
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<WebCore::InputMode> m_pendingInputModeChange;
-    int32_t m_deviceOrientation { 0 };
+    WebCore::IntDegrees m_deviceOrientation { 0 };
     bool m_hasNetworkRequestsOnSuspended { false };
     bool m_isKeyboardAnimatingIn { false };
     bool m_isScrollingOrZooming { false };

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -271,7 +271,7 @@ void WebPageProxy::scrollingNodeScrollDidEndScroll(ScrollingNodeID nodeID)
     pageClient().scrollingNodeScrollDidEndScroll(nodeID);
 }
 
-void WebPageProxy::dynamicViewportSizeUpdate(const FloatSize& viewLayoutSize, const WebCore::FloatSize& minimumUnobscuredSize, const WebCore::FloatSize& maximumUnobscuredSize, const FloatRect& targetExposedContentRect, const FloatRect& targetUnobscuredRect, const FloatRect& targetUnobscuredRectInScrollViewCoordinates, const WebCore::FloatBoxExtent& unobscuredSafeAreaInsets, double targetScale, int32_t deviceOrientation, double minimumEffectiveDeviceWidth, DynamicViewportSizeUpdateID dynamicViewportSizeUpdateID)
+void WebPageProxy::dynamicViewportSizeUpdate(const FloatSize& viewLayoutSize, const WebCore::FloatSize& minimumUnobscuredSize, const WebCore::FloatSize& maximumUnobscuredSize, const FloatRect& targetExposedContentRect, const FloatRect& targetUnobscuredRect, const FloatRect& targetUnobscuredRectInScrollViewCoordinates, const WebCore::FloatBoxExtent& unobscuredSafeAreaInsets, double targetScale, IntDegrees deviceOrientation, double minimumEffectiveDeviceWidth, DynamicViewportSizeUpdateID dynamicViewportSizeUpdateID)
 {
     if (!hasRunningProcess())
         return;
@@ -310,7 +310,7 @@ void WebPageProxy::setForceAlwaysUserScalable(bool userScalable)
         m_process->send(Messages::WebPage::SetForceAlwaysUserScalable(userScalable), m_webPageID);
 }
 
-void WebPageProxy::setDeviceOrientation(int32_t deviceOrientation)
+void WebPageProxy::setDeviceOrientation(IntDegrees deviceOrientation)
 {
     if (deviceOrientation != m_deviceOrientation) {
         m_deviceOrientation = deviceOrientation;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1496,7 +1496,7 @@ void WebChromeClient::shouldAllowDeviceOrientationAndMotionAccess(LocalFrame& fr
 #endif
 
 #if ENABLE(ORIENTATION_EVENTS) && !PLATFORM(IOS_FAMILY)
-int WebChromeClient::deviceOrientation() const
+IntDegrees WebChromeClient::deviceOrientation() const
 {
     notImplemented();
     return 0;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -199,7 +199,7 @@ private:
 #endif
 
 #if ENABLE(ORIENTATION_EVENTS)
-    int deviceOrientation() const final;
+    WebCore::IntDegrees deviceOrientation() const final;
 #endif
 
     void runOpenPanel(WebCore::LocalFrame&, WebCore::FileChooser&) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm
@@ -145,7 +145,7 @@ Seconds WebChromeClient::eventThrottlingDelay()
 }
 
 #if ENABLE(ORIENTATION_EVENTS)
-int WebChromeClient::deviceOrientation() const
+IntDegrees WebChromeClient::deviceOrientation() const
 {
     return m_page.deviceOrientation();
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -803,7 +803,7 @@ public:
     WebCore::FloatSize screenSize() const;
     WebCore::FloatSize availableScreenSize() const;
     WebCore::FloatSize overrideScreenSize() const;
-    int32_t deviceOrientation() const { return m_deviceOrientation; }
+    WebCore::IntDegrees deviceOrientation() const { return m_deviceOrientation; }
     void didReceiveMobileDocType(bool);
     
     bool screenIsBeingCaptured() const { return m_screenIsBeingCaptured; }
@@ -1168,8 +1168,8 @@ public:
     void updateVisibilityState(bool isInitialState = false);
 
 #if PLATFORM(IOS_FAMILY)
-    void setDeviceOrientation(int32_t);
-    void dynamicViewportSizeUpdate(const WebCore::FloatSize& viewLayoutSize, const WebCore::FloatSize& minimumUnobscuredSize, const WebCore::FloatSize& maximumUnobscuredSize, const WebCore::FloatRect& targetExposedContentRect, const WebCore::FloatRect& targetUnobscuredRect, const WebCore::FloatRect& targetUnobscuredRectInScrollViewCoordinates, const WebCore::FloatBoxExtent& targetUnobscuredSafeAreaInsets, double scale, int32_t deviceOrientation, double minimumEffectiveDeviceWidth, DynamicViewportSizeUpdateID);
+    void setDeviceOrientation(WebCore::IntDegrees);
+    void dynamicViewportSizeUpdate(const WebCore::FloatSize& viewLayoutSize, const WebCore::FloatSize& minimumUnobscuredSize, const WebCore::FloatSize& maximumUnobscuredSize, const WebCore::FloatRect& targetExposedContentRect, const WebCore::FloatRect& targetUnobscuredRect, const WebCore::FloatRect& targetUnobscuredRectInScrollViewCoordinates, const WebCore::FloatBoxExtent& targetUnobscuredSafeAreaInsets, double scale, WebCore::IntDegrees deviceOrientation, double minimumEffectiveDeviceWidth, DynamicViewportSizeUpdateID);
     bool scaleWasSetByUIProcess() const { return m_scaleWasSetByUIProcess; }
     void willStartUserTriggeredZooming();
     void applicationWillResignActive();
@@ -2427,7 +2427,7 @@ private:
 
     std::optional<WebCore::SimpleRange> m_initialSelection;
     WebCore::VisibleSelection m_storedSelectionForAccessibility { WebCore::VisibleSelection() };
-    int32_t m_deviceOrientation { 0 };
+    WebCore::IntDegrees m_deviceOrientation { 0 };
     bool m_keyboardIsAttached { false };
     bool m_canShowWhileLocked { false };
     bool m_inDynamicSizeUpdate { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -56,9 +56,9 @@ messages -> WebPage LegacyReceiver {
 
 #if PLATFORM(IOS_FAMILY)
     SetViewportConfigurationViewLayoutSize(WebCore::FloatSize size, double scaleFactor, double minimumEffectiveDeviceWidth)
-    SetDeviceOrientation(int32_t deviceOrientation)
+    SetDeviceOrientation(WebCore::IntDegrees deviceOrientation)
     SetOverrideViewportArguments(std::optional<WebCore::ViewportArguments> arguments)
-    DynamicViewportSizeUpdate(WebCore::FloatSize viewLayoutSize, WebCore::FloatSize minimumUnobscuredSize, WebCore::FloatSize maximumUnobscuredSize, WebCore::FloatRect targetExposedContentRect, WebCore::FloatRect targetUnobscuredRect, WebCore::FloatRect targetUnobscuredRectInScrollViewCoordinates, WebCore::RectEdges<float> targetUnobscuredSafeAreaInsets, double scale, int32_t deviceOrientation, double minimumEffectiveDeviceWidth, uint64_t dynamicViewportSizeUpdateID)
+    DynamicViewportSizeUpdate(WebCore::FloatSize viewLayoutSize, WebCore::FloatSize minimumUnobscuredSize, WebCore::FloatSize maximumUnobscuredSize, WebCore::FloatRect targetExposedContentRect, WebCore::FloatRect targetUnobscuredRect, WebCore::FloatRect targetUnobscuredRectInScrollViewCoordinates, WebCore::RectEdges<float> targetUnobscuredSafeAreaInsets, double scale, WebCore::IntDegrees deviceOrientation, double minimumEffectiveDeviceWidth, uint64_t dynamicViewportSizeUpdateID)
     
     SetScreenIsBeingCaptured(bool captured)
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3611,7 +3611,7 @@ void WebPage::setViewportConfigurationViewLayoutSize(const FloatSize& size, doub
     viewportConfigurationChanged(zoomToInitialScale);
 }
 
-void WebPage::setDeviceOrientation(int32_t deviceOrientation)
+void WebPage::setDeviceOrientation(IntDegrees deviceOrientation)
 {
     if (deviceOrientation == m_deviceOrientation)
         return;
@@ -3627,7 +3627,7 @@ void WebPage::setOverrideViewportArguments(const std::optional<WebCore::Viewport
     m_page->setOverrideViewportArguments(arguments);
 }
 
-void WebPage::dynamicViewportSizeUpdate(const FloatSize& viewLayoutSize, const WebCore::FloatSize& minimumUnobscuredSize, const WebCore::FloatSize& maximumUnobscuredSize, const FloatRect& targetExposedContentRect, const FloatRect& targetUnobscuredRect, const WebCore::FloatRect& targetUnobscuredRectInScrollViewCoordinates, const WebCore::FloatBoxExtent& targetUnobscuredSafeAreaInsets, double targetScale, int32_t deviceOrientation, double minimumEffectiveDeviceWidth, DynamicViewportSizeUpdateID dynamicViewportSizeUpdateID)
+void WebPage::dynamicViewportSizeUpdate(const FloatSize& viewLayoutSize, const WebCore::FloatSize& minimumUnobscuredSize, const WebCore::FloatSize& maximumUnobscuredSize, const FloatRect& targetExposedContentRect, const FloatRect& targetUnobscuredRect, const WebCore::FloatRect& targetUnobscuredRectInScrollViewCoordinates, const WebCore::FloatBoxExtent& targetUnobscuredSafeAreaInsets, double targetScale, IntDegrees deviceOrientation, double minimumEffectiveDeviceWidth, DynamicViewportSizeUpdateID dynamicViewportSizeUpdateID)
 {
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
     if (!localMainFrame)

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
@@ -105,7 +105,7 @@ private:
     bool showDataDetectorsUIForElement(const WebCore::Element&, const WebCore::Event&) final { return false; }
 
 #if ENABLE(ORIENTATION_EVENTS)
-    int deviceOrientation() const final;
+    WebCore::IntDegrees deviceOrientation() const final;
 #endif
 
     int m_formNotificationSuppressions { 0 };

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
@@ -378,7 +378,7 @@ RefPtr<Icon> WebChromeClientIOS::createIconForFiles(const Vector<String>& filena
 }
 
 #if ENABLE(ORIENTATION_EVENTS)
-int WebChromeClientIOS::deviceOrientation() const
+IntDegrees WebChromeClientIOS::deviceOrientation() const
 {
     return [webView() _deviceOrientation];
 }


### PR DESCRIPTION
#### 2d003f3ffdfec7138fb4702bb33b703235f35a6b
<pre>
Clarify type for &quot;integer degrees&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=254015">https://bugs.webkit.org/show_bug.cgi?id=254015</a>
rdar://106798211

Reviewed by Eric Carlson.

Across the codebase, we currently use int, int32_t, and uint64_t for representing
&quot;integer degrees&quot; (which can be negative!). Make this more consistent by introducing
a IntDegrees typedef, and adopting it everywhere.

* Source/WTF/wtf/Logger.h:
(WTF::LogArgument::toString):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::currentOrientation):
(WebCore::Document::orientationChanged):
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::orientation const):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::orientation const):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/platform/OrientationNotifier.h:
(WebCore::OrientationNotifier::OrientationNotifier):
(WebCore::OrientationNotifier::orientation const):
(WebCore::OrientationNotifier::orientationChanged):
* Source/WebCore/platform/graphics/IntDegrees.h: Added.
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::sensorOrientation):
(WebCore::sensorOrientationFromVideoOutput):
(WebCore::AVVideoCaptureSource::orientationChanged):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::orientationChanged):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::setOrientationForMediaCapture):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::setOrientationForMediaCapture):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(deviceOrientationForUIInterfaceOrientation):
(-[WKWebView _deviceOrientation]):
(-[WKWebView _dispatchSetDeviceOrientation:]):
(activeOrientation):
(-[WKWebView _didStopDeferringGeometryUpdates]):
(-[WKWebView _beginAnimatedResizeWithUpdates:]):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::setOrientation):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::setOrientationForMediaCapture):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setOrientationForMediaCapture):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::dynamicViewportSizeUpdate):
(WebKit::WebPageProxy::setDeviceOrientation):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::deviceOrientation const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebChromeClientIOS.mm:
(WebKit::WebChromeClient::deviceOrientation const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::deviceOrientation const):
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::setDeviceOrientation):
(WebKit::WebPage::dynamicViewportSizeUpdate):
* Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h:
* Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm:
(WebChromeClientIOS::deviceOrientation const):

Canonical link: <a href="https://commits.webkit.org/261772@main">https://commits.webkit.org/261772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6614e0baaded7da499ed208360e44dac3a2d7007

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/112739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4541 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121282 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/116809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5715 "Passed tests") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/118508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105846 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/116172 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1066 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/101045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14233 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1107 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12360 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14925 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102554 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53098 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/32012 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8207 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16772 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110597 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27314 "Passed tests") | 
<!--EWS-Status-Bubble-End-->