### PR TITLE
[MediaStream][GStreamer] Add support for InputDeviceInfo

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1743,8 +1743,6 @@ webkit.org/b/235885 webrtc/video-stats.html [ Failure ]
 webkit.org/b/235885 webrtc/video.html [ Failure ]
 webkit.org/b/235885 webrtc/vp8-then-h264.html [ Failure ]
 
-imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getCapabilities.https.html [ Failure ]
-
 # In these tests only one canvas frame is pushed towards the sender webrtcbin,
 # this is not enough for the receiver webrtcbin to create its video source pad,
 # because on sender side we need at least a complete GOP... So the tests time

--- a/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
@@ -38,15 +38,9 @@ void UserMediaPermissionRequestManagerProxy::platformValidateUserMediaRequestCon
     });
 }
 
-void UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices(bool /* revealIdsAndLabels */, CompletionHandler<void(Vector<CaptureDeviceWithCapabilities>&&)>&& completionHandler)
+void UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices(bool revealIdsAndLabels, CompletionHandler<void(Vector<CaptureDeviceWithCapabilities>&&)>&& completionHandler)
 {
-    // FIXME: Set capabilities if revealIdsAndLabels is true.
-    m_page.process().connection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::GetMediaStreamDevices(), [completionHandler = WTFMove(completionHandler)](auto&& devices) mutable {
-        auto deviceWithCapabilities = map(devices, [](auto&& device) -> CaptureDeviceWithCapabilities {
-            return { WTFMove(device), { } };
-        });
-        completionHandler(WTFMove(deviceWithCapabilities));
-    });
+    m_page.process().connection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::GetMediaStreamDevices(revealIdsAndLabels), WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
@@ -33,6 +33,7 @@
 
 namespace WebCore {
 class CaptureDevice;
+struct CaptureDeviceWithCapabilities;
 struct MediaDeviceHashSalts;
 struct MediaStreamRequest;
 }
@@ -59,8 +60,8 @@ private:
     void validateUserMediaRequestConstraints(WebCore::MediaStreamRequest, WebCore::MediaDeviceHashSalts&&, ValidateUserMediaRequestConstraintsCallback&&);
     ValidateUserMediaRequestConstraintsCallback m_validateUserMediaRequestConstraintsCallback;
 
-    using GetMediaStreamDevicesCallback = CompletionHandler<void(Vector<WebCore::CaptureDevice>&&)>;
-    void getMediaStreamDevices(GetMediaStreamDevicesCallback&&);
+    using GetMediaStreamDevicesCallback = CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>;
+    void getMediaStreamDevices(bool revealIdsAndLabels, GetMediaStreamDevicesCallback&&);
 
     WebProcess& m_process;
 };

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in
@@ -25,7 +25,7 @@
 
 messages -> UserMediaCaptureManager NotRefCounted {
     ValidateUserMediaRequestConstraints(struct WebCore::MediaStreamRequest request, struct WebCore::MediaDeviceHashSalts mediaDeviceIdentifierHashSalts) -> (std::optional<String> invalidConstraint, Vector<WebCore::CaptureDevice> audioDevices, Vector<WebCore::CaptureDevice> videoDevices)
-    GetMediaStreamDevices() -> (Vector<WebCore::CaptureDevice> devices)
+    GetMediaStreamDevices(bool revealIdsAndLabels) -> (Vector<WebCore::CaptureDeviceWithCapabilities> devices)
 }
 
 #endif


### PR DESCRIPTION
#### dcc9895b6eca34153724e9ad1ba1114e5eb83693
<pre>
[MediaStream][GStreamer] Add support for InputDeviceInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=254040">https://bugs.webkit.org/show_bug.cgi?id=254040</a>

Reviewed by Carlos Garcia Campos.

The GLib UIProcess-&gt;WebProcess IPC now takes in account the desire for the UIProcess to reveal
device IDs and labels.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices):
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::getMediaStreamDevices):
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/262065@main">https://commits.webkit.org/262065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ee739c2c3782bf6ddf828fc52fd5f3e5a34f417

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4556 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121292 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5720 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105861 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99249 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1074 "4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46309 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14243 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1115 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10462 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53107 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/106 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16787 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->