### PR TITLE
Passkey access groups

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.h
@@ -53,6 +53,7 @@ public:
     bool synchronizable() const { return m_synchronizable; }
     LAContext * laContext() const { return m_laContext.get(); }
     RefPtr<ArrayBuffer> largeBlob() const { return m_largeBlob; }
+    const String& accessGroup() const { return m_accessGroup; }
 
     WEBCORE_EXPORT void setAuthenticatorData(Vector<uint8_t>&&);
     void setSignature(Ref<ArrayBuffer>&& signature) { m_signature = WTFMove(signature); }
@@ -63,6 +64,7 @@ public:
     void setSynchronizable(bool synchronizable) { m_synchronizable = synchronizable; }
     void setLAContext(LAContext *context) { m_laContext = context; }
     void setLargeBlob(Ref<ArrayBuffer>&& largeBlob) { m_largeBlob = WTFMove(largeBlob); }
+    void setAccessGroup(const String& accessGroup) { m_accessGroup = accessGroup; }
 
 private:
     AuthenticatorAssertionResponse(Ref<ArrayBuffer>&&, Ref<ArrayBuffer>&&, Ref<ArrayBuffer>&&, RefPtr<ArrayBuffer>&&, AuthenticatorAttachment);
@@ -83,6 +85,7 @@ private:
     RetainPtr<SecAccessControlRef> m_accessControl;
     RetainPtr<LAContext> m_laContext;
     RefPtr<ArrayBuffer> m_largeBlob;
+    String m_accessGroup;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
@@ -45,6 +45,7 @@ public:
     bool synchronizable() const { return m_response->synchronizable(); }
     const WTF::String& group() const { return m_response->group(); }
     RefPtr<Data> credentialID() const;
+    const WTF::String& accessGroup() const { return m_response->accessGroup(); }
 
     void setLAContext(LAContext *context) { m_response->setLAContext(context); }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h
@@ -39,6 +39,7 @@ WK_CLASS_AVAILABLE(macos(11.0), ios(14.0))
 @property (nonatomic, readonly) BOOL synchronizable;
 @property (nonatomic, readonly, copy) NSString *group;
 @property (nonatomic, readonly, copy) NSData *credentialID;
+@property (nonatomic, readonly, copy) NSString *accessGroup;
 
 - (void)setLAContext:(LAContext *)context WK_API_AVAILABLE(macos(12.0), ios(15.0));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
@@ -73,6 +73,11 @@
     return wrapper(_response->credentialID());
 }
 
+- (NSString *)accessGroup
+{
+    return _response->accessGroup();
+}
+
 #endif // ENABLE(WEB_AUTHN)
 
 - (void)setLAContext:(LAContext *)context

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -204,6 +204,8 @@ static std::optional<Vector<Ref<AuthenticatorAssertionResponse>>> getExistingCre
         if (it != responseMap.end() && it->second.isByteString())
             response->setLargeBlob(ArrayBuffer::create(it->second.getByteString()));
 
+        response->setAccessGroup(attributes[(id)kSecAttrAccessGroup]);
+
         result.uncheckedAppend(WTFMove(response));
     }
     return result;


### PR DESCRIPTION
#### 692085fef038e6da61320f39459e3de6756f5320
<pre>
Passkey access groups
<a href="https://bugs.webkit.org/show_bug.cgi?id=254082">https://bugs.webkit.org/show_bug.cgi?id=254082</a>
rdar://105987226

Reviewed by J Pascoe.

Add access group to AuthenticatorAssertionResponse.

* Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.h:
(WebCore::AuthenticatorAssertionResponse::accessGroup const):
(WebCore::AuthenticatorAssertionResponse::setAccessGroup):
* Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm:
(-[_WKWebAuthenticationAssertionResponse accessGroup]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::getExistingCredentials):

Canonical link: <a href="https://commits.webkit.org/262167@main">https://commits.webkit.org/262167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce88116f48a49779cb48c48e611419638425f566

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/331 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/574 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/382 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/394 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/333 "9 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/402 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/310 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/350 "9 failures") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/448 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/181 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/339 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->