### PR TITLE
Fix undefined behavior in pas_bitvector.h's PAS_BITVECTOR_BIT_MASK()

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitvector.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitvector.h
@@ -48,7 +48,7 @@ PAS_BEGIN_EXTERN_C;
 #define PAS_BITVECTOR_BIT_INDEX64(word_index) ((word_index) << 6)
 #define PAS_BITVECTOR_BIT_SHIFT(bit_index) ((bit_index) & 31)
 #define PAS_BITVECTOR_BIT_SHIFT64(bit_index) ((bit_index) & 63)
-#define PAS_BITVECTOR_BIT_MASK(bit_index) (1 << PAS_BITVECTOR_BIT_SHIFT(bit_index))
+#define PAS_BITVECTOR_BIT_MASK(bit_index) (((uint32_t)1) << PAS_BITVECTOR_BIT_SHIFT(bit_index))
 #define PAS_BITVECTOR_BIT_MASK64(bit_index) (((uint64_t)1) << PAS_BITVECTOR_BIT_SHIFT64(bit_index))
 
 /* Backward bitvectors are negatively indexed and big endian. That means, for example, that bit


### PR DESCRIPTION
#### 0d4acd6a56aa2244c83c28d541ed531cdd540940
<pre>
Fix undefined behavior in pas_bitvector.h&apos;s PAS_BITVECTOR_BIT_MASK()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254035">https://bugs.webkit.org/show_bug.cgi?id=254035</a>

Reviewed by Yusuke Suzuki.

Fix undefined behavior in pas_bitvector.h&apos;s PAS_BITVECTOR_BIT_MASK():
/Volumes/Work/WebKit/OpenSource/Source/bmalloc/libpas/src/libpas/pas_bitvector.h:97:24: runtime error: left shift of 1 by 31 places cannot be represented in type &apos;int&apos;
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior

This was found by UBSan.

* Source/bmalloc/libpas/src/libpas/pas_bitvector.h:

Canonical link: <a href="https://commits.webkit.org/261764@main">https://commits.webkit.org/261764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6ce4619a222d0ce394b54b642742d07cd882a64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/112735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4536 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121278 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5704 "Passed tests") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/118504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105840 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1063 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/101041 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14229 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1104 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12355 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14920 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102549 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53095 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/32011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8206 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16767 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110592 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27313 "Passed tests") | 
<!--EWS-Status-Bubble-End-->