### PR TITLE
[UI-side compositing] Add logging for painting new tile for ScrollPerf

### DIFF
--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -63,13 +63,14 @@ String TileController::zoomedOutTileGridContainerLayerName()
     return "Zoomed-out TileGrid container"_s;
 }
 
-TileController::TileController(PlatformCALayer* rootPlatformLayer)
+TileController::TileController(PlatformCALayer* rootPlatformLayer, AllowScrollPerformanceLogging shouldLogScrollingPerformance)
     : m_tileCacheLayer(rootPlatformLayer)
     , m_deviceScaleFactor(owningGraphicsLayer()->platformCALayerDeviceScaleFactor())
     , m_tileGrid(makeUnique<TileGrid>(*this))
     , m_tileRevalidationTimer(*this, &TileController::tileRevalidationTimerFired)
     , m_tileSizeChangeTimer(*this, &TileController::tileSizeChangeTimerFired, tileSizeUpdateDelay)
     , m_marginEdges(false, false, false, false)
+    , m_shouldAllowScrollPerformanceLogging(shouldLogScrollingPerformance)
 {
 }
 
@@ -794,7 +795,8 @@ void TileController::removeUnparentedTilesNow()
 
 void TileController::logFilledVisibleFreshTile(unsigned blankPixelCount)
 {
-    owningGraphicsLayer()->platformCALayerLogFilledVisibleFreshTile(blankPixelCount);
+    if (m_shouldAllowScrollPerformanceLogging == AllowScrollPerformanceLogging::Yes)
+        owningGraphicsLayer()->platformCALayerLogFilledVisibleFreshTile(blankPixelCount);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -55,7 +55,9 @@ class TileController final : public TiledBacking {
     friend class TileCoverageMap;
     friend class TileGrid;
 public:
-    WEBCORE_EXPORT explicit TileController(PlatformCALayer*);
+    enum class AllowScrollPerformanceLogging { Yes, No };
+    
+    WEBCORE_EXPORT explicit TileController(PlatformCALayer*, AllowScrollPerformanceLogging = AllowScrollPerformanceLogging::Yes);
     WEBCORE_EXPORT ~TileController();
     
     WEBCORE_EXPORT static String tileGridContainerLayerName();
@@ -91,7 +93,7 @@ public:
     void setTileSizeUpdateDelayDisabledForTesting(bool) final;
 
     unsigned blankPixelCount() const;
-    static unsigned blankPixelCountForTiles(const PlatformLayerList&, const FloatRect&, const IntPoint&);
+    WEBCORE_EXPORT static unsigned blankPixelCountForTiles(const PlatformLayerList&, const FloatRect&, const IntPoint&);
 
 #if PLATFORM(IOS_FAMILY)
     unsigned numberOfUnparentedTiles() const;
@@ -241,6 +243,8 @@ private:
     bool m_tileSizeLocked { false };
     bool m_haveExternalVelocityData { false };
     bool m_isTileSizeUpdateDelayDisabledForTesting { false };
+    
+    AllowScrollPerformanceLogging m_shouldAllowScrollPerformanceLogging { AllowScrollPerformanceLogging::Yes };
 
     Color m_tileDebugBorderColor;
     float m_tileDebugBorderWidth { 0 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -85,7 +85,6 @@ public:
     const HashSet<WebCore::PlatformLayerIdentifier>& overlayRegionIDs() const { return m_overlayRegionIDs; }
     void updateOverlayRegionIDs(const HashSet<WebCore::PlatformLayerIdentifier> &overlayRegionNodes) { m_overlayRegionIDs = overlayRegionNodes; }
 #endif
-
 private:
     void createLayer(const RemoteLayerTreeTransaction::LayerCreationProperties&);
     std::unique_ptr<RemoteLayerTreeNode> makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -102,6 +102,7 @@ public:
     {
         m_cachedContentsBuffers = WTFMove(buffers);
     }
+
 private:
     void initializeLayer();
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
@@ -28,7 +28,9 @@
 
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteLayerTreeHost.h"
+#import "WebPageProxy.h"
 #import <QuartzCore/CALayer.h>
+#import <WebCore/PerformanceLoggingClient.h>
 #import <WebCore/TileController.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
@@ -47,37 +49,55 @@ RemoteLayerTreeScrollingPerformanceData::~RemoteLayerTreeScrollingPerformanceDat
 void RemoteLayerTreeScrollingPerformanceData::didCommitLayerTree(const FloatRect& visibleRect)
 {
     // FIXME: maybe we only care about newly created tiles?
-    appendBlankPixelCount(BlankPixelCount::Filled, blankPixelCount(visibleRect));
+    appendBlankPixelCount(ScrollingLogEvent::Filled, blankPixelCount(visibleRect));
 }
 
 void RemoteLayerTreeScrollingPerformanceData::didScroll(const FloatRect& visibleRect)
 {
-    appendBlankPixelCount(BlankPixelCount::Exposed, blankPixelCount(visibleRect));
+    auto pixelCount = blankPixelCount(visibleRect);
+#if PLATFORM(MAC)
+    if (pixelCount || m_lastUnfilledArea)
+        m_lastUnfilledArea = pixelCount;
+    else
+        return;
+#endif
+    appendBlankPixelCount(ScrollingLogEvent::Exposed, pixelCount);
 }
 
-bool RemoteLayerTreeScrollingPerformanceData::BlankPixelCount::canCoalesce(BlankPixelCount::EventType type, unsigned pixelCount) const
+bool RemoteLayerTreeScrollingPerformanceData::ScrollingLogEvent::canCoalesce(ScrollingLogEvent::EventType type, uint64_t pixelCount) const
 {
-    return eventType == type && blankPixelCount == pixelCount;
+    return eventType == type && value == pixelCount;
 }
 
-void RemoteLayerTreeScrollingPerformanceData::appendBlankPixelCount(BlankPixelCount::EventType eventType, unsigned blankPixelCount)
+void RemoteLayerTreeScrollingPerformanceData::didChangeSynchronousScrollingReasons(WTF::MonotonicTime timestamp, uint64_t data)
 {
-    double now = CFAbsoluteTimeGetCurrent();
-    if (!m_blankPixelCounts.isEmpty() && m_blankPixelCounts.last().canCoalesce(eventType, blankPixelCount)) {
-        m_blankPixelCounts.last().endTime = now;
+    appendSynchronousScrollingChange(timestamp, data);
+}
+
+void RemoteLayerTreeScrollingPerformanceData::appendBlankPixelCount(ScrollingLogEvent::EventType eventType, uint64_t blankPixelCount)
+{
+    auto now = MonotonicTime::now();
+#if !PLATFORM(MAC)
+    if (!m_events.isEmpty() && m_events.last().canCoalesce(eventType, blankPixelCount)) {
+        m_events.last().endTime = now;
         return;
     }
+#endif
+    m_events.append(ScrollingLogEvent(now, now, eventType, blankPixelCount));
+}
 
-    m_blankPixelCounts.append(BlankPixelCount(now, now, eventType, blankPixelCount));
+void RemoteLayerTreeScrollingPerformanceData::appendSynchronousScrollingChange(WTF::MonotonicTime timestamp, uint64_t scrollingChangeData)
+{
+    m_events.append(ScrollingLogEvent(timestamp, timestamp, ScrollingLogEvent::SwitchedScrollingMode, scrollingChangeData));
 }
 
 NSArray *RemoteLayerTreeScrollingPerformanceData::data()
 {
-    return createNSArray(m_blankPixelCounts, [] (auto& pixelData) {
+    return createNSArray(m_events, [] (auto& pixelData) {
         return @[
-            @(pixelData.startTime),
-            (pixelData.eventType == BlankPixelCount::Filled) ? @"filled" : @"exposed",
-            @(pixelData.blankPixelCount)
+            @(pixelData.startTime.toMachAbsoluteTime()),
+            (pixelData.eventType == ScrollingLogEvent::Filled) ? @"filled" : @"exposed",
+            @(pixelData.value)
         ];
     }).autorelease();
 }
@@ -125,6 +145,31 @@ unsigned RemoteLayerTreeScrollingPerformanceData::blankPixelCount(const FloatRec
     uncoveredRegion.subtract(paintedVisibleTileRegion);
 
     return uncoveredRegion.totalArea();
+}
+
+void RemoteLayerTreeScrollingPerformanceData::logData()
+{
+#if PLATFORM(MAC)
+    for (auto event : m_events) {
+        switch (event.eventType) {
+        case ScrollingLogEvent::SwitchedScrollingMode: {
+            m_drawingArea.page().logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::SwitchedScrollingMode), event.startTime, event.value);
+            break;
+        }
+        case ScrollingLogEvent::Exposed: {
+            m_drawingArea.page().logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::ExposedTilelessArea), event.startTime, event.value);
+            break;
+        }
+        case ScrollingLogEvent::Filled: {
+            m_drawingArea.page().logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::FilledTile), event.startTime, event.value);
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    m_events.clear();
+#endif
 }
 
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -134,7 +134,9 @@ public:
     virtual void displayDidRefresh(WebCore::PlatformDisplayID);
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea);
     void reportSynchronousScrollingReasonsChanged(MonotonicTime, OptionSet<WebCore::SynchronousScrollingReason>);
-
+    void reportFilledVisibleFreshTile(MonotonicTime, unsigned);
+    bool scrollingPerformanceTestingEnabled() const;
+    
     void receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase);
     void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
     void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -30,6 +30,7 @@
 
 #import "DrawingArea.h"
 #import "DrawingAreaMessages.h"
+#import "RemoteLayerTreeScrollingPerformanceData.h"
 #import "RemoteScrollingCoordinatorProxyMac.h"
 #import "WebPageProxy.h"
 #import "WebProcessPool.h"
@@ -41,6 +42,7 @@
 #import <WebCore/ScrollView.h>
 #import <WebCore/ScrollingTreeFrameScrollingNode.h>
 #import <WebCore/ScrollingTreeScrollingNode.h>
+#import <WebCore/TileController.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/mac/NSScrollerImpSPI.h>
 #import <wtf/BlockObjCExceptions.h>
@@ -186,6 +188,13 @@ void RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree(IPC::Connection&, co
         
         NSScrollerStyle style = m_usesOverlayScrollbars ? NSScrollerStyleOverlay : NSScrollerStyleLegacy;
         [NSScrollerImpPair _updateAllScrollerImpPairsForNewRecommendedScrollerStyle:style];
+    }
+
+    m_webPageProxy.setScrollPerformanceDataCollectionEnabled(m_webPageProxy.scrollingCoordinatorProxy()->scrollingPerformanceTestingEnabled());
+    
+    if (transaction.createdLayers().size() > 0) {
+        if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = m_webPageProxy.scrollingPerformanceData())
+            scrollPerfData->didCommitLayerTree(LayoutRect(transaction.scrollPosition(),  transaction.baseLayoutViewportSize()));
     }
 
     layoutBannerLayers(transaction);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1204,6 +1204,8 @@ void WebPageProxy::close()
     if (m_isClosed)
         return;
 
