### PR TITLE
Set the traffic class of the NW WebRTC backend based on WebRTC backend DSCP information

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.h
@@ -29,6 +29,7 @@
 
 #include "NWSPI.h"
 #include <optional>
+#include <webrtc/rtc_base/dscp.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -40,6 +41,7 @@ namespace WebKit {
 void setNWParametersApplicationIdentifiers(nw_parameters_t, const char* sourceApplicationBundleIdentifier, std::optional<audit_token_t>, const String& attributedBundleIdentifier);
 void setNWParametersTrackerOptions(nw_parameters_t, bool shouldBypassRelay, bool isFirstParty, bool isKnownTracker);
 bool isKnownTracker(const WebCore::RegistrableDomain&);
+std::optional<uint32_t> trafficClassFromDSCP(rtc::DiffServCodePoint);
 
 } // namespace WebKit
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
@@ -80,6 +80,42 @@ bool isKnownTracker(const WebCore::RegistrableDomain& domain)
 #endif
 }
 
+std::optional<uint32_t> trafficClassFromDSCP(rtc::DiffServCodePoint dscpValue)
+{
+    switch (dscpValue) {
+    case rtc::DiffServCodePoint::DSCP_NO_CHANGE:
+        return { };
+    case rtc::DiffServCodePoint::DSCP_CS0:
+        return SO_TC_BE;
+    case rtc::DiffServCodePoint::DSCP_CS1:
+        return SO_TC_BK_SYS;
+    case rtc::DiffServCodePoint::DSCP_AF41:
+        return SO_TC_VI;
+    case rtc::DiffServCodePoint::DSCP_AF42:
+        return SO_TC_VI;
+    case rtc::DiffServCodePoint::DSCP_EF:
+        return SO_TC_VO;
+    case rtc::DiffServCodePoint::DSCP_AF11:
+    case rtc::DiffServCodePoint::DSCP_AF12:
+    case rtc::DiffServCodePoint::DSCP_AF13:
+    case rtc::DiffServCodePoint::DSCP_CS2:
+    case rtc::DiffServCodePoint::DSCP_AF21:
+    case rtc::DiffServCodePoint::DSCP_AF22:
+    case rtc::DiffServCodePoint::DSCP_AF23:
+    case rtc::DiffServCodePoint::DSCP_CS3:
+    case rtc::DiffServCodePoint::DSCP_AF31:
+    case rtc::DiffServCodePoint::DSCP_AF32:
+    case rtc::DiffServCodePoint::DSCP_AF33:
+    case rtc::DiffServCodePoint::DSCP_CS4:
+    case rtc::DiffServCodePoint::DSCP_AF43:
+    case rtc::DiffServCodePoint::DSCP_CS5:
+    case rtc::DiffServCodePoint::DSCP_CS6:
+    case rtc::DiffServCodePoint::DSCP_CS7:
+        break;
+    };
+    return { };
+}
+
 } // namespace WebKit
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebKit/Platform/spi/Cocoa/NWSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/NWSPI.h
@@ -46,6 +46,14 @@ void nw_parameters_set_is_known_tracker(nw_parameters_t, bool is_known_tracker);
 void nw_parameters_allow_sharing_port_with_listener(nw_parameters_t, nw_listener_t);
 #endif // HAVE(NWPARAMETERS_TRACKER_API)
 
+#define SO_TC_BK_SYS 100
+#define SO_TC_BE 0
+#define SO_TC_VI 700
+#define SO_TC_VO 800
+
+void nw_connection_reset_traffic_class(nw_connection_t, uint32_t traffic_class);
+void nw_parameters_set_traffic_class(nw_parameters_t, uint32_t traffic_class);
+
 WTF_EXTERN_C_END
 
 #endif // USE(APPLE_INTERNAL_SDK)


### PR DESCRIPTION
#### 51c4e45400a9953900408217cb4ac5b9a74f5f86
<pre>
Set the traffic class of the NW WebRTC backend based on WebRTC backend DSCP information
<a href="https://bugs.webkit.org/show_bug.cgi?id=254072">https://bugs.webkit.org/show_bug.cgi?id=254072</a>
rdar://106722223

Reviewed by Alex Christensen.

Set traffic class based on provided DSCP values for TCP and UDP nw sockets.

* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
(WebKit::NetworkRTCTCPSocketCocoa::setOption):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::NetworkRTCUDPSocketCocoaConnections::setOption):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm:
(WebKit::trafficClassFromDSCP):

Canonical link: <a href="https://commits.webkit.org/261917@main">https://commits.webkit.org/261917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57ecfde590891a329c0ddf0bb29227de61aacd30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121391 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5866 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/105983 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99341 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1179 "4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46400 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1219 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10551 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53211 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8330 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16900 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->