### PR TITLE
[WebGPU] Implement resource deallocation

### DIFF
--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -557,7 +557,7 @@ RefPtr<BindGroupLayout> RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
     auto bindGroupLayout = m_device->createBindGroupLayout(bindGroupLayoutDescriptor);
     m_cachedBindGroupLayouts.add(groupIndex + 1, bindGroupLayout);
 
-    return bindGroupLayout.ptr();
+    return WebGPU::releaseToAPI(WTFMove(bindGroupLayout));
 #else
     UNUSED_PARAM(groupIndex);
     // FIXME: Return an invalid object instead of nullptr.

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
@@ -52,6 +52,11 @@ RemoteAdapter::RemoteAdapter(PAL::WebGPU::Adapter& adapter, WebGPU::ObjectHeap& 
 
 RemoteAdapter::~RemoteAdapter() = default;
 
+void RemoteAdapter::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteAdapter::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteAdapter::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
@@ -76,6 +76,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void requestDevice(const WebGPU::DeviceDescriptor&, WebGPUIdentifier, WebGPUIdentifier queueIdentifier, CompletionHandler<void(WebGPU::SupportedFeatures&&, WebGPU::SupportedLimits&&)>&&);
+    void destruct();
 
     Ref<PAL::WebGPU::Adapter> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteAdapter NotRefCounted Stream {
+    void Destruct()
     void RequestDevice(WebKit::WebGPU::DeviceDescriptor deviceDescriptor, WebKit::WebGPUIdentifier identifier, WebKit::WebGPUIdentifier queueIdentifier) -> (WebKit::WebGPU::SupportedFeatures supportedFeatures, WebKit::WebGPU::SupportedLimits supportedLimits) Synchronous
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
@@ -46,6 +46,11 @@ RemoteBindGroup::RemoteBindGroup(PAL::WebGPU::BindGroup& bindGroup, WebGPU::Obje
 
 RemoteBindGroup::~RemoteBindGroup() = default;
 
+void RemoteBindGroup::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteBindGroup::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteBindGroup::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::BindGroup> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteBindGroup NotRefCounted Stream {
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
@@ -46,6 +46,11 @@ RemoteBindGroupLayout::RemoteBindGroupLayout(PAL::WebGPU::BindGroupLayout& bindG
 
 RemoteBindGroupLayout::~RemoteBindGroupLayout() = default;
 
+void RemoteBindGroupLayout::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteBindGroupLayout::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteBindGroupLayout::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::BindGroupLayout> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteBindGroupLayout NotRefCounted Stream {
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -97,6 +97,11 @@ void RemoteBuffer::destroy()
     m_backing->destroy();
 }
 
+void RemoteBuffer::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteBuffer::setLabel(String&& label)
 {
     m_backing->setLabel(WTFMove(label));

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -82,6 +82,7 @@ private:
     void unmap(Vector<uint8_t>&&);
 
     void destroy();
+    void destruct();
 
     void setLabel(String&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
@@ -28,6 +28,7 @@ messages -> RemoteBuffer NotRefCounted Stream {
     void MapAsync(PAL::WebGPU::MapModeFlags mapModeFlags, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data)
     void Unmap(Vector<uint8_t> data)
     void Destroy()
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
@@ -46,6 +46,11 @@ RemoteCommandBuffer::RemoteCommandBuffer(PAL::WebGPU::CommandBuffer& commandBuff
 
 RemoteCommandBuffer::~RemoteCommandBuffer() = default;
 
+void RemoteCommandBuffer::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteCommandBuffer::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteCommandBuffer::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::CommandBuffer> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteCommandBuffer NotRefCounted Stream {
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
@@ -50,6 +50,11 @@ RemoteCommandEncoder::RemoteCommandEncoder(PAL::WebGPU::CommandEncoder& commandE
 
 RemoteCommandEncoder::~RemoteCommandEncoder() = default;
 
+void RemoteCommandEncoder::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteCommandEncoder::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteCommandEncoder::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -125,6 +125,7 @@ private:
     void finish(const WebGPU::CommandBufferDescriptor&, WebGPUIdentifier);
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::CommandEncoder> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in
@@ -31,6 +31,7 @@ messages -> RemoteCommandEncoder NotRefCounted Stream {
     void CopyTextureToBuffer(WebKit::WebGPU::ImageCopyTexture source, WebKit::WebGPU::ImageCopyBuffer destination, WebKit::WebGPU::Extent3D copySize)
     void CopyTextureToTexture(WebKit::WebGPU::ImageCopyTexture source, WebKit::WebGPU::ImageCopyTexture destination, WebKit::WebGPU::Extent3D copySize)
     void ClearBuffer(WebKit::WebGPUIdentifier buffer, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size)
+    void Destruct()
     void PushDebugGroup(String groupLabel)
     void PopDebugGroup()
     void InsertDebugMarker(String markerLabel)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -46,6 +46,11 @@ RemoteCompositorIntegration::RemoteCompositorIntegration(PAL::WebGPU::Compositor
 
 RemoteCompositorIntegration::~RemoteCompositorIntegration() = default;
 
+void RemoteCompositorIntegration::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteCompositorIntegration::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -77,6 +77,7 @@ private:
     PAL::WebGPU::CompositorIntegration& backing() { return m_backing; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void destruct();
 
 #if PLATFORM(COCOA)
     void recreateRenderBuffers(int width, int height, CompletionHandler<void(Vector<MachSendRight>&&)>&&);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
@@ -28,6 +28,7 @@ messages -> RemoteCompositorIntegration NotRefCounted Stream {
 void RecreateRenderBuffers(int width, int height) -> (Vector<MachSendRight> renderBuffers) Synchronous NotStreamEncodableReply
 #endif
 void PrepareForDisplay() -> (bool dummy) Synchronous NotStreamEncodableReply // Because CanvasRenderingContext::prepareForDisplay() requires the layer contents synchronously, this needs to be Synchronous.
+void Destruct()
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
@@ -46,6 +46,11 @@ RemoteComputePassEncoder::RemoteComputePassEncoder(PAL::WebGPU::ComputePassEncod
 
 RemoteComputePassEncoder::~RemoteComputePassEncoder() = default;
 
+void RemoteComputePassEncoder::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteComputePassEncoder::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteComputePassEncoder::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
@@ -87,6 +87,7 @@ private:
     void insertDebugMarker(String&& markerLabel);
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::ComputePassEncoder> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteComputePassEncoder NotRefCounted Stream {
+    void Destruct()
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
     void Dispatch(PAL::WebGPU::Size32 workgroupCountX, PAL::WebGPU::Size32 workgroupCountY, PAL::WebGPU::Size32 workgroupCountZ)
     void DispatchIndirect(WebKit::WebGPUIdentifier indirectBuffer, PAL::WebGPU::Size64 indirectOffset)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
@@ -48,6 +48,11 @@ RemoteComputePipeline::RemoteComputePipeline(PAL::WebGPU::ComputePipeline& compu
 
 RemoteComputePipeline::~RemoteComputePipeline() = default;
 
+void RemoteComputePipeline::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteComputePipeline::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteComputePipeline::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
@@ -75,6 +75,7 @@ private:
     void getBindGroupLayout(uint32_t index, WebGPUIdentifier);
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::ComputePipeline> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteComputePipeline NotRefCounted Stream {
+    void Destruct()
     void GetBindGroupLayout(uint32_t index, WebKit::WebGPUIdentifier identifier)
     void SetLabel(String label)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -106,6 +106,11 @@ void RemoteDevice::destroy()
     m_backing->destroy();
 }
 
+void RemoteDevice::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteDevice::createBuffer(const WebGPU::BufferDescriptor& descriptor, WebGPUIdentifier identifier)
 {
     auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -92,6 +92,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void destroy();
+    void destruct();
 
     void createBuffer(const WebGPU::BufferDescriptor&, WebGPUIdentifier);
     void createTexture(const WebGPU::TextureDescriptor&, WebGPUIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
@@ -25,6 +25,7 @@
 
 messages -> RemoteDevice NotRefCounted Stream {
     void Destroy()
+    void Destruct()
     void CreateBuffer(WebKit::WebGPU::BufferDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateTexture(WebKit::WebGPU::TextureDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void CreateSampler(WebKit::WebGPU::SamplerDescriptor descriptor, WebKit::WebGPUIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
@@ -46,6 +46,11 @@ RemoteExternalTexture::RemoteExternalTexture(PAL::WebGPU::ExternalTexture& exter
 
 RemoteExternalTexture::~RemoteExternalTexture() = default;
 
+void RemoteExternalTexture::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteExternalTexture::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteExternalTexture::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::ExternalTexture> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteExternalTexture NotRefCounted Stream {
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
@@ -46,6 +46,11 @@ RemotePipelineLayout::RemotePipelineLayout(PAL::WebGPU::PipelineLayout& pipeline
 
 RemotePipelineLayout::~RemotePipelineLayout() = default;
 
+void RemotePipelineLayout::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemotePipelineLayout::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemotePipelineLayout::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::PipelineLayout> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemotePipelineLayout NotRefCounted Stream {
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
@@ -56,6 +56,11 @@ void RemoteQuerySet::destroy()
     m_backing->destroy();
 }
 
+void RemoteQuerySet::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteQuerySet::setLabel(String&& label)
 {
     m_backing->setLabel(WTFMove(label));

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void destroy();
+    void destruct();
 
     void setLabel(String&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.messages.in
@@ -25,6 +25,7 @@
 
 messages -> RemoteQuerySet NotRefCounted Stream {
     void Destroy()
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -46,6 +46,11 @@ RemoteQueue::RemoteQueue(PAL::WebGPU::Queue& queue, WebGPU::ObjectHeap& objectHe
 
 RemoteQueue::~RemoteQueue() = default;
 
+void RemoteQueue::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteQueue::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteQueue::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -102,6 +102,7 @@ private:
         const WebGPU::Extent3D& copySize);
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::Queue> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteQueue NotRefCounted Stream {
+    void Destruct()
     void Submit(Vector<WebKit::WebGPUIdentifier> commandBuffers)
     void OnSubmittedWorkDone() -> () Synchronous NotStreamEncodableReply
     void WriteBuffer(WebKit::WebGPUIdentifier identifier, PAL::WebGPU::Size64 bufferOffset, Vector<uint8_t> data)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
@@ -46,6 +46,11 @@ RemoteRenderBundle::RemoteRenderBundle(PAL::WebGPU::RenderBundle& renderBundle, 
 
 RemoteRenderBundle::~RemoteRenderBundle() = default;
 
+void RemoteRenderBundle::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteRenderBundle::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::RenderBundle> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteRenderBundle NotRefCounted Stream {
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
@@ -48,6 +48,11 @@ RemoteRenderBundleEncoder::RemoteRenderBundleEncoder(PAL::WebGPU::RenderBundleEn
 
 RemoteRenderBundleEncoder::~RemoteRenderBundleEncoder() = default;
 
+void RemoteRenderBundleEncoder::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteRenderBundleEncoder::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteRenderBundleEncoder::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
@@ -100,6 +100,7 @@ private:
     void finish(const WebGPU::RenderBundleDescriptor&, WebGPUIdentifier);
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::RenderBundleEncoder> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteRenderBundleEncoder NotRefCounted Stream {
+    void Destruct()
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
     void SetIndexBuffer(WebKit::WebGPUIdentifier identifier, PAL::WebGPU::IndexFormat indexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
     void SetVertexBuffer(PAL::WebGPU::Index32 slot, WebKit::WebGPUIdentifier identifier, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -46,6 +46,11 @@ RemoteRenderPassEncoder::RemoteRenderPassEncoder(PAL::WebGPU::RenderPassEncoder&
 
 RemoteRenderPassEncoder::~RemoteRenderPassEncoder() = default;
 
+void RemoteRenderPassEncoder::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteRenderPassEncoder::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteRenderPassEncoder::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -114,6 +114,7 @@ private:
     void end();
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::RenderPassEncoder> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteRenderPassEncoder NotRefCounted Stream {
+    void Destruct()
     void SetPipeline(WebKit::WebGPUIdentifier identifier)
     void SetIndexBuffer(WebKit::WebGPUIdentifier identifier, PAL::WebGPU::IndexFormat indexFormat, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)
     void SetVertexBuffer(PAL::WebGPU::Index32 slot, WebKit::WebGPUIdentifier identifier, std::optional<PAL::WebGPU::Size64> offset, std::optional<PAL::WebGPU::Size64> size)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
@@ -48,6 +48,11 @@ RemoteRenderPipeline::RemoteRenderPipeline(PAL::WebGPU::RenderPipeline& renderPi
 
 RemoteRenderPipeline::~RemoteRenderPipeline() = default;
 
+void RemoteRenderPipeline::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteRenderPipeline::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteRenderPipeline::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
@@ -75,6 +75,7 @@ private:
     void getBindGroupLayout(uint32_t index, WebGPUIdentifier);
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::RenderPipeline> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteRenderPipeline NotRefCounted Stream {
+    void Destruct()
     void GetBindGroupLayout(uint32_t index, WebKit::WebGPUIdentifier identifier);
     void SetLabel(String label)
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
@@ -46,6 +46,11 @@ RemoteSampler::RemoteSampler(PAL::WebGPU::Sampler& sampler, WebGPU::ObjectHeap& 
 
 RemoteSampler::~RemoteSampler() = default;
 
+void RemoteSampler::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteSampler::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteSampler::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::Sampler> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteSampler NotRefCounted Stream {
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
@@ -48,6 +48,11 @@ RemoteShaderModule::RemoteShaderModule(PAL::WebGPU::ShaderModule& shaderModule, 
 
 RemoteShaderModule::~RemoteShaderModule() = default;
 
+void RemoteShaderModule::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteShaderModule::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteShaderModule::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -78,6 +78,7 @@ private:
     void compilationInfo(CompletionHandler<void(Vector<WebGPU::CompilationMessage>&&)>&&);
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::ShaderModule> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.messages.in
@@ -26,6 +26,7 @@
 messages -> RemoteShaderModule NotRefCounted Stream {
     void CompilationInfo() -> (Vector<WebKit::WebGPU::CompilationMessage> messages)
     void SetLabel(String label)
+    void Destruct()
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -76,6 +76,11 @@ void RemoteTexture::destroy()
     m_backing->destroy();
 }
 
+void RemoteTexture::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteTexture::setLabel(String&& label)
 {
     m_backing->setLabel(WTFMove(label));

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
@@ -76,6 +76,7 @@ private:
     void createView(const std::optional<WebGPU::TextureViewDescriptor>&, WebGPUIdentifier);
 
     void destroy();
+    void destruct();
 
     void setLabel(String&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.messages.in
@@ -26,6 +26,7 @@
 messages -> RemoteTexture NotRefCounted Stream {
     void CreateView(std::optional<WebKit::WebGPU::TextureViewDescriptor> descriptor, WebKit::WebGPUIdentifier identifier)
     void Destroy()
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
@@ -46,6 +46,11 @@ RemoteTextureView::RemoteTextureView(PAL::WebGPU::TextureView& textureView, WebG
 
 RemoteTextureView::~RemoteTextureView() = default;
 
+void RemoteTextureView::destruct()
+{
+    m_objectHeap.removeObject(m_identifier);
+}
+
 void RemoteTextureView::stopListeningForIPC()
 {
     m_streamConnection->stopReceivingMessages(Messages::RemoteTextureView::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
@@ -73,6 +73,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);
+    void destruct();
 
     Ref<PAL::WebGPU::TextureView> m_backing;
     WebGPU::ObjectHeap& m_objectHeap;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.messages.in
@@ -24,6 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteTextureView NotRefCounted Stream {
+    void Destruct()
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
@@ -44,6 +44,8 @@ RemoteAdapterProxy::RemoteAdapterProxy(String&& name, PAL::WebGPU::SupportedFeat
 
 RemoteAdapterProxy::~RemoteAdapterProxy()
 {
+    auto sendResult = send(Messages::RemoteAdapter::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteAdapterProxy::requestDevice(const PAL::WebGPU::DeviceDescriptor& descriptor, CompletionHandler<void(RefPtr<PAL::WebGPU::Device>&&)>&& callback)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp
@@ -42,6 +42,8 @@ RemoteBindGroupLayoutProxy::RemoteBindGroupLayoutProxy(RemoteDeviceProxy& parent
 
 RemoteBindGroupLayoutProxy::~RemoteBindGroupLayoutProxy()
 {
+    auto sendResult = send(Messages::RemoteBindGroupLayout::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteBindGroupLayoutProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp
@@ -42,6 +42,8 @@ RemoteBindGroupProxy::RemoteBindGroupProxy(RemoteDeviceProxy& parent, ConvertToB
 
 RemoteBindGroupProxy::~RemoteBindGroupProxy()
 {
+    auto sendResult = send(Messages::RemoteBindGroup::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteBindGroupProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -42,6 +42,8 @@ RemoteBufferProxy::RemoteBufferProxy(RemoteDeviceProxy& parent, ConvertToBacking
 
 RemoteBufferProxy::~RemoteBufferProxy()
 {
+    auto sendResult = send(Messages::RemoteBuffer::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteBufferProxy::mapAsync(PAL::WebGPU::MapModeFlags mapModeFlags, PAL::WebGPU::Size64 offset, std::optional<PAL::WebGPU::Size64> size, CompletionHandler<void(bool)>&& callback)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp
@@ -42,6 +42,8 @@ RemoteCommandBufferProxy::RemoteCommandBufferProxy(RemoteDeviceProxy& parent, Co
 
 RemoteCommandBufferProxy::~RemoteCommandBufferProxy()
 {
+    auto sendResult = send(Messages::RemoteCommandBuffer::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteCommandBufferProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp
@@ -45,6 +45,8 @@ RemoteCommandEncoderProxy::RemoteCommandEncoderProxy(RemoteDeviceProxy& parent, 
 
 RemoteCommandEncoderProxy::~RemoteCommandEncoderProxy()
 {
+    auto sendResult = send(Messages::RemoteCommandEncoder::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 Ref<PAL::WebGPU::RenderPassEncoder> RemoteCommandEncoderProxy::beginRenderPass(const PAL::WebGPU::RenderPassDescriptor& descriptor)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -41,7 +41,11 @@ RemoteCompositorIntegrationProxy::RemoteCompositorIntegrationProxy(RemoteGPUProx
 {
 }
 
-RemoteCompositorIntegrationProxy::~RemoteCompositorIntegrationProxy() = default;
+RemoteCompositorIntegrationProxy::~RemoteCompositorIntegrationProxy()
+{
+    auto sendResult = send(Messages::RemoteCompositorIntegration::Destruct());
+    UNUSED_VARIABLE(sendResult);
+}
 
 #if PLATFORM(COCOA)
 Vector<MachSendRight> RemoteCompositorIntegrationProxy::recreateRenderBuffers(int height, int width)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
@@ -42,6 +42,8 @@ RemoteComputePassEncoderProxy::RemoteComputePassEncoderProxy(RemoteCommandEncode
 
 RemoteComputePassEncoderProxy::~RemoteComputePassEncoderProxy()
 {
+    auto sendResult = send(Messages::RemoteComputePassEncoder::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteComputePassEncoderProxy::setPipeline(const PAL::WebGPU::ComputePipeline& computePipeline)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
@@ -43,6 +43,8 @@ RemoteComputePipelineProxy::RemoteComputePipelineProxy(RemoteDeviceProxy& parent
 
 RemoteComputePipelineProxy::~RemoteComputePipelineProxy()
 {
+    auto sendResult = send(Messages::RemoteComputePipeline::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 Ref<PAL::WebGPU::BindGroupLayout> RemoteComputePipelineProxy::getBindGroupLayout(uint32_t index)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -59,6 +59,8 @@ RemoteDeviceProxy::RemoteDeviceProxy(Ref<PAL::WebGPU::SupportedFeatures>&& featu
 
 RemoteDeviceProxy::~RemoteDeviceProxy()
 {
+    auto sendResult = send(Messages::RemoteDevice::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 Ref<PAL::WebGPU::Queue> RemoteDeviceProxy::queue()

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp
@@ -42,6 +42,8 @@ RemoteExternalTextureProxy::RemoteExternalTextureProxy(RemoteDeviceProxy& parent
 
 RemoteExternalTextureProxy::~RemoteExternalTextureProxy()
 {
+    auto sendResult = send(Messages::RemoteExternalTexture::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteExternalTextureProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp
@@ -42,6 +42,8 @@ RemotePipelineLayoutProxy::RemotePipelineLayoutProxy(RemoteDeviceProxy& parent, 
 
 RemotePipelineLayoutProxy::~RemotePipelineLayoutProxy()
 {
+    auto sendResult = send(Messages::RemotePipelineLayout::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemotePipelineLayoutProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp
@@ -42,6 +42,8 @@ RemoteQuerySetProxy::RemoteQuerySetProxy(RemoteDeviceProxy& parent, ConvertToBac
 
 RemoteQuerySetProxy::~RemoteQuerySetProxy()
 {
+    auto sendResult = send(Messages::RemoteQuerySet::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteQuerySetProxy::destroy()

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -42,6 +42,8 @@ RemoteQueueProxy::RemoteQueueProxy(RemoteDeviceProxy& parent, ConvertToBackingCo
 
 RemoteQueueProxy::~RemoteQueueProxy()
 {
+    auto sendResult = send(Messages::RemoteQueue::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteQueueProxy::submit(Vector<std::reference_wrapper<PAL::WebGPU::CommandBuffer>>&& commandBuffers)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
@@ -43,6 +43,8 @@ RemoteRenderBundleEncoderProxy::RemoteRenderBundleEncoderProxy(RemoteDeviceProxy
 
 RemoteRenderBundleEncoderProxy::~RemoteRenderBundleEncoderProxy()
 {
+    auto sendResult = send(Messages::RemoteRenderBundleEncoder::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteRenderBundleEncoderProxy::setPipeline(const PAL::WebGPU::RenderPipeline& renderPipeline)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp
@@ -42,6 +42,8 @@ RemoteRenderBundleProxy::RemoteRenderBundleProxy(RemoteDeviceProxy& parent, Conv
 
 RemoteRenderBundleProxy::~RemoteRenderBundleProxy()
 {
+    auto sendResult = send(Messages::RemoteRenderBundle::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteRenderBundleProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -42,6 +42,8 @@ RemoteRenderPassEncoderProxy::RemoteRenderPassEncoderProxy(RemoteCommandEncoderP
 
 RemoteRenderPassEncoderProxy::~RemoteRenderPassEncoderProxy()
 {
+    auto sendResult = send(Messages::RemoteRenderPassEncoder::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteRenderPassEncoderProxy::setPipeline(const PAL::WebGPU::RenderPipeline& renderPipeline)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
@@ -43,6 +43,8 @@ RemoteRenderPipelineProxy::RemoteRenderPipelineProxy(RemoteDeviceProxy& parent, 
 
 RemoteRenderPipelineProxy::~RemoteRenderPipelineProxy()
 {
+    auto sendResult = send(Messages::RemoteRenderPipeline::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 Ref<PAL::WebGPU::BindGroupLayout> RemoteRenderPipelineProxy::getBindGroupLayout(uint32_t index)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp
@@ -42,6 +42,8 @@ RemoteSamplerProxy::RemoteSamplerProxy(RemoteDeviceProxy& parent, ConvertToBacki
 
 RemoteSamplerProxy::~RemoteSamplerProxy()
 {
+    auto sendResult = send(Messages::RemoteSampler::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteSamplerProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
@@ -44,6 +44,8 @@ RemoteShaderModuleProxy::RemoteShaderModuleProxy(RemoteDeviceProxy& parent, Conv
 
 RemoteShaderModuleProxy::~RemoteShaderModuleProxy()
 {
+    auto sendResult = send(Messages::RemoteShaderModule::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteShaderModuleProxy::compilationInfo(CompletionHandler<void(Ref<PAL::WebGPU::CompilationInfo>&&)>&& callback)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp
@@ -44,6 +44,8 @@ RemoteTextureProxy::RemoteTextureProxy(RemoteGPUProxy& root, ConvertToBackingCon
 
 RemoteTextureProxy::~RemoteTextureProxy()
 {
+    auto sendResult = send(Messages::RemoteTexture::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 Ref<PAL::WebGPU::TextureView> RemoteTextureProxy::createView(const std::optional<PAL::WebGPU::TextureViewDescriptor>& descriptor)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp
@@ -42,6 +42,8 @@ RemoteTextureViewProxy::RemoteTextureViewProxy(RemoteTextureProxy& parent, Conve
 
 RemoteTextureViewProxy::~RemoteTextureViewProxy()
 {
+    auto sendResult = send(Messages::RemoteTextureView::Destruct());
+    UNUSED_VARIABLE(sendResult);
 }
 
 void RemoteTextureViewProxy::setLabelInternal(const String& label)


### PR DESCRIPTION
#### 9013908c531cdd2c7bdd7b6e5f58fedfa2b901c7
<pre>
[WebGPU] Implement resource deallocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=250865">https://bugs.webkit.org/show_bug.cgi?id=250865</a>
&lt;radar://103963935&gt;

Reviewed by Myles C. Maxfield.

When the proxy objects are destroyed they need to tell
the GPU process to destroy the corresponding objects.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::getBindGroupLayout):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp:
(WebKit::RemoteAdapter::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp:
(WebKit::RemoteBindGroup::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp:
(WebKit::RemoteBindGroupLayout::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp:
(WebKit::RemoteCommandBuffer::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp:
(WebKit::RemoteCommandEncoder::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp:
(WebKit::RemoteComputePassEncoder::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp:
(WebKit::RemoteComputePipeline::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp:
(WebKit::RemoteExternalTexture::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::RemoteGPU):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp:
(WebKit::RemotePipelineLayout::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp:
(WebKit::RemoteQuerySet::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp:
(WebKit::RemoteRenderBundle::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp:
(WebKit::RemoteRenderBundleEncoder::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp:
(WebKit::RemoteRenderPassEncoder::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp:
(WebKit::RemoteRenderPipeline::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp:
(WebKit::RemoteSampler::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp:
(WebKit::RemoteShaderModule::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp:
(WebKit::RemoteTexture::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp:
(WebKit::RemoteTextureView::destroy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.cpp:
(WebKit::WebGPU::RemoteBindGroupLayoutProxy::~RemoteBindGroupLayoutProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.cpp:
(WebKit::WebGPU::RemoteBindGroupProxy::~RemoteBindGroupProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.cpp:
(WebKit::WebGPU::RemoteCommandBufferProxy::RemoteCommandBufferProxy):
(WebKit::WebGPU::RemoteCommandBufferProxy::~RemoteCommandBufferProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.cpp:
(WebKit::WebGPU::RemoteCommandEncoderProxy::~RemoteCommandEncoderProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteComputePassEncoderProxy::~RemoteComputePassEncoderProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp:
(WebKit::WebGPU::RemoteComputePipelineProxy::~RemoteComputePipelineProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.cpp:
(WebKit::WebGPU::RemoteExternalTextureProxy::~RemoteExternalTextureProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.cpp:
(WebKit::WebGPU::RemotePipelineLayoutProxy::~RemotePipelineLayoutProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.cpp:
(WebKit::WebGPU::RemoteQuerySetProxy::~RemoteQuerySetProxy):
(WebKit::WebGPU::RemoteQuerySetProxy::destroy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::RemoteQueueProxy):
(WebKit::WebGPU::RemoteQueueProxy::~RemoteQueueProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::~RemoteRenderBundleEncoderProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.cpp:
(WebKit::WebGPU::RemoteRenderBundleProxy::~RemoteRenderBundleProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::~RemoteRenderPassEncoderProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp:
(WebKit::WebGPU::RemoteRenderPipelineProxy::~RemoteRenderPipelineProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.cpp:
(WebKit::WebGPU::RemoteSamplerProxy::~RemoteSamplerProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp:
(WebKit::WebGPU::RemoteShaderModuleProxy::~RemoteShaderModuleProxy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.cpp:
(WebKit::WebGPU::RemoteTextureProxy::~RemoteTextureProxy):
(WebKit::WebGPU::RemoteTextureProxy::destroy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.cpp:
(WebKit::WebGPU::RemoteTextureViewProxy::~RemoteTextureViewProxy):

Canonical link: <a href="https://commits.webkit.org/261998@main">https://commits.webkit.org/261998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0312687d984d96542a2fb7667016af681542e16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/200 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/223 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/226 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/243 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/189 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/230 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/211 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/49 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/214 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->