### PR TITLE
Avoid unnecessary tree traversals in Page::setMemoryCacheClientCallsEnabled()

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3835,6 +3835,7 @@ void FrameLoader::loadedResourceFromMemoryCache(CachedResource& resource, Resour
         InspectorInstrumentation::didLoadResourceFromMemoryCache(*page, m_documentLoader.get(), &resource);
         m_documentLoader->recordMemoryCacheLoadForFutureClientNotification(resource.resourceRequest());
         m_documentLoader->didTellClientAboutLoad(resource.url().string());
+        page->setHasPendingMemoryCacheLoadNotifications(true);
         return;
     }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2307,7 +2307,7 @@ void Page::setMemoryCacheClientCallsEnabled(bool enabled)
         return;
 
     m_areMemoryCacheClientCallsEnabled = enabled;
-    if (!enabled)
+    if (!enabled || !m_hasPendingMemoryCacheLoadNotifications)
         return;
 
     for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
@@ -2316,6 +2316,7 @@ void Page::setMemoryCacheClientCallsEnabled(bool enabled)
             continue;
         localFrame->loader().tellClientAboutPastMemoryCacheLoads();
     }
+    m_hasPendingMemoryCacheLoadNotifications = false;
 }
 
 void Page::hiddenPageDOMTimerThrottlingStateChanged()

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -707,6 +707,7 @@ public:
 
     WEBCORE_EXPORT void setMemoryCacheClientCallsEnabled(bool);
     bool areMemoryCacheClientCallsEnabled() const { return m_areMemoryCacheClientCallsEnabled; }
+    void setHasPendingMemoryCacheLoadNotifications(bool hasPendingMemoryCacheLoadNotifications) { m_hasPendingMemoryCacheLoadNotifications = hasPendingMemoryCacheLoadNotifications; }
 
     // Don't allow more than a certain number of frames in a page.
     // This seems like a reasonable upper bound, and otherwise mutually
@@ -1135,6 +1136,7 @@ private:
 
     bool m_inLowQualityInterpolationMode { false };
     bool m_areMemoryCacheClientCallsEnabled { true };
+    bool m_hasPendingMemoryCacheLoadNotifications { false };
     float m_mediaVolume { 1 };
     MediaProducerMutedStateFlags m_mutedState;
 


### PR DESCRIPTION
#### 61fadadf20f5f65495e6cd2d060c782ee87576e5
<pre>
Avoid unnecessary tree traversals in Page::setMemoryCacheClientCallsEnabled()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254058">https://bugs.webkit.org/show_bug.cgi?id=254058</a>

Reviewed by Darin Adler.

Avoid unnecessary tree traversals in Page::setMemoryCacheClientCallsEnabled().
There are often no loads to notify the frames about and we end up traversing
the whole frame tree unnecessarily. To avoid this, I am introducing a new
hasPendingMemoryCacheLoadNotifications flag on the page that gets set whenever
we queue a notification for one of the frames. We nos only traverse the frame
tree when this flag is set.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadedResourceFromMemoryCache):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setMemoryCacheClientCallsEnabled):
* Source/WebCore/page/Page.h:
(WebCore::Page::setHasPendingMemoryCacheLoadNotifications):

Canonical link: <a href="https://commits.webkit.org/261797@main">https://commits.webkit.org/261797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d543b133567f57007259aa71244cb876969ca7b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121338 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5783 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46355 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14291 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1167 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10512 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53160 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8232 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16842 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->