### PR TITLE
Disable native appearance of devolvable widgets

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -96,6 +96,10 @@
         "Indicates that this CSS property can use the fast-path inheritance mechanism.",
         "This generates code that disables the mechanism if the property is explicitly mutated.",
         "",
+        "* disables-native-appearance",
+        "Indicates that this CSS property, when declared in the Author Origin,",
+        "will disable the native appearance of devolvable widgets.",
+        "",
         "* logical-property-group:",
         "Indicates that this CSS property belongs to a logical property group",
         "(https://drafts.csswg.org/css-logical/#logical-property-group)",
@@ -1600,6 +1604,7 @@
             "codegen-properties": {
                 "name-for-methods": "Attachment",
                 "fill-layer-property": true,
+                "disables-native-appearance": true,
                 "separator": ",",
                 "parser-grammar": "<single-background-attachment>#"
             },
@@ -1669,6 +1674,7 @@
                 "related-property": "-webkit-background-clip",
                 "name-for-methods": "Clip",
                 "fill-layer-property": true,
+                "disables-native-appearance": true,
                 "separator": " ",
                 "parser-grammar": "<single-background-clip>#"
             },
@@ -1681,6 +1687,7 @@
             "codegen-properties": {
                 "visited-link-color-support": true,
                 "color-property": true,
+                "disables-native-appearance": true,
                 "parser-grammar": "<color accept-quirky-colors-in-quirks-mode>"
             },
             "specification": {
@@ -1692,6 +1699,7 @@
             "codegen-properties": {
                 "name-for-methods": "Image",
                 "fill-layer-property": true,
+                "disables-native-appearance": true,
                 "separator": " ",
                 "parser-grammar": "<single-background-image>#"
             },
@@ -1705,6 +1713,7 @@
                 "related-property": "-webkit-background-origin",
                 "name-for-methods": "Origin",
                 "fill-layer-property": true,
+                "disables-native-appearance": true,
                 "separator": " ",
                 "parser-grammar": "<single-background-origin>#"
             },
@@ -1729,6 +1738,7 @@
             "codegen-properties": {
                 "name-for-methods": "XPosition",
                 "fill-layer-property": true,
+                "disables-native-appearance": true,
                 "parser-grammar": "<single-background-position-x>#"
             },
             "specification": {
@@ -1740,6 +1750,7 @@
             "codegen-properties": {
                 "name-for-methods": "YPosition",
                 "fill-layer-property": true,
+                "disables-native-appearance": true,
                 "parser-grammar": "<single-background-position-y>#"
             },
             "specification": {
@@ -1762,6 +1773,7 @@
             "codegen-properties": {
                 "name-for-methods": "Size",
                 "fill-layer-property": true,
+                "disables-native-appearance": true,
                 "separator": " ",
                 "parser-grammar": "<single-background-size>#"
             },
@@ -1881,6 +1893,7 @@
                 ],
                 "skip-builder": true,
                 "color-property": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-color",
                     "resolver": "block-end"
@@ -1910,6 +1923,7 @@
                     "-webkit-border-after-style"
                 ],
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-style",
                     "resolver": "block-end"
@@ -1932,6 +1946,7 @@
                     "-webkit-border-after-width"
                 ],
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-width",
                     "resolver": "block-end"
@@ -1966,6 +1981,7 @@
                 ],
                 "skip-builder": true,
                 "color-property": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-color",
                     "resolver": "block-start"
@@ -1995,6 +2011,7 @@
                     "-webkit-border-before-style"
                 ],
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-style",
                     "resolver": "block-start"
@@ -2017,6 +2034,7 @@
                     "-webkit-border-before-width"
                 ],
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-width",
                     "resolver": "block-start"
@@ -2070,6 +2088,7 @@
                 "initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-color",
                     "resolver": "bottom"
@@ -2091,6 +2110,7 @@
                     "-webkit-border-bottom-left-radius"
                 ],
                 "custom": "All",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-radius",
                     "resolver": "bottom-left"
