### PR TITLE
CSS Nesting: fix performance regression by storing selector in StyleRule

### DIFF
--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -83,6 +83,9 @@ StylePropertyMap& CSSStyleRule::styleMap()
 
 String CSSStyleRule::generateSelectorText() const
 {
+    if (m_styleRule->isStyleRuleWithNesting())
+        return downcast<StyleRuleWithNesting>(m_styleRule.get()).originalSelectorList().selectorsText();
+
     return m_styleRule->selectorList().selectorsText();
 }
 

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -303,15 +303,6 @@ Vector<RefPtr<StyleRule>> StyleRule::splitIntoMultipleRulesWithMaximumSelectorCo
     return rules;
 }
 
-
-const CSSSelectorList& StyleRule::resolvedSelectorList() const
-{
-    if (isStyleRuleWithNesting())
-        return downcast<StyleRuleWithNesting>(*this).resolvedSelectorList();
-
-    return m_selectorList;
-}
-
 Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)
 { 
     return adoptRef(* new StyleRuleWithNesting(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(selectors), WTFMove(nestedRules)));
@@ -320,13 +311,9 @@ Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(Ref<StyleProperties>&& pr
 StyleRuleWithNesting::StyleRuleWithNesting(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)
     : StyleRule(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(selectors))
     , m_nestedRules(WTFMove(nestedRules))
+    , m_originalSelectorList(selectorList())
 { 
     setType(StyleRuleType::StyleWithNesting);
-}
-
-void StyleRuleWithNesting::setResolvedSelectorList(CSSSelectorList&& selectorList) const
-{
-    m_resolvedSelectorList = WTFMove(selectorList);
 }
 
 StyleRulePage::StyleRulePage(Ref<StyleProperties>&& properties, CSSSelectorList&& selectors)

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -160,15 +160,14 @@ public:
     static Ref<StyleRuleWithNesting> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
 
     const Vector<Ref<StyleRuleBase>>& nestedRules() const { return m_nestedRules; }
-    const CSSSelectorList& resolvedSelectorList() const { return m_resolvedSelectorList; }
-    void setResolvedSelectorList(CSSSelectorList&&) const;
+    const CSSSelectorList& originalSelectorList() const { return m_originalSelectorList; }
     StyleRuleWithNesting(const StyleRuleWithNesting&) = delete;
 
 private:
     StyleRuleWithNesting(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
 
     Vector<Ref<StyleRuleBase>> m_nestedRules;
-    mutable CSSSelectorList m_resolvedSelectorList;
+    CSSSelectorList m_originalSelectorList;
 };
 
 class StyleRuleFontFace final : public StyleRuleBase {

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -1275,7 +1275,7 @@ Ref<JSON::ArrayOf<Protocol::CSS::RuleMatch>> InspectorCSSAgent::buildArrayForMat
             continue;
 
         auto matchingSelectors = JSON::ArrayOf<int>::create();
-        const CSSSelectorList& selectorList = matchedRule->resolvedSelectorList();
+        const CSSSelectorList& selectorList = matchedRule->selectorList();
         int index = 0;
         for (const CSSSelector* selector = selectorList.first(); selector; selector = CSSSelectorList::next(selector)) {
             bool matched = selectorChecker.match(*selector, element, context);

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -48,8 +48,7 @@ public:
 
     const CSSSelector* selector() const
     { 
-        auto& selectorList = m_styleRule->resolvedSelectorList();
-        return selectorList.selectorAt(m_selectorIndex);
+        return m_styleRule->selectorList().selectorAt(m_selectorIndex);
     }
 
 #if ENABLE(CSS_SELECTOR_JIT)

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -215,13 +215,14 @@ void RuleSetBuilder::addRulesFromSheetContents(const StyleSheetContents& sheet)
     addChildRules(sheet.childRules());
 }
 
-void RuleSetBuilder::populateStyleRuleResolvedSelectorList(const StyleRuleWithNesting& rule)
+void RuleSetBuilder::resolveSelectorListWithNesting(StyleRuleWithNesting& rule)
 {
     const CSSSelectorList* parentResolvedSelectorList = nullptr;
     if (m_styleRuleStack.size()) 
         parentResolvedSelectorList =  m_styleRuleStack.last();
     auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(rule.selectorList(), parentResolvedSelectorList);
-    rule.setResolvedSelectorList(WTFMove(resolvedSelectorList));    
+    ASSERT(!resolvedSelectorList.hasExplicitNestingParent());
+    rule.wrapperAdoptSelectorList(WTFMove(resolvedSelectorList));    
 }
 
 void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selectorList, const StyleRule& rule)
@@ -237,11 +238,11 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
     }
 }
 
