### PR TITLE
[webkitbugspy] Add support for sourceChanges

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -206,6 +206,7 @@ class Tracker(GenericTracker):
         issue._link = '{}/show_bug.cgi?id={}'.format(self.url, issue.id)
         issue._labels = []
         issue._classification = ''  # Bugzilla doesn't have a concept of "classification"
+        issue._source_changes = []  # We need to parse the bug to find any source changes
 
         if member in ('title', 'timestamp', 'modified', 'creator', 'opened', 'assignee', 'watchers', 'project', 'component', 'version', 'keywords', 'related'):
             response = self.session.get(
@@ -350,7 +351,7 @@ class Tracker(GenericTracker):
 
         return issue
 
-    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, **properties):
+    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, source_changes=None, **properties):
         update_dict = dict()
 
         if properties:
@@ -439,6 +440,10 @@ class Tracker(GenericTracker):
                 issue._version = version
             if keywords is not None:
                 issue._keywords = keywords
+
+        if source_changes:
+            sys.stderr.write('Bugzilla does not support source changes at this time\n')
+            return None
 
         return issue
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -238,6 +238,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
         issue._project = self.name
         issue._keywords = []  # We don't yet have a defined idiom for "keywords" in GitHub Issues
         issue._classification = ''  # We don't yet have a defined idiom for "classification" in GitHub issues
+        issue._source_changes = []  # We need to parse the issue to find any source changes
 
         if member in ('title', 'timestamp', 'modified', 'creator', 'opened', 'assignee', 'description', 'project', 'component', 'version', 'labels', 'milestone'):
             response = self.request(path='issues/{}'.format(issue.id))
@@ -339,7 +340,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
 
         return issue
 
-    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, labels=None, original=None, **properties):
+    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, labels=None, original=None, source_changes=None, **properties):
         update_dict = dict()
 
         if properties:
@@ -424,6 +425,10 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
                 if opened is not None:
                     issue._opened = None
                 return None
+
+        if source_changes:
+            sys.stderr.write('GitHub does not support source changes at this time\n')
+            return None
 
         if issue and original:
             issue = self.add_comment(issue, 'Duplicate of #{}'.format(original.id))

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -20,6 +20,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import sys
+
 from .tracker import Tracker
 from .user import User
 from datetime import datetime
@@ -77,6 +79,8 @@ class Issue(object):
         self._milestone = None
         self._keywords = None
         self._classification = None
+
+        self._source_changes = None
 
         self.tracker.populate(self, None)
 
@@ -236,6 +240,23 @@ class Issue(object):
         if self._classification is None:
             self.tracker.populate(self, 'classification')
         return self._classification
+
+    @property
+    def source_changes(self):
+        if self._source_changes is None:
+            self.tracker.populate(self, 'source_changes')
+        return self._source_changes
+
+    def add_source_change(self, line):
+        parts = line.split(', ')
+        parts[-1] = parts[-1][:12]
+        search_for = ', '.join(parts) if parts[-1] else line
+
+        for change in self.source_changes:
+            if change.startswith(search_for):
+                sys.stderr.write("'{}' is already a registered source change\n".format(line))
+                return None
+        return self.tracker.set(self, source_changes=self.source_changes + [line])
 
     @property
     def _redaction_match(self):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -141,8 +141,10 @@ class RadarModel(object):
         def __init__(self, name):
             self.name = name
 
-    def __init__(self, client, issue):
+    def __init__(self, client, issue, additional_fields=None):
         from datetime import datetime, timedelta
+
+        additional_fields = additional_fields or []
 
         self.client = client
         self._issue = issue
@@ -192,6 +194,9 @@ class RadarModel(object):
             self.component = components[0]
         else:
             self.component = None
+
+        if 'sourceChanges' in additional_fields:
+            self.sourceChanges = issue.get('sourceChanges', None)
 
     def related_radars(self):
         for reference in self._issue.get('references', []):
@@ -246,6 +251,9 @@ class RadarModel(object):
                 self.client.parent.issues[r.related_radar_id]['related'] = list()
             self.client.parent.issues[r.related_radar_id]['related'].append(inverse_r_dict)
 
+        if getattr(self, 'sourceChanges', None):
+            self.client.parent.issues[self.id]['sourceChanges'] = self.sourceChanges
+
     def milestone_associations(self, milestone=None):
         return RadarModel.MilestoneAssociations(milestone or self.milestone)
 
@@ -284,11 +292,11 @@ class RadarClient(object):
         self.parent = parent
         self.authentication_strategy = authentication_strategy
 
-    def radar_for_id(self, problem_id):
+    def radar_for_id(self, problem_id, additional_fields=None):
         found = self.parent.issues.get(problem_id)
         if not found:
             return None
-        return RadarModel(self, found)
+        return RadarModel(self, found, additional_fields=additional_fields)
 
     def find_radars(self, query, return_find_results_directly=False):
         result = []

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -666,3 +666,14 @@ What component in 'WebKit' should the bug be associated with?:
                 issue.relate(blocks=radar_tracker.issue(1))
             self.assertEqual('Cannot relate issues of different types.', str(c.exception))
             self.assertEqual(issue.related, {'depends_on': [], 'blocks': [], 'regressions': [], 'regressed_by': []})
