### PR TITLE
REGRESSION (258767@main): image on studioneat.com is strangely masked

### DIFF
--- a/LayoutTests/fast/css/mask-box-image-parsing-expected.txt
+++ b/LayoutTests/fast/css/mask-box-image-parsing-expected.txt
@@ -1,0 +1,80 @@
+Blocked access to external URL https://example.test/
+Blocked access to external URL https://example.test/
+Tests the parsing of the -webkit-mask-box-image CSS shorthand.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS target.style.webkitMaskBoxImage is ""
+PASS target.style.webkitMaskBoxImageSource is ""
+PASS target.style.webkitMaskBoxImageSlice is ""
+PASS target.style.webkitMaskBoxImageWidth is ""
+PASS target.style.webkitMaskBoxImageOutset is ""
+PASS target.style.webkitMaskBoxImageRepeat is ""
+PASS getComputedStyle(target).webkitMaskBoxImage is "none"
+PASS getComputedStyle(target).webkitMaskBoxImageSource is "none"
+PASS getComputedStyle(target).webkitMaskBoxImageSlice is "0 fill"
+PASS getComputedStyle(target).webkitMaskBoxImageWidth is "auto"
+PASS getComputedStyle(target).webkitMaskBoxImageOutset is "0"
+PASS getComputedStyle(target).webkitMaskBoxImageRepeat is "stretch"
+
+target.style = '-webkit-mask-box-image: initial'
+PASS target.style.webkitMaskBoxImage is "initial"
+PASS target.style.webkitMaskBoxImageSource is "initial"
+PASS target.style.webkitMaskBoxImageSlice is "initial"
+PASS target.style.webkitMaskBoxImageWidth is "initial"
+PASS target.style.webkitMaskBoxImageOutset is "initial"
+PASS target.style.webkitMaskBoxImageRepeat is "initial"
+PASS getComputedStyle(target).webkitMaskBoxImage is "none"
+PASS getComputedStyle(target).webkitMaskBoxImageSource is "none"
+PASS getComputedStyle(target).webkitMaskBoxImageSlice is "0 fill"
+PASS getComputedStyle(target).webkitMaskBoxImageWidth is "auto"
+PASS getComputedStyle(target).webkitMaskBoxImageOutset is "0"
+PASS getComputedStyle(target).webkitMaskBoxImageRepeat is "stretch"
+
+target.style = '-webkit-mask-box-image: none'
+PASS target.style.webkitMaskBoxImage is "none"
+PASS target.style.webkitMaskBoxImageSource is "none"
+PASS target.style.webkitMaskBoxImageSlice is "0 fill"
+PASS target.style.webkitMaskBoxImageWidth is "auto"
+PASS target.style.webkitMaskBoxImageOutset is "0"
+PASS target.style.webkitMaskBoxImageRepeat is "stretch"
+PASS getComputedStyle(target).webkitMaskBoxImage is "none"
+PASS getComputedStyle(target).webkitMaskBoxImageSource is "none"
+PASS getComputedStyle(target).webkitMaskBoxImageSlice is "0 fill"
+PASS getComputedStyle(target).webkitMaskBoxImageWidth is "auto"
+PASS getComputedStyle(target).webkitMaskBoxImageOutset is "0"
+PASS getComputedStyle(target).webkitMaskBoxImageRepeat is "stretch"
+
+target.style = '-webkit-mask-box-image: url("https://example.test/")'
+PASS target.style.webkitMaskBoxImage is "url(\"https://example.test/\")"
+PASS target.style.webkitMaskBoxImageSource is "url(\"https://example.test/\")"
+PASS target.style.webkitMaskBoxImageSlice is "0 fill"
+PASS target.style.webkitMaskBoxImageWidth is "auto"
+PASS target.style.webkitMaskBoxImageOutset is "0"
+PASS target.style.webkitMaskBoxImageRepeat is "stretch"
+PASS getComputedStyle(target).webkitMaskBoxImage is "url(\"https://example.test/\") 0 fill / auto / 0 stretch"
+PASS getComputedStyle(target).webkitMaskBoxImageSource is "url(\"https://example.test/\")"
+PASS getComputedStyle(target).webkitMaskBoxImageSlice is "0 fill"
+PASS getComputedStyle(target).webkitMaskBoxImageWidth is "auto"
+PASS getComputedStyle(target).webkitMaskBoxImageOutset is "0"
+PASS getComputedStyle(target).webkitMaskBoxImageRepeat is "stretch"
+
+target.style = '-webkit-mask-box-image: url("https://example.test/") 0 fill / auto / 0 stretch'
+PASS target.style.webkitMaskBoxImage is "url(\"https://example.test/\")"
+PASS target.style.webkitMaskBoxImageSource is "url(\"https://example.test/\")"
+PASS target.style.webkitMaskBoxImageSlice is "0 fill"
+PASS target.style.webkitMaskBoxImageWidth is "auto"
+PASS target.style.webkitMaskBoxImageOutset is "0"
+PASS target.style.webkitMaskBoxImageRepeat is "stretch"
+PASS getComputedStyle(target).webkitMaskBoxImage is "url(\"https://example.test/\") 0 fill / auto / 0 stretch"
+PASS getComputedStyle(target).webkitMaskBoxImageSource is "url(\"https://example.test/\")"
+PASS getComputedStyle(target).webkitMaskBoxImageSlice is "0 fill"
+PASS getComputedStyle(target).webkitMaskBoxImageWidth is "auto"
+PASS getComputedStyle(target).webkitMaskBoxImageOutset is "0"
+PASS getComputedStyle(target).webkitMaskBoxImageRepeat is "stretch"
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/mask-box-image-parsing.html
+++ b/LayoutTests/fast/css/mask-box-image-parsing.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<div id="target"></div>
+<script>
+    description("Tests the parsing of the -webkit-mask-box-image CSS shorthand.")
+
+    const target = document.getElementById("target")
+
+    shouldBeEqualToString("target.style.webkitMaskBoxImage", "")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageSource", "")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageSlice", "")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageWidth", "")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageOutset", "")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageRepeat", "")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImage", "none")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageSource", "none")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageSlice", "0 fill")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageWidth", "auto")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageOutset", "0")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageRepeat", "stretch")
+
+    evalAndLog("\ntarget.style = '-webkit-mask-box-image: initial'")
+    shouldBeEqualToString("target.style.webkitMaskBoxImage", "initial")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageSource", "initial")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageSlice", "initial")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageWidth", "initial")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageOutset", "initial")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageRepeat", "initial")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImage", "none")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageSource", "none")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageSlice", "0 fill")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageWidth", "auto")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageOutset", "0")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageRepeat", "stretch")
+
+    evalAndLog("\ntarget.style = '-webkit-mask-box-image: none'")
+    shouldBeEqualToString("target.style.webkitMaskBoxImage", "none")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageSource", "none")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageSlice", "0 fill")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageWidth", "auto")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageOutset", "0")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageRepeat", "stretch")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImage", "none")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageSource", "none")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageSlice", "0 fill")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageWidth", "auto")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageOutset", "0")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageRepeat", "stretch")
+
+    evalAndLog("\ntarget.style = '-webkit-mask-box-image: url(\"https://example.test/\")'")
+    shouldBeEqualToString("target.style.webkitMaskBoxImage", "url(\"https://example.test/\")")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageSource", "url(\"https://example.test/\")")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageSlice", "0 fill")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageWidth", "auto")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageOutset", "0")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageRepeat", "stretch")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImage", "url(\"https://example.test/\") 0 fill / auto / 0 stretch")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageSource", "url(\"https://example.test/\")")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageSlice", "0 fill")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageWidth", "auto")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageOutset", "0")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageRepeat", "stretch")
+
+    evalAndLog("\ntarget.style = '-webkit-mask-box-image: url(\"https://example.test/\") 0 fill / auto / 0 stretch'")
+    shouldBeEqualToString("target.style.webkitMaskBoxImage", "url(\"https://example.test/\")")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageSource", "url(\"https://example.test/\")")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageSlice", "0 fill")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageWidth", "auto")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageOutset", "0")
+    shouldBeEqualToString("target.style.webkitMaskBoxImageRepeat", "stretch")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImage", "url(\"https://example.test/\") 0 fill / auto / 0 stretch")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageSource", "url(\"https://example.test/\")")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageSlice", "0 fill")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageWidth", "auto")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageOutset", "0")
+    shouldBeEqualToString("getComputedStyle(target).webkitMaskBoxImageRepeat", "stretch")
+
+    debug('')
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/mask-box-image-slices-expected.html
+++ b/LayoutTests/fast/css/mask-box-image-slices-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.mask {
+    -webkit-mask-box-image: url('resources/mask.png') 0;
+    background-color: black;
+    width: 11px;
+    height: 11px;
+}
+</style>
+</head>
+<body>
+<p>This should be a single black dot.</p>
+<div class="mask"></div>
+</body>
+</html>

