### PR TITLE
[WebGPU] copyTextureToTexture does not work with compressed formats

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -472,7 +472,7 @@ static bool validateCopyBufferToTexture(const WGPUImageCopyBuffer& source, const
         if (!Texture::refersToSingleAspect(destinationTexture.format(), destination.aspect))
             return false;
 
-        if (!Texture::isValidImageCopyDestination(destinationTexture.format(), destination.aspect))
+        if (!Texture::isValidDepthStencilCopyDestination(destinationTexture.format(), destination.aspect))
             return false;
 
         aspectSpecificFormat = Texture::aspectSpecificFormat(destinationTexture.format(), destination.aspect);
@@ -631,7 +631,7 @@ static bool validateCopyTextureToBuffer(const WGPUImageCopyTexture& source, cons
         if (!Texture::refersToSingleAspect(sourceTexture.format(), source.aspect))
             return false;
 
-        if (!Texture::isValidImageCopySource(sourceTexture.format(), source.aspect))
+        if (!Texture::isValidDepthStencilCopySource(sourceTexture.format(), source.aspect))
             return false;
 
         aspectSpecificFormat = Texture::aspectSpecificFormat(sourceTexture.format(), source.aspect);

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -285,13 +285,14 @@ static bool validateWriteTexture(const WGPUImageCopyTexture& destination, const 
     if (!Texture::refersToSingleAspect(texture.format(), destination.aspect))
         return false;
 
-    if (!Texture::isValidImageCopyDestination(texture.format(), destination.aspect))
-        return false;
-
     auto aspectSpecificFormat = texture.format();
 
-    if (Texture::isDepthOrStencilFormat(texture.format()))
+    if (Texture::isDepthOrStencilFormat(texture.format())) {
+        if (!Texture::isValidDepthStencilCopyDestination(texture.format(), destination.aspect))
+            return false;
+
         aspectSpecificFormat = Texture::aspectSpecificFormat(texture.format(), destination.aspect);
+    }
 
     if (!Texture::validateLinearTextureData(dataLayout, dataByteSize, aspectSpecificFormat, size))
         return false;

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -71,8 +71,8 @@ public:
     static bool validateImageCopyTexture(const WGPUImageCopyTexture&, const WGPUExtent3D&);
     static bool validateTextureCopyRange(const WGPUImageCopyTexture&, const WGPUExtent3D&);
     static bool refersToSingleAspect(WGPUTextureFormat, WGPUTextureAspect);
-    static bool isValidImageCopySource(WGPUTextureFormat, WGPUTextureAspect);
-    static bool isValidImageCopyDestination(WGPUTextureFormat, WGPUTextureAspect);
+    static bool isValidDepthStencilCopySource(WGPUTextureFormat, WGPUTextureAspect);
+    static bool isValidDepthStencilCopyDestination(WGPUTextureFormat, WGPUTextureAspect);
     static bool validateLinearTextureData(const WGPUTextureDataLayout&, uint64_t, WGPUTextureFormat, WGPUExtent3D);
     static MTLTextureUsage usage(WGPUTextureUsageFlags);
     static MTLPixelFormat pixelFormat(WGPUTextureFormat);

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2469,9 +2469,10 @@ bool Texture::refersToSingleAspect(WGPUTextureFormat format, WGPUTextureAspect a
     return true;
 }
 
-bool Texture::isValidImageCopySource(WGPUTextureFormat format, WGPUTextureAspect aspect)
+bool Texture::isValidDepthStencilCopySource(WGPUTextureFormat format, WGPUTextureAspect aspect)
 {
     // https://gpuweb.github.io/gpuweb/#depth-formats
+    ASSERT(Texture::isDepthOrStencilFormat(format));
 
     switch (format) {
     case WGPUTextureFormat_Undefined:
@@ -2581,13 +2582,13 @@ bool Texture::isValidImageCopySource(WGPUTextureFormat format, WGPUTextureAspect
     }
 }
 
-bool Texture::isValidImageCopyDestination(WGPUTextureFormat format, WGPUTextureAspect aspect)
+bool Texture::isValidDepthStencilCopyDestination(WGPUTextureFormat format, WGPUTextureAspect aspect)
 {
     // https://gpuweb.github.io/gpuweb/#depth-formats
+    ASSERT(Texture::isDepthOrStencilFormat(format));
 
     switch (format) {
     case WGPUTextureFormat_Undefined:
-        return false;
     case WGPUTextureFormat_R8Unorm:
     case WGPUTextureFormat_R8Snorm:
     case WGPUTextureFormat_R8Uint:
@@ -2624,7 +2625,7 @@ bool Texture::isValidImageCopyDestination(WGPUTextureFormat format, WGPUTextureA
     case WGPUTextureFormat_RGBA32Float:
     case WGPUTextureFormat_RGBA32Uint:
     case WGPUTextureFormat_RGBA32Sint:
-        return true;
+        return false;
     case WGPUTextureFormat_Stencil8:
     case WGPUTextureFormat_Depth16Unorm:
         return true;


### PR DESCRIPTION
#### f6ed3474524d1341c873608922814812d0b5fcda
<pre>
[WebGPU] copyTextureToTexture does not work with compressed formats
<a href="https://bugs.webkit.org/show_bug.cgi?id=254103">https://bugs.webkit.org/show_bug.cgi?id=254103</a>
&lt;radar://106887775&gt;

Reviewed by Tadeu Zagallo.

Texture::isValidImageCopySource / isValidImageCopyDestination are only supposed
to be called on depth or stencil formats. They do not return expected values
except for depth formats.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::validateWriteTexture):
Only validate if this is a depth format.

* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::isValidDepthStencilCopySource):
(WebGPU::Texture::isValidDepthStencilCopyDestination):
Assert this is a depth or stencil format.

Canonical link: <a href="https://commits.webkit.org/261880@main">https://commits.webkit.org/261880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3cca43b7c2b19f90dedd3e77733034d7f4d3270

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121555 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6106 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106174 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1332 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46561 "38 flakes 109 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14527 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1374 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10708 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53366 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8296 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17088 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->