### PR TITLE
Run MockMediaSource in the GPU Process

### DIFF
--- a/LayoutTests/media/media-source/media-source-minimumupcomingpresentationtime.html
+++ b/LayoutTests/media/media-source/media-source-minimumupcomingpresentationtime.html
@@ -36,7 +36,7 @@
             makeASample(6, 6, 1, 1, 1, SAMPLE_FLAG.NONE),
             makeASample(8, 7, 1, 1, 1, SAMPLE_FLAG.NONE),
         ]);
-        
+
         run('sourceBuffer.appendBuffer(samples)');
         await waitFor(sourceBuffer, 'updateend');
 
@@ -56,7 +56,7 @@
 
         endTest();
     });
-    
+
     </script>
 </head>
 <body>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7148,11 +7148,6 @@ void HTMLMediaElement::clearMediaCacheForOrigins(const String& path, const HashS
     MediaPlayer::clearMediaCacheForOrigins(path, origins);
 }
 
-void HTMLMediaElement::resetMediaEngines()
-{
-    MediaPlayer::resetMediaEngines();
-}
-
 void HTMLMediaElement::privateBrowsingStateDidChange(PAL::SessionID sessionID)
 {
     // FIXME: We should try to reconcile this so there's no difference for PLATFORM(IOS_FAMILY).

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -496,7 +496,6 @@ public:
     WEBCORE_EXPORT static HashSet<SecurityOriginData> originsInMediaCache(const String&);
     WEBCORE_EXPORT static void clearMediaCache(const String&, WallTime modifiedSince = { });
     WEBCORE_EXPORT static void clearMediaCacheForOrigins(const String&, const HashSet<SecurityOriginData>&);
-    static void resetMediaEngines();
 
     bool isPlaying() const final { return m_playing; }
 

--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -29,7 +29,9 @@
 #include "AudioSession.h"
 #include "HTMLMediaElement.h"
 #include "MediaPlayer.h"
+#include "MediaStrategy.h"
 #include "PlatformMediaSessionManager.h"
+#include "PlatformStrategies.h"
 #include <wtf/NeverDestroyed.h>
 
 #if PLATFORM(COCOA)
@@ -84,7 +86,7 @@ void DeprecatedGlobalSettings::setAVFoundationEnabled(bool enabled)
         return;
 
     shared().m_AVFoundationEnabled = enabled;
-    HTMLMediaElement::resetMediaEngines();
+    platformStrategies()->mediaStrategy().resetMediaEngines();
 }
 #endif
 
@@ -97,7 +99,7 @@ void DeprecatedGlobalSettings::setGStreamerEnabled(bool enabled)
     shared().m_GStreamerEnabled = enabled;
 
 #if ENABLE(VIDEO)
-    HTMLMediaElement::resetMediaEngines();
+    platformStrategies()->mediaStrategy().resetMediaEngines();
 #endif
 }
 #endif

--- a/Source/WebCore/platform/MediaStrategy.cpp
+++ b/Source/WebCore/platform/MediaStrategy.cpp
@@ -26,6 +26,12 @@
 #include "config.h"
 #include "MediaStrategy.h"
 
+#include "MediaPlayer.h"
+#if ENABLE(MEDIA_SOURCE)
+#include "DeprecatedGlobalSettings.h"
+#include "MockMediaPlayerMediaSource.h"
+#endif
+
 namespace WebCore {
 
 MediaStrategy::MediaStrategy() = default;
@@ -36,5 +42,36 @@ std::unique_ptr<NowPlayingManager> MediaStrategy::createNowPlayingManager() cons
 {
     return makeUnique<NowPlayingManager>();
 }
+
+void MediaStrategy::resetMediaEngines()
+{
+#if ENABLE(VIDEO)
+    MediaPlayer::resetMediaEngines();
+#endif
+    m_mockMediaSourceEnabled = false;
+}
+
+#if ENABLE(MEDIA_SOURCE)
+void MediaStrategy::enableMockMediaSource()
+{
+#if USE(AVFOUNDATION)
+    WebCore::DeprecatedGlobalSettings::setAVFoundationEnabled(false);
+#endif
+#if USE(GSTREAMER)
+    WebCore::DeprecatedGlobalSettings::setGStreamerEnabled(false);
+#endif
+    addMockMediaSourceEngine();
+}
+
+bool MediaStrategy::mockMediaSourceEnabled() const
+{
+    return m_mockMediaSourceEnabled;
+}
+
+void MediaStrategy::addMockMediaSourceEngine()
+{
+    MediaPlayerFactorySupport::callRegisterMediaEngine(MockMediaPlayerMediaSource::registerMediaEngine);
+}
+#endif
 
 }

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -43,10 +43,16 @@ public:
         AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate) = 0;
 #endif
     virtual std::unique_ptr<NowPlayingManager> createNowPlayingManager() const;
