### PR TITLE
[IFC][Ruby] Pass annotation adjustments to IFC

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -143,7 +143,7 @@ static inline bool computeInkOverflowForInlineBox(const InlineLevelBox& inlineBo
     auto inflateWithAnnotation = [&] {
         if (!inlineBox.hasAnnotation())
             return;
-        inkOverflow.inflate(0.f, inlineBox.annotationAbove().value_or(0.f), 0.f, inlineBox.annotationUnder().value_or(0.f));
+        inkOverflow.inflate(0.f, inlineBox.annotationAbove().value_or(0.f), 0.f, inlineBox.annotationBelow().value_or(0.f));
         hasVisualOverflow = true;
     };
     inflateWithAnnotation();

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
@@ -62,7 +62,7 @@ InlineDisplayLineBuilder::EnclosingLineGeometry InlineDisplayLineBuilder::collec
             return { };
         return {
             lineBoxRect.top() + rootInlineBox.logicalTop() - rootInlineBox.annotationAbove().value_or(0.f),
-            lineBoxRect.top() + rootInlineBox.logicalBottom() + rootInlineBox.annotationUnder().value_or(0.f)
+            lineBoxRect.top() + rootInlineBox.logicalBottom() + rootInlineBox.annotationBelow().value_or(0.f)
         };
     };
     auto [enclosingTop, enclosingBottom] = initialEnclosingTopAndBottom();
@@ -113,7 +113,7 @@ InlineDisplayLineBuilder::EnclosingLineGeometry InlineDisplayLineBuilder::collec
             ASSERT_NOT_REACHED();
 
         auto adjustedBorderBoxTop = borderBox.top() - inlineLevelBox.annotationAbove().value_or(0.f);
-        auto adjustedBorderBoxBottom = borderBox.bottom() + inlineLevelBox.annotationUnder().value_or(0.f);
+        auto adjustedBorderBoxBottom = borderBox.bottom() + inlineLevelBox.annotationBelow().value_or(0.f);
         enclosingTop = std::min(enclosingTop.value_or(adjustedBorderBoxTop), adjustedBorderBoxTop);
         enclosingBottom = std::max(enclosingBottom.value_or(adjustedBorderBoxBottom), adjustedBorderBoxBottom);
     }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -62,6 +62,7 @@
 #include "RenderListBox.h"
 #include "RenderListItem.h"
 #include "RenderListMarker.h"
+#include "RenderRubyRun.h"
 #include "RenderSlider.h"
 #include "RenderTable.h"
 #include "RenderTextControlMultiLine.h"
@@ -392,7 +393,8 @@ void LineLayout::updateLayoutBoxDimensions(const RenderBox& replacedOrInlineBloc
 #if ENABLE(ATTACHMENT_ELEMENT)
             || is<RenderAttachment>(replacedOrInlineBlock)
 #endif
-            || is<RenderButton>(replacedOrInlineBlock)) {
+            || is<RenderButton>(replacedOrInlineBlock)
+            || is<RenderRubyRun>(replacedOrInlineBlock)) {
             // These are special RenderBlock renderers that override the default baseline position behavior of the inline block box.
             return true;
         }
@@ -413,6 +415,11 @@ void LineLayout::updateLayoutBoxDimensions(const RenderBox& replacedOrInlineBloc
 
     if (auto* shapeOutsideInfo = replacedOrInlineBlock.shapeOutsideInfo())
         layoutBox.setShape(&shapeOutsideInfo->computedShape());
+
+    if (auto* rubyRun = dynamicDowncast<RenderRubyRun>(replacedOrInlineBlock)) {
+        auto [above, below] = rubyRun->annotationsAboveAndBelow();
+        layoutBox.setRubyAnnotationsAboveAndBelow(above, below);
+    }
 }
 
 void LineLayout::updateLineBreakBoxDimensions(const RenderLineBreak& lineBreakBox)

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -455,6 +455,25 @@ void Box::setShape(RefPtr<const Shape> shape)
     ensureRareData().shape = WTFMove(shape);
 }
 
