### PR TITLE
[Filters] Calculating the CSSFilter geometry and clipping sometimes is incorrect

### DIFF
--- a/LayoutTests/css3/filters/effect-blur-hw.html
+++ b/LayoutTests/css3/filters/effect-blur-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-61636">
+    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-61800">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-blur.html
+++ b/LayoutTests/css3/filters/effect-blur.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-2500">
+    <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-15059">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
     <script>

--- a/LayoutTests/css3/filters/effect-combined.html
+++ b/LayoutTests/css3/filters/effect-combined.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-600" />
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
     <script>

--- a/LayoutTests/css3/filters/svg-morphology-clipped-expected.html
+++ b/LayoutTests/css3/filters/svg-morphology-clipped-expected.html
@@ -1,0 +1,21 @@
+<style>
+    .filtered {
+        position: absolute;
+        width: 120px;
+        height: 120px;
+        margin: 40px;
+        border: none;
+        background-color: lime;
+    }
+    .bordered {
+        position: absolute;
+        width: 120px;
+        height: 120px;
+        margin: 30px;
+        border:10px solid black;
+    }
+</style>
+<body>
+    <div class="filtered"></div>
+    <div class="bordered"></div>
+</body>

--- a/LayoutTests/css3/filters/svg-morphology-clipped.html
+++ b/LayoutTests/css3/filters/svg-morphology-clipped.html
@@ -1,0 +1,28 @@
+<style>
+    .filtered {
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        margin: 50px;
+        border: none;
+        background-color: lime;
+        filter: url('#filter');
+    }
+    .bordered {
+        position: absolute;
+        width: 120px;
+        height: 120px;
+        margin: 30px;
+        border:10px solid black;
+        background-color: none;
+    }
+</style>
+<body>
+    <div class="filtered"></div>
+    <div class="bordered"></div>
+    <svg width="0" height="0">
+        <filter id="filter" primitiveUnits="userSpaceOnUse">
+            <feMorphology operator="dilate" radius="50"/>
+        </filter>
+    </svg>
+</body>

--- a/LayoutTests/fast/filter-image/filter-image-blur-expected.html
+++ b/LayoutTests/fast/filter-image/filter-image-blur-expected.html
@@ -1,17 +1,16 @@
 <!DOCTYPE html>
-
 <html>
 <head>
-  <style>
-    div {
-      width: 200px;
-      height: 100px;
-      background-image: url(resources/svg-blur.svg);
-    }
-  </style>
+    <style>
+        div {
+            position: absolute;
+            width: 200px;
+            height: 100px;
+            background-image: url(resources/svg-blur.svg);
+        }
+    </style>
 </head>
 <body>
-<div>
-</div>
+    <div></div>
 </body>
 </html>

--- a/LayoutTests/fast/filter-image/filter-image-blur.html
+++ b/LayoutTests/fast/filter-image/filter-image-blur.html
@@ -1,18 +1,20 @@
 <!DOCTYPE html>
-
 <html>
 <head>
-  <meta name="fuzzy" content="maxDifference=0-4; totalPixels=0-2196">
-  <style>
-    div {
-      width: 200px;
-      height: 100px;
-      background-image: filter(url(resources/svg-noblur.svg), blur(3px));
-    }
-  </style>
+    <meta name="fuzzy" content="maxDifference=0-10; totalPixels=0-500">
+    <style>
+        div {
+            position: absolute;
+            left: -22px;
+            top: -22px;
+            width: 260px;
+            height: 130px;
+            background-image: filter(url(resources/svg-noblur.svg), blur(3px));
+            clip-path: polygon(30px 30px, 230px 30px, 230px 130px, 30px 130px);
+        }
+    </style>
 </head>
 <body>
-<div>
-</div>
+    <div></div>
 </body>
 </html>

--- a/LayoutTests/fast/filter-image/resources/svg-blur.svg
+++ b/LayoutTests/fast/filter-image/resources/svg-blur.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="200" height="200">
 <defs>
 <filter id="blur">