@@ -2111,6 +2131,7 @@
                     "-webkit-border-bottom-right-radius"
                 ],
                 "custom": "All",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-radius",
                     "resolver": "bottom-right"
@@ -2140,6 +2161,7 @@
             ],
             "codegen-properties": {
                 "initial": "initialBorderStyle",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-style",
                     "resolver": "bottom"
@@ -2160,6 +2182,7 @@
             "codegen-properties": {
                 "initial": "initialBorderWidth",
                 "converter": "LineWidth<float>",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-width",
                     "resolver": "bottom"
@@ -2206,6 +2229,7 @@
         "border-end-end-radius": {
             "codegen-properties": {
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-radius",
                     "resolver": "end-end"
@@ -2223,6 +2247,7 @@
         "border-end-start-radius": {
             "codegen-properties": {
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-radius",
                     "resolver": "end-start"
@@ -2255,6 +2280,7 @@
         "border-image-outset": {
             "codegen-properties": {
                 "custom": "All",
+                "disables-native-appearance": true,
                 "parser-function": "consumeBorderImageOutset",
                 "parser-function-allows-number-or-integer-input": true,
                 "parser-grammar-unused": "[ <length [0,inf]> | <number [0,inf]> ]{1,4}",
@@ -2274,6 +2300,7 @@
             ],
             "codegen-properties": {
                 "custom": "All",
+                "disables-native-appearance": true,
                 "parser-function": "consumeBorderImageRepeat",
                 "parser-grammar-unused": "[ stretch | repeat | round | space ]{1,2}",
                 "parser-grammar-unused-reason": "Needs support for '{A,B}' multipliers."
@@ -2289,6 +2316,7 @@
             ],
             "codegen-properties": {
                 "custom": "All",
+                "disables-native-appearance": true,
                 "parser-function": "consumeBorderImageSlice",
                 "parser-function-allows-number-or-integer-input": true,
                 "parser-function-requires-current-property": true,
@@ -2306,6 +2334,7 @@
             ],
             "codegen-properties": {
                 "converter": "StyleImage<CSSPropertyBorderImageSource>",
+                "disables-native-appearance": true,
                 "parser-grammar": "none | <image>"
             },
             "specification": {
@@ -2319,6 +2348,7 @@
             ],
             "codegen-properties": {
                 "custom": "All",
+                "disables-native-appearance": true,
                 "parser-function": "consumeBorderImageWidth",
                 "parser-function-allows-number-or-integer-input": true,
                 "parser-function-requires-current-property": true,
@@ -2381,6 +2411,7 @@
                 ],
                 "skip-builder": true,
                 "color-property": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-color",
                     "resolver": "inline-end"
@@ -2410,6 +2441,7 @@
                     "-webkit-border-end-style"
                 ],
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-style",
                     "resolver": "inline-end"
@@ -2432,6 +2464,7 @@
                     "-webkit-border-end-width"
                 ],
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-width",
                     "resolver": "inline-end"
@@ -2466,6 +2499,7 @@
                 ],
                 "skip-builder": true,
                 "color-property": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-color",
                     "resolver": "inline-start"
@@ -2495,6 +2529,7 @@
                     "-webkit-border-start-style"
                 ],
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-style",
                     "resolver": "inline-start"
@@ -2517,6 +2552,7 @@
                     "-webkit-border-start-width"
                 ],
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-width",
                     "resolver": "inline-start"
@@ -2570,6 +2606,7 @@
                 "initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-color",
                     "resolver": "left"
@@ -2600,6 +2637,7 @@
             ],
             "codegen-properties": {
                 "initial": "initialBorderStyle",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-style",
                     "resolver": "left"
@@ -2620,6 +2658,7 @@
             "codegen-properties": {
                 "initial": "initialBorderWidth",
                 "converter": "LineWidth<float>",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-width",
                     "resolver": "left"
@@ -2667,6 +2706,7 @@
                 "initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-color",
                     "resolver": "right"
@@ -2697,6 +2737,7 @@
             ],
             "codegen-properties": {
                 "initial": "initialBorderStyle",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-style",
                     "resolver": "right"
@@ -2717,6 +2758,7 @@
             "codegen-properties": {
                 "initial": "initialBorderWidth",
                 "converter": "LineWidth<float>",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-width",
                     "resolver": "right"
@@ -2748,6 +2790,7 @@
         "border-start-end-radius": {
             "codegen-properties": {
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-radius",
                     "resolver": "start-end"
@@ -2765,6 +2808,7 @@
         "border-start-start-radius": {
             "codegen-properties": {
                 "skip-builder": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-radius",
                     "resolver": "start-start"
@@ -2811,6 +2855,7 @@
                 "initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-color",
                     "resolver": "top"
@@ -2832,6 +2877,7 @@
                     "-webkit-border-top-left-radius"
                 ],
                 "custom": "All",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-radius",
                     "resolver": "top-left"
@@ -2852,6 +2898,7 @@
                     "-webkit-border-top-right-radius"
                 ],
                 "custom": "All",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-radius",
                     "resolver": "top-right"
@@ -2881,6 +2928,7 @@
             ],
             "codegen-properties": {
                 "initial": "initialBorderStyle",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-style",
                     "resolver": "top"
@@ -2901,6 +2949,7 @@
             "codegen-properties": {
                 "initial": "initialBorderWidth",
                 "converter": "LineWidth<float>",
+                "disables-native-appearance": true,
                 "logical-property-group": {
                     "name": "border-width",
                     "resolver": "top"

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -90,6 +90,7 @@ public:
     static UChar listValuedPropertySeparator(CSSPropertyID);
     static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID); }
     static bool allowsNumberOrIntegerInput(CSSPropertyID);
+    static bool disablesNativeAppearance(CSSPropertyID);
 
     const StylePropertyMetadata& metadata() const { return m_metadata; }
 

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -453,6 +453,7 @@ class StylePropertyCodeGenProperties:
         Schema.Entry("conditional-converter", allowed_types=[str]),
         Schema.Entry("converter", allowed_types=[str]),
         Schema.Entry("custom", allowed_types=[str]),
+        Schema.Entry("disables-native-appearance", allowed_types=[bool], default_value=False),
         Schema.Entry("enable-if", allowed_types=[str]),
         Schema.Entry("fast-path-inherited", allowed_types=[bool], default_value=False),
         Schema.Entry("fill-layer-property", allowed_types=[bool], default_value=False),
@@ -2858,6 +2859,12 @@ class GenerateCSSPropertyNames:
                 to=writer,
                 signature="bool CSSProperty::allowsNumberOrIntegerInput(CSSPropertyID id)",
                 iterable=(p for p in self.properties_and_descriptors.style_properties.all if self._property_matches_number_or_integer(p))
+            )
+
+            self.generation_context.generate_property_id_switch_function_bool(
+                to=writer,
+                signature="bool CSSProperty::disablesNativeAppearance(CSSPropertyID id)",
+                iterable=(p for p in self.properties_and_descriptors.style_properties.all if p.codegen_properties.disables_native_appearance)
             )
 
             self.generation_context.generate_property_id_switch_function_bool(

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -550,6 +550,8 @@ public:
     virtual bool isSliderThumbElement() const { return false; }
     virtual bool isHTMLTablePartElement() const { return false; }
 
+    virtual bool isDevolvableWidget() const { return false; }
+
     bool canContainRangeEndPoint() const override;
 
     // Used for disabled form elements; if true, prevents mouse events from being dispatched

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -45,6 +45,8 @@ public:
 
     bool isExplicitlySetSubmitButton() const;
 
+    bool isDevolvableWidget() const override { return true; }
+
 private:
     HTMLButtonElement(const QualifiedName& tagName, Document&, HTMLFormElement*);
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1944,6 +1944,25 @@ bool HTMLInputElement::isEmptyValue() const
     return m_inputType->isEmptyValue();
 }
 
+bool HTMLInputElement::isDevolvableWidget() const
+{
+    return m_inputType->isTextType()
+        || m_inputType->isTelephoneField()
+        || m_inputType->isURLField()
+        || m_inputType->isURLField()
+        || m_inputType->isEmailField()
+        || m_inputType->isSearchField()
+        || m_inputType->isPasswordField()
+        || m_inputType->isDateField()
+        || m_inputType->isMonthField()
+        || m_inputType->isWeekField()
+        || m_inputType->isTimeField()
+        || m_inputType->isDateTimeLocalField()
+        || m_inputType->isNumberField()
+        || m_inputType->isColorControl()
+        || m_inputType->isTextButton();
+    }
+
 void HTMLInputElement::maxLengthAttributeChanged(const AtomString& newValue)
 {
     unsigned oldEffectiveMaxLength = effectiveMaxLength();

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -167,6 +167,8 @@ public:
     WEBCORE_EXPORT bool isTimeField() const;
     WEBCORE_EXPORT bool isWeekField() const;
 
+    bool isDevolvableWidget() const override;
+
     DateComponentsType dateType() const;
 
     HTMLElement* containerElement() const;

--- a/Source/WebCore/html/HTMLMeterElement.h
+++ b/Source/WebCore/html/HTMLMeterElement.h
@@ -61,6 +61,8 @@ public:
 
     bool canContainRangeEndPoint() const final { return false; }
 
+    bool isDevolvableWidget() const override { return true; }
+
 private:
     HTMLMeterElement(const QualifiedName&, Document&);
     virtual ~HTMLMeterElement();

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -43,6 +43,8 @@ public:
 
     double position() const;
 
+    bool isDevolvableWidget() const override { return true; }
+
 private:
     constexpr static auto CreateHTMLProgressElement = CreateHTMLElement | NodeFlag::HasCustomStyleResolveCallbacks;
     HTMLProgressElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -112,6 +112,8 @@ public:
     bool canContainRangeEndPoint() const override { return false; }
     bool shouldSaveAndRestoreFormControlState() const final { return true; }
 
+    bool isDevolvableWidget() const override { return true; }
+
 protected:
     HTMLSelectElement(const QualifiedName&, Document&, HTMLFormElement*);
 

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -53,6 +53,8 @@ public:
 
     bool shouldSaveAndRestoreFormControlState() const final { return true; }
 
+    bool isDevolvableWidget() const override { return true; }
+
 private:
     HTMLTextAreaElement(Document&, HTMLFormElement*);
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -182,6 +182,8 @@ static bool isAppearanceAllowedForAllElements(StyleAppearance appearance)
 
 void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const RenderStyle* userAgentAppearanceStyle)
 {
+    (void)userAgentAppearanceStyle;
+
     auto autoAppearance = autoAppearanceForElement(style, element);
     auto appearance = adjustAppearanceForElement(style, element, autoAppearance);
 
@@ -197,23 +199,27 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const 
     else if (style.display() == DisplayType::ListItem || style.display() == DisplayType::Table)
         style.setEffectiveDisplay(DisplayType::Block);
 
-    if (userAgentAppearanceStyle && isControlStyled(style, *userAgentAppearanceStyle)) {
-        switch (appearance) {
-        case StyleAppearance::Menulist:
-            appearance = StyleAppearance::MenulistButton;
-            break;
-        default:
-            appearance = StyleAppearance::None;
-            break;
-        }
+//    if (userAgentAppearanceStyle && isControlStyled(style, *userAgentAppearanceStyle)) {
+//        switch (appearance) {
+//        case StyleAppearance::Menulist:
+//            appearance = StyleAppearance::MenulistButton;
+//            break;
+//        default:
+//            appearance = StyleAppearance::None;
+//            break;
+//        }
+//
+//        style.setEffectiveAppearance(appearance);
+//    }
+//
+//    if (!isAppearanceAllowedForAllElements(appearance)
+//        && !userAgentAppearanceStyle
+//        && autoAppearance == StyleAppearance::None
+//        && !style.borderAndBackgroundEqual(RenderStyle::defaultStyle())) {
+//        style.setEffectiveAppearance(StyleAppearance::None);
+//    }
 
-        style.setEffectiveAppearance(appearance);
-    }
-
-    if (!isAppearanceAllowedForAllElements(appearance)
-        && !userAgentAppearanceStyle
-        && autoAppearance == StyleAppearance::None
-        && !style.borderAndBackgroundEqual(RenderStyle::defaultStyle()))
+    if (element->isDevolvableWidget() && style.isNativeAppearanceDisabled() && !isAppearanceAllowedForAllElements(appearance))
         style.setEffectiveAppearance(StyleAppearance::None);
 
     if (!style.hasEffectiveAppearance())

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -227,6 +227,7 @@ RenderStyle::RenderStyle(CreateDefaultStyleTag)
     m_nonInheritedFlags.hasContentNone = false;
     m_nonInheritedFlags.styleType = static_cast<unsigned>(PseudoId::None);
     m_nonInheritedFlags.pseudoBits = static_cast<unsigned>(PseudoId::None);
+    m_nonInheritedFlags.isNativeAppearanceDisabled = false;
 
     static_assert((sizeof(InheritedFlags) <= 8), "InheritedFlags does not grow");
     static_assert((sizeof(NonInheritedFlags) <= 8), "NonInheritedFlags does not grow");
@@ -400,6 +401,7 @@ inline void RenderStyle::NonInheritedFlags::copyNonInheritedFrom(const NonInheri
     usesContainerUnits = other.usesContainerUnits;
     usesViewportUnits = other.usesViewportUnits;
     verticalAlign = other.verticalAlign;
+    isNativeAppearanceDisabled = other.isNativeAppearanceDisabled;
 }
 
 void RenderStyle::copyNonInheritedFrom(const RenderStyle& other)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1307,6 +1307,9 @@ public:
     PrintColorAdjust printColorAdjust() const { return static_cast<PrintColorAdjust>(m_inheritedFlags.printColorAdjust); }
     void setPrintColorAdjust(PrintColorAdjust value) { m_inheritedFlags.printColorAdjust = static_cast<unsigned>(value); }
 
+    bool isNativeAppearanceDisabled() { return m_nonInheritedFlags.isNativeAppearanceDisabled; }
+    void setIsNativeAppearanceDisabled(bool isNativeAppearanceDisabled) { m_nonInheritedFlags.isNativeAppearanceDisabled = isNativeAppearanceDisabled; }
+
     inline int specifiedZIndex() const;
     inline bool hasAutoSpecifiedZIndex() const;
     inline void setSpecifiedZIndex(int);
@@ -2161,6 +2164,8 @@ private:
 
         unsigned styleType : 4; // PseudoId
         unsigned pseudoBits : PublicPseudoIDBits;
+
+        unsigned isNativeAppearanceDisabled : 1;
 
         // If you add more style bits here, you will also need to update RenderStyle::NonInheritedFlags::copyNonInheritedFrom().
     };

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -102,11 +102,18 @@ void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, 
     property.fromStyleAttribute = matchedProperties.fromStyleAttribute;
 
     if (matchedProperties.linkMatchType == SelectorChecker::MatchAll) {
-        property.cssValue[0] = &cssValue;
+        property.cascadeLevels[SelectorChecker::MatchDefault] = cascadeLevel;
+        property.cssValue[SelectorChecker::MatchDefault] = &cssValue;
+
+        property.cascadeLevels[SelectorChecker::MatchLink] = cascadeLevel;
         property.cssValue[SelectorChecker::MatchLink] = &cssValue;
+
+        property.cascadeLevels[SelectorChecker::MatchVisited] = cascadeLevel;
         property.cssValue[SelectorChecker::MatchVisited] = &cssValue;
-    } else
+    } else {
+        property.cascadeLevels[matchedProperties.linkMatchType] = cascadeLevel;
         property.cssValue[matchedProperties.linkMatchType] = &cssValue;
+    }
 }
 
 void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, CascadeLevel cascadeLevel)

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -60,6 +60,7 @@ public:
         CascadeLayerPriority cascadeLayerPriority;
         FromStyleAttribute fromStyleAttribute;
         std::array<CSSValue*, 3> cssValue; // Values for link match states MatchDefault, MatchLink and MatchVisited
+        std::array<CascadeLevel, 3> cascadeLevels;
     };
 
     bool isEmpty() const { return m_propertyIsPresent.none() && !m_seenDeferredPropertyCount; }

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -60,7 +60,7 @@ private:
     void applyPropertiesImpl(int firstProperty, int lastProperty);
     void applyCascadeProperty(const PropertyCascade::Property&);
     void applyRollbackCascadeProperty(const PropertyCascade::Property&, SelectorChecker::LinkMatchMask);
-    void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask);
+    void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask, CascadeLevel);
 
     Ref<CSSValue> resolveVariableReferences(CSSPropertyID, CSSValue&);
     RefPtr<CSSCustomPropertyValue> resolveCustomPropertyValueWithVariableReferences(CSSCustomPropertyValue&);

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -371,6 +371,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'conditional-converter': self.validate_string,
             'converter': self.validate_string,
             'custom': self.validate_string,