--- a/LayoutTests/fast/css/mask-box-image-slices.html
+++ b/LayoutTests/fast/css/mask-box-image-slices.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.mask {
+    -webkit-mask-box-image: url('resources/mask.png');
+    background-color: black;
+    width: 11px;
+    height: 11px;
+}
+</style>
+</head>
+<body>
+<p>This should be a single black dot.</p>
+<div class="mask"></div>
+</body>
+</html>

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -238,7 +238,7 @@ static Ref<CSSPrimitiveValue> valueForImageSliceSide(const Length& length)
     // a calculation that combines a percentage and a number.
     if (length.isPercent())
         return CSSPrimitiveValue::create(length.percent(), CSSUnitType::CSS_PERCENTAGE);
-    if (length.isAuto() || length.isFixed())
+    if (length.isFixed())
         return CSSPrimitiveValue::create(length.value());
 
     // Calculating the actual length currently in use would require most of the code from RenderBoxModelObject::paintNinePieceImage.

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1131,7 +1131,6 @@ static constexpr InitialValue initialValueForLonghand(CSSPropertyID longhand)
     case CSSPropertyWebkitMaskBoxImageRepeat:
         return CSSValueStretch;
     case CSSPropertyBorderImageSlice:
-    case CSSPropertyWebkitMaskBoxImageSlice:
         return InitialNumericValue { 100, CSSUnitType::CSS_PERCENTAGE };
     case CSSPropertyBoxSizing:
         return CSSValueContentBox;
