### PR TITLE
[WebGPU] Simplify samples after writeBuffer fixes

### DIFF
--- a/Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js
@@ -178,8 +178,7 @@ async function helloCube() {
         secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
                           seconds*5 * (6.28318530718 / 60.0),
                           seconds*1 * (6.28318530718 / 60.0)]);
-        // document.writeln(d.getSeconds());
-        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer);
 
         const canvas = document.querySelector("canvas");
         canvas.width = 600;

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-cube.js
@@ -314,8 +314,7 @@ function updateTransformArray() {
     mat4.rotate(viewMatrix, viewMatrix, 1, vec3.fromValues(Math.sin(now), Math.cos(now), 0));
     const modelViewProjectionMatrix = mat4.create();
     mat4.multiply(modelViewProjectionMatrix, projectionMatrix, viewMatrix);
-    // FIXME: we should not require the 4th argument here
-    device.queue.writeBuffer(transformBuffer, 0, modelViewProjectionMatrix, 0);
+    device.queue.writeBuffer(transformBuffer, 0, modelViewProjectionMatrix);
 }
 
 window.addEventListener("DOMContentLoaded", init);

--- a/Websites/webkit.org/demos/webgpu/scripts/hello-indexed-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-indexed-cube.js
@@ -174,8 +174,7 @@ async function helloCube() {
         secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
                           seconds*5 * (6.28318530718 / 60.0),
                           seconds*1 * (6.28318530718 / 60.0)]);
-        // document.writeln(d.getSeconds());
-        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer);
 
         const canvas = document.querySelector("canvas");
         canvas.width = 600;

--- a/Websites/webkit.org/demos/webgpu/scripts/indirect-command-buffer-textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/indirect-command-buffer-textured-cube.js
@@ -240,7 +240,7 @@ async function helloCube() {
         secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
                           seconds*5 * (6.28318530718 / 60.0),
                           seconds*1 * (6.28318530718 / 60.0)]);
-        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer);
 
         const gpuContext = canvas.getContext("webgpu");
         

--- a/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js
@@ -286,8 +286,8 @@ async function helloCube() {
             translations[i * 4 + 3] = 1;
         }
 
-        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, uniformBufferSize);
-        device.queue.writeBuffer(translationBuffer, 0, translations, 0, translationBufferSize);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer);
+        device.queue.writeBuffer(translationBuffer, 0, translations);
 
         const gpuContext = canvas.getContext("webgpu");
         

--- a/Websites/webkit.org/demos/webgpu/scripts/query-sets.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/query-sets.js
@@ -150,7 +150,7 @@ async function helloTriangle() {
         secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
                           seconds*5 * (6.28318530718 / 60.0),
                           seconds*1 * (6.28318530718 / 60.0)]);
-        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer);
 
         const currentTexture = gpuContext.getCurrentTexture();
         

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js
@@ -281,7 +281,7 @@ async function helloCube() {
         secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
                           seconds*5 * (6.28318530718 / 60.0),
                           seconds*1 * (6.28318530718 / 60.0)]);
-        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer);
 
         const gpuContext = canvas.getContext("webgpu");
         

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js
@@ -258,7 +258,7 @@ async function helloCube() {
         secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
                           seconds*5 * (6.28318530718 / 60.0),
                           seconds*1 * (6.28318530718 / 60.0)]);
-        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer);
 
         const gpuContext = canvas.getContext("webgpu");
         

--- a/Websites/webkit.org/demos/webgpu/scripts/textured-cube.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/textured-cube.js
@@ -232,7 +232,7 @@ async function helloCube() {
         secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0),
                           seconds*5 * (6.28318530718 / 60.0),
                           seconds*1 * (6.28318530718 / 60.0)]);
-        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 12);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer);
 
         const gpuContext = canvas.getContext("webgpu");
         

--- a/Websites/webkit.org/demos/webgpu/scripts/two-cubes.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/two-cubes.js
@@ -200,13 +200,13 @@ async function helloCube() {
                           seconds*1 * (6.28318530718 / 60.0),
                           .3]);
 
-        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer, 0, 16);
+        device.queue.writeBuffer(uniformBuffer, 0, secondsBuffer);
         
         secondsBuffer.set([seconds*10 * (6.28318530718 / 60.0) + 3.14159265359,
                           seconds*5 * (6.28318530718 / 60.0) + 3.14159265359,
                           seconds*1 * (6.28318530718 / 60.0) + 3.14159265359,
                           -.3]);
-        device.queue.writeBuffer(uniformBuffer, 256, secondsBuffer, 0, 16);
+        device.queue.writeBuffer(uniformBuffer, 256, secondsBuffer);
 
         const canvas = document.querySelector("canvas");
         canvas.width = 600;


### PR DESCRIPTION
#### 3a4945ba8a1449dc20b67f7113fc8fb7b95ebf93
<pre>
[WebGPU] Simplify samples after writeBuffer fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=254106">https://bugs.webkit.org/show_bug.cgi?id=254106</a>
&lt;radar://106888396&gt;

Reviewed by Tadeu Zagallo.

Simplify samples calls to writeBuffer now that writeBuffer passes
the CTS.

* Websites/webkit.org/demos/webgpu/scripts/hello-cube-auto-layout.js:
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/hello-cube.js:
(updateTransformArray):
* Websites/webkit.org/demos/webgpu/scripts/hello-indexed-cube.js:
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/indirect-command-buffer-textured-cube.js:
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/instanced-textured-cube.js:
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/query-sets.js:
(async helloTriangle.async frameUpdate):
(async helloTriangle):
* Websites/webkit.org/demos/webgpu/scripts/textured-cube-shader-constants.js:
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/textured-cube-vs-input-buffers.js:
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/textured-cube.js:
(async helloCube.frameUpdate):
(async helloCube):
* Websites/webkit.org/demos/webgpu/scripts/two-cubes.js:
(async helloCube.frameUpdate):
(async helloCube):

Canonical link: <a href="https://commits.webkit.org/261875@main">https://commits.webkit.org/261875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24e69ea882cd2036c94ef2c9d59232bfa428f865

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/112979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121465 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/5951 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106069 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46473 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14428 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1282 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10616 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53274 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8294 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/16986 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->