+            'disables-native-appearance': self.validate_boolean,
             'enable-if': self.validate_string,
             'fast-path-inherited': self.validate_boolean,
             'fill-layer-property': self.validate_boolean,


### PR DESCRIPTION
#### 482584f17a16511d68223b83469e1dbf88085e2b
<pre>
Disable native appearance of devolvable widgets
<a href="https://bugs.webkit.org/show_bug.cgi?id=243899">https://bugs.webkit.org/show_bug.cgi?id=243899</a>
rdar://98899342

Reviewed by NOBODY (OOPS!).

All HTML widgets can be divided into two groups: devolvable and
non-devolvable. When certain CSS properties are applied to a devolvable
widget by author styles, the widget must be rendered in its primitive
appearance. Non-devolvable widgets remain native regardless of any such
properties.

Properties that disable native appearance of devolvable widgets are now
marked with `disables-native-appearance` key in `CSSProperites.json`.

<a href="https://html.spec.whatwg.org/multipage/rendering.html#widgets">https://html.spec.whatwg.org/multipage/rendering.html#widgets</a>
<a href="https://drafts.csswg.org/css-ui-4/#appearance-disabling-properties">https://drafts.csswg.org/css-ui-4/#appearance-disabling-properties</a>

* LayoutTests/TestExpectations:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/process-css-properties.py:
(StylePropertyCodeGenProperties):
(GenerateCSSPropertyNames):
* Source/WebCore/dom/Element.h:
(WebCore::Element::isDevolvable const):
* Source/WebCore/html/HTMLButtonElement.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::isDevolvable const):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLMeterElement.h:
* Source/WebCore/html/HTMLProgressElement.h:
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/html/HTMLTextAreaElement.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::RenderStyle):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::isNativeAppearanceDisabled):
(WebCore::RenderStyle::setIsNativeAppearanceDisabled):
(WebCore::RenderStyle::NonInheritedFlags::operator== const):
(WebCore::RenderStyle::NonInheritedFlags::copyNonInheritedFrom):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomProperty):
(WebCore::Style::Builder::applyCascadeProperty):
(WebCore::Style::Builder::applyRollbackCascadeProperty):
(WebCore::Style::Builder::applyProperty):
* Source/WebCore/style/StyleBuilder.h:
* Tools/Scripts/webkitpy/style/checkers/jsonchecker.py:
(JSONCSSPropertiesChecker.check_codegen_properties):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/482584f17a16511d68223b83469e1dbf88085e2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15128 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16528 "9 flakes 156 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14902 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15403 "2 new passes 4 flakes 14 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17205 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/14824 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12687 "5 flakes 7 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13279 "14 flakes 7 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20273 "2 flakes 120 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13761 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13447 "14 flakes 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16687 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13991 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11841 "Exiting early after 60 failures. 42718 tests run. 60 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->