### PR TITLE
REGRESSION(261320@main): [GLib] Broke WebKitUserContentManager::script-message-received

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -106,7 +106,11 @@ static void webkit_user_content_manager_class_init(WebKitUserContentManagerClass
             G_TYPE_FROM_CLASS(gObjectClass),
             static_cast<GSignalFlags>(G_SIGNAL_RUN_LAST | G_SIGNAL_DETAILED),
             0, nullptr, nullptr,
+#if ENABLE(2022_GLIB_API)
+            g_cclosure_marshal_VOID__OBJECT,
+#else
             g_cclosure_marshal_VOID__BOXED,
+#endif
             G_TYPE_NONE, 1,
 #if ENABLE(2022_GLIB_API)
             JSC_TYPE_VALUE);


### PR DESCRIPTION
#### fa61ab3f24678c03f96ca6c4a51a8c7e21439f83
<pre>
REGRESSION(261320@main): [GLib] Broke WebKitUserContentManager::script-message-received
<a href="https://bugs.webkit.org/show_bug.cgi?id=254089">https://bugs.webkit.org/show_bug.cgi?id=254089</a>

Reviewed by Adrian Perez de Castro.

I forgot to update the marshaller used by
WebKitUserContentManager::script-message-received. It worked perfectly
fine in my development environment for whatever reason, but was broken
in at least Ephy Tech Preview.

* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:

Canonical link: <a href="https://commits.webkit.org/261810@main">https://commits.webkit.org/261810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bcb97382f2f347dc348c3c31416ae7fd760ce6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121429 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13252 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/5899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118720 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106022 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1198 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14386 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1238 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15091 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53230 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8245 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16942 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->