### PR TITLE
REGRESSION(261559@main) [Win] js/ShadowRealm-iframe-detach.html is randomly timing out

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -2505,10 +2505,6 @@ webkit.org/b/230413 fast/canvas/canvas-drawImage-detached-leak.html [ Pass Failu
 # Doesn't support variable fonts
 fast/text/variations [ Skip ]
 
-webkit.org/b/253868 js/ShadowRealm-iframe-detach.html [ Timeout Pass ]
-webkit.org/b/253868 js/ShadowRealm-iframe-sandboxed.html [ Timeout Pass ]
-webkit.org/b/253868 http/tests/misc/iframe-shadow-realm.html [ Timeout Pass ]
-
 fast/text/bidi-with-non-preserved-tab.html [ ImageOnlyFailure ]
 
 webgl/2.0.0/conformance/context/context-eviction-with-garbage-collection.html [ Skip ] # Crash Timeout only on Buildbot

--- a/Source/WebCore/bindings/js/GCController.cpp
+++ b/Source/WebCore/bindings/js/GCController.cpp
@@ -74,7 +74,7 @@ void GCController::garbageCollectSoon()
     JSLockHolder lock(commonVM());
     commonVM().heap.reportAbandonedObjectGraph();
 #else
-    garbageCollectOnNextRunLoop();
+    garbageCollectNow();
 #endif
 }
 
@@ -105,7 +105,7 @@ void GCController::garbageCollectNowIfNotDoneRecently()
     if (!commonVM().heap.currentThreadIsDoingGCWork())
         commonVM().heap.collectNowFullIfNotDoneRecently(Async);
 #else
-    garbageCollectSoon();
+    garbageCollectNow();
 #endif
 }
 


### PR DESCRIPTION
#### 6c72fadf79d31d56fedc26136ad0f7779c648ddd
<pre>
REGRESSION(261559@main) [Win] js/ShadowRealm-iframe-detach.html is randomly timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=253868">https://bugs.webkit.org/show_bug.cgi?id=253868</a>

Reviewed by Yusuke Suzuki.

After 261559@main (bug#175336) disabled USE_CF for WinCairo, the
following tests are randomly timing out.

js/ShadowRealm-iframe-detach.html
js/ShadowRealm-importValue.html

GCController::garbageCollectSoon has to do garbageCollectNow instead
of garbageCollectOnNextRunLoop.

* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/bindings/js/GCController.cpp:
(WebCore::GCController::garbageCollectSoon):

Canonical link: <a href="https://commits.webkit.org/262136@main">https://commits.webkit.org/262136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94db9bc9e59e59ca1963814503d625e58cb85198

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6115 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106186 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46566 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14539 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1381 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10714 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/155 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17100 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->