### PR TITLE
[WebGPU] RenderPassEncoder::draw() will fail debug device if pipeline is not set

### DIFF
--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -80,6 +80,7 @@ private:
     bool validatePopDebugGroup() const;
 
     void makeInvalid() { m_computeCommandEncoder = nil; }
+    bool validateEncoderBindGroups() const;
 
     id<MTLComputeCommandEncoder> m_computeCommandEncoder { nil };
 
@@ -92,6 +93,7 @@ private:
 
     const Ref<Device> m_device;
     MTLSize m_threadsPerThreadgroup;
+    bool m_pipelineIsValid { false };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -85,6 +85,7 @@ private:
     id<MTLIndirectRenderCommand> currentRenderCommand();
 
     void makeInvalid() { m_indirectCommandBuffer = nil; }
+    bool validateRenderBundle() const;
 
     id<MTLIndirectCommandBuffer> m_indirectCommandBuffer { nil };
     MTLIndirectCommandBufferDescriptor *m_icbDescriptor { nil };
@@ -98,6 +99,7 @@ private:
     Vector<WTF::Function<void(void)>> m_recordedCommands;
     Vector<BindableResource> m_resources;
     const Ref<Device> m_device;
+    bool m_pipelineIsValid { false };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -92,6 +92,7 @@ private:
     bool validatePopDebugGroup() const;
 
     void makeInvalid() { m_renderCommandEncoder = nil; }
+    bool validateEncoderBindGroups() const;
 
     id<MTLRenderCommandEncoder> m_renderCommandEncoder { nil };
 
@@ -111,6 +112,7 @@ private:
     NSUInteger m_visibilityResultBufferSize { 0 };
     bool m_depthReadOnly { false };
     bool m_stencilReadOnly { false };
+    bool m_pipelineIsValid { false };
 };
 
 } // namespace WebGPU


### PR DESCRIPTION
#### 28cb24a29284097dc7fa29536bc90c58665fad6a
<pre>
[WebGPU] RenderPassEncoder::draw() will fail debug device if pipeline is not set
<a href="https://bugs.webkit.org/show_bug.cgi?id=254105">https://bugs.webkit.org/show_bug.cgi?id=254105</a>
&lt;radar://106888082&gt;

Reviewed by NOBODY (OOPS!).

There is no guarantee the website calls setPipeline, if
they don&apos;t, the process will assert with a Metal debug device.

It seems like that should not happen. One can use a Metal debug
device in any configuration, not just debug builds.

* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::ComputePassEncoder::validateEncoderBindGroups const):
Start the validation as described in the specification to the
extent which avoids crashing the GPU process during this scenario.
(WebGPU::RenderPassEncoder::draw):
(WebGPU::RenderPassEncoder::setPipeline):
(WebGPU::RenderPassEncoder::drawIndexed):
(WebGPU::RenderPassEncoder::drawIndexedIndirect):
(WebGPU::RenderPassEncoder::drawIndirect):

* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::validateEncoderBindGroups const):
Start the validation as described in the specification to the
extent which avoids crashing the GPU process during this scenario.
(WebGPU::ComputePassEncoder::dispatch):
(WebGPU::ComputePassEncoder::dispatchIndirect):
(WebGPU::ComputePassEncoder::setPipeline):
Same logic for compute pipeline.

* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::validateRenderBundle const):
(WebGPU::RenderBundleEncoder::finish):
(WebGPU::RenderBundleEncoder::setPipeline):
Similar to other two encoders.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28cb24a29284097dc7fa29536bc90c58665fad6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/234 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/493 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/280 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/366 "2 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/323 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/218 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/255 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/394 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/250 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/246 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->