### PR TITLE
Optimize FormListedElement::resetFormOwner()

### DIFF
--- a/Source/WebCore/html/FormAssociatedElement.cpp
+++ b/Source/WebCore/html/FormAssociatedElement.cpp
@@ -35,16 +35,10 @@ FormAssociatedElement::FormAssociatedElement(HTMLFormElement* form)
 {
 }
 
-void FormAssociatedElement::setForm(HTMLFormElement* newForm)
+void FormAssociatedElement::setFormInternal(RefPtr<HTMLFormElement>&& newForm)
 {
-    if (m_form != newForm)
-        setFormInternal(newForm);
-}
-
-void FormAssociatedElement::setFormInternal(HTMLFormElement* newForm)
-{
-    ASSERT(m_form != newForm);
-    m_form = newForm;
+    ASSERT(m_form.get() != newForm);
+    m_form = WTFMove(newForm);
 }
 
 void FormAssociatedElement::elementInsertedIntoAncestor(Element& element, Node::InsertionType)

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -39,7 +39,7 @@ public:
 
     HTMLFormElement* form() const { return m_form.get(); }
 
-    virtual void setForm(HTMLFormElement*);
+    void setForm(RefPtr<HTMLFormElement>&&);
     virtual void elementInsertedIntoAncestor(Element&, Node::InsertionType);
     virtual void elementRemovedFromAncestor(Element&, Node::RemovalType);
 
@@ -49,7 +49,7 @@ protected:
     explicit FormAssociatedElement(HTMLFormElement*);
 
     virtual void resetFormOwner() = 0;
-    virtual void setFormInternal(HTMLFormElement*);
+    virtual void setFormInternal(RefPtr<HTMLFormElement>&&);
 
 private:
     virtual void refFormAssociatedElement() const = 0;
@@ -58,5 +58,11 @@ private:
     WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_form;
     WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_formSetByParser;
 };
+
+inline void FormAssociatedElement::setForm(RefPtr<HTMLFormElement>&& newForm)
+{
+    if (m_form.get() != newForm)
+        setFormInternal(WTFMove(newForm));
+}
 
 } // namespace WebCore

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -89,27 +89,24 @@ void FormListedElement::elementRemovedFromAncestor(Element& element, Node::Remov
     }
 }
 
