### PR TITLE
[WebGPU] GPUDevice.lost promise is never resolved

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -122,7 +122,7 @@ public:
     void popErrorScope(ErrorScopePromise&&);
 
     using LostPromise = DOMPromiseProxy<IDLInterface<GPUDeviceLostInfo>>;
-    LostPromise& lost() { return m_lostPromise; }
+    LostPromise& lost();
 
     PAL::WebGPU::Device& backing() { return m_backing; }
     const PAL::WebGPU::Device& backing() const { return m_backing; }
@@ -147,6 +147,7 @@ private:
     Ref<PAL::WebGPU::Device> m_backing;
     Ref<GPUQueue> m_queue;
     Ref<GPUPipelineLayout> m_autoPipelineLayout;
+    bool m_waitingForDeviceLostPromise { false };
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.cpp
@@ -28,12 +28,11 @@
 
 namespace WebCore {
 
-auto GPUDeviceLostInfo::reason() const -> Reason
+GPUDeviceLostReason GPUDeviceLostInfo::reason() const
 {
-    auto result = m_backing->reason();
-    if (!result)
-        return std::nullopt;
-    switch (*result) {
+    switch (m_backing->reason()) {
+    case PAL::WebGPU::DeviceLostReason::Unknown:
+        return GPUDeviceLostReason::Unknown;
     case PAL::WebGPU::DeviceLostReason::Destroyed:
         return GPUDeviceLostReason::Destroyed;
     }

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.h
@@ -36,14 +36,12 @@ namespace WebCore {
 
 class GPUDeviceLostInfo : public RefCounted<GPUDeviceLostInfo> {
 public:
-    using Reason = std::optional<GPUDeviceLostReason>;
-
     static Ref<GPUDeviceLostInfo> create(Ref<PAL::WebGPU::DeviceLostInfo>&& backing)
     {
         return adoptRef(*new GPUDeviceLostInfo(WTFMove(backing)));
     }
 
-    Reason reason() const;
+    GPUDeviceLostReason reason() const;
     const String& message() const;
 
     PAL::WebGPU::DeviceLostInfo& backing() { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl
@@ -31,6 +31,6 @@
     SecureContext
 ]
 interface GPUDeviceLostInfo {
-    readonly attribute GPUDeviceLostReason? reason; // FIXME: This is supposed to be (GPUDeviceLostReason or undefined)
+    readonly attribute GPUDeviceLostReason reason;
     readonly attribute DOMString message;
 };

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.h
@@ -31,12 +31,15 @@
 namespace WebCore {
 
 enum class GPUDeviceLostReason : uint8_t {
+    Unknown,
     Destroyed,
 };
 
 inline PAL::WebGPU::DeviceLostReason convertToBacking(GPUDeviceLostReason deviceLostReason)
 {
     switch (deviceLostReason) {
+    case GPUDeviceLostReason::Unknown:
+        return PAL::WebGPU::DeviceLostReason::Unknown;
     case GPUDeviceLostReason::Destroyed:
         return PAL::WebGPU::DeviceLostReason::Destroyed;
     }

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.idl
@@ -29,5 +29,6 @@
     EnabledBySetting=WebGPU
 ]
 enum GPUDeviceLostReason {
+    "unknown",
     "destroyed"
 };

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
@@ -612,6 +612,21 @@ void DeviceImpl::popErrorScope(CompletionHandler<void(std::optional<Error>&&)>&&
     }).get());
 }
 
+void DeviceImpl::resolveDeviceLostPromise(CompletionHandler<void(PAL::WebGPU::DeviceLostReason)>&& callback)
+{
+    wgpuDeviceSetDeviceLostCallbackWithBlock(m_backing, makeBlockPtr([callback = WTFMove(callback)] (WGPUDeviceLostReason reason, const char*) mutable {
+        switch (reason) {
+        case WGPUDeviceLostReason_Undefined:
+        case WGPUDeviceLostReason_Force32:
+            callback(PAL::WebGPU::DeviceLostReason::Unknown);
+            return;
+        case WGPUDeviceLostReason_Destroyed:
+            callback(PAL::WebGPU::DeviceLostReason::Destroyed);
+            return;
+        }
+    }).get());
+}
+
 void DeviceImpl::setLabelInternal(const String& label)
 {
     wgpuDeviceSetLabel(m_backing, label.utf8().data());

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h
@@ -36,6 +36,7 @@
 namespace PAL::WebGPU {
 
 class ConvertToBackingContext;
+enum class DeviceLostReason : uint8_t;
 
 class DeviceImpl final : public Device {
     WTF_MAKE_FAST_ALLOCATED;
@@ -85,6 +86,7 @@ private:
 
     void pushErrorScope(ErrorFilter) final;
     void popErrorScope(CompletionHandler<void(std::optional<Error>&&)>&&) final;
+    void resolveDeviceLostPromise(CompletionHandler<void(PAL::WebGPU::DeviceLostReason)>&&) final;
 
     void setLabelInternal(const String&) final;
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h
@@ -119,6 +119,7 @@ public:
 
     virtual void pushErrorScope(ErrorFilter) = 0;
     virtual void popErrorScope(CompletionHandler<void(std::optional<Error>&&)>&&) = 0;
+    virtual void resolveDeviceLostPromise(CompletionHandler<void(PAL::WebGPU::DeviceLostReason)>&&) = 0;
     class DeviceLostClient {
         virtual ~DeviceLostClient() = default;
         virtual void deviceLost() = 0;

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDeviceLostInfo.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDeviceLostInfo.h
@@ -35,19 +35,17 @@ namespace PAL::WebGPU {
 
 class DeviceLostInfo final : public RefCounted<DeviceLostInfo> {
 public:
-    using Reason = std::optional<DeviceLostReason>;
-
-    static Ref<DeviceLostInfo> create(Reason&& reason, String&& message)
+    static Ref<DeviceLostInfo> create(DeviceLostReason reason, String&& message)
     {
-        return adoptRef(*new DeviceLostInfo(WTFMove(reason), WTFMove(message)));
+        return adoptRef(*new DeviceLostInfo(reason, WTFMove(message)));
     }
 
-    const Reason& reason() const { return m_reason; }
+    DeviceLostReason reason() const { return m_reason; }
     const String& message() const { return m_message; }
 
 protected:
-    DeviceLostInfo(Reason&& reason, String&& message)
-        : m_reason(WTFMove(reason))
+    DeviceLostInfo(DeviceLostReason reason, String&& message)
+        : m_reason(reason)
         , m_message(WTFMove(message))
     {
     }
@@ -58,7 +56,7 @@ private:
     DeviceLostInfo& operator=(const DeviceLostInfo&) = delete;
     DeviceLostInfo& operator=(DeviceLostInfo&&) = delete;
 
-    Reason m_reason;
+    DeviceLostReason m_reason;
     String m_message;
 };
 

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDeviceLostReason.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDeviceLostReason.h
@@ -32,6 +32,7 @@ namespace PAL::WebGPU {
 
 enum class DeviceLostReason : uint8_t {
     Destroyed,
+    Unknown,
 };
 
 } // namespace PAL::WebGPU
@@ -41,7 +42,8 @@ namespace WTF {
 template<> struct EnumTraits<PAL::WebGPU::DeviceLostReason> {
     using values = EnumValues<
         PAL::WebGPU::DeviceLostReason,
-        PAL::WebGPU::DeviceLostReason::Destroyed
+        PAL::WebGPU::DeviceLostReason::Destroyed,
+        PAL::WebGPU::DeviceLostReason::Unknown
     >;
 };
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -329,6 +329,13 @@ void RemoteDevice::popErrorScope(CompletionHandler<void(std::optional<WebGPU::Er
     });
 }
 
+void RemoteDevice::resolveDeviceLostPromise(CompletionHandler<void(PAL::WebGPU::DeviceLostReason)>&& callback)
+{
+    m_backing->resolveDeviceLostPromise([callback = WTFMove(callback)] (PAL::WebGPU::DeviceLostReason reason) mutable {
+        callback(reason);
+    });
+}
+
 void RemoteDevice::setLabel(String&& label)
 {
     m_backing->setLabel(WTFMove(label));

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -38,6 +38,7 @@
 
 namespace PAL::WebGPU {
 class Device;
+enum class DeviceLostReason : uint8_t;
 }
 
 namespace IPC {
@@ -116,6 +117,7 @@ private:
 
     void pushErrorScope(PAL::WebGPU::ErrorFilter);
     void popErrorScope(CompletionHandler<void(std::optional<WebGPU::Error>&&)>&&);
+    void resolveDeviceLostPromise(CompletionHandler<void(PAL::WebGPU::DeviceLostReason)>&&);
 
     void setLabel(String&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in
@@ -43,6 +43,7 @@ messages -> RemoteDevice NotRefCounted Stream {
     void CreateQuerySet(WebKit::WebGPU::QuerySetDescriptor descriptor, WebKit::WebGPUIdentifier identifier)
     void PushErrorScope(PAL::WebGPU::ErrorFilter errorFilter)
     void PopErrorScope() -> (std::optional<WebKit::WebGPU::Error> error)
+    void ResolveDeviceLostPromise() -> (PAL::WebGPU::DeviceLostReason reason)
     void SetLabel(String label)
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -342,6 +342,15 @@ void RemoteDeviceProxy::setLabelInternal(const String& label)
     UNUSED_VARIABLE(sendResult);
 }
 
+void RemoteDeviceProxy::resolveDeviceLostPromise(CompletionHandler<void(PAL::WebGPU::DeviceLostReason)>&& callback)
+{
+    auto sendResult = sendWithAsyncReply(Messages::RemoteDevice::ResolveDeviceLostPromise(), [callback = WTFMove(callback)] (PAL::WebGPU::DeviceLostReason reason) mutable {
+        callback(reason);
+    });
+
+    UNUSED_PARAM(sendResult);
+}
+
 } // namespace WebKit::WebGPU
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -108,6 +108,7 @@ private:
     void popErrorScope(CompletionHandler<void(std::optional<PAL::WebGPU::Error>&&)>&&) final;
 
     void setLabelInternal(const String&) final;
+    void resolveDeviceLostPromise(CompletionHandler<void(PAL::WebGPU::DeviceLostReason)>&&) final;
 
     Deque<CompletionHandler<void(Ref<PAL::WebGPU::ComputePipeline>&&)>> m_createComputePipelineAsyncCallbacks;
     Deque<CompletionHandler<void(Ref<PAL::WebGPU::RenderPipeline>&&)>> m_createRenderPipelineAsyncCallbacks;


### PR DESCRIPTION
#### 65f2377f0c0973c8984aa4eda1a4cee8a173dcda
<pre>
[WebGPU] GPUDevice.lost promise is never resolved
<a href="https://bugs.webkit.org/show_bug.cgi?id=253086">https://bugs.webkit.org/show_bug.cgi?id=253086</a>
&lt;radar://106037229&gt;

Reviewed by Myles C. Maxfield.

Adopt new agreed upon API for device lost.

CTS test is not enabled because we fail requestDevice now due to
maxFragmentCombinedOutputResources being added to GPULimits.

Locally the requestDevice:invalid test is passing with this change.

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::lost):
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
(WebCore::GPUDevice::lost): Deleted.
* Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.cpp:
(WebCore::GPUDeviceLostInfo::reason const):
* Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.h:
* Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl:
* Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.idl:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp:
(PAL::WebGPU::DeviceImpl::resolveDeviceLostPromise):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDevice.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDeviceLostInfo.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUDeviceLostReason.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
(WebGPU::Device::~Device):
(WebGPU::Device::loseTheDevice):
(WebGPU::Device::setDeviceLostCallback):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::resolveDeviceLostPromise):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::resolveDeviceLostPromise):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:

Canonical link: <a href="https://commits.webkit.org/263100@main">https://commits.webkit.org/263100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67fa019f5975b364d843a2be35be382d9d4032a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5005 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3854 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3112 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4827 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3268 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4597 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3637 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3200 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/878 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->