### PR TITLE
[IFC][Ruby] Pass horizontal overhang values to IFC

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -189,9 +189,8 @@ inline InlineLevelBox::InlineLevelBox(const Box& layoutBox, const RenderStyle& s
         m_style.verticalAlignment.baselineOffset = floatValueForLength(style.verticalAlignLength(), preferredLineHeight());
 
     auto setAnnotationIfApplicable = [&] {
-        if (auto rubyAnnotations = layoutBox.rubyAnnotationsAboveAndBelow()) {
-            auto [above, below] = *rubyAnnotations;
-            m_annotation = { above, below };
+        if (auto* rubyAdjustments = layoutBox.rubyAdjustments()) {
+            m_annotation = { rubyAdjustments->annotationAbove, rubyAdjustments->annotationBelow };
             return;
         }
         // Generic, non-inline box inline-level content (e.g. replaced elements) can't have text-emphasis annotations.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
@@ -110,6 +110,11 @@ InlineRect LineBox::logicalBorderBoxForAtomicInlineLevelBox(const Box& layoutBox
     logicalRect.moveVertically(boxGeometry.marginBefore());
     auto verticalMargin = boxGeometry.marginBefore() + boxGeometry.marginAfter();
     logicalRect.expandVertically(-verticalMargin);
+
+    // FIXME: The overhang adjustment should be based on the computed value.
+    if (auto* rubyAdjustments = layoutBox.rubyAdjustments())
+        logicalRect.moveHorizontally(-rubyAdjustments->overhang.start);
+
     return logicalRect;
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -326,6 +326,12 @@ InlineLayoutUnit LineBuilder::inlineItemWidth(const InlineItem& inlineItem, Inli
     if (inlineItem.isInlineBoxEnd())
         return boxGeometry.marginEnd() + boxGeometry.borderEnd() + boxGeometry.paddingEnd().value_or(0);
 
+    // FIXME: The overhang should be computed to not overlap the neighboring runs or overflow the line.
+    if (auto* rubyAdjustments = layoutBox.rubyAdjustments()) {
+        auto& overhang = isFirstFormattedLine() ? rubyAdjustments->firstLineOverhang : rubyAdjustments->overhang;
+        return boxGeometry.marginBoxWidth() - (overhang.start + overhang.end);
+    }
+
     // Non-replaced inline box (e.g. inline-block)
     return boxGeometry.marginBoxWidth();
 }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -417,8 +417,13 @@ void LineLayout::updateLayoutBoxDimensions(const RenderBox& replacedOrInlineBloc
         layoutBox.setShape(&shapeOutsideInfo->computedShape());
 
     if (auto* rubyRun = dynamicDowncast<RenderRubyRun>(replacedOrInlineBlock)) {
-        auto [above, below] = rubyRun->annotationsAboveAndBelow();
-        layoutBox.setRubyAnnotationsAboveAndBelow(above, below);
+        auto adjustments = makeUnique<Layout::RubyAdjustments>();
+
+        std::tie(adjustments->annotationAbove, adjustments->annotationBelow) = rubyRun->annotationsAboveAndBelow();
+        std::tie(adjustments->overhang.start, adjustments->overhang.end) = rubyRun->startAndEndOverhang(false);
+        std::tie(adjustments->firstLineOverhang.start, adjustments->firstLineOverhang.end) = rubyRun->startAndEndOverhang(true);
+
+        layoutBox.setRubyAdjustments(WTFMove(adjustments));
     }
 }
 

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -455,23 +455,16 @@ void Box::setShape(RefPtr<const Shape> shape)
     ensureRareData().shape = WTFMove(shape);
 }
 
-std::optional<std::pair<LayoutUnit, LayoutUnit>> Box::rubyAnnotationsAboveAndBelow() const
+const RubyAdjustments* Box::rubyAdjustments() const
 {
     if (!hasRareData())
-        return { };
-
-    auto& rareData = this->rareData();
-    if (!rareData.rubyAnnotationAbove && !rareData.rubyAnnotationBelow)
-        return { };
-
-    return std::pair { rareData.rubyAnnotationAbove, rareData.rubyAnnotationBelow };
+        return nullptr;
+    return rareData().rubyAdjustments.get();
 }
 
-void Box::setRubyAnnotationsAboveAndBelow(LayoutUnit above, LayoutUnit below)
+void Box::setRubyAdjustments(std::unique_ptr<RubyAdjustments> rubyAdjustments)
 {
-    auto& rareData = ensureRareData();
-    rareData.rubyAnnotationAbove = above;
-    rareData.rubyAnnotationBelow = below;
+    ensureRareData().rubyAdjustments = WTFMove(rubyAdjustments);
 }
 
 void Box::setCachedGeometryForLayoutState(LayoutState& layoutState, std::unique_ptr<BoxGeometry> geometry) const

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -42,6 +42,19 @@ class InitialContainingBlock;
 class LayoutState;
 class TreeBuilder;
 
+struct RubyAdjustments {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    LayoutUnit annotationAbove;
+    LayoutUnit annotationBelow;
+    struct Overhang {
+        LayoutUnit start;
+        LayoutUnit end;
+    };
+    Overhang firstLineOverhang;
+    Overhang overhang;
+};
+
 class Box : public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(Box);
 public:
@@ -181,8 +194,8 @@ public:
     const Shape* shape() const;
     void setShape(RefPtr<const Shape>);
 
-    std::optional<std::pair<LayoutUnit, LayoutUnit>> rubyAnnotationsAboveAndBelow() const;
-    void setRubyAnnotationsAboveAndBelow(LayoutUnit above, LayoutUnit below);
+    const RubyAdjustments* rubyAdjustments() const;
+    void setRubyAdjustments(std::unique_ptr<RubyAdjustments>);
 
     bool canCacheForLayoutState(const LayoutState&) const;
     BoxGeometry* cachedGeometryForLayoutState(const LayoutState&) const;
@@ -208,8 +221,7 @@ private:
         std::optional<LayoutUnit> columnWidth;
         std::unique_ptr<RenderStyle> firstLineStyle;
         RefPtr<const Shape> shape;
-        LayoutUnit rubyAnnotationAbove;
-        LayoutUnit rubyAnnotationBelow;
+        std::unique_ptr<RubyAdjustments> rubyAdjustments;
     };
 
     bool hasRareData() const { return m_hasRareData; }

--- a/Source/WebCore/rendering/RenderRubyRun.h
+++ b/Source/WebCore/rendering/RenderRubyRun.h
@@ -59,6 +59,7 @@ public:
     bool isChildAllowed(const RenderObject&, const RenderStyle&) const override;
 
     void getOverhang(bool firstLine, RenderObject* startRenderer, RenderObject* endRenderer, float& startOverhang, float& endOverhang) const;
+    std::pair<float, float> startAndEndOverhang(bool forFirstLine) const;
 
     static RenderPtr<RenderRubyRun> staticCreateRubyRun(const RenderObject* parentRuby);
     


### PR DESCRIPTION
#### 9e463964ffe8d9c5f2f1dbeee7a7fd31b3b51642
<pre>
[IFC][Ruby] Pass horizontal overhang values to IFC
<a href="https://bugs.webkit.org/show_bug.cgi?id=254068">https://bugs.webkit.org/show_bug.cgi?id=254068</a>
rdar://106854905

Reviewed by Alan Baradlay.

* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp:
(WebCore::Layout::LineBox::logicalBorderBoxForAtomicInlineLevelBox const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:

Do a basic (non-dynamic, incorrect) overhang adjustment.

(WebCore::Layout::LineBuilder::inlineItemWidth const):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:

Add a define.

(WebCore::LayoutIntegration::canUseForChild):
(WebCore::LayoutIntegration::canUseForLineLayoutWithReason):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateLayoutBoxDimensions):

Pass the overhang values.

* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::rubyAdjustments const):
(WebCore::Layout::Box::setRubyAdjustments):

Put ruby stuff into a struct.

(WebCore::Layout::Box::rubyAnnotationsAboveAndBelow const): Deleted.
(WebCore::Layout::Box::setRubyAnnotationsAboveAndBelow): Deleted.
* Source/WebCore/layout/layouttree/LayoutBox.h:
* Source/WebCore/rendering/RenderRubyRun.cpp:
(WebCore::RenderRubyRun::getOverhang const):
(WebCore::RenderRubyRun::startAndEndOverhang const):

Factor computing static overhang values that don&apos;t depend on surrouding context into a function of their own.

* Source/WebCore/rendering/RenderRubyRun.h:

Canonical link: <a href="https://commits.webkit.org/261805@main">https://commits.webkit.org/261805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b126349963c31f6bd1d33da2e272645592f0eef7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13227 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118694 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105997 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1182 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14361 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1222 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15065 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20377 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53214 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8239 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16916 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->