-HTMLFormElement* FormListedElement::findAssociatedForm(const HTMLElement* element, HTMLFormElement* currentAssociatedForm)
+static RefPtr<HTMLFormElement> findAssociatedForm(const HTMLElement& element, HTMLFormElement* currentAssociatedForm)
 {
-    const AtomString& formId(element->attributeWithoutSynchronization(formAttr));
-    if (!formId.isNull() && element->isConnected()) {
-        // The HTML5 spec says that the element should be associated with
-        // the first element in the document to have an ID that equal to
-        // the value of form attribute, so we put the result of
-        // treeScope().getElementById() over the given element.
-        RefPtr<Element> newFormCandidate = element->treeScope().getElementById(formId);
-        if (!is<HTMLFormElement>(newFormCandidate))
-            return nullptr;
-        if (&element->traverseToRootNode() == &element->treeScope().rootNode()) {
-            ASSERT(&element->traverseToRootNode() == &newFormCandidate->traverseToRootNode());
-            return downcast<HTMLFormElement>(newFormCandidate.get());
+    if (element.isConnected()) {
+        if (auto& formId = element.attributeWithoutSynchronization(formAttr); !formId.isNull()) {
+            // The HTML5 spec says that the element should be associated with
+            // the first element in the document to have an ID that equal to
+            // the value of form attribute, so we put the result of
+            // treeScope().getElementById() over the given element.
+            RefPtr newFormCandidate = dynamicDowncast<HTMLFormElement>(element.treeScope().getElementById(formId));
+            if (!newFormCandidate)
+                return nullptr;
+            if (&element.traverseToRootNode() == &element.treeScope().rootNode()) {
+                ASSERT(&element.traverseToRootNode() == &newFormCandidate->traverseToRootNode());
+                return newFormCandidate;
+            }
         }
     }
-
-    if (!currentAssociatedForm)
-        return HTMLFormElement::findClosestFormAncestor(*element);
-
-    return currentAssociatedForm;
+    return currentAssociatedForm ? currentAssociatedForm : HTMLFormElement::findClosestFormAncestor(element);
 }
 
 void FormListedElement::formOwnerRemovedFromTree(const Node& formRoot)
@@ -133,12 +130,12 @@ void FormListedElement::formOwnerRemovedFromTree(const Node& formRoot)
         setForm(nullptr);
 }
 
-void FormListedElement::setFormInternal(HTMLFormElement* newForm)
+void FormListedElement::setFormInternal(RefPtr<HTMLFormElement>&& newForm)
 {
     willChangeForm();
     if (auto* oldForm = form())
         oldForm->unregisterFormListedElement(*this);
-    FormAssociatedElement::setFormInternal(newForm);
+    FormAssociatedElement::setFormInternal(newForm.copyRef());
     if (newForm)
         newForm->registerFormListedElement(*this);
     didChangeForm();
@@ -166,7 +163,7 @@ void FormListedElement::resetFormOwner()
 {
     RefPtr<HTMLFormElement> originalForm = form();
     HTMLElement& element = asHTMLElement();
-    setForm(findAssociatedForm(&element, originalForm.get()));
+    setForm(findAssociatedForm(element, originalForm.get()));
     auto* newForm = form();
     if (newForm && newForm != originalForm && newForm->isConnected())
         element.document().didAssociateFormControl(element);

--- a/Source/WebCore/html/FormListedElement.h
+++ b/Source/WebCore/html/FormListedElement.h
@@ -45,7 +45,6 @@ class FormListedElement : public FormAssociatedElement {
 public:
     virtual ~FormListedElement();
 
-    static HTMLFormElement* findAssociatedForm(const HTMLElement*, HTMLFormElement*);
     ValidityState* validity();
 
     virtual bool isValidatedFormListedElement() const = 0;
@@ -110,7 +109,7 @@ protected:
     String customValidationMessage() const;
 
 private:
-    void setFormInternal(HTMLFormElement*) final;
+    void setFormInternal(RefPtr<HTMLFormElement>&&) final;
     // "willValidate" means "is a candidate for constraint validation".
     virtual bool willValidate() const = 0;
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -113,11 +113,11 @@ void HTMLImageElement::resetFormOwner()
     setForm(HTMLFormElement::findClosestFormAncestor(*this));
 }
 
-void HTMLImageElement::setFormInternal(HTMLFormElement* newForm)
+void HTMLImageElement::setFormInternal(RefPtr<HTMLFormElement>&& newForm)
 {
     if (auto* form = FormAssociatedElement::form())
         form->unregisterImgElement(*this);
-    FormAssociatedElement::setFormInternal(newForm);
+    FormAssociatedElement::setFormInternal(newForm.copyRef());
     if (newForm)
         newForm->registerImgElement(*this);
 }

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -182,7 +182,7 @@ private:
     void resetFormOwner() final;
     void refFormAssociatedElement() const final { HTMLElement::ref(); }
     void derefFormAssociatedElement() const final { HTMLElement::deref(); }
-    void setFormInternal(HTMLFormElement*) final;
+    void setFormInternal(RefPtr<HTMLFormElement>&&) final;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void parseAttribute(const QualifiedName&, const AtomString&) override;


### PR DESCRIPTION
#### 9179c86d6cece98d4063152919f5f380f3c56aa5
<pre>
Optimize FormListedElement::resetFormOwner()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254104">https://bugs.webkit.org/show_bug.cgi?id=254104</a>

Reviewed by Darin Adler.

Optimize FormListedElement::resetFormOwner():
- Update findAssociatedForm() to only get the form attribute if the element is
  connected. Looking up an attribute is a linear search and this is often
  called for disconnected elements.
- setForm() was marked as virtual but never actually overriden. Drop the
  virtual. Also inline it so that we can avoid a function call if the new
  form is the same as the existing one. The slow path is a virtual function
  call to setFormInternal().

Also made a few drive-by cleanups:
- Update findAssociatedForm() to take the element by reference instead of a raw
  pointer since it cannot be null.
- Make findAssociatedForm() private since it is never called from outside the
  class.
- Use a bit more smart pointers for extra safety.

* Source/WebCore/html/FormAssociatedElement.cpp:
(WebCore::FormAssociatedElement::setFormInternal):
(WebCore::FormAssociatedElement::setForm): Deleted.
* Source/WebCore/html/FormAssociatedElement.h:
(WebCore::FormAssociatedElement::setForm):
* Source/WebCore/html/FormListedElement.cpp:
(WebCore::findAssociatedForm):
(WebCore::FormListedElement::setFormInternal):
(WebCore::FormListedElement::resetFormOwner):
(WebCore::FormListedElement::findAssociatedForm): Deleted.
* Source/WebCore/html/FormListedElement.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::setFormInternal):
* Source/WebCore/html/HTMLImageElement.h:

Canonical link: <a href="https://commits.webkit.org/261846@main">https://commits.webkit.org/261846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67768a6c48663823824e46d22cb475427c82dd2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4743 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121457 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5940 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106059 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46464 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14419 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1275 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10607 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53267 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8270 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16975 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->