### PR TITLE
web manifest: implement orientation member parsing

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -28,6 +28,7 @@
 #if ENABLE(APPLICATION_MANIFEST)
 
 #include "Color.h"
+#include "ScreenOrientationLockType.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -60,6 +61,7 @@ struct ApplicationManifest {
     String description;
     URL scope;
     Display display;
+    ScreenOrientationLockType orientation;
     URL startURL;
     URL id;
     Color themeColor;

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -81,6 +81,7 @@ ApplicationManifest ApplicationManifestParser::parseManifest(const String& text,
     parsedManifest.themeColor = parseColor(*manifest, "theme_color"_s);
     parsedManifest.icons = parseIcons(*manifest);
     parsedManifest.id = parseId(*manifest, parsedManifest.startURL);
+    parsedManifest.orientation = parseOrientation(*manifest);
 
     if (m_document)
         m_document->processApplicationManifest(parsedManifest);
@@ -160,6 +161,38 @@ ApplicationManifest::Display ApplicationManifestParser::parseDisplay(const JSON:
 
     logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid display mode."_s));
     return ApplicationManifest::Display::Browser;
+}
+
+WebCore::ScreenOrientationLockType ApplicationManifestParser::parseOrientation(const JSON::Object& manifest)
+{
+    auto value = manifest.getValue("orientation"_s);
+    if (!value)
+        return { };
+
+    auto stringValue = value->asString();
+    if (!stringValue) {
+        logManifestPropertyNotAString("orientation"_s);
+        return { };
+    }
+
+    static constexpr std::pair<ComparableLettersLiteral, WebCore::ScreenOrientationLockType> orientationValueMappings[] = {
+        { "any", WebCore::ScreenOrientationLockType::Any },
+        { "landscape", WebCore::ScreenOrientationLockType::Landscape },
+        { "landscape-primary", WebCore::ScreenOrientationLockType::LandscapePrimary },
+        { "landscape-secondary", WebCore::ScreenOrientationLockType::LandscapeSecondary },
+        { "natural", WebCore::ScreenOrientationLockType::Natural },
+        { "portrait", WebCore::ScreenOrientationLockType::Portrait },
+        { "portrait-primary", WebCore::ScreenOrientationLockType::PortraitPrimary },
+        { "portrait-secondary", WebCore::ScreenOrientationLockType::PortraitSecondary },
+    };
+
+    static SortedArrayMap orientationValues { orientationValueMappings };
+
+    if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).stripWhiteSpace()))
+        return *orientationValue;
+
+    logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid orientation."_s));
+    return { };
 }
 
 String ApplicationManifestParser::parseName(const JSON::Object& manifest)

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
@@ -46,6 +46,7 @@ private:
 
     URL parseStartURL(const JSON::Object&, const URL&);
     ApplicationManifest::Display parseDisplay(const JSON::Object&);
+    ScreenOrientationLockType parseOrientation(const JSON::Object&);
     String parseName(const JSON::Object&);
     String parseDescription(const JSON::Object&);
     String parseShortName(const JSON::Object&);

--- a/Source/WebCore/page/ScreenOrientationLockType.h
+++ b/Source/WebCore/page/ScreenOrientationLockType.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 
@@ -41,21 +40,3 @@ enum class ScreenOrientationLockType : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ScreenOrientationLockType> {
-    using values = EnumValues<
-        WebCore::ScreenOrientationLockType,
-        WebCore::ScreenOrientationLockType::Any,
-        WebCore::ScreenOrientationLockType::Natural,
-        WebCore::ScreenOrientationLockType::Landscape,
-        WebCore::ScreenOrientationLockType::Portrait,
-        WebCore::ScreenOrientationLockType::PortraitPrimary,
-        WebCore::ScreenOrientationLockType::PortraitSecondary,
-        WebCore::ScreenOrientationLockType::LandscapePrimary,
-        WebCore::ScreenOrientationLockType::LandscapeSecondary
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -755,6 +755,18 @@ struct WebCore::ApplePayCouponCodeUpdate : WebCore::ApplePayDetailsUpdateBase {
 };
 #endif
 
+header: <WebCore/ScreenOrientationLockType.h>
+enum class WebCore::ScreenOrientationLockType : uint8_t {
+    Any
+    Natural
+    Landscape
+    Portrait
+    PortraitPrimary
+    PortraitSecondary
+    LandscapePrimary
+    LandscapeSecondary
+};
+
 #if ENABLE(APPLICATION_MANIFEST)
 [Nested] enum class WebCore::ApplicationManifest::Display : uint8_t {
     Browser
@@ -782,6 +794,7 @@ struct WebCore::ApplicationManifest {
     String description
     URL scope
     WebCore::ApplicationManifest::Display display
+    WebCore::ScreenOrientationLockType orientation
     URL startURL
     URL id
     WebCore::Color themeColor

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
@@ -42,6 +42,17 @@ typedef NS_ENUM(NSInteger, _WKApplicationManifestDisplayMode) {
     _WKApplicationManifestDisplayModeFullScreen,
 } WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
 
+typedef NS_OPTIONS(NSInteger, _WKApplicationManifestOrientation) {
+    _WKApplicationManifestOrientationAny,
+    _WKApplicationManifestOrientationNatural,
+    _WKApplicationManifestOrientationLandscape,
+    _WKApplicationManifestOrientationPortrait,
+    _WKApplicationManifestOrientationPortraitPrimary,
+    _WKApplicationManifestOrientationPortraitSecondary,
+    _WKApplicationManifestOrientationLandscapePrimary,
+    _WKApplicationManifestOrientationLandscapeSecondary,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 typedef NS_ENUM(NSInteger, _WKApplicationManifestIconPurpose) {
     _WKApplicationManifestIconPurposeAny = (1 << 0),
     _WKApplicationManifestIconPurposeMonochrome = (1 << 1),

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -137,7 +137,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
 
 @end
 
-    
+
 @implementation _WKApplicationManifest
 
 #if ENABLE(APPLICATION_MANIFEST)
@@ -154,6 +154,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
     String description = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"description"];
     URL scopeURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"scope"];
     NSInteger display = [aDecoder decodeIntegerForKey:@"display"];
+    NSInteger orientation = [aDecoder decodeIntegerForKey:@"orientation"];
     URL startURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"start_url"];
     URL manifestId = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"manifestId"];
     WebCore::CocoaColor *themeColor = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"theme_color"];
