### PR TITLE
WTF: Simplify methods using std::fill

### DIFF
--- a/Source/WTF/wtf/fast_float/bigint.h
+++ b/Source/WTF/wtf/fast_float/bigint.h
@@ -116,10 +116,7 @@ struct stackvec {
   // appended item.
   void resize_unchecked(size_t new_len, limb value) noexcept {
     if (new_len > len()) {
-      size_t count = new_len - len();
-      limb* first = data + len();
-      limb* last = first + count;
-      ::std::fill(first, last, value);
+      ::std::fill(data + len(), data + new_len, value);
       set_len(new_len);
     } else {
       set_len(new_len);
@@ -472,13 +469,9 @@ struct bigint {
       return false;
     } else if (!vec.is_empty()) {
       // move limbs
-      limb* dst = vec.data + n;
-      const limb* src = vec.data;
-      ::memmove(dst, src, sizeof(limb) * vec.len());
+      ::memmove(vec.data + n, vec.data, sizeof(limb) * vec.len());
       // fill in empty limbs
-      limb* first = vec.data;
-      limb* last = first + n;
-      ::std::fill(first, last, 0);
+      ::std::fill_n(vec.data, n, 0);
       vec.set_len(n + vec.len());
       return true;
     } else {

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 static void fillWithValue(float* values, float value, unsigned endFrame, unsigned& writeIndex)
 {
     if (writeIndex < endFrame) {
-        std::fill_n(values + writeIndex, endFrame - writeIndex, value);
+        std::fill(values + writeIndex, values + endFrame, value);
         writeIndex = endFrame;
     }
 }


### PR DESCRIPTION
#### c849430a2e0faf80fcc65bdbb86bf60e04ecb679
<pre>
WTF: Simplify methods using std::fill
<a href="https://bugs.webkit.org/show_bug.cgi?id=254026">https://bugs.webkit.org/show_bug.cgi?id=254026</a>

Reviewed by NOBODY (OOPS!).

We can simplify some uses of std::fill to avoid unneeded calculations.

* Source\WTF\wtf\fast_float\bigint.h:(resize_unchecked): Calculate the
  arguments for std::fill in terms of data, between len() and new_len.
  (shl_limbs): Prefer std::fill_n over std::fill.

* Source\WebCore\Modules\webaudio\AudioParamTimeline.cpp:
  (fillWithValue): Prefer std::fill over std::fill_n.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c849430a2e0faf80fcc65bdbb86bf60e04ecb679

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112731 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121272 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5694 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118500 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105833 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46286 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/101035 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14223 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1094 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12348 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14913 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102542 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53086 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/32008 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16760 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110585 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27310 "Passed tests") | 
<!--EWS-Status-Bubble-End-->