### PR TITLE
[UI-side compositing] fast/scrolling/mac/adjust-scroll-snap-during-gesture.html fails

### DIFF
--- a/LayoutTests/fast/scrolling/mac/adjust-scroll-snap-during-gesture.html
+++ b/LayoutTests/fast/scrolling/mac/adjust-scroll-snap-during-gesture.html
@@ -49,6 +49,7 @@
             await UIHelper.startMonitoringWheelEvents();
             eventSender.mouseMoveTo(20, 20);
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-1, 0, "began", "none");
+            await UIHelper.renderingUpdate();
             eventSender.mouseScrollByWithWheelAndMomentumPhases(-20, 0, "changed", "none");
 
             await UIHelper.waitForEvent(scroller, 'scroll');

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1666,8 +1666,6 @@ webkit.org/b/239574 [ Monterey Release ] webanimations/frame-rate/animation-fram
 
 webkit.org/b/195635 [ arm64 ] scrollingcoordinator/mac/multiple-fixed.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/239627 [ arm64 ] fast/scrolling/mac/adjust-scroll-snap-during-gesture.html [ Pass Failure ]
-
 webkit.org/b/240123 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrate.html [ Pass Failure ]
 
 webkit.org/b/240670 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-move-into-script-disabled-iframe.html [ Pass Crash ]


### PR DESCRIPTION
#### 714724853f8432e46aaedc84d2be5269337f2990
<pre>
[UI-side compositing] fast/scrolling/mac/adjust-scroll-snap-during-gesture.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=254059">https://bugs.webkit.org/show_bug.cgi?id=254059</a>
rdar://106115809

Reviewed by Simon Fraser.

This test has been a flaky failure even without UI-side compositing. The test causes two scroll
events to be performed, and then the test waits for a `scroll` event. The flakiness is because
when the test waits for the scroll event, it may end up waiting for one event, or both events.
In the case of it waiting for only the first event, the test will fail because the second scroll
may still be ongoing.

This PR fixes the test by forcing a rendering update after the first scroll event to ensure
consistent behavior with how the test waits for the scroll events to finish.

* LayoutTests/fast/scrolling/mac/adjust-scroll-snap-during-gesture.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/261803@main">https://commits.webkit.org/261803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65ef2f4d7f117000d84d39d652a532c1a5084fd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/21991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121339 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5782 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1128 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46353 "1 flakes 139 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14292 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1168 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/98664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/14994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10513 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53161 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8240 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16843 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->