### PR TITLE
TestWebKitAPI.WebKit.AutoLayoutIntegration times out when enabling UI side compositing

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -81,6 +81,8 @@ private:
     void sizeDidChange() final;
     void deviceScaleFactorDidChange() final;
     void windowKindDidChange() final;
+    void minimumSizeForAutoLayoutDidChange() final;
+    void sizeToContentAutoSizeMaximumSizeDidChange() final;
     void didUpdateGeometry();
     void attachToProvisionalFrameProcess(WebProcessProxy&) final;
     void startReceivingRemoteLayerTreeDrawingAreaProxyMessages(WebProcessProxy&);
@@ -125,6 +127,8 @@ private:
     DidUpdateMessageState m_didUpdateMessageState { DoesNotNeedDidUpdate };
 
     WebCore::IntSize m_lastSentSize;
+    WebCore::IntSize m_lastSentMinimumSizeForAutoLayout;
+    WebCore::IntSize m_lastSentSizeToContentAutoSizeMaximumSize;
 
     std::unique_ptr<RemoteLayerTreeHost> m_debugIndicatorLayerTreeHost;
     RetainPtr<CALayer> m_tileMapHostLayer;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -150,7 +150,24 @@ void RemoteLayerTreeDrawingArea::setRootCompositingLayer(GraphicsLayer* rootLaye
 
 void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, bool flushSynchronously, const WTF::MachSendRight&, CompletionHandler<void()>&& completionHandler)
 {
-    m_webPage.setSize(viewSize);
+    IntSize size = viewSize;
+    IntSize contentSize = IntSize(-1, -1);
+
+    if (!m_webPage.minimumSizeForAutoLayout().width() || m_webPage.autoSizingShouldExpandToViewHeight() || (!m_webPage.sizeToContentAutoSizeMaximumSize().width() && !m_webPage.sizeToContentAutoSizeMaximumSize().height()))
+        m_webPage.setSize(size);
+
+    auto* frameView = m_webPage.mainFrameView();
+
+    if (m_webPage.autoSizingShouldExpandToViewHeight() && frameView)
+        frameView->setAutoSizeFixedMinimumHeight(viewSize.height());
+
+    m_webPage.layoutIfNeeded();
+
+    if (frameView && (m_webPage.minimumSizeForAutoLayout().width() || (m_webPage.sizeToContentAutoSizeMaximumSize().width() && m_webPage.sizeToContentAutoSizeMaximumSize().height()))) {
+        contentSize = frameView->autoSizingIntrinsicContentSize();
+        size = contentSize;
+    }
+
     triggerRenderingUpdate();
     completionHandler();
 }
@@ -294,6 +311,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
     SetForScope change(m_inUpdateRendering, true);
     m_webPage.updateRendering();
+    m_webPage.flushPendingIntrinsicContentSizeUpdate();
 
     auto size = m_webPage.size();
     FloatRect visibleRect(FloatPoint(), size);


### PR DESCRIPTION
#### 049d8918d770b00e67aa3124a60a4b23687c8705
<pre>
TestWebKitAPI.WebKit.AutoLayoutIntegration times out when enabling UI side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=254096">https://bugs.webkit.org/show_bug.cgi?id=254096</a>
rdar://104037445

Reviewed by Simon Fraser.

RemoteLayerTreeDrawingArea should implement autosizing code. This is needed when enabling
UI side compositing on Mac.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::didUpdateGeometry):
(WebKit::RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry):
(WebKit::RemoteLayerTreeDrawingAreaProxy::minimumSizeForAutoLayoutDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxy::sizeToContentAutoSizeMaximumSizeDidChange):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateGeometry):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):

Canonical link: <a href="https://commits.webkit.org/261853@main">https://commits.webkit.org/261853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e51b4a13a20fdcb49de679f7c24aa0856cfcadc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121449 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5926 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46451 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1265 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10597 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53257 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8277 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16965 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->