+    logScrollingPerformanceData();
+
     WEBPAGEPROXY_RELEASE_LOG(Loading, "close:");
 
     m_isClosed = true;
@@ -12062,6 +12064,14 @@ String WebPageProxy::scrollbarStateForScrollingNodeID(int scrollingNodeID, bool 
     return m_scrollingCoordinatorProxy->scrollbarStateForScrollingNodeID(scrollingNodeID, isVertical);
 #else
     return ""_s;
+#endif
+}
+
+void WebPageProxy::logScrollingPerformanceData()
+{
+#if PLATFORM(COCOA)
+    if (m_scrollingPerformanceData)
+        m_scrollingPerformanceData->logData();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1719,6 +1719,7 @@ public:
 
     // Performance logging.
     void logScrollingEvent(uint32_t eventType, MonotonicTime, uint64_t);
+    void logScrollingPerformanceData();
 
     // Form validation messages.
     void showValidationMessage(const WebCore::IntRect& anchorClientRect, const String& message);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
@@ -36,7 +36,7 @@ using namespace WebCore;
 
 PlatformCALayerRemoteTiledBacking::PlatformCALayerRemoteTiledBacking(LayerType layerType, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
     : PlatformCALayerRemote(layerType, owner, context)
-    , m_tileController(makeUnique<TileController>(this))
+    , m_tileController(makeUnique<TileController>(this, WebCore::TileController::AllowScrollPerformanceLogging::No))
 {
 }
 


### PR DESCRIPTION
#### d4f1d3db3f612fc1283129792b44882a657f7fa5
<pre>
[UI-side compositing] Add logging for painting new tile for ScrollPerf
<a href="https://bugs.webkit.org/show_bug.cgi?id=254050">https://bugs.webkit.org/show_bug.cgi?id=254050</a>
rdar://106775893

Reviewed by Simon Fraser.

Use iOS&apos;s RemoteLayerTreeScrollingPerformanceData to calculate blank tiles
for new tile creation and scrolling. Log all of the accumulated log events
when the WebPageProxy is closed. Also, disable the logging on TileController
to prevent double logging new tile events in the web process by having
PlatformCALayerRemoteTiledBacking set a bool.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::mainFrameScrollPosition const):
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::TileController):
(WebCore::TileController::logFilledVisibleFreshTile):
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::platformCALayerPaintContents):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::gatherPlatformLayerList):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::lastViewportRect const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::willCommitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::setViewportRect):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::hadFirstPaint):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::reportFilledVisibleFreshTile):
(WebKit::RemoteScrollingCoordinatorProxy::setScrollingPerformanceTestingEnabled const):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingPerformanceTestingEnabled const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:

Canonical link: <a href="https://commits.webkit.org/262258@main">https://commits.webkit.org/262258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c02ceec9c77a5c0630c73a32b0e9c063d1be8c0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1139 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1037 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1505 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/959 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/936 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/987 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/982 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/968 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/998 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/106 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->