@@ -1260,6 +1259,14 @@ static bool isNumber(const RectBase& quad, double number, CSSUnitType type)
         && isNumber(quad.left(), number, type);
 }
 
+static bool isValueID(const RectBase& quad, CSSValueID valueID)
+{
+    return isValueID(quad.top(), valueID)
+        && isValueID(quad.right(), valueID)
+        && isValueID(quad.bottom(), valueID)
+        && isValueID(quad.left(), valueID);
+}
+
 static bool isNumericQuad(const CSSValue& value, double number, CSSUnitType type)
 {
     return value.isQuad() && isNumber(value.quad(), number, type);
@@ -1276,10 +1283,12 @@ bool isInitialValueForLonghand(CSSPropertyID longhand, const CSSValue& value)
             return true;
         break;
     case CSSPropertyBorderImageOutset:
+    case CSSPropertyWebkitMaskBoxImageOutset:
         if (isNumericQuad(value, 0, CSSUnitType::CSS_NUMBER))
             return true;
         break;
     case CSSPropertyBorderImageRepeat:
+    case CSSPropertyWebkitMaskBoxImageRepeat:
         if (isValueIDPair(value, CSSValueStretch))
             return true;
         break;
@@ -1301,6 +1310,18 @@ bool isInitialValueForLonghand(CSSPropertyID longhand, const CSSValue& value)
                 return true;
         }
         break;
+    case CSSPropertyWebkitMaskBoxImageSlice:
+        if (auto sliceValue = dynamicDowncast<CSSBorderImageSliceValue>(value)) {
+            if (sliceValue->fill() && isNumber(sliceValue->slices(), 0, CSSUnitType::CSS_NUMBER))
+                return true;
+        }
+        return false;
+    case CSSPropertyWebkitMaskBoxImageWidth:
+        if (auto widthValue = dynamicDowncast<CSSBorderImageWidthValue>(value)) {
+            if (!widthValue->overridesBorderWidths() && isValueID(widthValue->widths(), CSSValueAuto))
+                return true;
+        }
+        break;
     default:
         break;
     }