-<feGaussianBlur stdDeviation="3" edgeMode="duplicate" color-interpolation-filters="sRGB"/>
+<feGaussianBlur stdDeviation="3" edgeMode="none" color-interpolation-filters="sRGB"/>
 </filter>
 </defs>
 <g filter="url(#blur)">

--- a/LayoutTests/fast/filter-image/resources/svg-noblur.svg
+++ b/LayoutTests/fast/filter-image/resources/svg-noblur.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
-<rect width="200" height="200" fill="green"/>
-<rect x="50" y="50" width="100" height="100" fill="blue"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="260" height="260">
+	<rect width="260" height="260" fill="green"/>
+	<rect x="80" y="80" width="100" height="100" fill="blue"/>
 </svg>

--- a/LayoutTests/fast/hidpi/filters-drop-shadow-expected.html
+++ b/LayoutTests/fast/hidpi/filters-drop-shadow-expected.html
@@ -1,0 +1,12 @@
+<script src="resources/ensure-hidpi.js"></script>
+<style>
+    div {
+        width: 300px;
+        height: 300px;
+        background-color: green;
+    }
+</style>
+<body>
+    <p>You should see a green box.</p>
+    <div></div>
+<body>

--- a/LayoutTests/fast/hidpi/filters-drop-shadow.html
+++ b/LayoutTests/fast/hidpi/filters-drop-shadow.html
@@ -1,0 +1,17 @@
+<meta name="fuzzy" content="maxDifference=60; totalPixels=1200" />
+<script src="resources/ensure-hidpi.js"></script>
+<style>
+    div {
+        width: 300px;
+        height: 300px;
+        top: -1000px;
+        left: -1000px;
+        background-color: red;
+        position: relative;
+        filter: drop-shadow(1000px 1000px 0 green);
+    }
+</style>
+<body>
+    <p>You should see a green box.</p>
+    <div></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-region-transformed-child-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-region-transformed-child-001-expected.html
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="0" height="0">
   <defs>
-    <filter id="filter" x="25%" y="0%" width="50%" height="100%">
+    <filter id="filter" x="0" y="0%" width="100%" height="100%">
       <feComponentTransfer>
         <feFuncR type="linear" intercept="0" slope="1"/>
         <feFuncG type="linear" intercept="0" slope="0"/>