+
+    def test_source_changes(self):
+        with OutputCapture() as captured, mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES):
+            tracker = bugzilla.Tracker(self.URL)
+            self.assertEqual(tracker.issue(1).source_changes, [])
+            self.assertIsNone(tracker.issue(1).add_source_change('WebKit, merge, a4daad5b9fbd26d557088037f54dc0935a437182'))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'Bugzilla does not support source changes at this time\n',
+        )

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -451,3 +451,14 @@ Documentation URL: https://docs.github.com/rest/reference/pulls#create-a-pull-re
         with mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES):
             tracker = github.Tracker(self.URL)
             self.assertEqual(tracker.issue(1).classification, '')
+
+    def test_source_changes(self):
+        with OutputCapture() as captured, mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES):
+            tracker = github.Tracker(self.URL)
+            self.assertEqual(tracker.issue(1).source_changes, [])
+            self.assertIsNone(tracker.issue(1).add_source_change('WebKit, merge, a4daad5b9fbd26d557088037f54dc0935a437182'))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'GitHub does not support source changes at this time\n',
+        )

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -518,3 +518,32 @@ What version of 'WebKit Text' should the bug be associated with?:
                 issue.relate(fake_relation=issue2)
             self.assertEqual('\'fake_relation\' is an invalid relation', str(c.exception))
             self.assertEqual(issue.related, RELATED_BLANK)
+
+    def test_source_changes(self):
+        with mocks.Radar(issues=mocks.ISSUES):
+            tracker = radar.Tracker()
+            self.assertEqual(tracker.issue(1).source_changes, [])
+            self.assertIsNotNone(tracker.issue(1).add_source_change('WebKit, merge, a4daad5b9fbd26d557088037f54dc0935a437182'))
+            self.assertEqual(tracker.issue(1).source_changes, ['WebKit, merge, a4daad5b9fbd26d557088037f54dc0935a437182'])
+
+            repr = tracker.client.radar_for_id(1, additional_fields=['sourceChanges'])
+            self.assertEqual(
+                repr.sourceChanges,
+                'WebKit, merge, a4daad5b9fbd26d557088037f54dc0935a437182',
+            )
+
+    def test_source_changes_advanced(self):
+        with mocks.Radar(issues=mocks.ISSUES), OutputCapture():
+            tracker = radar.Tracker()
+            self.assertEqual(tracker.issue(1).source_changes, [])
+            self.assertIsNotNone(tracker.issue(1).add_source_change('Repo1, merged, a4daad5b9fbd26d557088037f54dc0935a437182'))
+            self.assertIsNotNone(tracker.issue(1).add_source_change('Repo2, merged, 604395a516c13cff80d4b0400e43a4c322dbb32f'))
+
+            self.assertIsNone(tracker.issue(1).add_source_change('Repo1, merged, a4daad5b9fbd26d557088037f54dc0935a437182'))
+            self.assertIsNone(tracker.issue(1).add_source_change('Repo2, merged, 604395a516c1'))
+
+            self.assertEqual(
+                tracker.issue(1).source_changes, [
+                    'Repo1, merged, a4daad5b9fbd26d557088037f54dc0935a437182',
+                    'Repo2, merged, 604395a516c13cff80d4b0400e43a4c322dbb32f',
+                ])


### PR DESCRIPTION
#### 1517cb01bf1f338b0486f5c72ac9c3a02f784524
<pre>
[webkitbugspy] Add support for sourceChanges
<a href="https://bugs.webkit.org/show_bug.cgi?id=254023">https://bugs.webkit.org/show_bug.cgi?id=254023</a>
<a href="https://rdar.apple.com/106808712">rdar://106808712</a>

Reviewed by Dewei Zhu.

Add tooling to support the &quot;sourceChanges&quot; field in Radar, specify that field
as unsupported in GitHub and Bugzilla.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.populate): Populate source_changes with an empty list.
(Tracker.set): Reject any attempts to modify the unsupported source_changes field.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker.populate): Populate source_changes with an empty list.
(Tracker.set): Reject any attempts to modify the unsupported source_changes field.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.__init__): Add _source_changes field.
(Issue.source_changes): Return _source_changes.
(Issue.add_source_change): Add a source change to the source_changes field.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.__init__): Add sourceChanges field, if specified.
(RadarModel.commit_changes): Commit sourceChanges, if available.
(RadarClient.radar_for_id): Pass additional fields to RadarModel constructor.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.populate): Parse and populate source_changes.
(Tracker.set): Construct and update sourceChange field.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:

Canonical link: <a href="https://commits.webkit.org/277553@main">https://commits.webkit.org/277553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e93c018d5bff19aa6974b1ea54b9d8459fb4afc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23819 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38432 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47762 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/23848 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40670 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19743 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/47045 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21257 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41826 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5225 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42234 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51740 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22208 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18584 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45726 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23483 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44733 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24269 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6800 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->