### PR TITLE
CanvasRenderingContext::taintsOrigin is not easy to read

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -107,21 +107,17 @@ DestinationColorSpace CanvasRenderingContext::colorSpace() const
 
 bool CanvasRenderingContext::taintsOrigin(const CanvasPattern* pattern)
 {
-    if (m_canvas.originClean() && pattern && !pattern->originClean())
-        return true;
-    return false;
+    return pattern && !pattern->originClean();
 }
 
 bool CanvasRenderingContext::taintsOrigin(const CanvasBase* sourceCanvas)
 {
-    if (m_canvas.originClean() && sourceCanvas && !sourceCanvas->originClean())
-        return true;
-    return false;
+    return sourceCanvas && !sourceCanvas->originClean();
 }
 
 bool CanvasRenderingContext::taintsOrigin(const CachedImage* cachedImage)
 {
-    if (!m_canvas.originClean() || !cachedImage)
+    if (!cachedImage)
         return false;
 
     RefPtr image = cachedImage->image();
@@ -145,25 +141,18 @@ bool CanvasRenderingContext::taintsOrigin(const CachedImage* cachedImage)
 
 bool CanvasRenderingContext::taintsOrigin(const HTMLImageElement* element)
 {
-    if (!element)
-        return false;
-    return taintsOrigin(element->cachedImage());
+    return element && taintsOrigin(element->cachedImage());
 }
 
 bool CanvasRenderingContext::taintsOrigin(const SVGImageElement* element)
 {
-    if (!element)
-        return false;
-    return taintsOrigin(element->cachedImage());
+    return element && taintsOrigin(element->cachedImage());
 }
 
 bool CanvasRenderingContext::taintsOrigin(const HTMLVideoElement* video)
 {
 #if ENABLE(VIDEO)
-    if (!video || !m_canvas.originClean())
-        return false;
-
-    return video->taintsOrigin(*m_canvas.securityOrigin());
+    return video && video->taintsOrigin(*m_canvas.securityOrigin());
 #else
     UNUSED_PARAM(video);
     return false;
@@ -172,26 +161,17 @@ bool CanvasRenderingContext::taintsOrigin(const HTMLVideoElement* video)
 
 bool CanvasRenderingContext::taintsOrigin(const ImageBitmap* imageBitmap)
 {
-    if (!imageBitmap || !m_canvas.originClean())
-        return false;
-
-    return !imageBitmap->originClean();
+    return imageBitmap && !imageBitmap->originClean();
 }
 
 bool CanvasRenderingContext::taintsOrigin(const URL& url)
 {
-    if (!m_canvas.originClean())
-        return false;
-
-    if (url.protocolIsData())
-        return false;
-
-    return !m_canvas.securityOrigin()->canRequest(url);
+    return !url.protocolIsData() && !m_canvas.securityOrigin()->canRequest(url);
 }
 
 void CanvasRenderingContext::checkOrigin(const URL& url)
 {
-    if (taintsOrigin(url))
+    if (m_canvas.originClean() && taintsOrigin(url))
         m_canvas.setOriginTainted();
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -109,7 +109,7 @@ protected:
 
     template<class T> void checkOrigin(const T* arg)
     {
-        if (taintsOrigin(arg))
+        if (m_canvas.originClean() && taintsOrigin(arg))
             m_canvas.setOriginTainted();
     }
     void checkOrigin(const URL&);


### PR DESCRIPTION
#### 2bf6d1859ff5e571b0ed3386f6af8934b206e63d
<pre>
CanvasRenderingContext::taintsOrigin is not easy to read
<a href="https://bugs.webkit.org/show_bug.cgi?id=254019">https://bugs.webkit.org/show_bug.cgi?id=254019</a>
rdar://problem/106803255

Reviewed by Eric Carlson.

This is a refactoring to make code easier to read.
Instead of taintsOrigin returning false if canvas is already tainted, we are now checking whether canvas is already tainted in checkOrigin before calling taintsOrigin.
Other callers of taintsOrigin like WebGLRenderingContextBase::validateXXXElement are closer to spec with this change.

* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::taintsOrigin):
(WebCore::CanvasRenderingContext::checkOrigin):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::checkOrigin):

Canonical link: <a href="https://commits.webkit.org/261863@main">https://commits.webkit.org/261863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd42d9febe7d85a29d307b97a38909f137d1d93b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4646 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/116920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5825 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105955 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46377 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14322 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1195 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/98816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15024 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10532 "1 flakes 1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8283 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16874 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->