### PR TITLE
Avoid unnecessary call to toJS() in willCreatePossiblyOrphanedTreeByRemovalSlowCase()

### DIFF
--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -175,7 +175,8 @@ void willCreatePossiblyOrphanedTreeByRemovalSlowCase(Node& root)
 
     auto& globalObject = mainWorldGlobalObject(*frame);
     JSLockHolder lock(&globalObject);
-    toJS(&globalObject, &globalObject, root);
+    ASSERT(!root.wrapper());
+    createWrapper(&globalObject, &globalObject, root);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### e7acfe5b0dbf8aeab78bfe29db98a86bb94a5c49
<pre>
Avoid unnecessary call to toJS() in willCreatePossiblyOrphanedTreeByRemovalSlowCase()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254056">https://bugs.webkit.org/show_bug.cgi?id=254056</a>

Reviewed by Yusuke Suzuki.

willCreatePossiblyOrphanedTreeByRemoval() calls the slow path if root has no JS
wrapper and has child nodes. In the slow path, we were calling toJS() to
construct the JS wrapper. This was unnecessarily inefficient since toJS() first
has to check if there is an existing JS wrapper before calling createWrapper()
to create one. We don&apos;t need these checks since we know there is no wrapper at
this point. As a result, we should call createWrapper() directly.

* Source/WebCore/bindings/js/JSNodeCustom.cpp:
(WebCore::willCreatePossiblyOrphanedTreeByRemovalSlowCase):

Canonical link: <a href="https://commits.webkit.org/261800@main">https://commits.webkit.org/261800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36b9ec3ac03c1f7bf37ba97b28462b70062b6554

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4609 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121335 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5776 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105918 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46349 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14288 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1163 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10509 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53156 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8234 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16839 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->