### PR TITLE
MockSourceBufferPrivate should only process samples once init segment has been processed.

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -545,7 +545,7 @@ void SourceBuffer::appendBufferTimerFired()
     RefPtr<SharedBuffer> appendData = WTFMove(m_pendingAppendData);
     // 1. Loop Top: If the input buffer is empty, then jump to the need more data step below.
     if (!appendData || !appendData->size()) {
-        sourceBufferPrivateAppendComplete(AppendResult::AppendSucceeded);
+        sourceBufferPrivateAppendComplete(AppendResult::Succeeded);
         return;
     }
 
@@ -575,7 +575,7 @@ void SourceBuffer::sourceBufferPrivateAppendComplete(AppendResult result)
 
     // NOTE: return to Section 3.5.5
     // 2.If the segment parser loop algorithm in the previous step was aborted, then abort this algorithm.
-    if (result != AppendResult::AppendSucceeded)
+    if (result != AppendResult::Succeeded)
         return;
 
     // 3. Set the updating attribute to false.
@@ -940,7 +940,7 @@ void SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment(Initializa
     // (Note: Issue #155 adds this step after step 5:)
     // 6. Set  pending initialization segment for changeType flag  to false.
     m_pendingInitializationSegmentForChangeType = false;
-    completionHandler(ReceiveResult::RecieveSucceeded);
+    completionHandler(ReceiveResult::Succeeded);
 
     // 6. If the HTMLMediaElement.readyState attribute is HAVE_NOTHING, then run the following steps:
     if (m_private->readyState() == MediaPlayer::ReadyState::HaveNothing) {

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -62,6 +62,7 @@ enum class SourceBufferAppendMode : uint8_t {
 
 class SourceBufferPrivate
     : public RefCounted<SourceBufferPrivate>
+    , public CanMakeWeakPtr<SourceBufferPrivate>
 #if !RELEASE_LOG_DISABLED
     , public LoggerHelper
 #endif
@@ -73,7 +74,8 @@ public:
     virtual void setActive(bool) = 0;
     WEBCORE_EXPORT virtual void append(Ref<SharedBuffer>&&);
     virtual void abort() = 0;
-    virtual void resetParserState() = 0;
+    // Overrides must call the base class.
+    virtual void resetParserState();
     virtual void removedFromMediaSource() = 0;
     virtual MediaPlayer::ReadyState readyState() const = 0;
     virtual void setReadyState(MediaPlayer::ReadyState) = 0;
@@ -150,6 +152,10 @@ protected:
     virtual void setMinimumUpcomingPresentationTime(const AtomString&, const MediaTime&) { }
     virtual void clearMinimumUpcomingPresentationTime(const AtomString&) { }
 
+    bool processingInitializationSegment() const { return m_processingInitializationSegment; }
+
+    WEBCORE_EXPORT virtual void didReceiveSampleForTrackId(uint64_t, Ref<MediaSample>&&);
+
     void reenqueSamples(const AtomString& trackID);
     WEBCORE_EXPORT void didReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&&, CompletionHandler<void(SourceBufferPrivateClient::ReceiveResult)>&&);
     WEBCORE_EXPORT void didReceiveSample(Ref<MediaSample>&&);
@@ -157,7 +163,7 @@ protected:
     void provideMediaData(const AtomString& trackID);
 
     // Must be called once all samples have been processed.
-    WEBCORE_EXPORT void appendCompleted(bool parsingSucceeded, bool isEnded);
+    WEBCORE_EXPORT void appendCompleted(bool parsingSucceeded, bool isEnded, Function<void()>&& = [] { });
 
     WeakPtr<SourceBufferPrivateClient> m_client;
 
@@ -171,6 +177,14 @@ private:
     void trySignalAllSamplesInTrackEnqueued(TrackBuffer&, const AtomString& trackID);
     MediaTime findPreviousSyncSamplePresentationTime(const MediaTime&);
     bool evictFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded);
+    void processPendingSamples();
+
+    struct AppendCompletedArguments {
+        bool parsingSucceeded { false };
+        bool isEnded { false };
+        Function<void()> preTask;
+    };
+    std::optional<AppendCompletedArguments> m_appendCompletedPending;
 
     bool m_isAttached { false };
     bool m_hasAudio { false };
@@ -184,6 +198,10 @@ private:
     bool m_receivedFirstInitializationSegment { false };
     bool m_pendingInitializationSegmentForChangeType { false };
     bool m_didReceiveSampleErrored { false };
+
+    bool m_processingInitializationSegment { false };
+    Vector<std::pair<uint64_t, Ref<MediaSample>>> m_pendingMediaSamples;
+    bool m_hasPendingAppendCompleted { false };
 
     MediaTime m_timestampOffset;
     MediaTime m_appendWindowStart { MediaTime::zeroTime() };

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.cpp
@@ -34,13 +34,13 @@ namespace WebCore {
 String convertEnumerationToString(SourceBufferPrivateClient::ReceiveResult enumerationValue)
 {
     static const NeverDestroyed<String> values[] = {
-        MAKE_STATIC_STRING_IMPL("RecieveSucceeded"),
+        MAKE_STATIC_STRING_IMPL("Succeeded"),
         MAKE_STATIC_STRING_IMPL("AppendError"),
         MAKE_STATIC_STRING_IMPL("ClientDisconnected"),
         MAKE_STATIC_STRING_IMPL("BufferRemoved"),
         MAKE_STATIC_STRING_IMPL("IPCError"),
     };
-    static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::RecieveSucceeded) == 0, "ReceiveResult::RecieveSucceeded is not 0 as expected");
+    static_assert(!static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::Succeeded), "ReceiveResult::Succeeded is not 0 as expected");
     static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::AppendError) == 1, "ReceiveResult::AppendError is not 1 as expected");
     static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::ClientDisconnected) == 2, "ReceiveResult::ClientDisconnected is not 2 as expected");
     static_assert(static_cast<size_t>(SourceBufferPrivateClient::ReceiveResult::BufferRemoved) == 3, "ReceiveResult::BufferRemoved is not 3 as expected");

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -68,7 +68,7 @@ public:
     };
     
     enum class ReceiveResult : uint8_t {
-        RecieveSucceeded,
+        Succeeded,
         AppendError,
         ClientDisconnected,
         BufferRemoved,
@@ -78,7 +78,7 @@ public:
     virtual void sourceBufferPrivateStreamEndedWithDecodeError() = 0;
     virtual void sourceBufferPrivateAppendError(bool decodeError) = 0;
     enum class AppendResult : uint8_t {
-        AppendSucceeded,
+        Succeeded,
         ReadStreamFailed,
         ParsingFailed
     };
@@ -112,7 +112,7 @@ struct LogArgument<WebCore::SourceBufferPrivateClient::ReceiveResult> {
 template<> struct EnumTraits<WebCore::SourceBufferPrivateClient::ReceiveResult> {
     using values = EnumValues<
         WebCore::SourceBufferPrivateClient::ReceiveResult,
-        WebCore::SourceBufferPrivateClient::ReceiveResult::RecieveSucceeded,
+        WebCore::SourceBufferPrivateClient::ReceiveResult::Succeeded,
         WebCore::SourceBufferPrivateClient::ReceiveResult::AppendError,
         WebCore::SourceBufferPrivateClient::ReceiveResult::ClientDisconnected,
         WebCore::SourceBufferPrivateClient::ReceiveResult::BufferRemoved,
@@ -123,7 +123,7 @@ template<> struct EnumTraits<WebCore::SourceBufferPrivateClient::ReceiveResult> 
 template<> struct EnumTraits<WebCore::SourceBufferPrivateClient::AppendResult> {
     using values = EnumValues<
         WebCore::SourceBufferPrivateClient::AppendResult,
-        WebCore::SourceBufferPrivateClient::AppendResult::AppendSucceeded,
+        WebCore::SourceBufferPrivateClient::AppendResult::Succeeded,
         WebCore::SourceBufferPrivateClient::AppendResult::ReadStreamFailed,
         WebCore::SourceBufferPrivateClient::AppendResult::ParsingFailed
     >;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -123,7 +123,6 @@ private:
     MediaSourcePrivateAVFObjC(MediaPlayerPrivateMediaSourceAVFObjC&, MediaSourcePrivateClient&);
 
     void sourceBufferPrivateDidChangeActiveState(SourceBufferPrivateAVFObjC*, bool active);
-    void sourceBufferPrivateDidReceiveInitializationSegment(SourceBufferPrivateAVFObjC*);
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     void sourceBufferKeyNeeded(SourceBufferPrivateAVFObjC*, const SharedBuffer&);
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -87,7 +87,6 @@ public:
 
 class SourceBufferPrivateAVFObjC final
     : public SourceBufferPrivate
-    , public CanMakeWeakPtr<SourceBufferPrivateAVFObjC>
 {
 public:
     static Ref<SourceBufferPrivateAVFObjC> create(MediaSourcePrivateAVFObjC*, Ref<SourceBufferParser>&&);
@@ -159,6 +158,7 @@ private:
     void didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&&, uint64_t trackId, const String& mediaType);
 
     // SourceBufferPrivate overrides
+    void didReceiveSampleForTrackId(uint64_t, Ref<MediaSample>&&) final;
     void append(Ref<SharedBuffer>&&) final;
     void abort() final;
     void resetParserState() final;
@@ -180,6 +180,7 @@ private:
     MediaTime currentMediaTime() const final;
     MediaTime duration() const final;
 
+    void processPendingTrackChangeTasks();
     void enqueueSample(Ref<MediaSampleAVFObjC>&&, uint64_t trackID);
     void didBecomeReadyForMoreSamples(uint64_t trackID);
     void appendCompleted();
@@ -207,10 +208,7 @@ private:
     WeakPtrFactory<SourceBufferPrivateAVFObjC> m_appendWeakFactory;
 
     Ref<SourceBufferParser> m_parser;
-    bool m_processingInitializationSegment { false };
-    bool m_hasPendingAppendCompletedCallback { false };
-    Vector<Function<void()>> m_pendingTrackChangeCallbacks;
-    Vector<std::pair<uint64_t, Ref<MediaSampleAVFObjC>>> m_mediaSamples;
+    Vector<Function<void()>> m_pendingTrackChangeTasks;
     Deque<std::pair<uint64_t, Ref<MediaSampleAVFObjC>>> m_blockedSamples;
 
     RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -202,10 +202,6 @@ void MockSourceBufferPrivate::abort()
 {
 }
 
-void MockSourceBufferPrivate::resetParserState()
-{
-}
-
 void MockSourceBufferPrivate::removedFromMediaSource()
 {
     if (m_mediaSource)

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -52,7 +52,6 @@ private:
     // SourceBufferPrivate overrides
     void append(Vector<uint8_t>&&) final;
     void abort() final;
-    void resetParserState() final;
     void removedFromMediaSource() final;
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;


### PR DESCRIPTION
#### 30fd635c1cbe03f0e163665820c13900784a7336
<pre>
MockSourceBufferPrivate should only process samples once init segment has been processed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253997">https://bugs.webkit.org/show_bug.cgi?id=253997</a>
rdar://106784564

Reviewed by Youenn Fablet.

The ability of a SourceBufferPrivate to run in the GPU process required
some steps to be done asynchronously.
In particular no demuxed media segments should be processed until all
track buffers had been created as they would otherwise be dropped.
Currently, only the SourceBufferPrivateAVFObjC implementation had been
modified to run asynchronously and contained very specific handlings to
do so.

We move the responsibility of queuing samples for until the init segment
has been fully processed to the base SourceBufferPrivate class.
We allows the ability for any SourceBufferPrivate implementation to be
wrapped in a SourceBufferPrivateRemote and be platform agnostic, including
the MockMediaSource.

Fly-by changes:
- Rename ReceiveResult::RecieveSucceeded to ReceiveResult::Succeeded (and fix typo)
- Rename AppendResult::AppendSucceeded to AppendResult::Succeeded
- By spec, the Reset Parser State should process any frames left in the
  input buffer.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::appendBufferTimerFired):
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete):
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::appendCompleted):
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::didReceiveSampleForTrackId):
(WebCore::SourceBufferPrivate::didReceiveSample):
(WebCore::SourceBufferPrivate::processPendingSamples):
(WebCore::SourceBufferPrivate::resetParserState): Make default implementation.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::appendCompleted):
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h: Rename enum as name already contained in type.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::didParseInitializationData):
(WebCore::SourceBufferPrivateAVFObjC::didProvideMediaDataForTrackId):
(WebCore::SourceBufferPrivateAVFObjC::processPendingTrackChangeTasks):
(WebCore::SourceBufferPrivateAVFObjC::didReceiveSampleForTrackId):
(WebCore::SourceBufferPrivateAVFObjC::append):
(WebCore::SourceBufferPrivateAVFObjC::appendCompleted):
(WebCore::SourceBufferPrivateAVFObjC::resetParserState):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::resetParserState):
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp: Remove unnecessary method.
(WebCore::MockSourceBufferPrivate::resetParserState): Deleted.
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h: Remove unnecessary method.

Canonical link: <a href="https://commits.webkit.org/261799@main">https://commits.webkit.org/261799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1f4a6599c01b9b6e6b5c04c05a99d5a6513158c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112905 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/22064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/4682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/117005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/23411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/13225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/4682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118692 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105995 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/14359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/15063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/13225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8231 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16914 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->