### PR TITLE
Web Inspector: support OffscreenCanvas for Canvas related operations

### DIFF
--- a/LayoutTests/inspector/canvas/console-record-offscreen-canvas-2d-expected.txt
+++ b/LayoutTests/inspector/canvas/console-record-offscreen-canvas-2d-expected.txt
@@ -1,0 +1,9 @@
+Test that CanvasManager is able to record actions made to offscreen 2D canvas contexts.
+
+
+== Running test suite: Canvas.recording2D
+-- Running test case: Canvas.recording2D.Console.OffscreenCanvas2D
+PASS: The recording should have the name "TEST".
+PASS: The recording should have one frame.
+PASS: The first frame should have one action.
+

--- a/LayoutTests/inspector/canvas/console-record-offscreen-canvas-2d.html
+++ b/LayoutTests/inspector/canvas/console-record-offscreen-canvas-2d.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/recording-utilities.js"></script>
+<script src="resources/recording-2d.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.recording2D");
+
+    suite.addTestCase({
+        name: "Canvas.recording2D.Console.OffscreenCanvas2D",
+        description: "Check that a recording can be triggered by console.record().",
+        test(resolve, reject) {
+            consoleRecord(WI.Canvas.ContextType.OffscreenCanvas2D, resolve, reject);
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="load({offscreen: true})">
+    <p>Test that CanvasManager is able to record actions made to offscreen 2D canvas contexts.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/canvas/context-attributes.html
+++ b/LayoutTests/inspector/canvas/context-attributes.html
@@ -9,6 +9,10 @@ function createCanvas(contextType, attributes) {
     let canvas = document.body.appendChild(document.createElement("canvas"));
     contexts.push(canvas.getContext(contextType, attributes));
 }
+function createOffscreenCanvas(contextType, attributes) {
+    let canvas = new OffscreenCanvas(300, 150);
+    contexts.push(canvas.getContext(contextType, attributes));
+}
 
 function test() {
     let suite = InspectorTest.createAsyncSuite("Canvas.contextAttributes");
@@ -41,14 +45,19 @@ function test() {
                 .then(resolve, reject);
 
                 let type = "";
+                let createFunc = "createCanvas"
                 if (contextType === WI.Canvas.ContextType.Canvas2D)
                     type = "2d";
+                else if (contextType === WI.Canvas.ContextType.OffscreenCanvas2D) {
+                    type = "2d";
+                    createFunc = "createOffscreenCanvas";
+                }
                 else if (contextType === WI.Canvas.ContextType.BitmapRenderer)
                     type = "bitmaprenderer";
                 else if (contextType === WI.Canvas.ContextType.WebGL)
                     type = "webgl";
                 let attributes = JSON.stringify(contextAttributes);
-                InspectorTest.evaluateInPage(`createCanvas("${type}", ${attributes})`);
+                InspectorTest.evaluateInPage(`${createFunc}("${type}", ${attributes})`);
             }
         });
     }
@@ -79,7 +88,12 @@ function test() {
     ];
 
     testCases.forEach(addTestCase);
-
+    if (window.OffscreenCanvas) {
+        addTestCase({
+            name: "CreateOffscreenCanvasContext2D",
+            contextType: WI.Canvas.ContextType.OffscreenCanvas2D,
+        });
+    }
     suite.runTestCasesAndFinish();
 }
 </script>

--- a/LayoutTests/inspector/canvas/create-context-2d-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-2d-expected.txt
@@ -16,7 +16,15 @@ PASS: Removed canvas has expected ID.
 -- Running test case: Canvas.CreateContext2D.Detached
 PASS: Canvas context should be 2D.
   0: getContext - [native code]
-  1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:11:62
+  1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:13:62
+  2: Global Code - [program code]
+
+PASS: Removed canvas has expected ID.
+
+-- Running test case: Canvas.CreateContext2D.Offscreen
+PASS: Canvas context should be Offscreen2D.
+  0: getContext - [native code]
+  1: createOffscreenCanvas - inspector/canvas/resources/create-context-utilities.js:36:36
   2: Global Code - [program code]
 
 PASS: Removed canvas has expected ID.
@@ -25,7 +33,7 @@ PASS: Removed canvas has expected ID.
 Create CSS canvas from -webkit-canvas(css-canvas).
 PASS: Canvas context should be 2D.
   0: getCSSCanvasContext - [native code]
-  1: createCSSCanvas - inspector/canvas/resources/create-context-utilities.js:18:47
+  1: createCSSCanvas - inspector/canvas/resources/create-context-utilities.js:22:47
   2: Global Code - [program code]
 
 PASS: Canvas name should equal the identifier passed to -webkit-canvas.

--- a/LayoutTests/inspector/canvas/create-context-2d.html
+++ b/LayoutTests/inspector/canvas/create-context-2d.html
@@ -20,6 +20,12 @@ function test() {
         contextType: WI.Canvas.ContextType.Canvas2D,
     });
 
+    InspectorTest.CreateContextUtilities.addSimpleTestCase({
+        name: "Offscreen",
+        expression: `createOffscreenCanvas("2d")`,
+        contextType: WI.Canvas.ContextType.OffscreenCanvas2D,
+    });
+
     InspectorTest.CreateContextUtilities.addCSSCanvasTestCase(WI.Canvas.ContextType.Canvas2D);
 
     suite.runTestCasesAndFinish();

--- a/LayoutTests/inspector/canvas/create-context-bitmaprenderer-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-bitmaprenderer-expected.txt
@@ -16,7 +16,7 @@ PASS: Removed canvas has expected ID.
 -- Running test case: Canvas.CreateContextBitmapRenderer.Detached
 PASS: Canvas context should be Bitmap Renderer.
   0: getContext - [native code]
-  1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:11:62
+  1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:13:62
   2: Global Code - [program code]
 
 PASS: Removed canvas has expected ID.

--- a/LayoutTests/inspector/canvas/create-context-webgl-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-webgl-expected.txt
@@ -16,7 +16,7 @@ PASS: Removed canvas has expected ID.
 -- Running test case: Canvas.CreateContextWebGL.Detached
 PASS: Canvas context should be WebGL.
   0: getContext - [native code]
-  1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:11:62
+  1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:13:62
   2: Global Code - [program code]
 
 PASS: Removed canvas has expected ID.
@@ -25,7 +25,7 @@ PASS: Removed canvas has expected ID.
 Create CSS canvas from -webkit-canvas(css-canvas).
 PASS: Canvas context should be WebGL.
   0: getCSSCanvasContext - [native code]
-  1: createCSSCanvas - inspector/canvas/resources/create-context-utilities.js:18:47
+  1: createCSSCanvas - inspector/canvas/resources/create-context-utilities.js:22:47
   2: Global Code - [program code]
 
 PASS: Canvas name should equal the identifier passed to -webkit-canvas.

--- a/LayoutTests/inspector/canvas/create-context-webgl2-expected.txt
+++ b/LayoutTests/inspector/canvas/create-context-webgl2-expected.txt
@@ -16,7 +16,7 @@ PASS: Removed canvas has expected ID.
 -- Running test case: Canvas.CreateContextWebGL2.Detached
 PASS: Canvas context should be WebGL2.
   0: getContext - [native code]
-  1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:11:62
+  1: createDetachedCanvas - inspector/canvas/resources/create-context-utilities.js:13:62
   2: Global Code - [program code]
 
 PASS: Removed canvas has expected ID.
@@ -25,7 +25,7 @@ PASS: Removed canvas has expected ID.
 Create CSS canvas from -webkit-canvas(css-canvas).
 PASS: Canvas context should be WebGL2.
   0: getCSSCanvasContext - [native code]
-  1: createCSSCanvas - inspector/canvas/resources/create-context-utilities.js:18:47
+  1: createCSSCanvas - inspector/canvas/resources/create-context-utilities.js:22:47
   2: Global Code - [program code]
 
 PASS: Canvas name should equal the identifier passed to -webkit-canvas.

--- a/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-frameCount-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-frameCount-expected.txt
@@ -1,0 +1,58 @@
+Test that CanvasManager is able to record actions made to offscreen 2D canvas contexts.
+
+
+== Running test suite: Canvas.recording2D
+-- Running test case: Canvas.recording2D.singleFrame.OffscreenCanvas2D
+initialState:
+  attributes:
+    width: 2
+    height: 2
+  current state:
+    setTransform: [[1,0,0,1,0,0]]
+    globalAlpha: 1
+    globalCompositeOperation: "source-over"
+    lineWidth: 1
+    lineCap: "butt"
+    lineJoin: "miter"
+    miterLimit: 10
+    shadowOffsetX: 0
+    shadowOffsetY: 0
+    shadowBlur: 0
+    shadowColor: "rgba(0, 0, 0, 0)"
+    setLineDash: [[]]
+    lineDashOffset: 0
+    font: "10px sans-serif"
+    textAlign: "start"
+    textBaseline: "alphabetic"
+    direction: "inherit"
+    strokeStyle: "#000000"
+    fillStyle: "#000000"
+    imageSmoothingEnabled: true
+    imageSmoothingQuality: "low"
+    setPath: [""]
+  parameters:
+    0: {"colorSpace":"srgb","desynchronized":false}
+  content: <filtered>
+frames:
+  0: (duration)
+    0: arc(1, 2, 3, 4, 5, false)
+      swizzleTypes: [Number, Number, Number, Number, Number, Boolean]
+      trace:
+        0: arc
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+        5: performActions
+        6: Global Code
+    1: arc(6, 7, 8, 9, 10, true)
+      swizzleTypes: [Number, Number, Number, Number, Number, Boolean]
+      trace:
+        0: arc
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+        5: performActions
+        6: Global Code
+