-
+    void resetMediaEngines();
+#if ENABLE(MEDIA_SOURCE)
+    virtual void enableMockMediaSource();
+    bool mockMediaSourceEnabled() const;
+    static void addMockMediaSourceEngine();
+#endif
 protected:
     MediaStrategy();
     virtual ~MediaStrategy();
+    bool m_mockMediaSourceEnabled { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -97,11 +97,6 @@ MediaPlayer::SupportsType MockMediaPlayerMediaSource::supportsType(const MediaEn
 
 MockMediaPlayerMediaSource::MockMediaPlayerMediaSource(MediaPlayer* player)
     : m_player(player)
-    , m_currentTime(MediaTime::zeroTime())
-    , m_readyState(MediaPlayer::ReadyState::HaveNothing)
-    , m_networkState(MediaPlayer::NetworkState::Empty)
-    , m_playing(false)
-    , m_seekCompleted(true)
 {
 }
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef MockMediaPlayerMediaSource_h
@@ -97,10 +97,10 @@ private:
 
     MediaTime m_currentTime;
     MediaTime m_duration;
-    MediaPlayer::ReadyState m_readyState;
-    MediaPlayer::NetworkState m_networkState;
-    bool m_playing;
-    bool m_seekCompleted;
+    MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
+    MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
+    bool m_playing { false };
+    bool m_seekCompleted { false };
 };
 
 }

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -46,6 +46,8 @@ public:
 
     void clearMediaSource() { m_mediaSource = nullptr; }
 
+    bool isActive() const final;
+
 private:
     explicit MockSourceBufferPrivate(MockMediaSourcePrivate*);
 
@@ -67,7 +69,6 @@ private:
     void enqueueSample(Ref<MediaSample>&&, const AtomString&) final;
     bool isReadyForMoreSamples(const AtomString&) final { return !m_maxQueueDepth || m_enqueuedSamples.size() < m_maxQueueDepth.value(); }
     void setActive(bool) final;
-    bool isActive() const final;
 
     void enqueuedSamplesForTrackID(const AtomString&, CompletionHandler<void(Vector<String>&&)>&&) final;
     MediaTime minimumUpcomingPresentationTimeForTrackID(const AtomString&) final;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -146,6 +146,7 @@
 #include "MediaResourceLoader.h"
 #include "MediaSession.h"
 #include "MediaSessionActionDetails.h"
+#include "MediaStrategy.h"
 #include "MediaStreamTrack.h"
 #include "MediaUsageInfo.h"
 #include "MemoryCache.h"
@@ -315,10 +316,6 @@
 
 #if USE(LIBWEBRTC)
 #include "LibWebRTCProvider.h"
-#endif
-
-#if ENABLE(MEDIA_SOURCE)
-#include "MockMediaPlayerMediaSource.h"
 #endif
 
 #if ENABLE(CONTENT_FILTERING)
