### PR TITLE
TestWebKitAPI.DragAndDropTests.DragAndDropOnEmptyView is a flaky timeout when enabling UI side compositing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm
@@ -160,12 +160,13 @@ TEST(DragAndDropTests, DragAndDropOnEmptyView)
     [pasteboard writeObjects:@[ url ]];
     [simulator setExternalDragPasteboard:pasteboard];
 
-    [simulator runFrom:CGPointMake(0, 0) to:CGPointMake(100, 100)];
-
     __block bool finished = false;
     [webView performAfterLoading:^{
         finished = true;
     }];
+
+    [simulator runFrom:CGPointMake(0, 0) to:CGPointMake(100, 100)];
+
     TestWebKitAPI::Util::run(&finished);
 
     EXPECT_WK_STREQ("Simple HTML file.", [webView stringByEvaluatingJavaScript:@"document.body.innerText"]);


### PR DESCRIPTION
#### a5bf0812e4931675b842076e99cc94fa1a171206
<pre>
TestWebKitAPI.DragAndDropTests.DragAndDropOnEmptyView is a flaky timeout when enabling UI side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=254055">https://bugs.webkit.org/show_bug.cgi?id=254055</a>
rdar://106837765

Reviewed by Chris Dumez.

The page may finish loading before we finish the drag and drop, when the dispatch block is not set.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/261806@main">https://commits.webkit.org/261806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0484a75da5065e835184d7d7608c569a8661da8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121333 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5767 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105914 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1121 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14285 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1161 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/98613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10506 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53154 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8242 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16835 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->