### PR TITLE
[WGSL] Don't modify the AST directly when rewriting entry points

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTCompoundStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTCompoundStatement.h
@@ -42,6 +42,7 @@ public:
 
     NodeKind kind() const override;
     Statement::List& statements() { return m_statements; }
+    const Statement::List& statements() const { return m_statements; }
 
 private:
     Statement::List m_statements;

--- a/Source/WebGPU/WGSL/AST/ASTFunction.h
+++ b/Source/WebGPU/WGSL/AST/ASTFunction.h
@@ -58,6 +58,12 @@ public:
     Attribute::List& returnAttributes() { return m_returnAttributes; }
     TypeName* maybeReturnType() { return m_returnType.get(); }
     CompoundStatement& body() { return m_body; }
+    const Identifier& name() const { return m_name; }
+    const Parameter::List& parameters() const { return m_parameters; }
+    const Attribute::List& attributes() const { return m_attributes; }
+    const Attribute::List& returnAttributes() const { return m_returnAttributes; }
+    const TypeName* maybeReturnType() const { return m_returnType.get(); }
+    const CompoundStatement& body() const { return m_body; }
 
 private:
     Identifier m_name;

--- a/Source/WebGPU/WGSL/AST/ASTParameter.h
+++ b/Source/WebGPU/WGSL/AST/ASTParameter.h
@@ -28,6 +28,7 @@
 #include "ASTAttribute.h"
 #include "ASTIdentifier.h"
 #include "ASTTypeName.h"
+#include <wtf/RefCounted.h>
 
 namespace WGSL::AST {
 
@@ -37,10 +38,10 @@ enum class ParameterRole : uint8_t {
     BindGroup,
 };
 
-class Parameter final : public Node {
+class Parameter final : public Node, public RefCounted<Parameter> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    using List = UniqueRefVector<Parameter>;
+    using List = RefVector<Parameter>;
 
     Parameter(SourceSpan span, Identifier&& name, TypeName::Ref&& typeName, Attribute::List&& attributes, ParameterRole role)
         : Node(span)

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -228,7 +228,7 @@ void RewriteGlobalVariables::insertParameters(AST::Function& function, const Ind
 {
     auto span = function.span();
     for (unsigned group : requiredGroups) {
-        function.parameters().append(makeUniqueRef<AST::Parameter>(
+        function.parameters().append(adoptRef(*new AST::Parameter(
             span,
             argumentBufferParameterName(group),
             adoptRef(*new AST::NamedTypeName(span, argumentBufferStructName(group))),
@@ -236,7 +236,7 @@ void RewriteGlobalVariables::insertParameters(AST::Function& function, const Ind
                 adoptRef(*new AST::GroupAttribute(span, group))
             },
             AST::ParameterRole::BindGroup
-        ));
+        )));
     }
 }
 

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -731,7 +731,7 @@ Result<AST::Function> Parser<Lexer>::parseFunction(AST::Attribute::List&& attrib
     AST::Parameter::List parameters;
     while (current().type != TokenType::ParenRight) {
         PARSE(parameter, Parameter);
-        parameters.append(makeUniqueRef<AST::Parameter>(WTFMove(parameter)));
+        parameters.append(WTFMove(parameter));
         if (current().type == TokenType::Comma)
             consume();
         else
@@ -755,7 +755,7 @@ Result<AST::Function> Parser<Lexer>::parseFunction(AST::Attribute::List&& attrib
 }
 
 template<typename Lexer>
-Result<AST::Parameter> Parser<Lexer>::parseParameter()
+Result<Ref<AST::Parameter>> Parser<Lexer>::parseParameter()
 {
     START_PARSE();
 
@@ -764,7 +764,7 @@ Result<AST::Parameter> Parser<Lexer>::parseParameter()
     CONSUME_TYPE(Colon);
     PARSE(type, TypeName);
 
-    RETURN_NODE(Parameter, WTFMove(name), WTFMove(type), WTFMove(attributes), AST::ParameterRole::UserDefined);
+    RETURN_NODE_REF(Parameter, WTFMove(name), WTFMove(type), WTFMove(attributes), AST::ParameterRole::UserDefined);
 }
 
 template<typename Lexer>

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -68,7 +68,7 @@ public:
     Result<AST::StorageClass> parseStorageClass();
     Result<AST::AccessMode> parseAccessMode();
     Result<AST::Function> parseFunction(AST::Attribute::List&&);
-    Result<AST::Parameter> parseParameter();
+    Result<Ref<AST::Parameter>> parseParameter();
     Result<AST::Statement::Ref> parseStatement();
     Result<AST::CompoundStatement> parseCompoundStatement();
     Result<AST::ReturnStatement> parseReturnStatement();


### PR DESCRIPTION
#### c6450e38b6cede6d68c39146c196fd1f24438426
<pre>
[WGSL] Don&apos;t modify the AST directly when rewriting entry points
<a href="https://bugs.webkit.org/show_bug.cgi?id=254022">https://bugs.webkit.org/show_bug.cgi?id=254022</a>
rdar://106807949

Reviewed by Myles C. Maxfield.

This is part of the refactoring to stop modifying the AST directly, in order to be
able to reuse the AST across multiple compilations. Instead of directly modifying
the entry point function in `EntryPointRewriter` we add 3 new helpers to the shader
module to keep track of modifications made to vectors of nodes. The  unfortunate
constraint is that nodes must be copyable in order to manipulated, so we change
parameters to be Refs instead of UniqueRefs (since the latter can&apos;t by definition
be copied).

* Source/WebGPU/WGSL/AST/ASTCompoundStatement.h:
* Source/WebGPU/WGSL/AST/ASTFunction.h:
* Source/WebGPU/WGSL/AST/ASTParameter.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::EntryPointRewriter):
(WGSL::EntryPointRewriter::rewrite):
(WGSL::EntryPointRewriter::collectParameters):
(WGSL::EntryPointRewriter::constructInputStruct):
(WGSL::EntryPointRewriter::appendBuiltins):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertParameters):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseFunction):
(WGSL::Parser&lt;Lexer&gt;::parseParameter):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::replace):
(WGSL::ShaderModule::takeLast):
(WGSL::ShaderModule::append):
(WGSL::ShaderModule::insert):

Canonical link: <a href="https://commits.webkit.org/261913@main">https://commits.webkit.org/261913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7479500bd9e6f1f702e516c972bccab1aefd21ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/5014 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121693 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6238 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/119026 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106334 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1442 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14671 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1481 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/98937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15381 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53472 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8326 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17233 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->