-void RuleSetBuilder::addStyleRule(const StyleRuleWithNesting& rule)
+void RuleSetBuilder::addStyleRule(StyleRuleWithNesting& rule)
 {
-    populateStyleRuleResolvedSelectorList(rule);
+    resolveSelectorListWithNesting(rule);
 
-    auto& selectorList = rule.resolvedSelectorList();
+    auto& selectorList = rule.selectorList();
     addStyleRuleWithSelectorList(selectorList, rule);
     
     // Process nested rules

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -39,7 +39,7 @@ public:
 private:
     RuleSetBuilder(const MQ::MediaQueryEvaluator&);
 
-    void addStyleRule(const StyleRuleWithNesting&);
+    void addStyleRule(StyleRuleWithNesting&);
     void addRulesFromSheetContents(const StyleSheetContents&);
     void addChildRules(const Vector<RefPtr<StyleRuleBase>>&);
     void addChildRule(RefPtr<StyleRuleBase>);
@@ -53,7 +53,7 @@ private:
     
     void addMutatingRulesToResolver();
     void updateDynamicMediaQueries();
-    void populateStyleRuleResolvedSelectorList(const StyleRuleWithNesting&);
+    void resolveSelectorListWithNesting(StyleRuleWithNesting&);
 
     struct MediaQueryCollector {
         ~MediaQueryCollector();


### PR DESCRIPTION
#### 29a55829552726ea8b7310c95c3ff4bbcf591583
<pre>
CSS Nesting: fix performance regression by storing selector in StyleRule
<a href="https://bugs.webkit.org/show_bug.cgi?id=252904">https://bugs.webkit.org/show_bug.cgi?id=252904</a>
rdar://105883716

Reviewed by Antti Koivisto.

CSS Nesting introduces a performance regression in selector
matching because of a branch to select the appropriate selector list
(user-written/nested one VS resolved/flatten one).

This patch stores the resolved selector list in the original StyleRule,
thus allowing to have only this object to perform selector matching.

The original user-written selector list is stored in the StyleRuleWithNesting
object which is not an issue because it&apos;s never in a hot code path.

* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::generateSelectorText const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleWithNesting::StyleRuleWithNesting):
(WebCore::StyleRule::resolvedSelectorList const): Deleted.
(WebCore::StyleRuleWithNesting::setResolvedSelectorList const): Deleted.
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::buildArrayForMatchedRuleList):
* Source/WebCore/style/RuleData.h:
(WebCore::Style::RuleData::selector const):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::resolveSelectorListWithNesting):
(WebCore::Style::RuleSetBuilder::addStyleRule):
(WebCore::Style::RuleSetBuilder::populateStyleRuleResolvedSelectorList): Deleted.
* Source/WebCore/style/RuleSetBuilder.h:

Canonical link: <a href="https://commits.webkit.org/261809@main">https://commits.webkit.org/261809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aef2cdd71e476471e03cb22dde104783623e97e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112932 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/22090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4708 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13251 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118719 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106021 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/1203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14385 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1243 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15090 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20401 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53235 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8243 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16941 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->