@@ -16,8 +16,8 @@ div {
     filter: url(#filter);
     background-color: gray;
     width: 50px;
-    height: 50px;
-    transform: translate(25px, 25px) scale(2);
+    height: 100px;
+    transform: translate(25px, 0);
 }
 </style>
 <div></div>

--- a/Source/WebCore/platform/graphics/filters/Filter.cpp
+++ b/Source/WebCore/platform/graphics/filters/Filter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,10 +34,9 @@
 
 namespace WebCore {
 
-Filter::Filter(Filter::Type filterType, const FloatSize& filterScale, ClipOperation clipOperation, const FloatRect& filterRegion)
+Filter::Filter(Filter::Type filterType, const FloatSize& filterScale, const FloatRect& filterRegion)
     : FilterFunction(filterType)
     , m_filterScale(filterScale)
-    , m_clipOperation(clipOperation)
     , m_filterRegion(filterRegion)
 {
 }
@@ -67,7 +66,7 @@ FloatRect Filter::maxEffectRect(const FloatRect& primitiveSubregion) const
 FloatRect Filter::clipToMaxEffectRect(const FloatRect& imageRect, const FloatRect& primitiveSubregion) const
 {
     auto maxEffectRect = this->maxEffectRect(primitiveSubregion);
-    return m_clipOperation == ClipOperation::Intersect ? intersection(imageRect, maxEffectRect) : unionRect(imageRect, maxEffectRect);
+    return intersection(imageRect, maxEffectRect);
 }
 
 bool Filter::clampFilterRegionIfNeeded()

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) 2013 Google Inc. All rights reserved.
- * Copyright (C) 2021-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc.  All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -40,8 +40,6 @@ class Filter : public FilterFunction {
     using FilterFunction::createFilterStyles;
 
 public:
-    enum class ClipOperation { Intersect, Unite };
-
     RenderingMode renderingMode() const;
 
     OptionSet<FilterRenderingMode> filterRenderingModes() const { return m_filterRenderingModes; }
@@ -52,9 +50,6 @@ public:
 
     FloatRect filterRegion() const { return m_filterRegion; }
     void setFilterRegion(const FloatRect& filterRegion) { m_filterRegion = filterRegion; }
-
-    ClipOperation clipOperation() const { return m_clipOperation; }
-    void setClipOperation(ClipOperation clipOperation) { m_clipOperation = clipOperation; }
 
     virtual FloatSize resolvedSize(const FloatSize& size) const { return size; }
     virtual FloatPoint3D resolvedPoint3D(const FloatPoint3D& point) const { return point; }
@@ -75,7 +70,7 @@ public:
 
 protected:
     using FilterFunction::FilterFunction;
-    Filter(Filter::Type, const FloatSize& filterScale, ClipOperation, const FloatRect& filterRegion = { });
+    Filter(Filter::Type, const FloatSize& filterScale, const FloatRect& filterRegion = { });
 
     virtual RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) = 0;
     virtual FilterStyleVector createFilterStyles(const FilterStyle& sourceStyle) const = 0;
@@ -83,24 +78,10 @@ protected:
 private:
     OptionSet<FilterRenderingMode> m_filterRenderingModes { FilterRenderingMode::Software };
     FloatSize m_filterScale;
-    ClipOperation m_clipOperation;
     FloatRect m_filterRegion;
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::Filter::ClipOperation> {
-    using values = EnumValues<
-        WebCore::Filter::ClipOperation,
-
-        WebCore::Filter::ClipOperation::Intersect,
-        WebCore::Filter::ClipOperation::Unite
-    >;
-};
-
-} // namespace WTF
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::Filter)
     static bool isType(const WebCore::FilterFunction& function) { return function.isFilter(); }

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2012 University of Szeged
- * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -93,9 +93,13 @@ FloatRect FilterEffect::calculatePrimitiveSubregion(const Filter& filter, Span<c
 
 FloatRect FilterEffect::calculateImageRect(const Filter& filter, Span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const
 {
+    if (inputImageRects.empty())
+        return filter.maxEffectRect(primitiveSubregion);
+
     FloatRect imageRect;
     for (auto& inputImageRect : inputImageRects)
         imageRect.unite(inputImageRect);
+
     return filter.clipToMaxEffectRect(imageRect, primitiveSubregion);
 }
 

--- a/Source/WebCore/rendering/CSSFilter.h
+++ b/Source/WebCore/rendering/CSSFilter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@ class RenderElement;
 class CSSFilter final : public Filter {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static RefPtr<CSSFilter> create(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, ClipOperation, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
+    static RefPtr<CSSFilter> create(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
     WEBCORE_EXPORT static RefPtr<CSSFilter> create(Vector<Ref<FilterFunction>>&&);
 
     const Vector<Ref<FilterFunction>>& functions() const { return m_functions; }
@@ -56,7 +56,7 @@ public:
     static IntOutsets calculateOutsets(RenderElement&, const FilterOperations&, const FloatRect& targetBoundingBox);
 
 private:
-    CSSFilter(const FloatSize& filterScale, ClipOperation, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin);
+    CSSFilter(const FloatSize& filterScale, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin);
     CSSFilter(Vector<Ref<FilterFunction>>&&);
 
     bool buildFilterFunctions(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -147,7 +147,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     if (!m_filter || m_targetBoundingBox != targetBoundingBox) {
         m_targetBoundingBox = targetBoundingBox;
         // FIXME: This rebuilds the entire effects chain even if the filter style didn't change.
-        m_filter = CSSFilter::create(renderer, renderer.style().filter(), m_preferredFilterRenderingModes, m_filterScale, Filter::ClipOperation::Unite, m_targetBoundingBox, context);
+        m_filter = CSSFilter::create(renderer, renderer.style().filter(), m_preferredFilterRenderingModes, m_filterScale, m_targetBoundingBox, context);
     }
 
     if (!m_filter)
@@ -184,7 +184,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     filter.setFilterRegion(m_filterRegion);
 
     if (!m_targetSwitcher || hasUpdatedBackingStore)
-        m_targetSwitcher = FilterTargetSwitcher::create(context, filter, filterRegion, DestinationColorSpace::SRGB());
+        m_targetSwitcher = FilterTargetSwitcher::create(context, filter, m_targetBoundingBox, DestinationColorSpace::SRGB());
 
     if (!m_targetSwitcher)
         return nullptr;

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -127,7 +127,7 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
     auto preferredFilterRenderingModes = renderer->page().preferredFilterRenderingModes();
     auto sourceImageRect = FloatRect { { }, size };
 
-    auto cssFilter = CSSFilter::create(const_cast<RenderElement&>(*renderer), m_filterOperations, preferredFilterRenderingModes, FloatSize { 1, 1 }, Filter::ClipOperation::Intersect, sourceImageRect, NullGraphicsContext());
+    auto cssFilter = CSSFilter::create(const_cast<RenderElement&>(*renderer), m_filterOperations, preferredFilterRenderingModes, FloatSize { 1, 1 }, sourceImageRect, NullGraphicsContext());
     if (!cssFilter)
         return &Image::nullImage();
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -4,7 +4,7 @@
  * Copyright (C) 2005 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -130,7 +130,7 @@ bool RenderSVGResourceFilter::applyResource(RenderElement& renderer, const Rende
     auto preferredFilterModes = renderer.page().preferredFilterRenderingModes();
 
     // Create the SVGFilter object.
-    filterData->filter = SVGFilter::create(filterElement(), preferredFilterModes, filterScale, Filter::ClipOperation::Intersect, filterRegion, targetBoundingBox, *context);
+    filterData->filter = SVGFilter::create(filterElement(), preferredFilterModes, filterScale, filterRegion, targetBoundingBox, *context);
     if (!filterData->filter) {
         m_rendererFilterDataMap.remove(&renderer);
         return false;

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004, 2005, 2007, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  *           (C) 2005 Rob Buis <buis@kde.org>
  *           (C) 2006 Alexander Kellett <lypanov@kde.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
@@ -477,7 +477,7 @@ void writeSVGResourceContainer(TextStream& ts, const RenderSVGResourceContainer&
         // Creating a placeholder filter which is passed to the builder.
         FloatRect dummyRect;
         FloatSize dummyScale(1, 1);
-        auto dummyFilter = SVGFilter::create(filter.filterElement(), FilterRenderingMode::Software, dummyScale, Filter::ClipOperation::Intersect, dummyRect, dummyRect, NullGraphicsContext());
+        auto dummyFilter = SVGFilter::create(filter.filterElement(), FilterRenderingMode::Software, dummyScale, dummyRect, dummyRect, NullGraphicsContext());
         if (dummyFilter) {
             TextStream::IndentScope indentScope(ts);
             dummyFilter->externalRepresentation(ts, FilterRepresentation::TestOutput);

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -112,6 +112,12 @@ bool SVGFEMorphologyElement::isIdentity() const
     return !radiusX() && !radiusY();
 }
 
+IntOutsets SVGFEMorphologyElement::outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const
+{
+    auto radius = SVGFilter::calculateResolvedSize({ radiusX(), radiusY() }, targetBoundingBox, primitiveUnits);
+    return { radius.height(), radius.width(), radius.height(), radius.width() };
+}
+
 RefPtr<FilterEffect> SVGFEMorphologyElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const
 {
     if (radiusX() < 0 || radiusY() < 0)

--- a/Source/WebCore/svg/SVGFEMorphologyElement.h
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.h
@@ -81,6 +81,7 @@ private:
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
     bool isIdentity() const override;
+    IntOutsets outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 
     Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2013 Google Inc. All rights reserved.
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,9 +36,9 @@ namespace WebCore {
 static constexpr unsigned maxTotalNumberFilterEffects = 100;
 static constexpr unsigned maxCountChildNodes = 200;
 
-RefPtr<SVGFilter> SVGFilter::create(SVGFilterElement& filterElement, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, ClipOperation clipOperation, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
+RefPtr<SVGFilter> SVGFilter::create(SVGFilterElement& filterElement, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
 {
-    auto filter = adoptRef(*new SVGFilter(filterScale, clipOperation, filterRegion, targetBoundingBox, filterElement.primitiveUnits()));
+    auto filter = adoptRef(*new SVGFilter(filterScale, filterRegion, targetBoundingBox, filterElement.primitiveUnits()));
 
     auto expression = buildExpression(filterElement, filter, destinationContext);
     if (!expression)
@@ -56,8 +56,8 @@ RefPtr<SVGFilter> SVGFilter::create(const FloatRect& targetBoundingBox, SVGUnitT
     return adoptRef(*new SVGFilter(targetBoundingBox, primitiveUnits, WTFMove(expression)));
 }
 
-SVGFilter::SVGFilter(const FloatSize& filterScale, ClipOperation clipOperation, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits)
-    : Filter(Filter::Type::SVGFilter, filterScale, clipOperation, filterRegion)
+SVGFilter::SVGFilter(const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits)
+    : Filter(Filter::Type::SVGFilter, filterScale, filterRegion)
     , m_targetBoundingBox(targetBoundingBox)
     , m_primitiveUnits(primitiveUnits)
 {

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) 2013 Google Inc. All rights reserved.
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,7 +36,7 @@ class SVGFilterElement;
 
 class SVGFilter final : public Filter {
 public:
-    static RefPtr<SVGFilter> create(SVGFilterElement&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, ClipOperation, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
+    static RefPtr<SVGFilter> create(SVGFilterElement&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
     WEBCORE_EXPORT static RefPtr<SVGFilter> create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&);
 
     static bool isIdentity(SVGFilterElement&);
@@ -57,7 +57,7 @@ public:
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const final;
 
 private:
-    SVGFilter(const FloatSize& filterScale, ClipOperation, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits);
+    SVGFilter(const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits);
     SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&);
 
     static std::optional<SVGFilterExpression> buildExpression(SVGFilterElement&, const SVGFilter&, const GraphicsContext& destinationContext);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2100,7 +2100,6 @@ void ArgumentCoder<Filter>::encode(Encoder& encoder, const Filter& filter)
 
     encoder << filter.filterRenderingModes();
     encoder << filter.filterScale();
-    encoder << filter.clipOperation();
     encoder << filter.filterRegion();
 }
 
@@ -2144,11 +2143,6 @@ std::optional<Ref<Filter>> ArgumentCoder<Filter>::decode(Decoder& decoder)
     if (!filterScale)
         return std::nullopt;
 
-    std::optional<Filter::ClipOperation> clipOperation;
-    decoder >> clipOperation;
-    if (!clipOperation)
-        return std::nullopt;
-
     std::optional<FloatRect> filterRegion;
     decoder >> filterRegion;
     if (!filterRegion)
@@ -2156,7 +2150,6 @@ std::optional<Ref<Filter>> ArgumentCoder<Filter>::decode(Decoder& decoder)
 
     (*filter)->setFilterRenderingModes(*filterRenderingModes);
     (*filter)->setFilterScale(*filterScale);
-    (*filter)->setClipOperation(*clipOperation);
     (*filter)->setFilterRegion(*filterRegion);
 
     return filter;


### PR DESCRIPTION
#### 7acdd2650a9bc80317594614894d344b16ae6a16
<pre>
[Filters] Calculating the CSSFilter geometry and clipping sometimes is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=254062">https://bugs.webkit.org/show_bug.cgi?id=254062</a>
rdar://106844401

Reviewed by Simon Fraser.

Like SVGFilter, CSSFilter should always intersect the FilterEffect imageRect with
its primitiveSubregion. This will require:

1. Filter::ClipOperation will be removed.
2. Filter::clipToMaxEffectRect() will always clip the rectangle with maxEffectRect.
3. FilterEffect::calculateImageRect() will return the maxEffectRect if number of
   input effects is zero. This was a bug which was covered by the union mode of
   Filter::clipToMaxEffectRect().
4. RenderLayerFilters::beginFilterEffect() should set its targetBoundingBox the
   sourceImageRect of FilterTargetSwitcher.
5. SVGFilterGraph::getNamedNodes() should not return an error if one of the inputs
   is builtin and there is no node for it. This happens when we build a graph of
   primitives and one of the inputs is SourceGraphic or SourceAlpha. In this case
   we just need to ignore this input since there is no built-in primitive for it.
   This fixes the calculation of the filter outsets which was covered by the union
   mode of Filter::clipToMaxEffectRect().
6. SVGFEMorphologyElement::outsets() needs to implemented. This is a bug which was
   covered by the union mode of Filter::clipToMaxEffectRect().

Note: This work is towards enabling the GraphicsContext filters. The clipping has
to fixed first since no intermidate buffers are used to apply the CSSFilter.

* LayoutTests/css3/filters/effect-blur-hw.html:
* LayoutTests/css3/filters/effect-blur.html:
* LayoutTests/css3/filters/effect-combined.html:
* LayoutTests/css3/filters/svg-morphology-clipped-expected.html: Added.
* LayoutTests/css3/filters/svg-morphology-clipped.html: Added.
* LayoutTests/fast/filter-image/filter-image-blur-expected.html:
* LayoutTests/fast/filter-image/filter-image-blur.html:
* LayoutTests/fast/filter-image/resources/svg-blur.svg:
* LayoutTests/fast/filter-image/resources/svg-noblur.svg:
* LayoutTests/fast/hidpi/filters-drop-shadow-expected.html: Added.
* LayoutTests/fast/hidpi/filters-drop-shadow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-region-transformed-child-001-expected.html:
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::Filter):
(WebCore::Filter::clipToMaxEffectRect const):
* Source/WebCore/platform/graphics/filters/Filter.h:
(WebCore::Filter::Filter):
(WebCore::Filter::clipOperation const): Deleted.
(WebCore::Filter::setClipOperation): Deleted.
* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::calculateImageRect const):
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::create):
(WebCore::CSSFilter::CSSFilter):
(WebCore::createBlurEffect):
(WebCore::createReferenceFilter):
(WebCore::CSSFilter::buildFilterFunctions):
* Source/WebCore/rendering/CSSFilter.h:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::applyResource):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGResourceContainer):
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(WebCore::SVGFEMorphologyElement::outsets const):
* Source/WebCore/svg/SVGFEMorphologyElement.h:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::create):
(WebCore::SVGFilter::SVGFilter):
* Source/WebCore/svg/graphics/filters/SVGFilter.h:
* Source/WebCore/svg/graphics/filters/SVGFilterGraph.h:
(WebCore::SVGFilterGraph::SVGFilterGraph):
(WebCore::SVGFilterGraph::sourceGraphic const):
(WebCore::SVGFilterGraph::sourceAlpha const):
(WebCore::SVGFilterGraph::addNamedNode):
(WebCore::SVGFilterGraph::getNamedNode const):
(WebCore::SVGFilterGraph::getNamedNodes const):
(WebCore::SVGFilterGraph::isSourceName):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;Filter&gt;::encode):
(IPC::ArgumentCoder&lt;Filter&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/261827@main">https://commits.webkit.org/261827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fded22759800018adff67dacca8dd224bdae458

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4759 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121471 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5967 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106076 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1246 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46479 "1 flakes 139 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1288 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10622 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20449 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53279 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8258 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16992 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->