### PR TITLE
[JSC] Make vector / double / float materialization more efficient

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -1615,12 +1615,20 @@ public:
 #if CPU(X86_64) || CPU(RISCV64)
     void moveFloat(Imm32 imm, FPRegisterID dest)
     {
+        if (!imm.asTrustedImm32().m_value) {
+            moveZeroToFloat(dest);
+            return;
+        }
         move(imm, scratchRegister());
         move32ToFloat(scratchRegister(), dest);
     }
 
     void moveDouble(Imm64 imm, FPRegisterID dest)
     {
+        if (!imm.asTrustedImm64().m_value) {
+            moveZeroToDouble(dest);
+            return;
+        }
         move(imm, scratchRegister());
         move64ToDouble(scratchRegister(), dest);
     }
@@ -1629,12 +1637,20 @@ public:
 #if CPU(ARM64)
     void moveFloat(Imm32 imm, FPRegisterID dest)
     {
+        if (!imm.asTrustedImm32().m_value) {
+            moveZeroToFloat(dest);
+            return;
+        }
         move(imm, getCachedMemoryTempRegisterIDAndInvalidate());
         move32ToFloat(getCachedMemoryTempRegisterIDAndInvalidate(), dest);
     }
 
     void moveDouble(Imm64 imm, FPRegisterID dest)
     {
+        if (!imm.asTrustedImm64().m_value) {
+            moveZeroToDouble(dest);
+            return;
+        }
         move(imm, getCachedMemoryTempRegisterIDAndInvalidate());
         move64ToDouble(getCachedMemoryTempRegisterIDAndInvalidate(), dest);
     }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -2666,6 +2666,10 @@ public:
 
     void materializeVector(v128_t value, FPRegisterID dest)
     {
+        if (value.isAllZero()) {
+            moveZeroToVector(dest);
+            return;
+        }
         move(TrustedImm64(value.u64x2[0]), scratchRegister());
         vectorReplaceLaneInt64(TrustedImm32(0), scratchRegister(), dest);
         move(TrustedImm64(value.u64x2[1]), scratchRegister());
@@ -2699,6 +2703,10 @@ public:
 
     void move64ToDouble(TrustedImm64 imm, FPRegisterID dest)
     {
+        if (!imm.m_value) {
+            moveZeroToDouble(dest);
+            return;
+        }
         move(imm, getCachedDataTempRegisterIDAndInvalidate());
         m_assembler.fmov<64>(dest, dataTempRegister);
     }
@@ -2710,6 +2718,10 @@ public:
 
     void move32ToFloat(TrustedImm32 imm, FPRegisterID dest)
     {
+        if (!imm.m_value) {
+            moveZeroToFloat(dest);
+            return;
+        }
         move(imm, getCachedDataTempRegisterIDAndInvalidate());
         m_assembler.fmov<32>(dest, dataTempRegister);
     }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -1270,6 +1270,10 @@ public:
 
     void move32ToFloat(TrustedImm32 imm, FPRegisterID dest)
     {
+        if (!imm.m_value) {
+            moveZeroToFloat(dest);
+            return;
+        }
         move(imm, scratchRegister());
         if (supportsAVX())
             m_assembler.vmovd_rr(scratchRegister(), dest);
@@ -1287,6 +1291,10 @@ public:
 
     void move64ToDouble(TrustedImm64 imm, FPRegisterID dest)
     {
+        if (!imm.m_value) {
+            moveZeroToDouble(dest);
+            return;
+        }
         move(imm, scratchRegister());
         if (supportsAVX())
             m_assembler.vmovq_rr(scratchRegister(), dest);
@@ -1312,6 +1320,10 @@ public:
 
     void materializeVector(v128_t value, FPRegisterID dest)
     {
+        if (value.isAllZero()) {
+            moveZeroToVector(dest);
+            return;
+        }
         move(TrustedImm64(value.u64x2[0]), scratchRegister());
         vectorReplaceLaneInt64(TrustedImm32(0), scratchRegister(), dest);
         move(TrustedImm64(value.u64x2[1]), scratchRegister());

--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -41,6 +41,16 @@ typedef union v128_u {
     constexpr v128_u(uint64_t first, uint64_t second)
         : u64x2 { first, second }
     { }
+
+    constexpr bool isAllZero() const
+    {
+        return !u64x2[0] && !u64x2[1];
+    }
+
+    constexpr bool isAllOne() const
+    {
+        return u64x2[0] == UINT64_MAX && u64x2[1] == UINT64_MAX;
+    }
 } v128_t;
 
 constexpr v128_t vectorAllOnes()

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -7761,15 +7761,13 @@ public:
 
     void materializeVectorConstant(v128_t value, Location result)
     {
-        if (!value.u64x2[0] && !value.u64x2[1])
-            m_jit.moveZeroToVector(result.asFPR());
-        else if (value.u64x2[0] == 0xffffffffffffffffull && value.u64x2[1] == 0xffffffffffffffffull)
+        if (value.isAllOne()) {
 #if CPU(X86_64)
             m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::Unsigned }, result.asFPR(), result.asFPR(), result.asFPR(), wasmScratchFPR);
 #else
             m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::Unsigned }, result.asFPR(), result.asFPR(), result.asFPR());
 #endif
-        else
+        } else
             m_jit.materializeVector(value, result.asFPR());
     }
 


### PR DESCRIPTION
#### efa168a147f14e779e7b45c5f34b4116551e111c
<pre>
[JSC] Make vector / double / float materialization more efficient
<a href="https://bugs.webkit.org/show_bug.cgi?id=254122">https://bugs.webkit.org/show_bug.cgi?id=254122</a>
rdar://106903734

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/assembler/MacroAssembler.h:
(JSC::MacroAssembler::moveFloat):
(JSC::MacroAssembler::moveDouble):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::materializeVector):
(JSC::MacroAssemblerARM64::move64ToDouble):
(JSC::MacroAssemblerARM64::move32ToFloat):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::move32ToFloat):
(JSC::MacroAssemblerX86_64::move64ToDouble):
(JSC::MacroAssemblerX86_64::materializeVector):
* Source/JavaScriptCore/jit/SIMDInfo.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::materializeVectorConstant):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efa168a147f14e779e7b45c5f34b4116551e111c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6001 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106103 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46496 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/101268 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14459 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1308 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12616 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10645 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102805 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53300 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/32067 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17018 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110857 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27372 "Passed tests") | 
<!--EWS-Status-Bubble-End-->