@@ -4449,13 +4446,7 @@ bool Internals::isPluginSnapshotted(Element&)
 
 void Internals::initializeMockMediaSource()
 {
-#if USE(AVFOUNDATION)
-    WebCore::DeprecatedGlobalSettings::setAVFoundationEnabled(false);
-#endif
-#if USE(GSTREAMER)
-    WebCore::DeprecatedGlobalSettings::setGStreamerEnabled(false);
-#endif
-    MediaPlayerFactorySupport::callRegisterMediaEngine(MockMediaPlayerMediaSource::registerMediaEngine);
+    platformStrategies()->mediaStrategy().enableMockMediaSource();
 }
 
 void Internals::bufferedSamplesForTrackId(SourceBuffer& buffer, const AtomString& trackId, BufferedSamplesPromise&& promise)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -67,6 +67,7 @@
 #include "WebGPUObjectHeap.h"
 #include "WebProcessMessages.h"
 #include <WebCore/LogInitialization.h>
+#include <WebCore/MediaPlayer.h>
 #include <WebCore/MockRealtimeMediaSourceCenter.h>
 #include <WebCore/NowPlayingManager.h>
 #include <wtf/Language.h>
@@ -88,6 +89,10 @@
 #include "RemoteCDMInstanceProxyMessages.h"
 #include "RemoteCDMInstanceSessionProxyMessages.h"
 #include "RemoteCDMProxyMessages.h"
+#endif
+
+#if ENABLE(MEDIA_SOURCE)
+#include <WebCore/MediaStrategy.h>
 #endif
 
 // FIXME: <https://bugs.webkit.org/show_bug.cgi?id=211085>