+std::optional<std::pair<LayoutUnit, LayoutUnit>> Box::rubyAnnotationsAboveAndBelow() const
+{
+    if (!hasRareData())
+        return { };
+
+    auto& rareData = this->rareData();
+    if (!rareData.rubyAnnotationAbove && !rareData.rubyAnnotationBelow)
+        return { };
+
+    return std::pair { rareData.rubyAnnotationAbove, rareData.rubyAnnotationBelow };
+}
+
+void Box::setRubyAnnotationsAboveAndBelow(LayoutUnit above, LayoutUnit below)
+{
+    auto& rareData = ensureRareData();
+    rareData.rubyAnnotationAbove = above;
+    rareData.rubyAnnotationBelow = below;
+}
+
 void Box::setCachedGeometryForLayoutState(LayoutState& layoutState, std::unique_ptr<BoxGeometry> geometry) const
 {
     ASSERT(!m_cachedLayoutState);

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -181,6 +181,9 @@ public:
     const Shape* shape() const;
     void setShape(RefPtr<const Shape>);
 
+    std::optional<std::pair<LayoutUnit, LayoutUnit>> rubyAnnotationsAboveAndBelow() const;
+    void setRubyAnnotationsAboveAndBelow(LayoutUnit above, LayoutUnit below);
+
     bool canCacheForLayoutState(const LayoutState&) const;
     BoxGeometry* cachedGeometryForLayoutState(const LayoutState&) const;
     void setCachedGeometryForLayoutState(LayoutState&, std::unique_ptr<BoxGeometry>) const;
@@ -205,6 +208,8 @@ private:
         std::optional<LayoutUnit> columnWidth;
         std::unique_ptr<RenderStyle> firstLineStyle;
         RefPtr<const Shape> shape;
+        LayoutUnit rubyAnnotationAbove;
+        LayoutUnit rubyAnnotationBelow;
     };
 
     bool hasRareData() const { return m_hasRareData; }

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -1213,23 +1213,14 @@ LayoutUnit LegacyInlineFlowBox::computeOverAnnotationAdjustment(LayoutUnit allow
         
         if (child->renderer().isReplacedOrInlineBlock() && is<RenderRubyRun>(child->renderer()) && child->renderer().style().rubyPosition() == RubyPosition::Before) {
             auto& rubyRun = downcast<RenderRubyRun>(child->renderer());
-            RenderRubyText* rubyText = rubyRun.rubyText();
-            if (!rubyText)
-                continue;
-            
-            if (!rubyRun.style().isFlippedLinesWritingMode()) {
-                LayoutUnit topOfFirstRubyTextLine = rubyText->logicalTop() + (rubyText->firstRootBox() ? rubyText->firstRootBox()->lineTop() : 0_lu);
-                if (topOfFirstRubyTextLine >= 0)
-                    continue;
-                topOfFirstRubyTextLine += child->logicalTop();
-                result = std::max(result, allowedPosition - topOfFirstRubyTextLine);
-            } else {
-                LayoutUnit bottomOfLastRubyTextLine = rubyText->logicalTop() + (rubyText->lastRootBox() ? rubyText->lastRootBox()->lineBottom() : rubyText->logicalHeight());
-                if (bottomOfLastRubyTextLine <= child->logicalHeight())
-                    continue;
-                bottomOfLastRubyTextLine += child->logicalTop();
-                result = std::max(result, bottomOfLastRubyTextLine - allowedPosition);
-            }
+
+            auto [above, below] = rubyRun.annotationsAboveAndBelow();
+            auto top = LayoutUnit { child->logicalTop() - above };
+            auto bottom = LayoutUnit { child->logicalBottom() + below };
+            if (!rubyRun.style().isFlippedLinesWritingMode())
+                result = std::max(result, allowedPosition - top);
+            else
+                result = std::max(result, bottom - allowedPosition);
         }
 
         if (is<LegacyInlineTextBox>(*child)) {
@@ -1261,23 +1252,14 @@ LayoutUnit LegacyInlineFlowBox::computeUnderAnnotationAdjustment(LayoutUnit allo
 
         if (child->renderer().isReplacedOrInlineBlock() && is<RenderRubyRun>(child->renderer()) && child->renderer().style().rubyPosition() == RubyPosition::After) {
             auto& rubyRun = downcast<RenderRubyRun>(child->renderer());
-            RenderRubyText* rubyText = rubyRun.rubyText();
-            if (!rubyText)
-                continue;
 
-            if (rubyRun.style().isFlippedLinesWritingMode()) {
-                LayoutUnit topOfFirstRubyTextLine = rubyText->logicalTop() + (rubyText->firstRootBox() ? rubyText->firstRootBox()->lineTop() : 0_lu);
-                if (topOfFirstRubyTextLine >= 0)
-                    continue;
-                topOfFirstRubyTextLine += child->logicalTop();
-                result = std::max(result, allowedPosition - topOfFirstRubyTextLine);
-            } else {
-                LayoutUnit bottomOfLastRubyTextLine = rubyText->logicalTop() + (rubyText->lastRootBox() ? rubyText->lastRootBox()->lineBottom() : rubyText->logicalHeight());
-                if (bottomOfLastRubyTextLine <= child->logicalHeight())
-                    continue;
-                bottomOfLastRubyTextLine += child->logicalTop();
-                result = std::max(result, bottomOfLastRubyTextLine - allowedPosition);
-            }
+            auto [above, below] = rubyRun.annotationsAboveAndBelow();
+            auto top = LayoutUnit { child->logicalTop() - above };
+            auto bottom = LayoutUnit { child->logicalBottom() + below };
+            if (rubyRun.style().isFlippedLinesWritingMode())
+                result = std::max(result, allowedPosition - top);
+            else
+                result = std::max(result, bottom - allowedPosition);
         }
 
         if (is<LegacyInlineTextBox>(*child)) {

--- a/Source/WebCore/rendering/RenderRubyRun.cpp
+++ b/Source/WebCore/rendering/RenderRubyRun.cpp
@@ -277,4 +277,22 @@ bool RenderRubyRun::canBreakBefore(const LazyLineBreakIterator& iterator) const
     return rubyText->canBreakBefore(iterator);
 }
 
+std::pair<LayoutUnit, LayoutUnit> RenderRubyRun::annotationsAboveAndBelow() const
+{
+    auto* rubyText = this->rubyText();
+    if (!rubyText)
+        return { 0_lu, 0_lu };
+
+    auto firstLineBox = InlineIterator::firstLineBoxFor(*rubyText);
+    auto rubyTextTop = rubyText->logicalTop() + (firstLineBox ? LayoutUnit { firstLineBox->contentLogicalTop() } : 0_lu);
+    auto top = std::max(0_lu, -rubyTextTop);
+
+    auto lastLineBox = InlineIterator::lastLineBoxFor(*rubyText);
+    auto rubyTextBottom = rubyText->logicalTop() + (lastLineBox ? LayoutUnit { lastLineBox->contentLogicalBottom() } : rubyText->logicalHeight());
+    auto bottom = std::max(logicalHeight(), rubyTextBottom) - logicalHeight();
+
+    return { top, bottom };
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderRubyRun.h
+++ b/Source/WebCore/rendering/RenderRubyRun.h
@@ -69,7 +69,9 @@ public:
         m_secondToLastCharacter = secondToLast;
     }
     bool canBreakBefore(const LazyLineBreakIterator&) const;
-    
+
+    std::pair<LayoutUnit, LayoutUnit> annotationsAboveAndBelow() const;
+
     RenderPtr<RenderRubyBase> createRubyBase() const;
 
 private:


### PR DESCRIPTION
#### a8caffcf64e22d92bb25e5dfd2fcab4768534753
<pre>
[IFC][Ruby] Pass annotation adjustments to IFC
<a href="https://bugs.webkit.org/show_bug.cgi?id=254017">https://bugs.webkit.org/show_bug.cgi?id=254017</a>

Reviewed by Alan Baradlay.

* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
(WebCore::Layout::InlineLevelBox::hasAnnotation const):
(WebCore::Layout::InlineLevelBox::annotationAbove const):
(WebCore::Layout::InlineLevelBox::annotationBelow const):
(WebCore::Layout::InlineLevelBox::annotationUnder const): Deleted.

Rename for consistency.

* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp:
(WebCore::Layout::LineBoxVerticalAligner::adjustForAnnotationIfNeeded const):

Allow annotation adjustments for atomic inline boxes (because legacy ruby is wrapped to one).

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::computeInkOverflowForInlineBox):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp:
(WebCore::Layout::InlineDisplayLineBuilder::collectEnclosingLineGeometry const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateLayoutBoxDimensions):

Pass the annotation adjustments.

* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::rubyAnnotationsAboveAndBelow const):
(WebCore::Layout::Box::setRubyAnnotationsAboveAndBelow):

Add a rare data field.

* Source/WebCore/layout/layouttree/LayoutBox.h:
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::computeOverAnnotationAdjustment const):
(WebCore::LegacyInlineFlowBox::computeUnderAnnotationAdjustment const):

Factor code from here to RenderRubyRun.

* Source/WebCore/rendering/RenderRubyRun.cpp:
(WebCore::RenderRubyRun::annotationsAboveAndBelow const):

Compute the adjustments.

* Source/WebCore/rendering/RenderRubyRun.h:

Canonical link: <a href="https://commits.webkit.org/261788@main">https://commits.webkit.org/261788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f5122dcb29fca00de6017bc2a1c1e324ad6cb2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4640 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121360 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116902 "Failed to checkout and rebase branch from PR 11603") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5815 "Passed tests") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118601 "Failed to checkout and rebase branch from PR 11603") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105949 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46372 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14316 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1191 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/98812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15019 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53184 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8223 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16868 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->