@@ -165,6 +166,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
         WTFMove(description),
         WTFMove(scopeURL),
         static_cast<WebCore::ApplicationManifest::Display>(display),
+        static_cast<WebCore::ScreenOrientationLockType>(orientation),
         WTFMove(startURL),
         WTFMove(manifestId),
         WebCore::roundAndClampToSRGBALossy(themeColor.CGColor),
@@ -193,6 +195,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
     [aCoder encodeObject:self.applicationDescription forKey:@"description"];
     [aCoder encodeObject:self.scope forKey:@"scope"];
     [aCoder encodeInteger:static_cast<NSInteger>(_applicationManifest->applicationManifest().display) forKey:@"display"];
+    [aCoder encodeInteger:static_cast<NSInteger>(_applicationManifest->applicationManifest().orientation) forKey:@"orientation"];
     [aCoder encodeObject:self.startURL forKey:@"start_url"];
     [aCoder encodeObject:self.manifestId forKey:@"manifestId"];
     [aCoder encodeObject:self.themeColor forKey:@"theme_color"];
@@ -258,6 +261,29 @@ static NSString *nullableNSString(const WTF::String& string)
         return _WKApplicationManifestDisplayModeFullScreen;
     }
 
+    ASSERT_NOT_REACHED();
+}
+
+- (_WKApplicationManifestOrientation)orientation
+{
+    switch (_applicationManifest->applicationManifest().orientation) {
+    case WebCore::ScreenOrientationLockType::Any:
+        return _WKApplicationManifestOrientationAny;
+    case WebCore::ScreenOrientationLockType::Natural:
+        return _WKApplicationManifestOrientationNatural;
+    case WebCore::ScreenOrientationLockType::Landscape:
+        return _WKApplicationManifestOrientationLandscape;
+    case WebCore::ScreenOrientationLockType::Portrait:
+        return _WKApplicationManifestOrientationPortrait;
+    case WebCore::ScreenOrientationLockType::PortraitPrimary:
+        return _WKApplicationManifestOrientationPortraitPrimary;
+    case WebCore::ScreenOrientationLockType::PortraitSecondary:
+        return _WKApplicationManifestOrientationPortraitSecondary;
+    case WebCore::ScreenOrientationLockType::LandscapePrimary:
+        return _WKApplicationManifestOrientationLandscapePrimary;
+    case WebCore::ScreenOrientationLockType::LandscapeSecondary:
+        return _WKApplicationManifestOrientationLandscapeSecondary;
+    }
     ASSERT_NOT_REACHED();
 }
 
@@ -328,6 +354,11 @@ static NSString *nullableNSString(const WTF::String& string)
 - (_WKApplicationManifestDisplayMode)displayMode
 {
     return _WKApplicationManifestDisplayModeBrowser;
+}
+
+- (_WKApplicationManifestOrientation)orientation
+{
+    return nil;
 }
 
 - (NSArray<_WKApplicationManifestIcon *> *)icons

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
@@ -47,6 +47,29 @@ static inline std::ostream& operator<<(std::ostream& os, const ApplicationManife
         return os << "ApplicationManifest::Display::Fullscreen";
     }
 }