--- a/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-frameCount.html
+++ b/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-frameCount.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/recording-utilities.js"></script>
+<script src="resources/recording-2d.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.recording2D");
+
+    suite.addTestCase({
+        name: "Canvas.recording2D.singleFrame.OffscreenCanvas2D",
+        description: "Check that the recording is stopped after a single frame.",
+        test(resolve, reject) {
+            startRecording(WI.Canvas.ContextType.OffscreenCanvas2D, resolve, reject, {frameCount: 1});
+        },
+        timeout: -1,
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="load({offscreen: true})">
+    <p>Test that CanvasManager is able to record actions made to offscreen 2D canvas contexts.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-full-expected.txt
@@ -1,0 +1,800 @@
+Test that CanvasManager is able to record actions made to offscreen 2D canvas contexts.
+
+
+== Running test suite: Canvas.recording2D
+-- Running test case: Canvas.recording2D.multipleFrames.OffscreenCanvas2D
+initialState:
+  attributes:
+    width: 2
+    height: 2
+  current state:
+    setTransform: [[1,0,0,1,0,0]]
+    globalAlpha: 1
+    globalCompositeOperation: "source-over"
+    lineWidth: 1
+    lineCap: "butt"
+    lineJoin: "miter"
+    miterLimit: 10
+    shadowOffsetX: 0
+    shadowOffsetY: 0
+    shadowBlur: 0
+    shadowColor: "rgba(0, 0, 0, 0)"
+    setLineDash: [[]]
+    lineDashOffset: 0
+    font: "10px sans-serif"
+    textAlign: "start"
+    textBaseline: "alphabetic"
+    direction: "inherit"
+    strokeStyle: "#000000"
+    fillStyle: "#000000"
+    imageSmoothingEnabled: true
+    imageSmoothingQuality: "low"
+    setPath: [""]
+  parameters:
+    0: {"colorSpace":"srgb","desynchronized":false}
+  content: <filtered>
+frames:
+  0: (duration)
+    0: arc(1, 2, 3, 4, 5, false)
+      swizzleTypes: [Number, Number, Number, Number, Number, Boolean]
+      trace:
+        0: arc
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+        5: performActions
+        6: Global Code
+    1: arc(6, 7, 8, 9, 10, true)
+      swizzleTypes: [Number, Number, Number, Number, Number, Boolean]
+      trace:
+        0: arc
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+        5: performActions
+        6: Global Code
+  1: (duration)
+    0: arcTo(1, 2, 3, 4, 5)
+      swizzleTypes: [Number, Number, Number, Number, Number]
+      trace:
+        0: arcTo
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+  2: (duration)
+    0: beginPath()
+      trace:
+        0: beginPath
+        1: (anonymous function)
+        2: executeFrameFunction
+  3: (duration)
+    0: bezierCurveTo(1, 2, 3, 4, 5, 6)
+      swizzleTypes: [Number, Number, Number, Number, Number, Number]
+      trace:
+        0: bezierCurveTo
+        1: (anonymous function)
+        2: executeFrameFunction
+  4: (duration)
+    0: clearRect(1, 2, 3, 4)
+      swizzleTypes: [Number, Number, Number, Number]
+      trace:
+        0: clearRect
+        1: (anonymous function)
+        2: executeFrameFunction
+  5: (duration)
+    0: clip("nonzero")
+      swizzleTypes: [String]
+      trace:
+        0: clip
+        1: (anonymous function)
+        2: executeFrameFunction
+    1: clip("evenodd")
+      swizzleTypes: [String]
+      trace:
+        0: clip
+        1: (anonymous function)
+        2: executeFrameFunction
+    2: clip([object Path2D], "nonzero")
+      swizzleTypes: [Path2D, String]
+      trace:
+        0: clip
+        1: (anonymous function)
+        2: executeFrameFunction
+    3: clip([object Path2D], "evenodd")
+      swizzleTypes: [Path2D, String]
+      trace:
+        0: clip
+        1: (anonymous function)
+        2: executeFrameFunction
+  6: (duration)
+    0: closePath()
+      trace:
+        0: closePath
+        1: (anonymous function)
+        2: executeFrameFunction
+  7: (duration)
+    0: createImageData([object ImageData])
+      swizzleTypes: [ImageData]
+      trace:
+        0: createImageData
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    1: createImageData(2, 3)
+      swizzleTypes: [Number, Number]
+      trace:
+        0: createImageData
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+  8: (duration)
+    0: createLinearGradient(1, 2, 3, 4)
+      swizzleTypes: [Number, Number, Number, Number]
+      trace:
+        0: createLinearGradient
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+  9: (duration)
+    0: createPattern([object HTMLImageElement], "testA")
+      swizzleTypes: [Image, String]
+      trace:
+        0: createPattern
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    1: createPattern([object HTMLImageElement], "testB")
+      swizzleTypes: [Image, String]
+      trace:
+        0: createPattern
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    2: createPattern([object HTMLImageElement], "testC")
+      swizzleTypes: [Image, String]
+      trace:
+        0: createPattern
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    3: createPattern([object ImageBitmap], "testD")
+      swizzleTypes: [ImageBitmap, String]
+      trace:
+        0: createPattern
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+  10: (duration)
+    0: createRadialGradient(1, 2, 3, 4, 5, 6)
+      swizzleTypes: [Number, Number, Number, Number, Number, Number]
+      trace:
+        0: createRadialGradient
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+  11: (duration)
+    0: direction
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  12: (duration)
+    0: drawImage([object HTMLImageElement], 11, 12)
+      swizzleTypes: [Image, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    1: drawImage([object HTMLImageElement], 13, 14, 15, 16)
+      swizzleTypes: [Image, Number, Number, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    2: drawImage([object HTMLImageElement], 17, 18, 19, 110, 111, 112, 113, 114)
+      swizzleTypes: [Image, Number, Number, Number, Number, Number, Number, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    3: drawImage([object HTMLImageElement], 21, 22)
+      swizzleTypes: [Image, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    4: drawImage([object HTMLImageElement], 23, 24, 25, 26)
+      swizzleTypes: [Image, Number, Number, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    5: drawImage([object HTMLImageElement], 27, 28, 29, 210, 211, 212, 213, 214)
+      swizzleTypes: [Image, Number, Number, Number, Number, Number, Number, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    6: drawImage([object HTMLImageElement], 31, 32)
+      swizzleTypes: [Image, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    7: drawImage([object HTMLImageElement], 33, 34, 35, 36)
+      swizzleTypes: [Image, Number, Number, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    8: drawImage([object HTMLImageElement], 37, 38, 39, 310, 311, 312, 313, 314)
+      swizzleTypes: [Image, Number, Number, Number, Number, Number, Number, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    9: drawImage([object ImageBitmap], 41, 42)
+      swizzleTypes: [ImageBitmap, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    10: drawImage([object ImageBitmap], 43, 44, 45, 46)
+      swizzleTypes: [ImageBitmap, Number, Number, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    11: drawImage([object ImageBitmap], 47, 48, 49, 410, 411, 412, 413, 414)
+      swizzleTypes: [ImageBitmap, Number, Number, Number, Number, Number, Number, Number, Number]
+      trace:
+        0: drawImage
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+  13: (duration)
+    0: ellipse(1, 2, 3, 4, 5, 6, 7, false)
+      swizzleTypes: [Number, Number, Number, Number, Number, Number, Number, Boolean]
+      trace:
+        0: ellipse
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    1: ellipse(8, 9, 10, 11, 12, 13, 14, true)
+      swizzleTypes: [Number, Number, Number, Number, Number, Number, Number, Boolean]
+      trace:
+        0: ellipse
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+  14: (duration)
+    0: fill("nonzero")
+      swizzleTypes: [String]
+      trace:
+        0: fill
+        1: (anonymous function)
+        2: executeFrameFunction
+    1: fill("evenodd")
+      swizzleTypes: [String]
+      trace:
+        0: fill
+        1: (anonymous function)
+        2: executeFrameFunction
+    2: fill([object Path2D], "nonzero")
+      swizzleTypes: [Path2D, String]
+      trace:
+        0: fill
+        1: (anonymous function)
+        2: executeFrameFunction
+    3: fill([object Path2D], "evenodd")
+      swizzleTypes: [Path2D, String]
+      trace:
+        0: fill
+        1: (anonymous function)
+        2: executeFrameFunction
+  15: (duration)
+    0: fillRect(1, 2, 3, 4)
+      swizzleTypes: [Number, Number, Number, Number]
+      trace:
+        0: fillRect
+        1: (anonymous function)
+        2: executeFrameFunction
+  16: (duration)
+    0: fillStyle
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: fillStyle = "test"
+      swizzleTypes: [String]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    2: fillStyle = [object CanvasGradient]
+      swizzleTypes: [CanvasGradient]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    3: fillStyle = [object CanvasGradient]
+      swizzleTypes: [CanvasGradient]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    4: fillStyle = [object CanvasPattern]
+      swizzleTypes: [CanvasPattern]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  17: (duration)
+    0: fillText("testA", 1, 2)
+      swizzleTypes: [String, Number, Number]
+      trace:
+        0: fillText
+        1: (anonymous function)
+        2: executeFrameFunction
+    1: fillText("testB", 3, 4, 5)
+      swizzleTypes: [String, Number, Number, Number]
+      trace:
+        0: fillText
+        1: (anonymous function)
+        2: executeFrameFunction
+  18: (duration)
+    0: font
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: font = "test"
+      swizzleTypes: [String]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  19: (duration)
+    0: getImageData(1, 2, 3, 4)
+      swizzleTypes: [Number, Number, Number, Number]
+      trace:
+        0: getImageData
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+  20: (duration)
+    0: getLineDash()
+      trace:
+        0: getLineDash
+        1: (anonymous function)
+        2: executeFrameFunction
+  21: (duration)
+    0: getTransform()
+      trace:
+        0: getTransform
+        1: (anonymous function)
+        2: executeFrameFunction
+  22: (duration)
+    0: globalAlpha
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: globalAlpha = 0
+      swizzleTypes: [Number]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  23: (duration)
+    0: globalCompositeOperation
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: globalCompositeOperation = "test"
+      swizzleTypes: [String]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  24: (duration)
+    0: imageSmoothingEnabled
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: imageSmoothingEnabled = true
+      swizzleTypes: [Boolean]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  25: (duration)
+    0: imageSmoothingQuality
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: imageSmoothingQuality = "low"
+      swizzleTypes: [String]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  26: (duration)
+    0: isPointInPath([object Path2D], 5, 6, "nonzero")
+      swizzleTypes: [Path2D, Number, Number, String]
+      trace:
+        0: isPointInPath
+        1: (anonymous function)
+        2: executeFrameFunction
+    1: isPointInPath([object Path2D], 7, 8, "evenodd")
+      swizzleTypes: [Path2D, Number, Number, String]
+      trace:
+        0: isPointInPath
+        1: (anonymous function)
+        2: executeFrameFunction
+    2: isPointInPath(9, 10, "nonzero")
+      swizzleTypes: [Number, Number, String]
+      trace:
+        0: isPointInPath
+        1: (anonymous function)
+        2: executeFrameFunction
+    3: isPointInPath(11, 12, "evenodd")
+      swizzleTypes: [Number, Number, String]
+      trace:
+        0: isPointInPath
+        1: (anonymous function)
+        2: executeFrameFunction
+  27: (duration)
+    0: isPointInStroke([object Path2D], 3, 4)
+      swizzleTypes: [Path2D, Number, Number]
+      trace:
+        0: isPointInStroke
+        1: (anonymous function)
+        2: executeFrameFunction
+    1: isPointInStroke(5, 6)
+      swizzleTypes: [Number, Number]
+      trace:
+        0: isPointInStroke
+        1: (anonymous function)
+        2: executeFrameFunction
+  28: (duration)
+    0: lineCap
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  29: (duration)
+    0: lineDashOffset
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: lineDashOffset = 1
+      swizzleTypes: [Number]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  30: (duration)
+    0: lineJoin
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  31: (duration)
+    0: lineTo(1, 2)
+      swizzleTypes: [Number, Number]
+      trace:
+        0: lineTo
+        1: (anonymous function)
+        2: executeFrameFunction
+  32: (duration)
+    0: lineWidth
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: lineWidth = 1
+      swizzleTypes: [Number]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  33: (duration)
+    0: measureText("test")
+      swizzleTypes: [String]
+      trace:
+        0: measureText
+        1: (anonymous function)
+        2: executeFrameFunction
+  34: (duration)
+    0: miterLimit
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: miterLimit = 1
+      swizzleTypes: [Number]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  35: (duration)
+    0: moveTo(1, 2)
+      swizzleTypes: [Number, Number]
+      trace:
+        0: moveTo
+        1: (anonymous function)
+        2: executeFrameFunction
+  36: (duration)
+    0: putImageData([object ImageData], 5, 6)
+      swizzleTypes: [ImageData, Number, Number]
+      trace:
+        0: putImageData
+        1: (anonymous function)
+        2: executeFrameFunction
+    1: putImageData([object ImageData], 7, 8, 9, 10, 11, 12)
+      swizzleTypes: [ImageData, Number, Number, Number, Number, Number, Number]
+      trace:
+        0: putImageData
+        1: (anonymous function)
+        2: executeFrameFunction
+  37: (duration)
+    0: quadraticCurveTo(1, 2, 3, 4)
+      swizzleTypes: [Number, Number, Number, Number]
+      trace:
+        0: quadraticCurveTo
+        1: (anonymous function)
+        2: executeFrameFunction
+  38: (duration)
+    0: rect(1, 2, 3, 4)
+      swizzleTypes: [Number, Number, Number, Number]
+      trace:
+        0: rect
+        1: (anonymous function)
+        2: executeFrameFunction
+  39: (duration)
+    0: resetTransform()
+      trace:
+        0: resetTransform
+        1: (anonymous function)
+        2: executeFrameFunction
+  40: (duration)
+    0: restore()
+      trace:
+        0: restore
+        1: (anonymous function)
+        2: executeFrameFunction
+  41: (duration)
+    0: rotate(1)
+      swizzleTypes: [Number]
+      trace:
+        0: rotate
+        1: (anonymous function)
+        2: executeFrameFunction
+  42: (duration)
+    0: save()
+      trace:
+        0: save
+        1: (anonymous function)
+        2: executeFrameFunction
+  43: (duration)
+    0: scale(1, 2)
+      swizzleTypes: [Number, Number]
+      trace:
+        0: scale
+        1: (anonymous function)
+        2: executeFrameFunction
+  44: (duration)
+    0: setLineDash([1,2])
+      swizzleTypes: [Array]
+      trace:
+        0: setLineDash
+        1: (anonymous function)
+        2: executeFrameFunction
+  45: (duration)
+    0: setTransform(1, 2, 3, 4, 5, 6)
+      swizzleTypes: [Number, Number, Number, Number, Number, Number]
+      trace:
+        0: setTransform
+        1: (anonymous function)
+        2: executeFrameFunction
+    1: setTransform(matrix(1, 0, 0, 1, 0, 0))
+      swizzleTypes: [DOMMatrix]
+      trace:
+        0: setTransform
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+    2: setTransform(matrix(7, 8, 9, 10, 11, 12))
+      swizzleTypes: [DOMMatrix]
+      trace:
+        0: setTransform
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+  46: (duration)
+    0: shadowBlur
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: shadowBlur = 1
+      swizzleTypes: [Number]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  47: (duration)
+    0: shadowColor
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: shadowColor = "test"
+      swizzleTypes: [String]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  48: (duration)
+    0: shadowOffsetX
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: shadowOffsetX = 1
+      swizzleTypes: [Number]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  49: (duration)
+    0: shadowOffsetY
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: shadowOffsetY = 1
+      swizzleTypes: [Number]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  50: (duration)
+    0: stroke()
+      trace:
+        0: stroke
+        1: (anonymous function)
+        2: executeFrameFunction
+    1: stroke([object Path2D])
+      swizzleTypes: [Path2D]
+      trace:
+        0: stroke
+        1: (anonymous function)
+        2: executeFrameFunction
+  51: (duration)
+    0: strokeRect(1, 2, 3, 4)
+      swizzleTypes: [Number, Number, Number, Number]
+      trace:
+        0: strokeRect
+        1: (anonymous function)
+        2: executeFrameFunction
+  52: (duration)
+    0: strokeStyle
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: strokeStyle = "test"
+      swizzleTypes: [String]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    2: strokeStyle = [object CanvasGradient]
+      swizzleTypes: [CanvasGradient]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    3: strokeStyle = [object CanvasGradient]
+      swizzleTypes: [CanvasGradient]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    4: strokeStyle = [object CanvasPattern]
+      swizzleTypes: [CanvasPattern]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  53: (duration)
+    0: strokeText("testA", 1, 2)
+      swizzleTypes: [String, Number, Number]
+      trace:
+        0: strokeText
+        1: (anonymous function)
+        2: executeFrameFunction
+    1: strokeText("testB", 3, 4, 5)
+      swizzleTypes: [String, Number, Number, Number]
+      trace:
+        0: strokeText
+        1: (anonymous function)
+        2: executeFrameFunction
+  54: (duration)
+    0: textAlign
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  55: (duration)
+    0: textBaseline
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  56: (duration)
+    0: transform(1, 2, 3, 4, 5, 6)
+      swizzleTypes: [Number, Number, Number, Number, Number, Number]
+      trace:
+        0: transform
+        1: (anonymous function)
+        2: executeFrameFunction
+  57: (duration)
+    0: translate(1, 2)
+      swizzleTypes: [Number, Number]
+      trace:
+        0: translate
+        1: (anonymous function)
+        2: executeFrameFunction
+  58: (duration)
+    0: width
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: width = 2
+      swizzleTypes: [Number]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  59: (duration)
+    0: height
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+    1: height = 2
+      swizzleTypes: [Number]
+      trace:
+        0: (anonymous function)
+        1: executeFrameFunction
+  60: (duration)
+    0: roundRect(0, 0, 50, 50, 42)
+      swizzleTypes: [Number, Number, Number, Number, Number]
+      trace:
+        0: roundRect
+        1: (anonymous function)
+        2: executeFrameFunction
+    1: roundRect(0, 0, 50, 50, [23])
+      swizzleTypes: [Number, Number, Number, Number, Array]
+      trace:
+        0: roundRect
+        1: (anonymous function)
+        2: executeFrameFunction
+    2: roundRect(0, 0, 150, 150, [{"x":24,"y":42,"z":0,"w":1}])
+      swizzleTypes: [Number, Number, Number, Number, Array]
+      trace:
+        0: roundRect
+        1: (anonymous function)
+        2: executeFrameFunction
+  61: (duration)
+    0: commit()
+      trace:
+        0: commit
+        1: (anonymous function)
+        2: executeFrameFunction
+

--- a/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-full.html
+++ b/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-full.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/recording-utilities.js"></script>
+<script src="resources/recording-2d.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.recording2D");
+
+    suite.addTestCase({
+        name: "Canvas.recording2D.multipleFrames.OffscreenCanvas2D",
+        description: "Check that recording data is serialized correctly for multiple frames.",
+        test(resolve, reject) {
+            startRecording(WI.Canvas.ContextType.OffscreenCanvas2D, resolve, reject);
+        },
+        timeout: -1,
+    });
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="load({offscreen: true})">
+    <p>Test that CanvasManager is able to record actions made to offscreen 2D canvas contexts.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-memoryLimit-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-memoryLimit-expected.txt
@@ -1,0 +1,48 @@
+Test that CanvasManager is able to record actions made to offscreen 2D canvas contexts.
+
+
+== Running test suite: Canvas.recording2D
+-- Running test case: Canvas.recording2D.memoryLimit.OffscreenCanvas2D
+initialState:
+  attributes:
+    width: 2
+    height: 2
+  current state:
+    setTransform: [[1,0,0,1,0,0]]
+    globalAlpha: 1
+    globalCompositeOperation: "source-over"
+    lineWidth: 1
+    lineCap: "butt"
+    lineJoin: "miter"
+    miterLimit: 10
+    shadowOffsetX: 0
+    shadowOffsetY: 0
+    shadowBlur: 0
+    shadowColor: "rgba(0, 0, 0, 0)"
+    setLineDash: [[]]
+    lineDashOffset: 0
+    font: "10px sans-serif"
+    textAlign: "start"
+    textBaseline: "alphabetic"
+    direction: "inherit"
+    strokeStyle: "#000000"
+    fillStyle: "#000000"
+    imageSmoothingEnabled: true
+    imageSmoothingQuality: "low"
+    setPath: [""]
+  parameters:
+    0: {"colorSpace":"srgb","desynchronized":false}
+  content: <filtered>
+frames:
+  0: (duration) (incomplete)
+    0: arc(1, 2, 3, 4, 5, false)
+      swizzleTypes: [Number, Number, Number, Number, Number, Boolean]
+      trace:
+        0: arc
+        1: (anonymous function)
+        2: ignoreException
+        3: (anonymous function)
+        4: executeFrameFunction
+        5: performActions
+        6: Global Code
+

--- a/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-memoryLimit.html
+++ b/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-memoryLimit.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/recording-utilities.js"></script>
+<script src="resources/recording-2d.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.recording2D");
+
+    suite.addTestCase({
+        name: "Canvas.recording2D.memoryLimit.OffscreenCanvas2D",
+        description: "Check that the recording is stopped when it reaches the memory limit.",
+        test(resolve, reject) {
+            startRecording(WI.Canvas.ContextType.OffscreenCanvas2D, resolve, reject, {memoryLimit: 10});
+        },
+        timeout: -1,
+    });
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="load({offscreen:true})">
+    <p>Test that CanvasManager is able to record actions made to offscreen 2D canvas contexts.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-saves-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-saves-expected.txt
@@ -1,0 +1,95 @@
+Test that CanvasManager is able to record actions made to 2D canvas contexts.
+
+
+== Running test suite: Canvas.recording2D
+-- Running test case: Canvas.recording2D.ExistingSaves.OffscreenCanvas2D
+PASS: There should be 4 existing states.
+PASS: State 0 setTransform value should be matrix(1, 0, 0, 1, 0, 0).
+PASS: State 0 globalAlpha value should be 1.
+PASS: State 0 globalCompositeOperation value should be source-over.
+PASS: State 0 lineWidth value should be 1.
+PASS: State 0 lineCap value should be butt.
+PASS: State 0 lineJoin value should be miter.
+PASS: State 0 miterLimit value should be 10.
+PASS: State 0 shadowOffsetX value should be 0.
+PASS: State 0 shadowOffsetY value should be 0.
+PASS: State 0 shadowBlur value should be 0.
+PASS: State 0 shadowColor value should be rgba(0, 0, 0, 0).
+PASS: State 0 setLineDash value should be .
+PASS: State 0 lineDashOffset value should be 0.
+PASS: State 0 font value should be 10px sans-serif.
+PASS: State 0 textAlign value should be start.
+PASS: State 0 textBaseline value should be alphabetic.
+PASS: State 0 direction value should be inherit.
+PASS: State 0 strokeStyle value should be #000000.
+PASS: State 0 fillStyle value should be #000000.
+PASS: State 0 imageSmoothingEnabled value should be true.
+PASS: State 0 imageSmoothingQuality value should be low.
+PASS: State 0 setPath value should be [object Path2D].
+PASS: State 1 setTransform value should be matrix(1, 0, 0, 1, 1, 0).
+PASS: State 1 globalAlpha value should be 0.5.
+PASS: State 1 globalCompositeOperation value should be source-in.
+PASS: State 1 lineWidth value should be 0.5.
+PASS: State 1 lineCap value should be round.
+PASS: State 1 lineJoin value should be bevel.
+PASS: State 1 miterLimit value should be 20.
+PASS: State 1 shadowOffsetX value should be 2.
+PASS: State 1 shadowOffsetY value should be 3.
+PASS: State 1 shadowBlur value should be 4.
+PASS: State 1 shadowColor value should be #100000.
+PASS: State 1 setLineDash value should be 1,2.
+PASS: State 1 lineDashOffset value should be 10.
+PASS: State 1 font value should be 20px sans-serif.
+PASS: State 1 textAlign value should be left.
+PASS: State 1 textBaseline value should be top.
+PASS: State 1 direction value should be ltr.
+PASS: State 1 strokeStyle value should be [object CanvasPattern].
+PASS: State 1 fillStyle value should be [object CanvasGradient].
+PASS: State 1 imageSmoothingEnabled value should be false.
+PASS: State 1 imageSmoothingQuality value should be medium.
+PASS: State 1 setPath value should be [object Path2D].
+PASS: State 2 setTransform value should be matrix(1, 0, 0, 1, 1, 1).
+PASS: State 2 globalAlpha value should be 0.
+PASS: State 2 globalCompositeOperation value should be difference.
+PASS: State 2 lineWidth value should be 2.
+PASS: State 2 lineCap value should be square.
+PASS: State 2 lineJoin value should be round.
+PASS: State 2 miterLimit value should be 30.
+PASS: State 2 shadowOffsetX value should be 4.
+PASS: State 2 shadowOffsetY value should be 5.
+PASS: State 2 shadowBlur value should be 6.
+PASS: State 2 shadowColor value should be #001000.
+PASS: State 2 setLineDash value should be 3,4.
+PASS: State 2 lineDashOffset value should be 11.
+PASS: State 2 font value should be 30px cursive.
+PASS: State 2 textAlign value should be right.
+PASS: State 2 textBaseline value should be hanging.
+PASS: State 2 direction value should be inherit.
+PASS: State 2 strokeStyle value should be [object CanvasGradient].
+PASS: State 2 fillStyle value should be [object CanvasPattern].
+PASS: State 2 imageSmoothingEnabled value should be true.
+PASS: State 2 imageSmoothingQuality value should be high.
+PASS: State 2 setPath value should be [object Path2D].
+PASS: State 3 setTransform value should be matrix(1, 0, 0, 1, 0, -1).
+PASS: State 3 globalAlpha value should be 0.75.
+PASS: State 3 globalCompositeOperation value should be source-over.
+PASS: State 3 lineWidth value should be 3.
+PASS: State 3 lineCap value should be round.
+PASS: State 3 lineJoin value should be bevel.
+PASS: State 3 miterLimit value should be 40.
+PASS: State 3 shadowOffsetX value should be 6.
+PASS: State 3 shadowOffsetY value should be 7.
+PASS: State 3 shadowBlur value should be 8.
+PASS: State 3 shadowColor value should be #000010.
+PASS: State 3 setLineDash value should be 5,6.
+PASS: State 3 lineDashOffset value should be 12.
+PASS: State 3 font value should be 40px fantasy.
+PASS: State 3 textAlign value should be center.
+PASS: State 3 textBaseline value should be ideographic.
+PASS: State 3 direction value should be rtl.
+PASS: State 3 strokeStyle value should be #200000.
+PASS: State 3 fillStyle value should be #300000.
+PASS: State 3 imageSmoothingEnabled value should be false.
+PASS: State 3 imageSmoothingQuality value should be medium.
+PASS: State 3 setPath value should be [object Path2D].
+

--- a/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-saves.html
+++ b/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-saves.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/recording-utilities.js"></script>
+<script src="resources/recording-2d.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("Canvas.recording2D");
+
+    suite.addTestCase({
+        name: "Canvas.recording2D.ExistingSaves.OffscreenCanvas2D",
+        description: "Check that existing save calls are sent to the frontend.",
+        test(resolve, reject) {
+            let canvas = getCanvas(WI.Canvas.ContextType.OffscreenCanvas2D);
+            if (!canvas) {
+                reject("Missing 2D canvas.");
+                return;
+            }
+
+            async function logStates(recording) {
+                function check(index, state, name, expected) {
+                    InspectorTest.expectEqual("" + state.get(name), "" + expected, `State ${index} ${name} value should be ${expected}.`)
+                }
+                async function compare(index, transform, globalAlpha, globalCompositeOperation, lineWidth, lineCap, lineJoin, miterLimit, shadowOffsetX, shadowOffsetY, shadowBlur, shadowColor, lineDash, lineDashOffset, font, textAlign, textBaseline, direction, strokeStyle, fillStyle, imageSmoothingEnabled, imageSmoothingQuality, path) {
+                    let state = await WI.RecordingState.swizzleInitialState(recording, recording.initialState.states[index]);
+                    check(index, state, "setTransform", transform)
+                    check(index, state, "globalAlpha", globalAlpha)
+                    check(index, state, "globalCompositeOperation", globalCompositeOperation)
+                    check(index, state, "lineWidth", lineWidth)
+                    check(index, state, "lineCap", lineCap)
+                    check(index, state, "lineJoin", lineJoin)
+                    check(index, state, "miterLimit", miterLimit)
+                    check(index, state, "shadowOffsetX", shadowOffsetX)
+                    check(index, state, "shadowOffsetY", shadowOffsetY)
+                    check(index, state, "shadowBlur", shadowBlur)
+                    check(index, state, "shadowColor", shadowColor)
+                    check(index, state, "setLineDash", lineDash)
+                    check(index, state, "lineDashOffset", lineDashOffset)
+                    check(index, state, "font", font)
+                    check(index, state, "textAlign", textAlign)
+                    check(index, state, "textBaseline", textBaseline)
+                    check(index, state, "direction", direction)
+                    check(index, state, "strokeStyle", strokeStyle) // FIXME: Might want to do a better job at stringifying gradients and patterns for a better test.
+                    check(index, state, "fillStyle", fillStyle) // FIXME: Might want to do a better job at stringifying gradients and patterns for a better test.
+                    check(index, state, "imageSmoothingEnabled", imageSmoothingEnabled)
+                    check(index, state, "imageSmoothingQuality", imageSmoothingQuality)
+                    check(index, state, "setPath", path) // FIXME: Need to do a better job at stringifying a path for a useful test.
+                }
+
+                await compare(0, "matrix(1, 0, 0, 1, 0, 0)", 1, "source-over", 1, "butt", "miter", 10, 0, 0, 0, "rgba(0, 0, 0, 0)", "", 0, "10px sans-serif", "start", "alphabetic", "inherit", "#000000", "#000000", true, "low", "[object Path2D]")
+                await compare(1, "matrix(1, 0, 0, 1, 1, 0)", 0.5, "source-in", 0.5, "round", "bevel", 20, 2, 3, 4, "#100000", "1,2", 10, "20px sans-serif", "left", "top", "ltr", "[object CanvasPattern]", "[object CanvasGradient]", false, "medium", "[object Path2D]")
+                await compare(2, "matrix(1, 0, 0, 1, 1, 1)", 0, "difference", 2, "square", "round", 30, 4, 5, 6, "#001000", "3,4", 11, "30px cursive", "right", "hanging", "inherit", "[object CanvasGradient]", "[object CanvasPattern]", true, "high", "[object Path2D]")
+                await compare(3, "matrix(1, 0, 0, 1, 0, -1)", 0.75, "source-over", 3, "round", "bevel", 40, 6, 7, 8, "#000010", "5,6", 12, "40px fantasy", "center", "ideographic", "rtl", "#200000", "#300000", false, "medium", "[object Path2D]")
+            }
+
+            canvas.awaitEvent(WI.Canvas.Event.RecordingStopped)
+            .then((event) => {
+                let {recording} = event.data;
+
+                InspectorTest.expectEqual(recording.initialState.states.length, 4, "There should be 4 existing states.");
+
+                logStates(recording)
+                .then(resolve, reject);
+            });
+
+            canvas.awaitEvent(WI.Canvas.Event.RecordingStarted)
+            .then((event) => {
+                InspectorTest.evaluateInPage(`performSavePostActions()`).catch(reject);
+            });
+
+            InspectorTest.evaluateInPage(`performSavePreActions()`)
+            .then(() => {
+                const frameCount = 1;
+                CanvasAgent.startRecording(canvas.identifier, frameCount).catch(reject);
+            }, reject);
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="load({offscreen: true})">
+    <p>Test that CanvasManager is able to record actions made to 2D canvas contexts.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/canvas/requestClientNodes.html
+++ b/LayoutTests/inspector/canvas/requestClientNodes.html
@@ -4,27 +4,37 @@
 <script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script>
 function load() {
-    window.context2d = document.createElement("canvas").getContext("2d");
-
+    let context2Ds = [ ];
+    context2Ds.push(document.createElement("canvas").getContext("2d"));
+    if (window.OffscreenCanvas)
+        context2Ds.push(new OffscreenCanvas(300, 150).getContext("2d"));
+    window.context2Ds = context2Ds;
     runTest();
 }
 
 function test() {
     let suite = InspectorTest.createAsyncSuite("Canvas.requestClientNodes");
+    function addTestCase({name, contextType}) {
+        suite.addTestCase({
+            name,
+            description: "Check that creating a CSS canvas client node is tracked correctly.",
+            test(resolve, reject) {
+                let canvas = Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.contextType === contextType);
+                if (!canvas) {
+                    reject(`Missing canvas for type ${contextType}.`);
+                    return;
+                }
+                canvas.requestClientNodes((clientNodes) => {
+                    InspectorTest.expectEqual(clientNodes.length, 0, "There should initially be no client nodes.");
+                    resolve();
+                });
+            }
+        });
+    };
 
-    suite.addTestCase({
-        name: "Canvas.requestClientNodes.Initial",
-        description: "Check that creating a CSS canvas client node is tracked correctly.",
-        test(resolve, reject) {
-            let canvas = Array.from(WI.canvasManager.canvasCollection)[0];
-            InspectorTest.assert(canvas, "There should be at least one canvas.");
-
-            canvas.requestClientNodes((clientNodes) => {
-                InspectorTest.expectEqual(clientNodes.length, 0, "There should initially be no client nodes.");
-                resolve();
-            });
-        }
-    });
+    addTestCase({name: "Canvas.requestClientNodes.Initial.Canvas2D", contextType: WI.Canvas.ContextType.Canvas2D});
+    if (window.OffscreenCanvas)
+        addTestCase({name: "CCanvas.requestClientNodes.Initial.OffscreenCanvas2D", contextType: WI.Canvas.ContextType.OffscreenCanvas2D});
 
     suite.addTestCase({
         name: "Canvas.CSSCanvasClients.InvalidCanvasId",

--- a/LayoutTests/inspector/canvas/requestContent-2d.html
+++ b/LayoutTests/inspector/canvas/requestContent-2d.html
@@ -4,31 +4,41 @@
 <script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script>
 function load() {
-    window.context2d = document.createElement("canvas").getContext("2d");
-    window.context2d.fillStyle = "rgba(255, 0, 0, 0.5)"; // Half-transparent red
-    window.context2d.fillRect(0, 0, 300, 150);
-
+    let context2Ds = [ ];
+    context2Ds.push(document.createElement("canvas").getContext("2d"));
+    if (window.OffscreenCanvas)
+        context2Ds.push(new OffscreenCanvas(300, 150).getContext("2d"));
+    for (context of context2Ds) {
+        context.fillStyle = "rgba(255, 0, 0, 0.5)"; // Half-transparent red
+        context.fillRect(0, 0, 300, 150);
+    }
+    window.context2Ds = context2Ds;
     runTest();
 }
 
 function test() {
     let suite = InspectorTest.createAsyncSuite("Canvas.requestContent2D");
 
-    suite.addTestCase({
-        name: "Canvas.requestContent2D.validCanvasId",
-        description: "Get the base64 encoded data for the canvas on the page with the given type.",
-        test(resolve, reject) {
-            let canvas = Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.contextType === WI.Canvas.ContextType.Canvas2D);
-            if (!canvas) {
-                reject(`Missing Canvas.`);
-                return;
-            }
+    function addTestCase({name, contextType}) {
+        suite.addTestCase({
+            name,
+            description: "Get the base64 encoded data for the canvas on the page with the given type.",
+            test(resolve, reject) {
+                let canvas = Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.contextType === contextType);
+                if (!canvas) {
+                    reject(`Missing canvas for type ${contextType}.`);
+                    return;
+                }
 
-            CanvasAgent.requestContent(canvas.identifier)
-            .then(({content}) => InspectorTest.expectGreaterThan(content.length, "data:image/png;base64,".length, "Content should not be empty."))
-            .then(resolve, reject);
-        }
-    });
+                CanvasAgent.requestContent(canvas.identifier)
+                .then(({content}) => InspectorTest.expectGreaterThan(content.length, "data:image/png;base64,".length, "Content should not be empty."))
+                .then(resolve, reject);
+            }
+        });
+    }
+    addTestCase({name: "Canvas.requestContent.validCanvasId.Canvas2D", contextType: WI.Canvas.ContextType.Canvas2D});
+    if (window.OffscreenCanvas)
+        addTestCase({name: "Canvas.requestContent.validCanvasId.OffscreenCanvas2D", contextType: WI.Canvas.ContextType.OffscreenCanvas2D});
 
     // ------
 

--- a/LayoutTests/inspector/canvas/resolveContext-2d.html
+++ b/LayoutTests/inspector/canvas/resolveContext-2d.html
@@ -4,34 +4,51 @@
 <script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script>
 function load() {
-    window.context2d = document.body.appendChild(document.createElement("canvas")).getContext("2d");
-
+    let context2Ds = [ ];
+    context2Ds.push(document.createElement("canvas").getContext("2d"));
+    if (window.OffscreenCanvas)
+        context2Ds.push(new OffscreenCanvas(300, 150).getContext("2d"));
+    window.context2Ds = context2Ds;
     runTest();
 }
 
+
 function test()
 {
+    function classNameForContextType(contextType)
+    {
+        if (contextType == WI.Canvas.ContextType.Canvas2D)
+            return "CanvasRenderingContext2D";
+        if (contextType == WI.Canvas.ContextType.OffscreenCanvas2D)
+            return "OffscreenCanvasRenderingContext2D";
+        return "unknown context type";
+    }
     let suite = InspectorTest.createAsyncSuite("Canvas.resolveContext2D");
+    function addTestCase({name, contextType}) {
+        suite.addTestCase({
+            name,
+            description: "Should return a valid object for the given canvas identifier.",
+            test(resolve, reject) {
+                let canvas = Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.contextType === contextType);
+                if (!canvas) {
+                    reject(`Missing canvas for type ${contextType}.`);
+                    return;
+                }
 
-    suite.addTestCase({
-        name: `Canvas.resolveContext2D.validIdentifier`,
-        description: "Should return a valid object for the given canvas identifier.",
-        test(resolve, reject) {
-            let canvas = Array.from(WI.canvasManager.canvasCollection).find((canvas) => canvas.contextType === WI.Canvas.ContextType.Canvas2D);
-            if (!canvas) {
-                reject(`Missing Canvas.`);
-                return;
+                const objectGroup = "test";
+                CanvasAgent.resolveContext(canvas.identifier, objectGroup)
+                .then(({object}) => {
+                    InspectorTest.expectEqual(object.type, "object", `Payload should have type "object".`);
+                    InspectorTest.expectEqual(object.className, classNameForContextType(contextType), `Payload should have expected className"`); 
+                })
+                .then(resolve, reject);
             }
+        });
+    }
+    addTestCase({name: `Canvas.resolveContext2D.validIdentifier.Canvas2D`, contextType: WI.Canvas.ContextType.Canvas2D});
+    if (window.OffscreenCanvas)
+        addTestCase({name: `Canvas.resolveContext2D.validIdentifier.OffscreenCanvas2D`, contextType: WI.Canvas.ContextType.OffscreenCanvas2D});
 
-            const objectGroup = "test";
-            CanvasAgent.resolveContext(canvas.identifier, objectGroup)
-            .then(({object}) => {
-                InspectorTest.expectEqual(object.type, "object", `Payload should have type "object".`);
-                InspectorTest.expectEqual(object.className, "CanvasRenderingContext2D", `Payload should have className "CanvasRenderingContext2D".`);
-            })
-            .then(resolve, reject);
-        }
-    });
 
     // ------
 

--- a/LayoutTests/inspector/canvas/resources/create-context-utilities.js
+++ b/LayoutTests/inspector/canvas/resources/create-context-utilities.js
@@ -3,32 +3,50 @@ window.contexts = [];
 function createAttachedCanvas(contextType) {
     let canvas = document.body.appendChild(document.createElement("canvas"));
     let context = canvas.getContext(contextType);
-    if (!context)
+    if (!context) {
         TestPage.addResult("FAIL: missing context for type " + contextType);
+        return;
+    }
     window.contexts.push(context);
 }
 
 function createDetachedCanvas(contextType) {
     let context = document.createElement("canvas").getContext(contextType);
-    if (!context)
+    if (!context) {
         TestPage.addResult("FAIL: missing context for type " + contextType);
+        return;
+    }
     window.contexts.push(context);
 }
 
 function createCSSCanvas(contextType, canvasName) {
     let context = document.getCSSCanvasContext(contextType, canvasName, 10, 10);
-    if (!context)
+    if (!context) {
         TestPage.addResult("FAIL: missing context for type " + contextType);
-    window.contexts.push();
+        return;
+    }
+    window.contexts.push(context);
+}
+
+function createOffscreenCanvas(contextType, canvasName) {
+    if (!window.OffscreenCanvas) {
+        TestPage.addResult("FAIL: missing OffscreenCanvas implementation");
+        return;
+    }
+    let canvas = new OffscreenCanvas(10, 10);
+    let context = canvas.getContext(contextType);
+
+    if (!context) {
+        TestPage.addResult("FAIL: missing offscreen context for type " + contextType);
+        return;
+    }
+    window.contexts.push(context);
 }
 
 let destroyCanvasesInterval = null;
 
 function destroyCanvases() {
     for (let context of window.contexts) {
-        if (!context)
-            continue;
-
         let canvasElement = context.canvas;
         if (canvasElement && canvasElement.parentNode)
             canvasElement.remove();

--- a/LayoutTests/inspector/canvas/resources/recording-2d.js
+++ b/LayoutTests/inspector/canvas/resources/recording-2d.js
@@ -26,15 +26,22 @@ let imageData23 = new ImageData(2, 3);
 
 let bitmap = null;
 
-async function load() {
-    ctx = canvas.getContext("2d");
-    linearGradient = ctx.createLinearGradient(1, 2, 3, 4);
-    radialGradient = ctx.createRadialGradient(1, 2, 3, 4, 5, 6);
-    pattern = ctx.createPattern(image, "no-repeat");
-    bitmap = await createImageBitmap(image);
+async function load({offscreen = false} = { }) {
+    if (offscreen) {
+        if (window.OffscreenCanvas)
+            ctx = new OffscreenCanvas(2, 2).getContext("2d");
+    } else
+        ctx = canvas.getContext("2d");
 
-    ctx.save();
-    cancelActions();
+    if (ctx) {
+        linearGradient = ctx.createLinearGradient(1, 2, 3, 4);
+        radialGradient = ctx.createRadialGradient(1, 2, 3, 4, 5, 6);
+        pattern = ctx.createPattern(image, "no-repeat");
+        bitmap = await createImageBitmap(image);
+
+        ctx.save();
+        cancelActions();
+    }
 
     runTest();
 }
@@ -84,7 +91,7 @@ function performActions() {
             ctx.clearRect(1, 2, 3, 4);
         },
         () => {
-            ctx.clearShadow();
+            ctx.clearShadow?.();
         },
         () => {
             ctx.clip();
@@ -116,8 +123,8 @@ function performActions() {
             ctx.direction = "test";
         },
         () => {
-            ctx.drawFocusIfNeeded(document.body);
-            ctx.drawFocusIfNeeded(path12, document.body);
+            ctx.drawFocusIfNeeded?.(document.body);
+            ctx.drawFocusIfNeeded?.(path12, document.body);
         },
         () => {
             ignoreException(() => ctx.drawImage(image, 11, 12));
@@ -137,8 +144,8 @@ function performActions() {
             ignoreException(() => ctx.drawImage(bitmap, 47, 48, 49, 410, 411, 412, 413, 414));
         },
         () => {
-            ctx.drawImageFromRect(image, 1, 2, 3, 4, 5, 6, 7, 8)
-            ctx.drawImageFromRect(image, 9, 10, 11, 12, 13, 14, 15, 16, "test");
+            ctx.drawImageFromRect?.(image, 1, 2, 3, 4, 5, 6, 7, 8)
+            ctx.drawImageFromRect?.(image, 9, 10, 11, 12, 13, 14, 15, 16, "test");
         },
         () => {
             ignoreException(() => ctx.ellipse(1, 2, 3, 4, 5, 6, 7));
@@ -260,53 +267,53 @@ function performActions() {
             ctx.scale(1, 2);
         },
         () => {
-            ctx.setAlpha();
-            ctx.setAlpha(1);
+            ctx.setAlpha?.();
+            ctx.setAlpha?.(1);
         },
         () => {
-            ctx.setCompositeOperation();
-            ctx.setCompositeOperation("test");
+            ctx.setCompositeOperation?.();
+            ctx.setCompositeOperation?.("test");
         },
         () => {
-            ctx.setFillColor("testA");
-            ctx.setFillColor("testB", 1);
-            ctx.setFillColor(2);
-            ctx.setFillColor(3, 4);
-            ctx.setFillColor(5, 6, 7, 8);
+            ctx.setFillColor?.("testA");
+            ctx.setFillColor?.("testB", 1);
+            ctx.setFillColor?.(2);
+            ctx.setFillColor?.(3, 4);
+            ctx.setFillColor?.(5, 6, 7, 8);
         },
         () => {
-            ctx.setLineCap();
-            ctx.setLineCap("test");
+            ctx.setLineCap?.();
+            ctx.setLineCap?.("test");
         },
         () => {
             ctx.setLineDash([1, 2]);
         },
         () => {
-            ctx.setLineJoin();
-            ctx.setLineJoin("test");
+            ctx.setLineJoin?.();
+            ctx.setLineJoin?.("test");
         },
         () => {
-            ctx.setLineWidth();
-            ctx.setLineWidth(1);
+            ctx.setLineWidth?.();
+            ctx.setLineWidth?.(1);
         },
         () => {
-            ctx.setMiterLimit();
-            ctx.setMiterLimit(1);
+            ctx.setMiterLimit?.();
+            ctx.setMiterLimit?.(1);
         },
         () => {
-            ctx.setShadow(1, 2, 3);
-            ctx.setShadow(4, 5, 6, "test", 7);
-            ctx.setShadow(8, 9, 10, 11);
-            ctx.setShadow(12, 13, 14, 15, 16);
-            ctx.setShadow(17, 18, 19, 20, 21, 22, 23);
-            ctx.setShadow(24, 25, 26, 27, 28, 29, 30, 31);
+            ctx.setShadow?.(1, 2, 3);
+            ctx.setShadow?.(4, 5, 6, "test", 7);
+            ctx.setShadow?.(8, 9, 10, 11);
+            ctx.setShadow?.(12, 13, 14, 15, 16);
+            ctx.setShadow?.(17, 18, 19, 20, 21, 22, 23);
+            ctx.setShadow?.(24, 25, 26, 27, 28, 29, 30, 31);
         },
         () => {
-            ctx.setStrokeColor("testA");
-            ctx.setStrokeColor("testB", 1);
-            ctx.setStrokeColor(2);
-            ctx.setStrokeColor(3, 4);
-            ctx.setStrokeColor(5, 6, 7, 8);
+            ctx.setStrokeColor?.("testA");
+            ctx.setStrokeColor?.("testB", 1);
+            ctx.setStrokeColor?.(2);
+            ctx.setStrokeColor?.(3, 4);
+            ctx.setStrokeColor?.(5, 6, 7, 8);
         },
         () => {
             ctx.setTransform(1, 2, 3, 4, 5, 6);
@@ -362,14 +369,20 @@ function performActions() {
             ctx.translate(1, 2);
         },
         () => {
+            if (window.OffscreenCanvasRenderingContext2D && ctx instanceof OffscreenCanvasRenderingContext2D)
+                return;
             ctx.webkitImageSmoothingEnabled;
             ctx.webkitImageSmoothingEnabled = true;
         },
         () => {
+            if (window.OffscreenCanvasRenderingContext2D && ctx instanceof OffscreenCanvasRenderingContext2D)
+                return;
             ctx.webkitLineDash;
             ctx.webkitLineDash = [1, 2];
         },
         () => {
+            if (window.OffscreenCanvasRenderingContext2D && ctx instanceof OffscreenCanvasRenderingContext2D)
+                return;
             ctx.webkitLineDashOffset;
             ctx.webkitLineDashOffset = 1;
         },
@@ -386,6 +399,9 @@ function performActions() {
             ctx.roundRect(0, 0, 50, 50, 42);
             ctx.roundRect(0, 0, 50, 50, [23]);
             ctx.roundRect(0, 0, 150, 150, [{x: 24, y: 42}]);
+        },
+        () => {
+            ctx.commit?.();
         },
         () => {
             TestPage.dispatchEventToFrontend("LastFrame");

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -181,6 +181,9 @@ webkit.org/b/217947 http/tests/security/mixedContent/secure-redirect-to-secure-r
 # WebInspector.
 webkit.org/b/217966 [ Release ] inspector/console/queryHolders.html [ Failure ]
 webkit.org/b/218367 inspector/page/setScreenSizeOverride.html [ Failure Pass ]
+webkit.org/b/254733 inspector/canvas/recording-offscreen-canvas-2d-frameCount.html [ Failure ]
+webkit.org/b/254733 inspector/canvas/recording-offscreen-canvas-2d-full.html [ Failure ]
+webkit.org/b/254733 inspector/canvas/recording-offscreen-canvas-2d-memoryLimit.html [ Failure ]
 
 # WebXR is not yet supported in GTK
 webkit.org/b/208988 http/wpt/webxr [ Skip ]

--- a/LayoutTests/platform/gtk/inspector/canvas/context-attributes-expected.txt
+++ b/LayoutTests/platform/gtk/inspector/canvas/context-attributes-expected.txt
@@ -54,11 +54,3 @@ PASS: Canvas context should be "WebGL".
 }
 PASS: Canvas context should have attribute "alpha" with value "false".
 
--- Running test case: CreateOffscreenCanvasContext2D
-Added canvas.
-PASS: Canvas context should be "Offscreen2D".
-{
-  "colorSpace": "srgb",
-  "desynchronized": false
-}
-

--- a/LayoutTests/platform/gtk/inspector/canvas/requestClientNodes-expected.txt
+++ b/LayoutTests/platform/gtk/inspector/canvas/requestClientNodes-expected.txt
@@ -5,9 +5,6 @@ Test that CanvasAgent tracks changes in the client nodes of a CSS canvas.
 -- Running test case: Canvas.requestClientNodes.Initial.Canvas2D
 PASS: There should initially be no client nodes.
 
--- Running test case: CCanvas.requestClientNodes.Initial.OffscreenCanvas2D
-PASS: There should initially be no client nodes.
-
 -- Running test case: Canvas.CSSCanvasClients.InvalidCanvasId
 PASS: Should produce an error.
 Error: Missing canvas for given canvasId

--- a/LayoutTests/platform/gtk/inspector/canvas/requestContent-2d-expected.txt
+++ b/LayoutTests/platform/gtk/inspector/canvas/requestContent-2d-expected.txt
@@ -5,9 +5,6 @@ Test that CanvasAgent.requestContent can retrieve a dataURL with the current con
 -- Running test case: Canvas.requestContent.validCanvasId.Canvas2D
 PASS: Content should not be empty.
 
--- Running test case: Canvas.requestContent.validCanvasId.OffscreenCanvas2D
-PASS: Content should not be empty.
-
 -- Running test case: Canvas.requestContent.invalidCanvasId
 PASS: Should produce an error.
 Error: Missing canvas for given canvasId

--- a/LayoutTests/platform/gtk/inspector/canvas/resolveContext-2d-expected.txt
+++ b/LayoutTests/platform/gtk/inspector/canvas/resolveContext-2d-expected.txt
@@ -6,10 +6,6 @@ Tests for the Canvas.resolveContext command for 2D contexts.
 PASS: Payload should have type "object".
 PASS: Payload should have expected className"
 
--- Running test case: Canvas.resolveContext2D.validIdentifier.OffscreenCanvas2D
-PASS: Payload should have type "object".
-PASS: Payload should have expected className"
-
 -- Running test case: Canvas.resolveContext.invalidIdentifier
 PASS: Should produce an error.
 Error: Missing canvas for given canvasId

--- a/Source/JavaScriptCore/inspector/protocol/Canvas.json
+++ b/Source/JavaScriptCore/inspector/protocol/Canvas.json
@@ -23,7 +23,7 @@
         {
             "id": "ContextType",
             "type": "string",
-            "enum": ["canvas-2d", "bitmaprenderer", "webgl", "webgl2"],
+            "enum": ["canvas-2d", "offscreen-canvas-2d", "bitmaprenderer", "webgl", "webgl2"],
             "description": "The type of rendering context backing the canvas element."
         },
         {

--- a/Source/JavaScriptCore/inspector/protocol/Recording.json
+++ b/Source/JavaScriptCore/inspector/protocol/Recording.json
@@ -8,7 +8,7 @@
         {
             "id": "Type",
             "type": "string",
-            "enum": ["canvas-2d", "canvas-bitmaprenderer", "canvas-webgl", "canvas-webgl2"],
+            "enum": ["canvas-2d", "offscreen-canvas-2d", "canvas-bitmaprenderer", "canvas-webgl", "canvas-webgl2"],
             "description": "The type of the recording."
         },
         {

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -251,7 +251,7 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
         auto settings = convert<IDLDictionary<CanvasRenderingContext2DSettings>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
         RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
 
-        m_context = makeUnique<OffscreenCanvasRenderingContext2D>(*this, WTFMove(settings));
+        m_context = OffscreenCanvasRenderingContext2D::create(*this, WTFMove(settings));
         if (!m_context)
             return { { std::nullopt } };
 

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -56,8 +56,8 @@ enum OffscreenRenderingContextType
 ] interface OffscreenCanvas : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor([EnforceRange] unsigned long width, [EnforceRange] unsigned long height);
 
-    attribute [EnforceRange] unsigned long width;
-    attribute [EnforceRange] unsigned long height;
+    [CallTracer=InspectorCanvasCallTracer] attribute [EnforceRange] unsigned long width;
+    [CallTracer=InspectorCanvasCallTracer] attribute [EnforceRange] unsigned long height;
 
     [CallWith=CurrentGlobalObject] OffscreenRenderingContext? getContext(OffscreenRenderingContextType contextType, any... arguments);
     ImageBitmap transferToImageBitmap();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -64,6 +64,7 @@ public:
 
     CanvasBase& canvasBase() const { return m_canvas; }
 
+    virtual bool is2dBase() const { return false; }
     virtual bool is2d() const { return false; }
     virtual bool isWebGL1() const { return false; }
     virtual bool isWebGL2() const { return false; }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -342,6 +342,7 @@ private:
     void didDraw(bool entireCanvas, const FloatRect&);
     template<typename RectProvider> void didDraw(bool entireCanvas, RectProvider);
 
+    bool is2dBase() const final { return true; }
     void paintRenderingResultsToCanvas() override;
     bool needsPreparationForDisplay() const final;
     void prepareForDisplay() final;
@@ -431,3 +432,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CANVASRENDERINGCONTEXT(WebCore::CanvasRenderingContext2DBase, is2dBase())

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -38,6 +38,7 @@
 #include "CSSFontSelector.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CSSPropertyParserWorkerSafe.h"
+#include "InspectorInstrumentation.h"
 #include "RenderStyle.h"
 #include "ScriptExecutionContext.h"
 #include "StyleResolveForFontRaw.h"
@@ -58,6 +59,16 @@ bool OffscreenCanvasRenderingContext2D::enabledForContext(ScriptExecutionContext
 
     ASSERT(context.isDocument());
     return true;
+}
+
+
+std::unique_ptr<OffscreenCanvasRenderingContext2D> OffscreenCanvasRenderingContext2D::create(CanvasBase& canvas, CanvasRenderingContext2DSettings&& settings)
+{
+    auto renderingContext = std::unique_ptr<OffscreenCanvasRenderingContext2D>(new OffscreenCanvasRenderingContext2D(canvas, WTFMove(settings)));
+
+    InspectorInstrumentation::didCreateCanvasRenderingContext(*renderingContext);
+
+    return renderingContext;
 }
 
 OffscreenCanvasRenderingContext2D::OffscreenCanvasRenderingContext2D(CanvasBase& canvas, CanvasRenderingContext2DSettings&& settings)

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
@@ -37,8 +37,8 @@ class OffscreenCanvasRenderingContext2D final : public CanvasRenderingContext2DB
     WTF_MAKE_ISO_ALLOCATED(OffscreenCanvasRenderingContext2D);
 public:
     static bool enabledForContext(ScriptExecutionContext&);
+    static std::unique_ptr<OffscreenCanvasRenderingContext2D> create(CanvasBase&, CanvasRenderingContext2DSettings&&);
 
-    OffscreenCanvasRenderingContext2D(CanvasBase&, CanvasRenderingContext2DSettings&&);
     virtual ~OffscreenCanvasRenderingContext2D();
 
     OffscreenCanvas& canvas() const { return downcast<OffscreenCanvas>(canvasBase()); }
@@ -52,6 +52,7 @@ public:
     Ref<TextMetrics> measureText(const String& text);
 
 private:
+    OffscreenCanvasRenderingContext2D(CanvasBase&, CanvasRenderingContext2DSettings&&);
     bool isOffscreen2d() const final { return true; }
     const FontProxy* fontProxy() final;
 };

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
@@ -33,7 +33,7 @@
     JSGenerateToJSObject,
     JSCustomMarkFunction,
     TaggedWrapper,
-    // CallTracer=InspectorCanvasCallTracer, // FIXME: OffscreenCanvas.
+    CallTracer=InspectorCanvasCallTracer,
 ] interface OffscreenCanvasRenderingContext2D {
     readonly attribute OffscreenCanvas canvas;
     undefined commit();

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -93,7 +93,8 @@ public:
     Ref<Inspector::Protocol::Canvas::Canvas> buildObjectForCanvas(bool captureBacktrace);
     Ref<Inspector::Protocol::Recording::Recording> releaseObjectForRecording();
 
-    String getCanvasContentAsDataURL(Inspector::Protocol::ErrorString&);
+    static Inspector::Protocol::ErrorStringOr<String> getContentAsDataURL(CanvasRenderingContext&);
+    Inspector::Protocol::ErrorStringOr<String> getContentAsDataURL() { return getContentAsDataURL(m_context); };
 
 private:
     explicit InspectorCanvas(CanvasRenderingContext&);

--- a/Source/WebCore/inspector/InspectorCanvasCallTracer.cpp
+++ b/Source/WebCore/inspector/InspectorCanvasCallTracer.cpp
@@ -100,16 +100,16 @@ void InspectorCanvasCallTracer::recordAction(CanvasRenderingContext& canvasRende
         canvasAgent->recordAction(canvasRenderingContext, WTFMove(name), WTFMove(arguments));
 }
 
-std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvasCallTracer::processArgument(const HTMLCanvasElement& canvasElement, uint32_t argument)
+std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvasCallTracer::processArgument(const CanvasBase& canvasBase, uint32_t argument)
 {
-    ASSERT(canvasElement.renderingContext());
-    return processArgument(*canvasElement.renderingContext(), argument);
+    ASSERT(canvasBase.renderingContext());
+    return processArgument(*canvasBase.renderingContext(), argument);
 }
 
-void InspectorCanvasCallTracer::recordAction(const HTMLCanvasElement& canvasElement, String&& name, InspectorCanvasCallTracer::ProcessedArguments&& arguments)
+void InspectorCanvasCallTracer::recordAction(const CanvasBase& canvasBase, String&& name, InspectorCanvasCallTracer::ProcessedArguments&& arguments)
 {
-    ASSERT(canvasElement.renderingContext());
-    recordAction(*canvasElement.renderingContext(), WTFMove(name), WTFMove(arguments));
+    ASSERT(canvasBase.renderingContext());
+    recordAction(*canvasBase.renderingContext(), WTFMove(name), WTFMove(arguments));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/InspectorCanvasCallTracer.h
+++ b/Source/WebCore/inspector/InspectorCanvasCallTracer.h
@@ -206,8 +206,8 @@ public:
 
     static void recordAction(CanvasRenderingContext&, String&&, ProcessedArguments&& = { });
 
-    static std::optional<ProcessedArgument> processArgument(const HTMLCanvasElement&, uint32_t);
-    static void recordAction(const HTMLCanvasElement&, String&&, ProcessedArguments&& = { });
+    static std::optional<ProcessedArgument> processArgument(const CanvasBase&, uint32_t);
+    static void recordAction(const CanvasBase&, String&&, ProcessedArguments&& = { });
 };
 
 } // namespace WebCore

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1117,6 +1117,7 @@ localizedStrings["Observer Callback"] = "Observer Callback";
 localizedStrings["Observer Handlers:"] = "Observer Handlers:";
 localizedStrings["Observers:"] = "Observers:";
 localizedStrings["Off"] = "Off";
+localizedStrings["2D"] = "2D (Offscreen)";
 /* Label for a preference that is turned off. */
 localizedStrings["Off @ User Preferences Overrides"] = "Off";
 /* Input label for the x-axis of the offset of a CSS box shadow */

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -64,6 +64,9 @@ WI.Canvas = class Canvas extends WI.Object
         case InspectorBackend.Enum.Canvas.ContextType.Canvas2D:
             contextType = WI.Canvas.ContextType.Canvas2D;
             break;
+        case InspectorBackend.Enum.Canvas.ContextType.OffscreenCanvas2D:
+            contextType = WI.Canvas.ContextType.OffscreenCanvas2D;
+            break;
         case InspectorBackend.Enum.Canvas.ContextType.BitmapRenderer:
             contextType = WI.Canvas.ContextType.BitmapRenderer;
             break;
@@ -101,6 +104,8 @@ WI.Canvas = class Canvas extends WI.Object
         switch (contextType) {
         case WI.Canvas.ContextType.Canvas2D:
             return WI.UIString("2D");
+        case WI.Canvas.ContextType.OffscreenCanvas2D:
+            return WI.UIString("Offscreen2D");
         case WI.Canvas.ContextType.BitmapRenderer:
             return WI.UIString("Bitmap Renderer", "Canvas Context Type Bitmap Renderer", "Bitmap Renderer is a type of rendering context associated with a <canvas> element");
         case WI.Canvas.ContextType.WebGL:
@@ -199,6 +204,11 @@ WI.Canvas = class Canvas extends WI.Object
         if (!this._uniqueDisplayNameNumber)
             this._uniqueDisplayNameNumber = Canvas._nextContextUniqueDisplayNameNumber++;
         return WI.UIString("Canvas %d").format(this._uniqueDisplayNameNumber);
+    }
+
+    is2D()
+    {
+        return this._contextType === Canvas.ContextType.Canvas2D || this._contextType === Canvas.ContextType.OffscreenCanvas2D;
     }
 
     requestNode()
@@ -465,6 +475,7 @@ WI.Canvas.CSSCanvasNameCookieKey = "canvas-css-canvas-name";
 
 WI.Canvas.ContextType = {
     Canvas2D: "canvas-2d",
+    OffscreenCanvas2D: "offscreen-canvas-2d",
     BitmapRenderer: "bitmaprenderer",
     WebGL: "webgl",
     WebGL2: "webgl2",

--- a/Source/WebInspectorUI/UserInterface/Models/Recording.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Recording.js
@@ -71,6 +71,9 @@ WI.Recording = class Recording extends WI.Object
         case InspectorBackend.Enum.Recording.Type.Canvas2D:
             type = WI.Recording.Type.Canvas2D;
             break;
+        case InspectorBackend.Enum.Recording.Type.OffscreenCanvas2D:
+            type = WI.Recording.Type.OffscreenCanvas2D;
+            break;
         case InspectorBackend.Enum.Recording.Type.CanvasBitmapRenderer:
             type = WI.Recording.Type.CanvasBitmapRenderer;
             break;
@@ -153,6 +156,8 @@ WI.Recording = class Recording extends WI.Object
         switch (recordingType) {
         case Recording.Type.Canvas2D:
             return WI.UIString("2D");
+        case Recording.Type.OffscreenCanvas2D:
+            return WI.UIString("2D (Offscreen)");
         case Recording.Type.CanvasBitmapRenderer:
             return WI.UIString("Bitmap Renderer", "Recording Type Canvas Bitmap Renderer", "A type of canvas recording in the Graphics Tab");
         case Recording.Type.CanvasWebGL:
@@ -254,6 +259,11 @@ WI.Recording = class Recording extends WI.Object
         consoleMessage.shouldRevealConsole = true;
 
         WI.consoleLogViewController.appendConsoleMessage(consoleMessage);
+    }
+
+    static is2D(contextType)
+    {
+        return contextType === WI.Recording.Type.Canvas2D || contextType === WI.Recording.Type.OffscreenCanvas2D;
     }
 
     // Public
@@ -515,9 +525,22 @@ WI.Recording = class Recording extends WI.Object
                 canvas.height = this._initialState.attributes.height;
             return canvas.getContext(type, ...this._initialState.parameters);
         };
+        let createOffscreenCanvasContext = (type) => {
+            let width = 1;
+            let height = 1;
+            if ("width" in this._initialState.attributes)
+                width = this._initialState.attributes.width;
+            if ("height" in this._initialState.attributes)
+                height = this._initialState.attributes.height;
+            let canvas = new OffscreenCanvas(width, height);
+            return canvas.getContext(type, ...this._initialState.parameters);
+        };
 
         if (this._type === WI.Recording.Type.Canvas2D)
             return createCanvasContext("2d");
+
+        if (this._type === WI.Recording.Type.OffscreenCanvas2D)
+            return createOffscreenCanvasContext("2d");
 
         if (this._type === WI.Recording.Type.CanvasBitmapRenderer)
             return createCanvasContext("bitmaprenderer");
@@ -555,7 +578,7 @@ WI.Recording = class Recording extends WI.Object
 
     toHTML()
     {
-        console.assert(this._type === WI.Recording.Type.Canvas2D);
+        console.assert(WI.Recording.is2D(this._type));
         console.assert(this.ready);
 
         let lines = [];
@@ -830,7 +853,7 @@ WI.Recording = class Recording extends WI.Object
         if (!this._processContext) {
             this._processContext = this.createContext();
 
-            if (this._type === WI.Recording.Type.Canvas2D) {
+            if (WI.Recording.is2D(this._type)) {
                 let initialContent = await WI.ImageUtilities.promisifyLoad(this._initialState.content);
                 this._processContext.drawImage(initialContent, 0, 0);
 
@@ -925,6 +948,7 @@ WI.Recording.CanvasRecordingNamesSymbol = Symbol("canvas-recording-names");
 
 WI.Recording.Type = {
     Canvas2D: "canvas-2d",
+    OffscreenCanvas2D: "offscreen-canvas-2d",
     CanvasBitmapRenderer: "canvas-bitmaprenderer",
     CanvasWebGL: "canvas-webgl",
     CanvasWebGL2: "canvas-webgl2",

--- a/Source/WebInspectorUI/UserInterface/Models/RecordingState.js
+++ b/Source/WebInspectorUI/UserInterface/Models/RecordingState.js
@@ -35,7 +35,7 @@ WI.RecordingState = class RecordingState
 
     static fromContext(type, context, options = {})
     {
-        if (type !== WI.Recording.Type.Canvas2D)
+        if (!WI.Recording.is2D(type))
             return null;
 
         let matrix = context.getTransform();
@@ -76,7 +76,7 @@ WI.RecordingState = class RecordingState
 
     static async swizzleInitialState(recording, initialState)
     {
-        if (recording.type === WI.Recording.Type.Canvas2D) {
+        if (WI.Recording.is2D(recording.type)) {
             let swizzledState = {};
 
             for (let [name, value] of Object.entries(initialState)) {

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js
@@ -113,7 +113,7 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
 
             let navigationBar = new WI.NavigationBar;
 
-            if (this.representedObject.contextType === WI.Canvas.ContextType.Canvas2D || this.representedObject.contextType === WI.Canvas.ContextType.BitmapRenderer || this.representedObject.contextType === WI.Canvas.ContextType.WebGL || this.representedObject.contextType === WI.Canvas.ContextType.WebGL2) {
+            if (this.representedObject.contextType === WI.Canvas.ContextType.Canvas2D || this.representedObject.contextType === WI.Canvas.ContextType.OffscreenCanvas2D || this.representedObject.contextType === WI.Canvas.ContextType.BitmapRenderer || this.representedObject.contextType === WI.Canvas.ContextType.WebGL || this.representedObject.contextType === WI.Canvas.ContextType.WebGL2) {
                 const toolTip = WI.UIString("Start recording canvas actions.\nShift-click to record a single frame.");
                 const altToolTip = WI.UIString("Stop recording canvas actions");
                 this._recordButtonNavigationItem = new WI.ToggleButtonNavigationItem("record-start-stop", toolTip, altToolTip, "Images/Record.svg", "Images/Stop.svg", 13, 13);

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.js
@@ -381,7 +381,7 @@ WI.CanvasSidebarPanel = class CanvasSidebarPanel extends WI.NavigationSidebarPan
         const selectedByUser = false;
         canvasTreeElement.revealAndSelect(omitFocus, selectedByUser);
 
-        if (WI.Canvas.ContextType.Canvas2D || this._canvas.contextType === WI.Canvas.ContextType.WebGL || this._canvas.contextType === WI.Canvas.ContextType.WebGL2)
+        if (this._canvas.contextType === WI.Canvas.ContextType.Canvas2D || this._canvas.contextType === WI.Canvas.ContextType.OffscreenCanvas2D || this._canvas.contextType === WI.Canvas.ContextType.WebGL || this._canvas.contextType === WI.Canvas.ContextType.WebGL2)
             this._recordButtonNavigationItem.enabled = true;
 
         this.recording = null;
@@ -480,7 +480,7 @@ WI.CanvasSidebarPanel = class CanvasSidebarPanel extends WI.NavigationSidebarPan
 
     _updateRecordNavigationItem()
     {
-        if (!this._canvas || !(this._canvas.contextType === WI.Canvas.ContextType.Canvas2D || this._canvas.contextType === WI.Canvas.ContextType.WebGL || this._canvas.contextType === WI.Canvas.ContextType.WebGL2)) {
+        if (!this._canvas || !(this._canvas.contextType === WI.Canvas.ContextType.Canvas2D || this._canvas.contextType === WI.Canvas.ContextType.OffscreenCanvas2D || this._canvas.contextType === WI.Canvas.ContextType.WebGL || this._canvas.contextType === WI.Canvas.ContextType.WebGL2)) {
             this._recordButtonNavigationItem.enabled = false;
             return;
         }

--- a/Source/WebInspectorUI/UserInterface/Views/RecordingContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingContentView.js
@@ -31,7 +31,7 @@ WI.RecordingContentView = class RecordingContentView extends WI.ContentView
 
         super(representedObject);
 
-        let isCanvas2D = this.representedObject.type === WI.Recording.Type.Canvas2D;
+        let isCanvas2D = this.representedObject.is2D();
         let isCanvasBitmapRenderer = this.representedObject.type === WI.Recording.Type.CanvasBitmapRenderer;
         let isCanvasWebGL = this.representedObject.type === WI.Recording.Type.CanvasWebGL;
         let isCanvasWebGL2 = this.representedObject.type === WI.Recording.Type.CanvasWebGL2;
@@ -84,7 +84,7 @@ WI.RecordingContentView = class RecordingContentView extends WI.ContentView
 
     get navigationItems()
     {
-        let isCanvas2D = this.representedObject.type === WI.Recording.Type.Canvas2D;
+        let isCanvas2D = this.representedObject.is2D();
         let isCanvasBitmapRenderer = this.representedObject.type === WI.Recording.Type.CanvasBitmapRenderer;
         let isCanvasWebGL = this.representedObject.type === WI.Recording.Type.CanvasWebGL;
         let isCanvasWebGL2 = this.representedObject.type === WI.Recording.Type.CanvasWebGL2;
@@ -132,7 +132,7 @@ WI.RecordingContentView = class RecordingContentView extends WI.ContentView
     {
         super.attached();
 
-        let isCanvas2D = this.representedObject.type === WI.Recording.Type.Canvas2D;
+        let isCanvas2D = this.representedObject.is2D();
         let isCanvasBitmapRenderer = this.representedObject.type === WI.Recording.Type.CanvasBitmapRenderer;
         let isCanvasWebGL = this.representedObject.type === WI.Recording.Type.CanvasWebGL;
         let isCanvasWebGL2 = this.representedObject.type === WI.Recording.Type.CanvasWebGL2;
@@ -216,7 +216,7 @@ WI.RecordingContentView = class RecordingContentView extends WI.ContentView
             content: JSON.stringify(this.representedObject.toJSON()),
             suggestedName: filename + ".recording",
         });
-        if (this.representedObject.type === WI.Recording.Type.Canvas2D && this.representedObject.ready) {
+        if (this.representedObject.is2D() && this.representedObject.ready) {
             data.push({
                 displayType: WI.UIString("Reduction"),
                 content: this.representedObject.toHTML(),
@@ -489,7 +489,7 @@ WI.RecordingContentView = class RecordingContentView extends WI.ContentView
         if (this._saveMode !== WI.FileUtilities.SaveMode.SingleFile)
             return;
 
-        if (this.representedObject.type === WI.Recording.Type.Canvas2D && this.representedObject.ready)
+        if (this.representedObject.is2D() && this.representedObject.ready)
             this._exportButtonNavigationItem.tooltip = WI.UIString("Export recording (%s)\nShift-click to export a HTML reduction").format(WI.saveKeyboardShortcut.displayName);
         else
             this._exportButtonNavigationItem.tooltip = WI.UIString("Export recording (%s)").format(WI.saveKeyboardShortcut.displayName);
@@ -547,7 +547,7 @@ WI.RecordingContentView = class RecordingContentView extends WI.ContentView
 
     _handleExportNavigationItemClicked(event)
     {
-        if (this._saveMode === WI.FileUtilities.SaveMode.SingleFile && this.representedObject.type === WI.Recording.Type.Canvas2D && this.representedObject.ready && event.data.nativeEvent.shiftKey) {
+        if (this._saveMode === WI.FileUtilities.SaveMode.SingleFile && this.representedObject.is2D() && this.representedObject.ready && event.data.nativeEvent.shiftKey) {
             this._exportReduction();
             return;
         }

--- a/Source/WebInspectorUI/UserInterface/Views/RecordingStateDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/RecordingStateDetailsSidebarPanel.js
@@ -42,7 +42,7 @@ WI.RecordingStateDetailsSidebarPanel = class RecordingStateDetailsSidebarPanel e
         if (!(objects instanceof Array))
             objects = [objects];
 
-        this.recording = objects.find((object) => object instanceof WI.Recording && object.type === WI.Recording.Type.Canvas2D);
+        this.recording = objects.find((object) => object instanceof WI.Recording && object.is2D());
         this.action = objects.find((object) => object instanceof WI.RecordingAction);
 
         return this._recording && this._action;
@@ -70,7 +70,7 @@ WI.RecordingStateDetailsSidebarPanel = class RecordingStateDetailsSidebarPanel e
 
         this._action = action;
 
-        if (this._action && this._recording.type === WI.Recording.Type.Canvas2D)
+        if (this._action && WI.Recording.is2D(this._recording.type))
             this._generateDetailsCanvas2D(this._action);
 
         this.updateLayoutIfNeeded();


### PR DESCRIPTION
#### 552a34376f9678e24c422e71dfdb3539bc9b096e
<pre>
Web Inspector: support OffscreenCanvas for Canvas related operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=180833">https://bugs.webkit.org/show_bug.cgi?id=180833</a>
rdar://36059660

Reviewed by Devin Rousso.

Implement Inspector support for OffscreenCanvas
OffscreenCanvasRenderingContext2D for main page (not workers).
Later commits may add support for workers.

Fixes assertion failures when bringing up Inspector for pages
that use OffscreenCanvas.

* LayoutTests/inspector/canvas/console-record-offscreen-canvas-2d-expected.txt: Added.
* LayoutTests/inspector/canvas/console-record-offscreen-canvas-2d.html: Added.
* LayoutTests/inspector/canvas/context-attributes-expected.txt:
* LayoutTests/inspector/canvas/context-attributes.html:
* LayoutTests/inspector/canvas/create-context-2d-expected.txt:
* LayoutTests/inspector/canvas/create-context-2d.html:
* LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-frameCount-expected.txt: Added.
* LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-frameCount.html: Added.
* LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-full-expected.txt: Added.
* LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-full.html: Added.
* LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-memoryLimit-expected.txt: Added.
* LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-memoryLimit.html: Added.
* LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-saves-expected.txt: Added.
* LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-saves.html: Added.
* LayoutTests/inspector/canvas/requestClientNodes-expected.txt:
* LayoutTests/inspector/canvas/requestClientNodes.html:
* LayoutTests/inspector/canvas/requestContent-2d-expected.txt:
* LayoutTests/inspector/canvas/requestContent-2d.html:
* LayoutTests/inspector/canvas/resolveContext-2d-expected.txt:
* LayoutTests/inspector/canvas/resolveContext-2d.html:
* LayoutTests/inspector/canvas/resources/create-context-utilities.js:

Add new tests for test runner .html files for tests that use recording-2d.js.
The current test driver logic is a bit too convoluted to run these tests in
the same .html runner as non-offscreen variants. Later commits can refactor
the tests if needed.

For other tests, add the tests in the respective -2d.html file.

(createDetachedCanvas):
(createCSSCanvas):
(createOffscreenCanvas):
(destroyCanvases):
* LayoutTests/inspector/canvas/resources/recording-2d.js:
(async load):
(ignoreException): Deleted.
(cancelActions): Deleted.
(performActions.executeFrameFunction): Deleted.
(performActions): Deleted.
(performConsoleActions): Deleted.
(performSavePreActions.saveAndSet): Deleted.
(performSavePreActions): Deleted.
(performSavePostActions): Deleted.
* Source/JavaScriptCore/inspector/protocol/Canvas.json:
* Source/JavaScriptCore/inspector/protocol/Recording.json:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::getContext):
* Source/WebCore/html/OffscreenCanvas.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::is2dBase const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
(WebCore::OffscreenCanvasRenderingContext2D::create):
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::resolveContext const):
(WebCore::InspectorCanvas::canvasChanged):
(WebCore::buildObjectForCanvasContextAttributes):
(WebCore::InspectorCanvas::buildObjectForCanvas):
(WebCore::InspectorCanvas::releaseObjectForRecording):
(WebCore::InspectorCanvas::getContentAsDataURL):
(WebCore::InspectorCanvas::appendActionSnapshotIfNeeded):
(WebCore::InspectorCanvas::buildInitialState):
(WebCore::InspectorCanvas::getCanvasContentAsDataURL): Deleted.
* Source/WebCore/inspector/InspectorCanvas.h:
* Source/WebCore/inspector/InspectorCanvasCallTracer.cpp:
(WebCore::InspectorCanvasCallTracer::processArgument):
(WebCore::InspectorCanvasCallTracer::recordAction):
* Source/WebCore/inspector/InspectorCanvasCallTracer.h:
(WebCore::InspectorCanvasCallTracer::recordAction):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::enable):
(WebCore::InspectorCanvasAgent::requestContent):
(WebCore::InspectorCanvasAgent::didChangeCanvasMemory):
(WebCore::InspectorCanvasAgent::startRecording):
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::canvasRenderingContext):
(WebCore::PageConsoleClient::screenshot):
(WebCore::snapshotCanvas): Deleted.
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas.fromPayload):
(WI.Canvas.displayNameForContextType):
* Source/WebInspectorUI/UserInterface/Models/Recording.js:
(WI.Recording.fromPayload):
(WI.Recording.displayNameForRecordingType):
(WI.Recording.prototype.createContext):
(WI.Recording.prototype.async _process):
(WI.Recording):
* Source/WebInspectorUI/UserInterface/Models/RecordingAction.js:
(WI.RecordingAction._prototypeForType):
(WI.RecordingAction.prototype.process):
(WI.RecordingAction.prototype.async swizzle):
* Source/WebInspectorUI/UserInterface/Models/RecordingState.js:
(WI.RecordingState.prototype.fromContext):
(WI.RecordingState.async swizzleInitialState):
* Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js:
(WI.CanvasContentView.prototype.initialLayout):
* Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.js:
(WI.CanvasSidebarPanel.prototype._canvasChanged):
(WI.CanvasSidebarPanel.prototype._updateRecordNavigationItem):
* Source/WebInspectorUI/UserInterface/Views/RecordingContentView.js:
(WI.RecordingContentView):
(WI.RecordingContentView.prototype.get navigationItems):
(WI.RecordingContentView.prototype.attached):
(WI.RecordingContentView.prototype._export):
(WI.RecordingContentView.prototype._updateExportButton):
(WI.RecordingContentView.prototype._handleExportNavigationItemClicked):
* Source/WebInspectorUI/UserInterface/Views/RecordingStateDetailsSidebarPanel.js:
(WI.RecordingStateDetailsSidebarPanel.prototype.inspect):
(WI.RecordingStateDetailsSidebarPanel.prototype.set action):

Canonical link: <a href="https://commits.webkit.org/262388@main">https://commits.webkit.org/262388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c51acbd174cbacbb40e7298b4f77deec935b32a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1120 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1278 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1918 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1138 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1099 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1145 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1183 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2253 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1226 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1093 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1283 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1162 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/259 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/351 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1220 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1286 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/255 "Passed tests") | 
<!--EWS-Status-Bubble-End-->