@@ -1313,6 +1334,8 @@ bool isInitialValueForLonghand(CSSPropertyID longhand, const CSSValue& value)
 
 ASCIILiteral initialValueTextForLonghand(CSSPropertyID longhand)
 {
+    if (longhand == CSSPropertyWebkitMaskBoxImageSlice)
+        return "0 fill"_s;
     return WTF::switchOn(initialValueForLonghand(longhand), [](CSSValueID value) {
         return nameLiteral(value);
     }, [](InitialNumericValue initialValue) {
@@ -1357,6 +1380,8 @@ ASCIILiteral initialValueTextForLonghand(CSSPropertyID longhand)
 
 CSSValueID initialValueIDForLonghand(CSSPropertyID longhand)
 {
+    if (longhand == CSSPropertyWebkitMaskBoxImageSlice)
+        return CSSValueInvalid;
     return WTF::switchOn(initialValueForLonghand(longhand), [](CSSValueID value) {
         return value;
     }, [](InitialNumericValue) {

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -537,7 +537,7 @@ public:
             break;
         case Slice:
             // Masks have a different initial value for slices. Preserve the value of "0 fill" for backwards compatibility.
-            image.setImageSlices(type == BorderImage ? LengthBox(Length(100, LengthType::Percent), Length(100, LengthType::Percent), Length(100, LengthType::Percent), Length(100, LengthType::Percent)) : LengthBox());
+            image.setImageSlices(type == BorderImage ? LengthBox(Length(100, LengthType::Percent), Length(100, LengthType::Percent), Length(100, LengthType::Percent), Length(100, LengthType::Percent)) : LengthBox(LengthType::Fixed));
             image.setFill(type != BorderImage);
             break;
         case Width:


### PR DESCRIPTION
#### 2e5421f37cc928528af98194c3bc1aa5fb1c571e
<pre>
REGRESSION (258767@main): image on studioneat.com is strangely masked
<a href="https://bugs.webkit.org/show_bug.cgi?id=254063">https://bugs.webkit.org/show_bug.cgi?id=254063</a>
rdar://106464942

Reviewed by Oriol Brufau.

The 258767@main change caused -webkit-mask-box-image to set -webkit-mask-box-image-slices
to &quot;auto&quot; internally instead of to &quot;0 fill&quot;, indirectly, by using an initial value.
This was not detectable by computed style, because the computed style code covered it up
and converted auto to 0. But it caused incorrect rendering.

* LayoutTests/fast/css/mask-box-image-parsing-expected.txt: Added.
* LayoutTests/fast/css/mask-box-image-parsing.html: Added.
* LayoutTests/fast/css/mask-box-image-slices-expected.html: Added.
* LayoutTests/fast/css/mask-box-image-slices.html: Added.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForImageSliceSide): Removed isAuto case. No auto value will eveer get here.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::initialValueForLonghand): Removed incorrect default value for
CSSPropertyWebkitMaskBoxImageSlice.
(WebCore::isInitialValueForLonghand): Added cases for all 4 of the -webkit-mask-box-image
longhands, since the parser expands them out into objects. This is the same as what we
already had here for border-image longhands.
(WebCore::initialValueTextForLonghand): Added a special case for
CSSPropertyWebkitMaskBoxImageSlice.
(WebCore::initialValueIDForLonghand): Ditto.

* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::ApplyPropertyBorderImageModifier::applyInitialValue): Use a box of
fixed 0 for -webkit-mask-box-image-slices instead of auto. The auto here was incorrect
and is what led to the strange results above.

Canonical link: <a href="https://commits.webkit.org/261808@main">https://commits.webkit.org/261808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5f494954278079ed6ee035b40452c1e85d51218

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4685 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117010 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/23638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5875 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118695 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/23638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105998 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/23638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46411 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1221 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15066 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53213 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8244 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16917 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->