+
+static inline std::ostream& operator<<(std::ostream& os, const ScreenOrientationLockType& orientation)
+{
+    switch (orientation) {
+    case WebCore::ScreenOrientationLockType::Any:
+        return os << "WebCore::ScreenOrientationLockType::Any";
+    case WebCore::ScreenOrientationLockType::Landscape:
+        return os << "WebCore::ScreenOrientationLockType::Landscape";
+    case WebCore::ScreenOrientationLockType::Portrait:
+        return os << "WebCore::ScreenOrientationLockType::Portrait";
+    case WebCore::ScreenOrientationLockType::PortraitPrimary:
+        return os << "WebCore::ScreenOrientationLockType::PortraitPrimary";
+    case WebCore::ScreenOrientationLockType::PortraitSecondary:
+        return os << "WebCore::ScreenOrientationLockType::PortraitSecondary";
+    case WebCore::ScreenOrientationLockType::LandscapePrimary:
+        return os << "WebCore::ScreenOrientationLockType::LandscapePrimary";
+    case WebCore::ScreenOrientationLockType::LandscapeSecondary:
+        return os << "WebCore::ScreenOrientationLockType::LandscapeSecondary";
+    case WebCore::ScreenOrientationLockType::Natural:
+        return os << "WebCore::ScreenOrientationLockType::Natural";
+    }
+}
+
 } // namespace WebCore
 
 class ApplicationManifestParserTest : public testing::Test {
@@ -103,6 +126,13 @@ public:
     {
         auto manifest = parseTopLevelProperty("display"_s, rawJSON);
         auto value = manifest.display;
+        EXPECT_EQ(expectedValue, value);
+    }
+
+    void testOrientation(const String& rawJSON, WebCore::ScreenOrientationLockType expectedValue)
+    {
+        auto manifest = parseTopLevelProperty("orientation"_s, rawJSON);
+        auto value = manifest.orientation;
         EXPECT_EQ(expectedValue, value);
     }
 
@@ -305,6 +335,26 @@ TEST_F(ApplicationManifestParserTest, Display)
     testDisplay("\"\t\nMINIMAL-UI \""_s, ApplicationManifest::Display::MinimalUI);
 }
 
+TEST_F(ApplicationManifestParserTest, Orientation)
+{
+    testOrientation("123"_s, WebCore::ScreenOrientationLockType());
+    testOrientation("null"_s, WebCore::ScreenOrientationLockType());
+    testOrientation("true"_s, WebCore::ScreenOrientationLockType());
+    testOrientation("{ }"_s, WebCore::ScreenOrientationLockType());
+    testOrientation("[ ]"_s, WebCore::ScreenOrientationLockType());
+    testOrientation("\"\""_s, WebCore::ScreenOrientationLockType());
+    testOrientation("\"garbage string\""_s, WebCore::ScreenOrientationLockType());
+
+    testOrientation("\"any\""_s, WebCore::ScreenOrientationLockType::Any);
+    testOrientation("\"natural\""_s, WebCore::ScreenOrientationLockType::Natural);
+    testOrientation("\"landscape\""_s, WebCore::ScreenOrientationLockType::Landscape);
+    testOrientation("\"landscape-primary\""_s, WebCore::ScreenOrientationLockType::LandscapePrimary);
+    testOrientation("\"landscape-secondary\""_s, WebCore::ScreenOrientationLockType::LandscapeSecondary);
+    testOrientation("\"portrait\""_s, WebCore::ScreenOrientationLockType::Portrait);
+    testOrientation("\"portrait-primary\""_s, WebCore::ScreenOrientationLockType::PortraitPrimary);
+    testOrientation("\"portrait-secondary\""_s, WebCore::ScreenOrientationLockType::PortraitSecondary);
+}
+
 TEST_F(ApplicationManifestParserTest, Name)
 {
     testName("123"_s, String());
@@ -440,7 +490,6 @@ TEST_F(ApplicationManifestParserTest, Icons)
     OptionSet<ApplicationManifest::Icon::Purpose> purposeMonochromeAny { ApplicationManifest::Icon::Purpose::Monochrome, ApplicationManifest::Icon::Purpose::Any };
 
     testIconsPurposes("\"monochrome any\""_s, purposeMonochromeAny);
-
 }
 
 #endif


### PR DESCRIPTION
#### 746f7da43ae0588f794a556344ecad4cea27efa5
<pre>
web manifest: implement orientation member parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=247275">https://bugs.webkit.org/show_bug.cgi?id=247275</a>
rdar://101770484

Reviewed by NOBODY (OOPS!).

Implement parsing of the orientation member, as specified in Web Manifest.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseManifest):
(WebCore::ApplicationManifestParser::parseOrientation):
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h:
* Source/WebCore/page/ScreenOrientationLockType.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithCoder:]):
(-[_WKApplicationManifest encodeWithCoder:]):
(-[_WKApplicationManifest orientation]):
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(WebCore::operator&lt;&lt;):
(ApplicationManifestParserTest::testOrientation):
(TEST_F):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/746f7da43ae0588f794a556344ecad4cea27efa5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/208 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/456 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/476 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/252 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/347 "1 api test failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/225 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/302 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 11636") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/196 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/239 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/366 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/234 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/221 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->