### PR TITLE
Use CheckedRef for m_documentLoader in ApplicationCacheHost

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -164,6 +164,7 @@ using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentLoader);
 class DocumentLoader
     : public RefCounted<DocumentLoader>
+    , public CanMakeCheckedPtr
     , public FrameDestructionObserver
     , public ContentSecurityPolicyClient
 #if ENABLE(CONTENT_FILTERING)

--- a/Source/WebCore/loader/appcache/ApplicationCacheHost.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheHost.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -151,7 +152,7 @@ private:
     bool maybeLoadFallbackForMainError(const ResourceRequest&, const ResourceError&);
 
     WeakPtr<DOMApplicationCache, WeakPtrImplWithEventTargetData> m_domApplicationCache;
-    DocumentLoader& m_documentLoader;
+    CheckedRef<DocumentLoader> m_documentLoader;
 
     bool m_defersEvents { true }; // Events are deferred until after document onload.
     Vector<DeferredEvent> m_deferredEvents;


### PR DESCRIPTION
#### 1b354fa4ac8a76b80ec9678da8d00c67adca663a
<pre>
Use CheckedRef for m_documentLoader in ApplicationCacheHost
<a href="https://bugs.webkit.org/show_bug.cgi?id=254086">https://bugs.webkit.org/show_bug.cgi?id=254086</a>
rdar://106870953

Reviewed by Ryosuke Niwa.

DocumentLoader is RefCountable so we should use a smart pointer for
ApplicationCacheHost&apos;s m_documentLoader member variable.

* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/appcache/ApplicationCacheHost.cpp:
(WebCore::ApplicationCacheHost::ApplicationCacheHost):
(WebCore::ApplicationCacheHost::selectCacheWithoutManifest):
(WebCore::ApplicationCacheHost::selectCacheWithManifest):
(WebCore::ApplicationCacheHost::canLoadMainResource):
(WebCore::ApplicationCacheHost::maybeLoadMainResource):
(WebCore::ApplicationCacheHost::maybeLoadFallbackForMainResponse):
(WebCore::ApplicationCacheHost::maybeLoadFallbackForMainError):
(WebCore::ApplicationCacheHost::maybeLoadResource):
(WebCore::ApplicationCacheHost::maybeLoadFallbackForError):
(WebCore::ApplicationCacheHost::maybeLoadSynchronously):
(WebCore::ApplicationCacheHost::notifyDOMApplicationCache):
(WebCore::ApplicationCacheHost::shouldLoadResourceFromApplicationCache):
(WebCore::ApplicationCacheHost::scheduleLoadFallbackResourceFromApplicationCache):
(WebCore::ApplicationCacheHost::update):
(WebCore::ApplicationCacheHost::swapCache):
(WebCore::ApplicationCacheHost::abort):
(WebCore::ApplicationCacheHost::isApplicationCacheEnabled):
(WebCore::ApplicationCacheHost::isApplicationCacheBlockedForRequest):
* Source/WebCore/loader/appcache/ApplicationCacheHost.h:

Canonical link: <a href="https://commits.webkit.org/261896@main">https://commits.webkit.org/261896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec866f1ca507f1d8f35cd2e612c1513a186fbc91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4740 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121454 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5934 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106055 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46458 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1270 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10724 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53262 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8313 "'git push ...'") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16972 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->