### PR TITLE
[WGSL] Remove m_ prefix from public struct members

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -36,9 +36,9 @@ namespace WGSL::AST {
 
 struct Indent {
     Indent(StringDumper& dumper)
-        : m_scope(dumper.m_indent, dumper.m_indent + "    ")
+        : scope(dumper.m_indent, dumper.m_indent + "    ")
     { }
-    SetForScope<String> m_scope;
+    SetForScope<String> scope;
 };
 
 static Indent bumpIndent(StringDumper& dumper)

--- a/Source/WebGPU/WGSL/CallGraph.h
+++ b/Source/WebGPU/WGSL/CallGraph.h
@@ -40,13 +40,13 @@ class CallGraph {
 
 public:
     struct Callee {
-        AST::Function* m_target;
-        Vector<AST::CallExpression*> m_callSites;
+        AST::Function* target;
+        Vector<AST::CallExpression*> callSites;
     };
 
     struct EntryPoint {
-        AST::Function& m_function;
-        AST::StageAttribute::Stage m_stage;
+        AST::Function& function;
+        AST::StageAttribute::Stage stage;
     };
 
     ShaderModule& ast() const { return m_ast; }

--- a/Source/WebGPU/WGSL/CompilationMessage.cpp
+++ b/Source/WebGPU/WGSL/CompilationMessage.cpp
@@ -32,7 +32,7 @@ namespace WGSL {
 
 void CompilationMessage::dump(PrintStream& out) const
 {
-    out.print(m_span.m_line, ":", m_span.m_lineOffset, ": ", m_message);
+    out.print(m_span.line, ":", m_span.lineOffset, ": ", m_message);
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/CompilationMessage.h
+++ b/Source/WebGPU/WGSL/CompilationMessage.h
@@ -43,10 +43,10 @@ public:
     void dump(PrintStream& out) const;
 
     const String& message() const { return m_message; }
-    unsigned lineNumber() const { return m_span.m_line; }
-    unsigned lineOffset() const { return m_span.m_lineOffset; }
-    unsigned offset() const { return m_span.m_offset; }
-    unsigned length() const { return m_span.m_length; }
+    unsigned lineNumber() const { return m_span.line; }
+    unsigned lineOffset() const { return m_span.lineOffset; }
+    unsigned offset() const { return m_span.offset; }
+    unsigned length() const { return m_span.length; }
 
 private:
     String m_message;

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -60,12 +60,12 @@ private:
 
     struct Global {
         struct Resource {
-            unsigned m_group;
-            unsigned m_binding;
+            unsigned group;
+            unsigned binding;
         };
 
-        std::optional<Resource> m_resource;
-        AST::Variable* m_declaration;
+        std::optional<Resource> resource;
+        AST::Variable* declaration;
     };
 
     static AST::Identifier argumentBufferParameterName(unsigned group);
@@ -92,7 +92,7 @@ void RewriteGlobalVariables::run()
     collectGlobals();
     insertStructs();
     for (auto& entryPoint : m_callGraph.entrypoints())
-        visitEntryPoint(entryPoint.m_function);
+        visitEntryPoint(entryPoint.function);
     m_callGraph.ast().variables().clear();
 }
 
@@ -116,8 +116,8 @@ void RewriteGlobalVariables::visit(AST::IdentifierExpression& identifier)
 {
     auto name = identifier.identifier();
     if (Global* global = read(name)) {
-        if (auto resource = global->m_resource) {
-            auto base = makeUniqueRef<AST::IdentifierExpression>(identifier.span(), argumentBufferParameterName(resource->m_group));
+        if (auto resource = global->resource) {
+            auto base = makeUniqueRef<AST::IdentifierExpression>(identifier.span(), argumentBufferParameterName(resource->group));
             auto structureAccess = makeUniqueRef<AST::FieldAccessExpression>(identifier.span(), WTFMove(base), WTFMove(name));
             m_callGraph.ast().replace(&identifier, AST::IdentityExpression(identifier.span(), WTFMove(structureAccess)));
         }
@@ -154,8 +154,8 @@ void RewriteGlobalVariables::collectGlobals()
 
         if (resource.has_value()) {
             Global& global = result.iterator->value;
-            auto result = m_groupBindingMap.add(resource->m_group, IndexMap<Global*>());
-            result.iterator->value.add(resource->m_binding, &global);
+            auto result = m_groupBindingMap.add(resource->group, IndexMap<Global*>());
+            result.iterator->value.add(resource->binding, &global);
         }
     }
 }
@@ -182,9 +182,9 @@ auto RewriteGlobalVariables::requiredGroups() -> IndexSet
         auto it = m_globals.find(globalName);
         RELEASE_ASSERT(it != m_globals.end());
         auto& global = it->value;
-        if (!global.m_resource.has_value())
+        if (!global.resource.has_value())
             continue;
-        groups.add(global.m_resource->m_group);
+        groups.add(global.resource->group);
     }
     return groups;
 }
@@ -202,12 +202,12 @@ void RewriteGlobalVariables::insertStructs()
             unsigned binding = bindingGlobal.key;
             auto& global = *bindingGlobal.value;
 
-            ASSERT(global.m_declaration->maybeTypeName());
-            auto span = global.m_declaration->span();
+            ASSERT(global.declaration->maybeTypeName());
+            auto span = global.declaration->span();
             structMembers.append(makeUniqueRef<AST::StructureMember>(
                 span,
-                AST::Identifier::make(global.m_declaration->name()),
-                adoptRef(*new AST::ReferenceTypeName(span, *global.m_declaration->maybeTypeName())),
+                AST::Identifier::make(global.declaration->name()),
+                adoptRef(*new AST::ReferenceTypeName(span, *global.declaration->maybeTypeName())),
                 AST::Attribute::List {
                     adoptRef(*new AST::BindingAttribute(span, binding))
                 }

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -337,8 +337,8 @@ T Lexer<T>::shift(unsigned i)
     // At one point timing showed that setting m_current to 0 unconditionally was faster than an if-else sequence.
     m_current = 0;
     m_code += i;
-    m_currentPosition.m_offset += i;
-    m_currentPosition.m_lineOffset += i;
+    m_currentPosition.offset += i;
+    m_currentPosition.lineOffset += i;
     if (LIKELY(m_code < m_codeEnd))
         m_current = *m_code;
     return last;
@@ -355,8 +355,8 @@ T Lexer<T>::peek(unsigned i)
 template <typename T>
 void Lexer<T>::newLine()
 {
-    m_currentPosition.m_line += 1;
-    m_currentPosition.m_lineOffset = 0;
+    m_currentPosition.line += 1;
+    m_currentPosition.lineOffset = 0;
 }
 
 template <typename T>

--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -55,8 +55,8 @@ public:
     SourcePosition currentPosition() const { return m_currentPosition; }
 
 private:
-    unsigned currentOffset() const { return m_currentPosition.m_offset; }
-    unsigned currentTokenLength() const { return currentOffset() - m_tokenStartingPosition.m_offset; }
+    unsigned currentOffset() const { return m_currentPosition.offset; }
+    unsigned currentTokenLength() const { return currentOffset() - m_tokenStartingPosition.offset; }
 
     Token makeToken(TokenType type)
     {

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -105,11 +105,11 @@ private:
 void NameManglerVisitor::run()
 {
     for (const auto& entrypoint : m_callGraph.entrypoints()) {
-        String originalName = entrypoint.m_function.name();
-        introduceVariable(entrypoint.m_function.name(), MangledName::Function);
+        String originalName = entrypoint.function.name();
+        introduceVariable(entrypoint.function.name(), MangledName::Function);
         auto it = m_result.entryPoints.find(originalName);
         RELEASE_ASSERT(it != m_result.entryPoints.end());
-        it->value.mangledName = entrypoint.m_function.name();
+        it->value.mangledName = entrypoint.function.name();
     }
 
     auto& module = m_callGraph.ast();

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -105,7 +105,7 @@ void FunctionDefinitionWriter::write()
     for (auto& structure : m_callGraph.ast().structures())
         visit(structure);
     for (auto& entryPoint : m_callGraph.entrypoints())
-        visit(entryPoint.m_function);
+        visit(entryPoint.function);
 }
 
 void FunctionDefinitionWriter::visit(AST::Function& functionDefinition)

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -141,7 +141,7 @@ struct TemplateTypes<TT> {
 
 static bool canBeginUnaryExpression(const Token& token)
 {
-    switch (token.m_type) {
+    switch (token.type) {
     case TokenType::And:
     case TokenType::Tilde:
     case TokenType::Star:
@@ -155,7 +155,7 @@ static bool canBeginUnaryExpression(const Token& token)
 
 static bool canContinueMultiplicativeExpression(const Token& token)
 {
-    switch (token.m_type) {
+    switch (token.type) {
     case TokenType::Modulo:
     case TokenType::Slash:
     case TokenType::Star:
@@ -167,7 +167,7 @@ static bool canContinueMultiplicativeExpression(const Token& token)
 
 static bool canContinueAdditiveExpression(const Token& token)
 {
-    switch (token.m_type) {
+    switch (token.type) {
     case TokenType::Minus:
     case TokenType::Plus:
         return true;
@@ -178,7 +178,7 @@ static bool canContinueAdditiveExpression(const Token& token)
 
 static bool canContinueBitwiseExpression(const Token& token)
 {
-    switch (token.m_type) {
+    switch (token.type) {
     case TokenType::And:
     case TokenType::Or:
     case TokenType::Xor:
@@ -190,7 +190,7 @@ static bool canContinueBitwiseExpression(const Token& token)
 
 static bool canContinueRelationalExpression(const Token& token)
 {
-    switch (token.m_type) {
+    switch (token.type) {
     case TokenType::Gt:
     case TokenType::GtEq:
     case TokenType::Lt:
@@ -205,17 +205,17 @@ static bool canContinueRelationalExpression(const Token& token)
 
 static bool canContinueShortCircuitAndExpression(const Token& token)
 {
-    return token.m_type == TokenType::AndAnd;
+    return token.type == TokenType::AndAnd;
 }
 
 static bool canContinueShortCircuitOrExpression(const Token& token)
 {
-    return token.m_type == TokenType::OrOr;
+    return token.type == TokenType::OrOr;
 }
 
 static AST::BinaryOperation toBinaryOperation(const Token& token)
 {
-    switch (token.m_type) {
+    switch (token.type) {
     case TokenType::And:
         return AST::BinaryOperation::And;
     case TokenType::AndAnd:
@@ -259,7 +259,7 @@ static AST::BinaryOperation toBinaryOperation(const Token& token)
 
 static AST::UnaryOperation toUnaryOperation(const Token& token)
 {
-    switch (token.m_type) {
+    switch (token.type) {
     case TokenType::And:
         return AST::UnaryOperation::AddressOf;
     case TokenType::Tilde:
@@ -313,12 +313,12 @@ Result<AST::Expression::Ref> parseExpression(const String& source)
 template<typename Lexer>
 Expected<Token, TokenType> Parser<Lexer>::consumeType(TokenType type)
 {
-    if (current().m_type == type) {
+    if (current().type == type) {
         Expected<Token, TokenType> result = { m_current };
         m_current = m_lexer.lex();
         return result;
     }
-    return makeUnexpected(current().m_type);
+    return makeUnexpected(current().type);
 }
 
 template<typename Lexer>
@@ -326,11 +326,11 @@ template<TokenType... TTs>
 Expected<Token, TokenType> Parser<Lexer>::consumeTypes()
 {
     auto token = m_current;
-    if (TemplateTypes<TTs...>::includes(token.m_type)) {
+    if (TemplateTypes<TTs...>::includes(token.type)) {
         m_current = m_lexer.lex();
         return { token };
     }
-    return makeUnexpected(token.m_type);
+    return makeUnexpected(token.type);
 }
 
 template<typename Lexer>
@@ -360,7 +360,7 @@ Result<AST::Identifier> Parser<Lexer>::parseIdentifier()
 
     CONSUME_TYPE_NAMED(name, Identifier);
 
-    return AST::Identifier::makeWithSpan(CURRENT_SOURCE_SPAN(), WTFMove(name.m_ident));
+    return AST::Identifier::makeWithSpan(CURRENT_SOURCE_SPAN(), WTFMove(name.ident));
 }
 
 template<typename Lexer>
@@ -368,10 +368,10 @@ Result<void> Parser<Lexer>::parseGlobalDecl()
 {
     START_PARSE();
 
-    while (current().m_type == TokenType::Semicolon)
+    while (current().type == TokenType::Semicolon)
         consume();
 
-    if (current().m_type == TokenType::KeywordConst) {
+    if (current().type == TokenType::KeywordConst) {
         PARSE(variable, Variable);
         CONSUME_TYPE(Semicolon);
         m_shaderModule.variables().append(WTFMove(variable));
@@ -380,7 +380,7 @@ Result<void> Parser<Lexer>::parseGlobalDecl()
 
     PARSE(attributes, Attributes);
 
-    switch (current().m_type) {
+    switch (current().type) {
     case TokenType::KeywordStruct: {
         PARSE(structure, Structure, WTFMove(attributes));
         m_shaderModule.structures().append(WTFMove(structure));
@@ -408,7 +408,7 @@ Result<AST::Attribute::List> Parser<Lexer>::parseAttributes()
 {
     AST::Attribute::List attributes;
 
-    while (current().m_type == TokenType::Attribute) {
+    while (current().type == TokenType::Attribute) {
         PARSE(firstAttribute, Attribute);
         attributes.append(WTFMove(firstAttribute));
     }
@@ -424,51 +424,51 @@ Result<Ref<AST::Attribute>> Parser<Lexer>::parseAttribute()
     CONSUME_TYPE(Attribute);
     CONSUME_TYPE_NAMED(ident, Identifier);
 
-    if (ident.m_ident == "group"_s) {
+    if (ident.ident == "group"_s) {
         CONSUME_TYPE(ParenLeft);
         // FIXME: should more kinds of literals be accepted here?
         CONSUME_TYPE_NAMED(id, IntegerLiteral);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(GroupAttribute, id.m_literalValue);
+        RETURN_NODE_REF(GroupAttribute, id.literalValue);
     }
 
-    if (ident.m_ident == "binding"_s) {
+    if (ident.ident == "binding"_s) {
         CONSUME_TYPE(ParenLeft);
         // FIXME: should more kinds of literals be accepted here?
         CONSUME_TYPE_NAMED(id, IntegerLiteral);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(BindingAttribute, id.m_literalValue);
+        RETURN_NODE_REF(BindingAttribute, id.literalValue);
     }
 
-    if (ident.m_ident == "location"_s) {
+    if (ident.ident == "location"_s) {
         CONSUME_TYPE(ParenLeft);
         // FIXME: should more kinds of literals be accepted here?
         CONSUME_TYPE_NAMED(id, IntegerLiteral);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(LocationAttribute, id.m_literalValue);
+        RETURN_NODE_REF(LocationAttribute, id.literalValue);
     }
 
-    if (ident.m_ident == "builtin"_s) {
+    if (ident.ident == "builtin"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(name, Identifier);
         CONSUME_TYPE(ParenRight);
         RETURN_NODE_REF(BuiltinAttribute, WTFMove(name));
     }
 
-    if (ident.m_ident == "workgroup_size"_s) {
+    if (ident.ident == "workgroup_size"_s) {
         CONSUME_TYPE(ParenLeft);
         // FIXME: should more kinds of literals be accepted here?
         CONSUME_TYPE_NAMED(id, IntegerLiteralUnsigned);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(WorkgroupSizeAttribute, id.m_literalValue);
+        RETURN_NODE_REF(WorkgroupSizeAttribute, id.literalValue);
     }
 
     // https://gpuweb.github.io/gpuweb/wgsl/#pipeline-stage-attributes
-    if (ident.m_ident == "vertex"_s)
+    if (ident.ident == "vertex"_s)
         RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Vertex);
-    if (ident.m_ident == "compute"_s)
+    if (ident.ident == "compute"_s)
         RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Compute);
-    if (ident.m_ident == "fragment"_s)
+    if (ident.ident == "fragment"_s)
         RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Fragment);
 
     FAIL("Unknown attribute. Supported attributes are 'group', 'binding', 'location', 'builtin', 'vertex', 'compute', 'fragment'."_s);
@@ -484,10 +484,10 @@ Result<AST::Structure::Ref> Parser<Lexer>::parseStructure(AST::Attribute::List&&
     CONSUME_TYPE(BraceLeft);
 
     AST::StructureMember::List members;
-    while (current().m_type != TokenType::BraceRight) {
+    while (current().type != TokenType::BraceRight) {
         PARSE(member, StructureMember);
         members.append(makeUniqueRef<AST::StructureMember>(WTFMove(member)));
-        if (current().m_type == TokenType::Comma)
+        if (current().type == TokenType::Comma)
             consume();
         else
             break;
@@ -516,25 +516,25 @@ Result<AST::TypeName::Ref> Parser<Lexer>::parseTypeName()
 {
     START_PARSE();
 
-    if (current().m_type == TokenType::KeywordArray)
+    if (current().type == TokenType::KeywordArray)
         return parseArrayType();
-    if (current().m_type == TokenType::KeywordI32) {
+    if (current().type == TokenType::KeywordI32) {
         consume();
         RETURN_NODE_REF(NamedTypeName, AST::Identifier::makeWithSpan(CURRENT_SOURCE_SPAN(), StringView { "i32"_s }));
     }
-    if (current().m_type == TokenType::KeywordF32) {
+    if (current().type == TokenType::KeywordF32) {
         consume();
         RETURN_NODE_REF(NamedTypeName, AST::Identifier::makeWithSpan(CURRENT_SOURCE_SPAN(), StringView { "f32"_s }));
     }
-    if (current().m_type == TokenType::KeywordU32) {
+    if (current().type == TokenType::KeywordU32) {
         consume();
         RETURN_NODE_REF(NamedTypeName, AST::Identifier::makeWithSpan(CURRENT_SOURCE_SPAN(), StringView { "u32"_s }));
     }
-    if (current().m_type == TokenType::KeywordBool) {
+    if (current().type == TokenType::KeywordBool) {
         consume();
         RETURN_NODE_REF(NamedTypeName, AST::Identifier::makeWithSpan(CURRENT_SOURCE_SPAN(), StringView { "bool"_s }));
     }
-    if (current().m_type == TokenType::Identifier) {
+    if (current().type == TokenType::Identifier) {
         PARSE(name, Identifier);
         return parseTypeNameAfterIdentifier(WTFMove(name), _startOfElementPosition);
     }
@@ -546,7 +546,7 @@ template<typename Lexer>
 Result<AST::TypeName::Ref> Parser<Lexer>::parseTypeNameAfterIdentifier(AST::Identifier&& name, SourcePosition _startOfElementPosition) // NOLINT
 {
     auto kind = AST::ParameterizedTypeName::stringViewToKind(name.id());
-    if (kind && current().m_type == TokenType::Lt) {
+    if (kind && current().type == TokenType::Lt) {
         CONSUME_TYPE(Lt);
         PARSE(elementType, TypeName);
         CONSUME_TYPE(Gt);
@@ -565,7 +565,7 @@ Result<AST::TypeName::Ref> Parser<Lexer>::parseArrayType()
     AST::TypeName::Ptr maybeElementType;
     AST::Expression::Ptr maybeElementCount;
 
-    if (current().m_type == TokenType::Lt) {
+    if (current().type == TokenType::Lt) {
         // We differ from the WGSL grammar here by allowing the type to be optional,
         // which allows us to use `parseArrayType` in `parseCallExpression`.
         consume();
@@ -573,7 +573,7 @@ Result<AST::TypeName::Ref> Parser<Lexer>::parseArrayType()
         PARSE(elementType, TypeName);
         maybeElementType = WTFMove(elementType);
 
-        if (current().m_type == TokenType::Comma) {
+        if (current().type == TokenType::Comma) {
             consume();
             // FIXME: According to https://www.w3.org/TR/WGSL/#syntax-element_count_expression
             // this should be: AdditiveExpression | BitwiseExpression.
@@ -600,7 +600,7 @@ template<typename Lexer>
 Result<AST::Variable::Ref> Parser<Lexer>::parseVariableWithAttributes(AST::Attribute::List&& attributes)
 {
     auto flavor = [](const Token& token) -> AST::VariableFlavor {
-        switch (token.m_type) {
+        switch (token.type) {
         case TokenType::KeywordConst:
             return AST::VariableFlavor::Const;
         case TokenType::KeywordLet:
@@ -608,7 +608,7 @@ Result<AST::Variable::Ref> Parser<Lexer>::parseVariableWithAttributes(AST::Attri
         case TokenType::KeywordOverride:
             return AST::VariableFlavor::Override;
         default:
-            ASSERT(token.m_type == TokenType::KeywordVar);
+            ASSERT(token.type == TokenType::KeywordVar);
             return AST::VariableFlavor::Var;
         }
     };
@@ -624,7 +624,7 @@ Result<AST::Variable::Ref> Parser<Lexer>::parseVariableWithAttributes(AST::Attri
     auto varFlavor = flavor(varKind);
 
     std::unique_ptr<AST::VariableQualifier> maybeQualifier = nullptr;
-    if (current().m_type == TokenType::Lt) {
+    if (current().type == TokenType::Lt) {
         PARSE(variableQualifier, VariableQualifier);
         maybeQualifier = WTF::makeUnique<AST::VariableQualifier>(WTFMove(variableQualifier));
     }
@@ -632,14 +632,14 @@ Result<AST::Variable::Ref> Parser<Lexer>::parseVariableWithAttributes(AST::Attri
     PARSE(name, Identifier);
 
     AST::TypeName::Ptr maybeType = nullptr;
-    if (current().m_type == TokenType::Colon) {
+    if (current().type == TokenType::Colon) {
         consume();
         PARSE(TypeName, TypeName);
         maybeType = WTFMove(TypeName);
     }
 
     std::unique_ptr<AST::Expression> maybeInitializer = nullptr;
-    if (current().m_type == TokenType::Equal) {
+    if (current().type == TokenType::Equal) {
         consume();
         PARSE(initializerExpr, Expression);
         maybeInitializer = initializerExpr.moveToUniquePtr();
@@ -658,7 +658,7 @@ Result<AST::VariableQualifier> Parser<Lexer>::parseVariableQualifier()
 
     // FIXME: verify that Read is the correct default in all cases.
     AST::AccessMode accessMode = AST::AccessMode::Read;
-    if (current().m_type == TokenType::Comma) {
+    if (current().type == TokenType::Comma) {
         consume();
         PARSE(actualAccessMode, AccessMode);
         accessMode = actualAccessMode;
@@ -674,23 +674,23 @@ Result<AST::StorageClass> Parser<Lexer>::parseStorageClass()
 {
     START_PARSE();
 
-    if (current().m_type == TokenType::KeywordFunction) {
+    if (current().type == TokenType::KeywordFunction) {
         consume();
         return { AST::StorageClass::Function };
     }
-    if (current().m_type == TokenType::KeywordPrivate) {
+    if (current().type == TokenType::KeywordPrivate) {
         consume();
         return { AST::StorageClass::Private };
     }
-    if (current().m_type == TokenType::KeywordWorkgroup) {
+    if (current().type == TokenType::KeywordWorkgroup) {
         consume();
         return { AST::StorageClass::Workgroup };
     }
-    if (current().m_type == TokenType::KeywordUniform) {
+    if (current().type == TokenType::KeywordUniform) {
         consume();
         return { AST::StorageClass::Uniform };
     }
-    if (current().m_type == TokenType::KeywordStorage) {
+    if (current().type == TokenType::KeywordStorage) {
         consume();
         return { AST::StorageClass::Storage };
     }
@@ -703,15 +703,15 @@ Result<AST::AccessMode> Parser<Lexer>::parseAccessMode()
 {
     START_PARSE();
 
-    if (current().m_type == TokenType::KeywordRead) {
+    if (current().type == TokenType::KeywordRead) {
         consume();
         return { AST::AccessMode::Read };
     }
-    if (current().m_type == TokenType::KeywordWrite) {
+    if (current().type == TokenType::KeywordWrite) {
         consume();
         return { AST::AccessMode::Write };
     }
-    if (current().m_type == TokenType::KeywordReadWrite) {
+    if (current().type == TokenType::KeywordReadWrite) {
         consume();
         return { AST::AccessMode::ReadWrite };
     }
@@ -729,10 +729,10 @@ Result<AST::Function> Parser<Lexer>::parseFunction(AST::Attribute::List&& attrib
 
     CONSUME_TYPE(ParenLeft);
     AST::Parameter::List parameters;
-    while (current().m_type != TokenType::ParenRight) {
+    while (current().type != TokenType::ParenRight) {
         PARSE(parameter, Parameter);
         parameters.append(makeUniqueRef<AST::Parameter>(WTFMove(parameter)));
-        if (current().m_type == TokenType::Comma)
+        if (current().type == TokenType::Comma)
             consume();
         else
             break;
@@ -741,7 +741,7 @@ Result<AST::Function> Parser<Lexer>::parseFunction(AST::Attribute::List&& attrib
 
     AST::Attribute::List returnAttributes;
     AST::TypeName::Ptr maybeReturnType = nullptr;
-    if (current().m_type == TokenType::Arrow) {
+    if (current().type == TokenType::Arrow) {
         consume();
         PARSE(parsedReturnAttributes, Attributes);
         returnAttributes = WTFMove(parsedReturnAttributes);
@@ -772,10 +772,10 @@ Result<AST::Statement::Ref> Parser<Lexer>::parseStatement()
 {
     START_PARSE();
 
-    while (current().m_type == TokenType::Semicolon)
+    while (current().type == TokenType::Semicolon)
         consume();
 
-    switch (current().m_type) {
+    switch (current().type) {
     case TokenType::BraceLeft: {
         PARSE(compoundStmt, CompoundStatement);
         return { makeUniqueRef<AST::CompoundStatement>(WTFMove(compoundStmt)) };
@@ -813,7 +813,7 @@ Result<AST::CompoundStatement> Parser<Lexer>::parseCompoundStatement()
     CONSUME_TYPE(BraceLeft);
 
     AST::Statement::List statements;
-    while (current().m_type != TokenType::BraceRight) {
+    while (current().type != TokenType::BraceRight) {
         PARSE(stmt, Statement);
         statements.append(WTFMove(stmt));
     }
@@ -830,7 +830,7 @@ Result<AST::ReturnStatement> Parser<Lexer>::parseReturnStatement()
 
     CONSUME_TYPE(KeywordReturn);
 
-    if (current().m_type == TokenType::Semicolon) {
+    if (current().type == TokenType::Semicolon) {
         RETURN_NODE(ReturnStatement, { });
     }
 
@@ -842,7 +842,7 @@ template<typename Lexer>
 Result<AST::Expression::Ref> Parser<Lexer>::parseShortCircuitExpression(AST::Expression::Ref&& lhs, TokenType continuingToken, AST::BinaryOperation op)
 {
     START_PARSE();
-    while (current().m_type == continuingToken) {
+    while (current().type == continuingToken) {
         consume();
         PARSE(rhs, RelationalExpression);
         lhs = MAKE_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), op);
@@ -890,7 +890,7 @@ Result<AST::Expression::Ref> Parser<Lexer>::parseShiftExpressionPostUnary(AST::E
         return parseAdditiveExpressionPostUnary(WTFMove(lhs));
 
     START_PARSE();
-    switch (current().m_type) {
+    switch (current().type) {
     case TokenType::GtGt: {
         consume();
         PARSE(rhs, UnaryExpression);
@@ -917,7 +917,7 @@ Result<AST::Expression::Ref> Parser<Lexer>::parseAdditiveExpressionPostUnary(AST
     while (canContinueAdditiveExpression(current())) {
         // parseMultiplicativeExpression handles multiplicative operators so
         // token should be PLUS or MINUS.
-        ASSERT(current().m_type == TokenType::Plus || current().m_type == TokenType::Minus);
+        ASSERT(current().type == TokenType::Plus || current().type == TokenType::Minus);
         const auto op = toBinaryOperation(current());
         consume();
         PARSE(unary, UnaryExpression);
@@ -933,8 +933,8 @@ Result<AST::Expression::Ref> Parser<Lexer>::parseBitwiseExpressionPostUnary(AST:
 {
     START_PARSE();
     const auto op = toBinaryOperation(current());
-    const TokenType continuingToken = current().m_type;
-    while (current().m_type == continuingToken) {
+    const TokenType continuingToken = current().type;
+    while (current().type == continuingToken) {
         consume();
         PARSE(rhs, UnaryExpression);
         lhs = MAKE_NODE_UNIQUE_REF(BinaryExpression, WTFMove(lhs), WTFMove(rhs), op);
@@ -949,7 +949,7 @@ Result<AST::Expression::Ref> Parser<Lexer>::parseMultiplicativeExpressionPostUna
     START_PARSE();
     while (canContinueMultiplicativeExpression(current())) {
         auto op = AST::BinaryOperation::Multiply;
-        switch (current().m_type) {
+        switch (current().type) {
         case TokenType::Modulo:
             op = AST::BinaryOperation::Modulo;
             break;
@@ -1006,7 +1006,7 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePostfixExpression(UniqueRef<AST
     // FIXME: add the case for array/vector/matrix access
 
     for (;;) {
-        switch (current().m_type) {
+        switch (current().type) {
         case TokenType::BracketLeft: {
             consume();
             PARSE(arrayIndex, Expression);
@@ -1044,7 +1044,7 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePrimaryExpression()
 {
     START_PARSE();
 
-    switch (current().m_type) {
+    switch (current().type) {
     // paren_expression
     case TokenType::ParenLeft: {
         consume();
@@ -1059,7 +1059,7 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePrimaryExpression()
         // template-parameter list. Here we are checking for vector or matrix
         // type names. Alternatively, those names could be turned into keywords
         auto typePrefix = AST::ParameterizedTypeName::stringViewToKind(ident.id());
-        if ((typePrefix && current().m_type == TokenType::Lt) || current().m_type == TokenType::ParenLeft) {
+        if ((typePrefix && current().type == TokenType::Lt) || current().type == TokenType::ParenLeft) {
             PARSE(type, TypeNameAfterIdentifier, WTFMove(ident), _startOfElementPosition);
             PARSE(arguments, ArgumentExpressionList);
             RETURN_NODE_UNIQUE_REF(CallExpression, WTFMove(type), WTFMove(arguments));
@@ -1081,23 +1081,23 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePrimaryExpression()
         RETURN_NODE_UNIQUE_REF(BoolLiteral, false);
     case TokenType::IntegerLiteral: {
         CONSUME_TYPE_NAMED(lit, IntegerLiteral);
-        RETURN_NODE_UNIQUE_REF(AbstractIntegerLiteral, lit.m_literalValue);
+        RETURN_NODE_UNIQUE_REF(AbstractIntegerLiteral, lit.literalValue);
     }
     case TokenType::IntegerLiteralSigned: {
         CONSUME_TYPE_NAMED(lit, IntegerLiteralSigned);
-        RETURN_NODE_UNIQUE_REF(Signed32Literal, lit.m_literalValue);
+        RETURN_NODE_UNIQUE_REF(Signed32Literal, lit.literalValue);
     }
     case TokenType::IntegerLiteralUnsigned: {
         CONSUME_TYPE_NAMED(lit, IntegerLiteralUnsigned);
-        RETURN_NODE_UNIQUE_REF(Unsigned32Literal, lit.m_literalValue);
+        RETURN_NODE_UNIQUE_REF(Unsigned32Literal, lit.literalValue);
     }
     case TokenType::DecimalFloatLiteral: {
         CONSUME_TYPE_NAMED(lit, DecimalFloatLiteral);
-        RETURN_NODE_UNIQUE_REF(AbstractFloatLiteral, lit.m_literalValue);
+        RETURN_NODE_UNIQUE_REF(AbstractFloatLiteral, lit.literalValue);
     }
     case TokenType::HexFloatLiteral: {
         CONSUME_TYPE_NAMED(lit, HexFloatLiteral);
-        RETURN_NODE_UNIQUE_REF(AbstractFloatLiteral, lit.m_literalValue);
+        RETURN_NODE_UNIQUE_REF(AbstractFloatLiteral, lit.literalValue);
     }
     // TODO: bitcast expression
 
@@ -1141,7 +1141,7 @@ Result<AST::Expression::Ref> Parser<Lexer>::parseCoreLHSExpression()
 {
     START_PARSE();
 
-    switch (current().m_type) {
+    switch (current().type) {
     case TokenType::ParenLeft: {
         consume();
         PARSE(expr, LHSExpression);
@@ -1166,10 +1166,10 @@ Result<AST::Expression::List> Parser<Lexer>::parseArgumentExpressionList()
     CONSUME_TYPE(ParenLeft);
 
     AST::Expression::List arguments;
-    while (current().m_type != TokenType::ParenRight) {
+    while (current().type != TokenType::ParenRight) {
         PARSE(expr, Expression);
         arguments.append(WTFMove(expr));
-        if (current().m_type != TokenType::ParenRight) {
+        if (current().type != TokenType::ParenRight) {
             CONSUME_TYPE(Comma);
         }
     }

--- a/Source/WebGPU/WGSL/SourceSpan.h
+++ b/Source/WebGPU/WGSL/SourceSpan.h
@@ -28,38 +28,38 @@
 namespace WGSL {
 
 struct SourcePosition {
-    unsigned m_line;
-    unsigned m_lineOffset;
-    unsigned m_offset;
+    unsigned line;
+    unsigned lineOffset;
+    unsigned offset;
 };
 
 struct SourceSpan {
-    // FIXME: we could possibly skip m_lineOffset and recompute it only when trying to show an error
+    // FIXME: we could possibly skip lineOffset and recompute it only when trying to show an error
     // This would shrink the AST size by 32 bits per AST node, at the cost of a bit of code complexity in the error toString function.
-    unsigned m_line;
-    unsigned m_lineOffset;
-    unsigned m_offset;
-    unsigned m_length;
+    unsigned line;
+    unsigned lineOffset;
+    unsigned offset;
+    unsigned length;
 
     static constexpr SourceSpan empty() { return { 0, 0, 0, 0 }; }
 
     constexpr SourceSpan(unsigned line, unsigned lineOffset, unsigned offset, unsigned length)
-        : m_line(line)
-        , m_lineOffset(lineOffset)
-        , m_offset(offset)
-        , m_length(length)
+        : line(line)
+        , lineOffset(lineOffset)
+        , offset(offset)
+        , length(length)
     { }
 
     constexpr SourceSpan(SourcePosition start, SourcePosition end)
-        : SourceSpan(start.m_line, start.m_lineOffset, start.m_offset, end.m_offset - start.m_offset)
+        : SourceSpan(start.line, start.lineOffset, start.offset, end.offset - start.offset)
     { }
 
     constexpr bool operator==(const SourceSpan& other) const
     {
-        return (m_line == other.m_line
-            && m_lineOffset == other.m_lineOffset
-            && m_offset == other.m_offset
-            && m_length == other.m_length);
+        return (line == other.line
+            && lineOffset == other.lineOffset
+            && offset == other.offset
+            && length == other.length);
     }
 
     constexpr bool operator!=(const SourceSpan& other) const

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -114,16 +114,16 @@ enum class TokenType: uint32_t {
 String toString(TokenType);
 
 struct Token {
-    TokenType m_type;
-    SourceSpan m_span;
+    TokenType type;
+    SourceSpan span;
     union {
-        double m_literalValue;
-        String m_ident;
+        double literalValue;
+        String ident;
     };
 
     Token(TokenType type, SourcePosition position, unsigned length)
-        : m_type(type)
-        , m_span(position.m_line, position.m_lineOffset, position.m_offset, length)
+        : type(type)
+        , span(position.line, position.lineOffset, position.offset, length)
     {
         ASSERT(type != TokenType::Identifier);
         ASSERT(type != TokenType::IntegerLiteral);
@@ -134,9 +134,9 @@ struct Token {
     }
 
     Token(TokenType type, SourcePosition position, unsigned length, double literalValue)
-        : m_type(type)
-        , m_span(position.m_line, position.m_lineOffset, position.m_offset, length)
-        , m_literalValue(literalValue)
+        : type(type)
+        , span(position.line, position.lineOffset, position.offset, length)
+        , literalValue(literalValue)
     {
         ASSERT(type == TokenType::IntegerLiteral
             || type == TokenType::IntegerLiteralSigned
@@ -146,33 +146,33 @@ struct Token {
     }
 
     Token(TokenType type, SourcePosition position, unsigned length, String&& ident)
-        : m_type(type)
-        , m_span(position.m_line, position.m_lineOffset, position.m_offset, length)
-        , m_ident(WTFMove(ident))
+        : type(type)
+        , span(position.line, position.lineOffset, position.offset, length)
+        , ident(WTFMove(ident))
     {
-        ASSERT(m_ident.impl() && m_ident.impl()->bufferOwnership() == StringImpl::BufferInternal);
+        ASSERT(this->ident.impl() && this->ident.impl()->bufferOwnership() == StringImpl::BufferInternal);
         ASSERT(type == TokenType::Identifier);
     }
 
     Token& operator=(Token&& other)
     {
-        if (m_type == TokenType::Identifier)
-            m_ident.~String();
+        if (type == TokenType::Identifier)
+            ident.~String();
 
-        m_type = other.m_type;
-        m_span = other.m_span;
+        type = other.type;
+        span = other.span;
 
-        switch (other.m_type) {
+        switch (other.type) {
         case TokenType::Identifier:
-            new (NotNull, &m_ident) String();
-            m_ident = other.m_ident;
+            new (NotNull, &ident) String();
+            ident = other.ident;
             break;
         case TokenType::IntegerLiteral:
         case TokenType::IntegerLiteralSigned:
         case TokenType::IntegerLiteralUnsigned:
         case TokenType::DecimalFloatLiteral:
         case TokenType::HexFloatLiteral:
-            m_literalValue = other.m_literalValue;
+            literalValue = other.literalValue;
             break;
         default:
             break;
@@ -182,20 +182,20 @@ struct Token {
     }
 
     Token(const Token& other)
-        : m_type(other.m_type)
-        , m_span(other.m_span)
+        : type(other.type)
+        , span(other.span)
     {
-        switch (other.m_type) {
+        switch (other.type) {
         case TokenType::Identifier:
-            new (NotNull, &m_ident) String();
-            m_ident = other.m_ident;
+            new (NotNull, &ident) String();
+            ident = other.ident;
             break;
         case TokenType::IntegerLiteral:
         case TokenType::IntegerLiteralSigned:
         case TokenType::IntegerLiteralUnsigned:
         case TokenType::DecimalFloatLiteral:
         case TokenType::HexFloatLiteral:
-            m_literalValue = other.m_literalValue;
+            literalValue = other.literalValue;
             break;
         default:
             break;
@@ -204,8 +204,8 @@ struct Token {
 
     ~Token()
     {
-        if (m_type == TokenType::Identifier)
-            (&m_ident)->~String();
+        if (type == TokenType::Identifier)
+            (&ident)->~String();
     }
 };
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -32,22 +32,22 @@ static WGSL::Token checkSingleToken(const String& string, WGSL::TokenType type)
 {
     WGSL::Lexer<LChar> lexer(string);
     WGSL::Token result = lexer.lex();
-    EXPECT_EQ(result.m_type, type);
+    EXPECT_EQ(result.type, type);
     return result;
 }
 
 static void checkSingleLiteral(const String& string, WGSL::TokenType type, double literalValue)
 {
     WGSL::Token result = checkSingleToken(string, type);
-    EXPECT_EQ(result.m_literalValue, literalValue);
+    EXPECT_EQ(result.literalValue, literalValue);
 }
 
 template<typename T>
 static WGSL::Token checkNextTokenIs(WGSL::Lexer<T>& lexer, WGSL::TokenType type, unsigned lineNumber)
 {
     WGSL::Token result = lexer.lex();
-    EXPECT_EQ(result.m_type, type);
-    EXPECT_EQ(result.m_span.m_line, lineNumber);
+    EXPECT_EQ(result.type, type);
+    EXPECT_EQ(result.span.line, lineNumber);
     return result;
 }
 
@@ -55,14 +55,14 @@ template<typename T>
 static void checkNextTokenIsIdentifier(WGSL::Lexer<T>& lexer, const String& ident, unsigned lineNumber)
 {
     WGSL::Token result = checkNextTokenIs(lexer, WGSL::TokenType::Identifier, lineNumber);
-    EXPECT_EQ(result.m_ident, ident);
+    EXPECT_EQ(result.ident, ident);
 }
 
 template<typename T>
 static void checkNextTokenIsLiteral(WGSL::Lexer<T>& lexer, WGSL::TokenType type, double literalValue, unsigned lineNumber)
 {
     WGSL::Token result = checkNextTokenIs(lexer, type, lineNumber);
-    EXPECT_EQ(result.m_literalValue, literalValue);
+    EXPECT_EQ(result.literalValue, literalValue);
 }
 
 template<typename T>


### PR DESCRIPTION
#### cac21a78dd10adb8cae00cf63c2d33bcf66d7009
<pre>
[WGSL] Remove m_ prefix from public struct members
<a href="https://bugs.webkit.org/show_bug.cgi?id=253665">https://bugs.webkit.org/show_bug.cgi?id=253665</a>
rdar://106512980

Reviewed by Myles C. Maxfield.

This was originally landed in <a href="https://commits.webkit.org/261690@main">https://commits.webkit.org/261690@main</a>, but contained
a bug in Token::Token (when I removed the `m_` prefix the class member `ident` was
shadowed by the parameter with the same name). This commit brings bag the original
change with the fix applied.

* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::Indent::Indent):
* Source/WebGPU/WGSL/CallGraph.h:
* Source/WebGPU/WGSL/CompilationMessage.cpp:
(WGSL::CompilationMessage::dump const):
* Source/WebGPU/WGSL/CompilationMessage.h:
(WGSL::CompilationMessage::lineNumber const):
(WGSL::CompilationMessage::lineOffset const):
(WGSL::CompilationMessage::offset const):
(WGSL::CompilationMessage::length const):
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::constructInputStruct):
(WGSL::EntryPointRewriter::materialize):
(WGSL::EntryPointRewriter::visit):
(WGSL::EntryPointRewriter::appendBuiltins):
(WGSL::rewriteEntryPoints):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::run):
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::requiredGroups):
(WGSL::RewriteGlobalVariables::insertStructs):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::shift):
(WGSL::Lexer&lt;T&gt;::newLine):
* Source/WebGPU/WGSL/Lexer.h:
(WGSL::Lexer::currentOffset const):
(WGSL::Lexer::currentTokenLength const):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::run):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::write):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::canBeginUnaryExpression):
(WGSL::canContinueMultiplicativeExpression):
(WGSL::canContinueAdditiveExpression):
(WGSL::canContinueBitwiseExpression):
(WGSL::canContinueRelationalExpression):
(WGSL::canContinueShortCircuitAndExpression):
(WGSL::canContinueShortCircuitOrExpression):
(WGSL::toBinaryOperation):
(WGSL::toUnaryOperation):
(WGSL::Parser&lt;Lexer&gt;::consumeType):
(WGSL::Parser&lt;Lexer&gt;::consumeTypes):
(WGSL::Parser&lt;Lexer&gt;::parseIdentifier):
(WGSL::Parser&lt;Lexer&gt;::parseGlobalDecl):
(WGSL::Parser&lt;Lexer&gt;::parseAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
(WGSL::Parser&lt;Lexer&gt;::parseStructure):
(WGSL::Parser&lt;Lexer&gt;::parseTypeName):
(WGSL::Parser&lt;Lexer&gt;::parseTypeNameAfterIdentifier):
(WGSL::Parser&lt;Lexer&gt;::parseArrayType):
(WGSL::Parser&lt;Lexer&gt;::parseVariableWithAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseVariableQualifier):
(WGSL::Parser&lt;Lexer&gt;::parseStorageClass):
(WGSL::Parser&lt;Lexer&gt;::parseAccessMode):
(WGSL::Parser&lt;Lexer&gt;::parseFunction):
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseCompoundStatement):
(WGSL::Parser&lt;Lexer&gt;::parseReturnStatement):
(WGSL::Parser&lt;Lexer&gt;::parseShortCircuitExpression):
(WGSL::Parser&lt;Lexer&gt;::parseShiftExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseAdditiveExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseBitwiseExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseMultiplicativeExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parsePostfixExpression):
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
(WGSL::Parser&lt;Lexer&gt;::parseCoreLHSExpression):
(WGSL::Parser&lt;Lexer&gt;::parseArgumentExpressionList):
* Source/WebGPU/WGSL/SourceSpan.h:
(WGSL::SourceSpan::SourceSpan):
(WGSL::SourceSpan::operator== const):
* Source/WebGPU/WGSL/Token.h:
(WGSL::Token::Token):
(WGSL::Token::operator=):
(WGSL::Token::~Token):
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::checkSingleToken):
(TestWGSLAPI::checkSingleLiteral):
(TestWGSLAPI::checkNextTokenIs):
(TestWGSLAPI::checkNextTokenIsIdentifier):
(TestWGSLAPI::checkNextTokenIsLiteral):

Canonical link: <a href="https://commits.webkit.org/261784@main">https://commits.webkit.org/261784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36c06d98d4731a1879e78b20dca73ab1d0128a0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4495 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121245 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5659 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118477 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17244 "4 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105799 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46262 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14194 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1066 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/95669 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10412 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53058 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8222 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16728 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->