### PR TITLE
Fix test crash because of missing copy() method

### DIFF
--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -171,7 +171,11 @@ String CSSStyleRule::cssText() const
 
 void CSSStyleRule::reattach(StyleRuleBase& rule)
 {
-    m_styleRule = downcast<StyleRule>(rule);
+    if (m_styleRule->isStyleRuleWithNesting())
+        m_styleRule = downcast<StyleRuleWithNesting>(rule);
+    else
+        m_styleRule = downcast<StyleRule>(rule);
+
     if (m_propertiesCSSOMWrapper)
         m_propertiesCSSOMWrapper->reattach(m_styleRule->mutableProperties());
 }

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -303,6 +303,21 @@ Vector<RefPtr<StyleRule>> StyleRule::splitIntoMultipleRulesWithMaximumSelectorCo
     return rules;
 }
 
+StyleRuleWithNesting::~StyleRuleWithNesting() = default;
+
+Ref<StyleRuleWithNesting> StyleRuleWithNesting::copy() const
+{
+    return adoptRef(*new StyleRuleWithNesting(*this));
+}
+
+StyleRuleWithNesting::StyleRuleWithNesting(const StyleRuleWithNesting& other)
+    : StyleRule(other)
+    , m_nestedRules(other.m_nestedRules.map( [](auto& rule) { return rule->copy(); }))
+    , m_originalSelectorList(other.m_originalSelectorList)
+{
+
+}
+
 Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)
 { 
     return adoptRef(* new StyleRuleWithNesting(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(selectors), WTFMove(nestedRules)));

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -158,10 +158,12 @@ class StyleRuleWithNesting final : public StyleRule {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleWithNesting);
 public:
     static Ref<StyleRuleWithNesting> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+    Ref<StyleRuleWithNesting> copy() const;
 
     const Vector<Ref<StyleRuleBase>>& nestedRules() const { return m_nestedRules; }
     const CSSSelectorList& originalSelectorList() const { return m_originalSelectorList; }
-    StyleRuleWithNesting(const StyleRuleWithNesting&) = delete;
+    StyleRuleWithNesting(const StyleRuleWithNesting&);
+    ~StyleRuleWithNesting();
 
 private:
     StyleRuleWithNesting(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);


### PR DESCRIPTION
#### 1274b2e8578441d52ca523154721d24ccd4f8335
<pre>
Fix test crash because of missing copy() method
<a href="https://bugs.webkit.org/show_bug.cgi?id=253723">https://bugs.webkit.org/show_bug.cgi?id=253723</a>
rdar://106561354

Reviewed by Brent Fulgham.

The visitDerived() dispatcher was calling StyleRule::copy()
because there was no implementation for StyleRuleWithNesting::copy().

A follow-up patch could improve the static assertion in copy() to catch that
at compile-time.

* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::reattach):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleWithNesting::copy const):
(WebCore::StyleRuleWithNesting::StyleRuleWithNesting):
(WebCore::m_originalSelectorList):
* Source/WebCore/css/StyleRule.h:

Canonical link: <a href="https://commits.webkit.org/261815@main">https://commits.webkit.org/261815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5ebed6019f8416f76a0148722c306788ec15770

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112942 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4718 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118729 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106032 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1211 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14395 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1251 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15100 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53243 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8247 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16951 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->