### PR TITLE
Expose RealtimeMediaSource fitnessScore as a double

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -155,7 +155,7 @@ public:
 
     const AtomString& name() const { return m_name; }
 
-    unsigned fitnessScore() const { return m_fitnessScore; }
+    double fitnessScore() const { return m_fitnessScore; }
 
     WEBCORE_EXPORT void addObserver(Observer&);
     WEBCORE_EXPORT void removeObserver(Observer&);

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -118,7 +118,7 @@ private:
     DisplayCaptureFactory& defaultDisplayCaptureFactory();
 
     struct DeviceInfo {
-        unsigned fitnessScore;
+        double fitnessScore;
         CaptureDevice device;
     };
 


### PR DESCRIPTION
#### 8684905426f0e9b37e116bb0c8b326f3405d8c97
<pre>
Expose RealtimeMediaSource fitnessScore as a double
<a href="https://bugs.webkit.org/show_bug.cgi?id=254018">https://bugs.webkit.org/show_bug.cgi?id=254018</a>
rdar://problem/106801067

Reviewed by Eric Carlson.

We should not silently cast double into unsigned, especially since we are doing comparison on the values.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:

Canonical link: <a href="https://commits.webkit.org/261785@main">https://commits.webkit.org/261785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1326f65ab07adb9127283a67e632975c0e3ca58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112705 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4489 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5650 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46257 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14189 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1061 "6 failures") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95664 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10409 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53053 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8221 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16722 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->