@@ -1043,6 +1048,16 @@ void GPUConnectionToWebProcess::dispatchDisplayWasReconfigured()
 void GPUConnectionToWebProcess::enableVP9Decoders(bool shouldEnableVP8Decoder, bool shouldEnableVP9Decoder, bool shouldEnableVP9SWDecoder)
 {
     m_gpuProcess->enableVP9Decoders(shouldEnableVP8Decoder, shouldEnableVP9Decoder, shouldEnableVP9SWDecoder);
+}
+#endif
+
+#if ENABLE(MEDIA_SOURCE)
+void GPUConnectionToWebProcess::enableMockMediaSource()
+{
+    if (m_mockMediaSourceEnabled)
+        return;
+    MediaStrategy::addMockMediaSourceEngine();
+    m_mockMediaSourceEnabled = true;
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -260,6 +260,10 @@ private:
     void enableVP9Decoders(bool shouldEnableVP8Decoder, bool shouldEnableVP9Decoder, bool shouldEnableVP9SWDecoder);
 #endif
 
+#if ENABLE(MEDIA_SOURCE)
+    void enableMockMediaSource();
+#endif
+
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     void createVisibilityPropagationContextForPage(WebPageProxyIdentifier, WebCore::PageIdentifier, bool canShowWhileLocked);
     void destroyVisibilityPropagationContextForPage(WebPageProxyIdentifier, WebCore::PageIdentifier);
@@ -389,6 +393,9 @@ private:
     bool m_isActiveNowPlayingProcess { false };
     bool m_isLockdownModeEnabled { false };
     bool m_allowTestOnlyIPC { false };
+#if ENABLE(MEDIA_SOURCE)
+    bool m_mockMediaSourceEnabled { false };
+#endif
 
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
     UniqueRef<LocalAudioSessionRoutingArbitrator> m_routingArbitrator;

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -58,6 +58,9 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
     CreateWCLayerTreeHost(WebKit::WCLayerTreeHostIdentifier identifier, uint64_t nativeWindow, bool usesOffscreenRendering) AllowedWhenWaitingForSyncReply
     ReleaseWCLayerTreeHost(WebKit::WCLayerTreeHostIdentifier identifier) AllowedWhenWaitingForSyncReply
 #endif
+#if ENABLE(MEDIA_SESSION)
+    EnableMockMediaSource();
+#endif
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -957,8 +957,10 @@ void RemoteMediaPlayerProxy::updateCachedState(bool forceCurrentTimeUpdate)
     maybeUpdateCachedVideoMetrics();
     if (m_bufferedChanged) {
         m_bufferedChanged = false;
-        if (m_engineIdentifier != MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE)
+        if (m_engineIdentifier != MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE
+            && m_engineIdentifier != MediaPlayerEnums::MediaEngineIdentifier::MockMSE) {
             m_cachedState.bufferedRanges = *m_player->buffered();
+        }
     }
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -375,6 +375,16 @@ void RemoteSourceBufferProxy::memoryPressure(uint64_t maximumBufferSize, const M
     completionHandler(WTFMove(buffered), m_sourceBufferPrivate->totalTrackBufferSizeInBytes());
 }
 
+void RemoteSourceBufferProxy::minimumUpcomingPresentationTimeForTrackID(const AtomString& trackID, CompletionHandler<void(MediaTime)>&& completionHandler)
+{
+    completionHandler(m_sourceBufferPrivate->minimumUpcomingPresentationTimeForTrackID(trackID));
+}
+
+void RemoteSourceBufferProxy::setMaximumQueueDepthForTrackID(const AtomString& trackID, uint64_t depth)
+{
+    m_sourceBufferPrivate->setMaximumQueueDepthForTrackID(trackID, depth);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -115,6 +115,8 @@ private:
     void bufferedSamplesForTrackId(TrackPrivateRemoteIdentifier, CompletionHandler<void(Vector<String>&&)>&&);
     void enqueuedSamplesForTrackID(TrackPrivateRemoteIdentifier, CompletionHandler<void(Vector<String>&&)>&&);
     void memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded, CompletionHandler<void(WebCore::PlatformTimeRanges&&, uint64_t)>&&);
+    void minimumUpcomingPresentationTimeForTrackID(const AtomString&, CompletionHandler<void(MediaTime)>&&);
+    void setMaximumQueueDepthForTrackID(const AtomString&, uint64_t);
 
     WeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
     RemoteSourceBufferIdentifier m_identifier;

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -56,6 +56,8 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     BufferedSamplesForTrackId(WebKit::TrackPrivateRemoteIdentifier remoteIdentifier) -> (Vector<String> samples)
     EnqueuedSamplesForTrackID(WebKit::TrackPrivateRemoteIdentifier remoteIdentifier) -> (Vector<String> samples)
     MemoryPressure(uint64_t maximumBufferSize, MediaTime currentTime, bool isEnded) -> (WebCore::PlatformTimeRanges buffered, uint64_t totalTrackBufferSizeInBytes)
+    SetMaximumQueueDepthForTrackID(AtomString trackID, uint64_t depth)
+    MinimumUpcomingPresentationTimeForTrackID(AtomString trackID) -> (MediaTime time) Synchronous
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -44,9 +44,11 @@
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/MediaPlayer.h>
+#include <WebCore/MediaStrategy.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/PlatformLayer.h>
 #include <WebCore/PlatformScreen.h>
+#include <WebCore/PlatformStrategies.h>
 #include <WebCore/PlatformTimeRanges.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/SecurityOrigin.h>
@@ -783,7 +785,8 @@ void MediaPlayerPrivateRemote::remoteVideoTrackConfigurationChanged(TrackPrivate
 #if ENABLE(MEDIA_SOURCE)
 void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentType, MediaSourcePrivateClient& client)
 {
-    if (m_remoteEngineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE) {
+    if (m_remoteEngineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE
+        || (platformStrategies()->mediaStrategy().mockMediaSourceEnabled() && m_remoteEngineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::MockMSE)) {
         auto identifier = RemoteMediaSourceIdentifier::generate();
         connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::LoadMediaSource(url, contentType, DeprecatedGlobalSettings::webMParserEnabled(), identifier), [weakThis = WeakPtr { *this }, this](auto&& configuration) {
             if (!weakThis)

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -490,6 +490,24 @@ void SourceBufferPrivateRemote::memoryPressure(uint64_t maximumBufferSize, const
         m_remoteSourceBufferIdentifier);
 }
 
+MediaTime SourceBufferPrivateRemote::minimumUpcomingPresentationTimeForTrackID(const AtomString& trackID)
+{
+    if (!m_gpuProcessConnection)
+        return MediaTime::invalidTime();
+    auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteSourceBufferProxy::MinimumUpcomingPresentationTimeForTrackID(trackID), m_remoteSourceBufferIdentifier);
+
+    return std::get<0>(sendResult.takeReplyOr(MediaTime::invalidTime()));
+}
+
+void SourceBufferPrivateRemote::setMaximumQueueDepthForTrackID(const AtomString& trackID, uint64_t depth)
+{
+    if (!m_gpuProcessConnection)
+        return;
+
+    m_gpuProcessConnection->connection().send(
+        Messages::RemoteSourceBufferProxy::SetMaximumQueueDepthForTrackID(trackID, depth), m_remoteSourceBufferIdentifier);
+}
+
 
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& SourceBufferPrivateRemote::logChannel() const

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -121,6 +121,8 @@ private:
     void sourceBufferPrivateDidDropSample();
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode);
     void sourceBufferPrivateReportExtraMemoryCost(uint64_t extraMemory);
+    MediaTime minimumUpcomingPresentationTimeForTrackID(const AtomString&) override;
+    void setMaximumQueueDepthForTrackID(const AtomString&, uint64_t) override;
 
     WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     RemoteSourceBufferIdentifier m_remoteSourceBufferIdentifier;

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-class WebMediaStrategy : public WebCore::MediaStrategy {
+class WebMediaStrategy final : public WebCore::MediaStrategy {
 public:
     virtual ~WebMediaStrategy();
 
@@ -43,6 +43,9 @@ private:
         const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate) override;
 #endif
     std::unique_ptr<WebCore::NowPlayingManager> createNowPlayingManager() const final;
+#if ENABLE(MEDIA_SOURCE)
+    void enableMockMediaSource() final;
+#endif
 
 #if ENABLE(GPU_PROCESS)
     bool m_useGPUProcess { false };


### PR DESCRIPTION
#### 9faed3b669e65d2fcb6157b6aa8c483500d22547
<pre>
Run MockMediaSource in the GPU Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=254074">https://bugs.webkit.org/show_bug.cgi?id=254074</a>
rdar://106858091

Reviewed by Youenn Fablet.

Related changes:
- Fix crashes when running/media/media-source/media-source-minimumupcomingpresentationtime.html,
some missing methods with the RemoteSourceBufferProxy required to run this
test.
- Use C++11 initializers in MockMediaPlayerMediaSource

Covered by existing tests.

* LayoutTests/media/media-source/media-source-minimumupcomingpresentationtime.html: whitespace changes.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::resetMediaEngines): Deleted.
* Source/WebCore/html/HTMLMediaElement.h: Delete resetMediaEngines, use mediaStragegy&apos;s resetMediaEngines instead.
* Source/WebCore/page/DeprecatedGlobalSettings.cpp: Use resetMediaEngines from mediaStrategy.
(WebCore::DeprecatedGlobalSettings::setAVFoundationEnabled):
(WebCore::DeprecatedGlobalSettings::setGStreamerEnabled):
* Source/WebCore/platform/MediaStrategy.cpp:
(WebCore::MediaStrategy::resetMediaEngines):
(WebCore::MediaStrategy::enableMockMediaSource):
(WebCore::MediaStrategy::mockMediaSourceEnabled const):
(WebCore::MediaStrategy::addMockMediaSourceEngine):
* Source/WebCore/platform/MediaStrategy.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(buildMediaEnginesVector()): Add MockMSE support to registerRemoteEngine.
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp: Use C++11 initializers.
(WebCore::MockMediaPlayerMediaSource::MockMediaPlayerMediaSource):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::initializeMockMediaSource):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::enableMockMediaSource):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::updateCachedState):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::minimumUpcomingPresentationTimeForTrackID):
(WebKit::RemoteSourceBufferProxy::setMaximumQueueDepthForTrackID):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::load):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::minimumUpcomingPresentationTimeForTrackID):
(WebKit::SourceBufferPrivateRemote::setMaximumQueueDepthForTrackID):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::enableMockMediaSource):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:
(WebKit::WebMediaStrategy::enableMockMediaSource): Add method

Canonical link: <a href="https://commits.webkit.org/262173@main">https://commits.webkit.org/262173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1047a724c63a882ad89b9e6f6695e3555dd59a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/903 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/955 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/731 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/690 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/736 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1703 "260 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/703 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/721 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/189 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/731 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->