### PR TITLE
Create entire frame tree in iframe processes

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4384,7 +4384,7 @@ webkit.org/b/251875 fast/dynamic/create-renderer-for-whitespace-only-text.html [
 
 webkit.org/b/252191 imported/w3c/web-platform-tests/editing/other/edit-in-textcontrol-immediately-after-hidden.tentative.html [ Skip ]
 
-webkit.org/b/252504 http/tests/site-isolation/basic-iframe.html [ Pass ImageOnlyFailure ]
+webkit.org/b/252504 http/tests/site-isolation/basic-iframe.html [ Pass Timeout ImageOnlyFailure ]
 
 http/wpt/service-workers/basic-fetch-with-contentfilter.https.html [ Pass ]
 

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -153,7 +153,7 @@ CachedFrame::CachedFrame(LocalFrame& frame)
 
     // Create the CachedFrames for all Frames in the FrameTree.
     for (auto* child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-        auto* localChild = downcast<LocalFrame>(child);
+        auto* localChild = dynamicDowncast<LocalFrame>(child);
         if (!localChild)
             continue;
         m_childFrames.append(makeUniqueRef<CachedFrame>(*localChild));

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2806,7 +2806,7 @@ void FrameLoader::didFirstLayout()
 
 void FrameLoader::didReachVisuallyNonEmptyState()
 {
-    ASSERT(m_frame.isMainFrame());
+    ASSERT(m_frame.isRootFrame());
     m_client->dispatchDidReachVisuallyNonEmptyState();
 }
 

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -396,9 +396,12 @@ LocalFrame& FocusController::focusedOrMainFrame() const
 {
     if (auto* frame = focusedFrame())
         return *frame;
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    ASSERT(localMainFrame);
-    return *localMainFrame;
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame()))
+        return *localMainFrame;
+
+    // FIXME: Do something better here in the site isolated case.
+    ASSERT(m_page.settings().siteIsolationEnabled());
+    return *m_page.rootFrames().begin();
 }
 
 void FocusController::setFocused(bool focused)

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -30,6 +30,7 @@
 #include "HTMLFrameOwnerElement.h"
 #include "LocalFrame.h"
 #include "Page.h"
+#include "RemoteFrame.h"
 #include "WindowProxy.h"
 
 namespace WebCore {
@@ -51,6 +52,23 @@ Frame::Frame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrame
 Frame::~Frame()
 {
     m_windowProxy->detachFromFrame();
+}
+
+bool Frame::isRootFrame() const
+{
+    // A root frame is a local frame with a remote frame parent or no parent.
+    // It is the root of its local frame tree in this process but might have
+    // a parent in another process.
+    switch (m_frameType) {
+    case FrameType::Local:
+        if (auto* parent = tree().parent())
+            return is<RemoteFrame>(parent);
+        ASSERT(&m_mainFrame == this);
+        return true;
+    case FrameType::Remote:
+        break;
+    }
+    return false;
 }
 
 void Frame::resetWindowProxy()

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -57,6 +57,7 @@ public:
     Settings& settings() const { return m_settings.get(); }
     Frame& mainFrame() const { return m_mainFrame; }
     bool isMainFrame() const { return this == &m_mainFrame; }
+    WEBCORE_EXPORT bool isRootFrame() const;
 
     WEBCORE_EXPORT void detachFromPage();
     inline HTMLFrameOwnerElement* ownerElement() const; // Defined in HTMLFrameOwnerElement.h.

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5108,7 +5108,7 @@ void LocalFrameView::checkAndDispatchDidReachVisuallyNonEmptyState()
         return;
 
     m_contentQualifiesAsVisuallyNonEmpty = true;
-    if (m_frame->isMainFrame())
+    if (m_frame->isRootFrame())
         m_frame->loader().didReachVisuallyNonEmptyState();
 }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -269,7 +269,9 @@ static constexpr OptionSet<ActivityState::Flag> pageInitialActivityState()
 static Ref<Frame> createMainFrame(Page& page, std::variant<UniqueRef<FrameLoaderClient>, UniqueRef<RemoteFrameClient>>&& client, FrameIdentifier identifier)
 {
     return switchOn(WTFMove(client), [&] (UniqueRef<FrameLoaderClient>&& localFrameClient) -> Ref<Frame> {
-        return LocalFrame::createMainFrame(page, WTFMove(localFrameClient), identifier);
+        auto localFrame = LocalFrame::createMainFrame(page, WTFMove(localFrameClient), identifier);
+        page.addRootFrame(localFrame.get());
+        return localFrame;
     }, [&] (UniqueRef<RemoteFrameClient>&& remoteFrameClient) -> Ref<Frame> {
         return RemoteFrame::createMainFrame(page, WTFMove(remoteFrameClient), identifier);
     });
@@ -1942,10 +1944,16 @@ auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
 
 void Page::finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags> flags)
 {
+    for (auto& rootFrame : m_rootFrames)
+        finalizeRenderingUpdateForRootFrame(rootFrame, flags);
+}
+
+void Page::finalizeRenderingUpdateForRootFrame(LocalFrame& rootFrame, OptionSet<FinalizeRenderingUpdateFlags> flags)
+{
     LOG(EventLoop, "Page %p finalizeRenderingUpdate()", this);
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());
-    auto* view = localMainFrame ? localMainFrame->view() : nullptr;
+    ASSERT(rootFrame.isRootFrame());
+    auto* view = rootFrame.view();
     if (!view)
         return;
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -650,6 +650,7 @@ public:
     WEBCORE_EXPORT void isolatedUpdateRendering();
     // Called when the rendering update steps are complete, but before painting.
     WEBCORE_EXPORT void finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags>);
+    WEBCORE_EXPORT void finalizeRenderingUpdateForRootFrame(LocalFrame&, OptionSet<FinalizeRenderingUpdateFlags>);
 
     // Called before and after the "display" steps of the rendering update: painting, and when we push
     // layers to the platform compositor.
@@ -1023,6 +1024,9 @@ public:
     void willBeginScrolling();
     void didFinishScrolling();
 
+    const WeakHashSet<LocalFrame>& rootFrames() const { return m_rootFrames; }
+    void addRootFrame(LocalFrame& frame) { m_rootFrames.add(frame); }
+
 private:
     struct Navigation {
         RegistrableDomain domain;
@@ -1097,6 +1101,7 @@ private:
     const std::unique_ptr<ProgressTracker> m_progress;
 
     const std::unique_ptr<BackForwardController> m_backForwardController;
+    WeakHashSet<LocalFrame> m_rootFrames;
     Ref<Frame> m_mainFrame;
 
     RefPtr<PluginData> m_pluginData;

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -567,7 +567,7 @@ private:
 #endif
 
     bool documentUsesTiledBacking() const;
-    bool isMainFrameCompositor() const;
+    bool isRootFrameCompositor() const;
 
     void updateCompositingForLayerTreeAsTextDump();
 

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -548,7 +548,6 @@ void RenderView::repaintViewRectangle(const LayoutRect& repaintRect) const
 
 void RenderView::flushAccumulatedRepaintRegion() const
 {
-    ASSERT(!document().ownerElement());
     ASSERT(m_accumulatedRepaintRegion);
     auto repaintRects = m_accumulatedRepaintRegion->rects();
     for (auto& rect : repaintRects)

--- a/Source/WebKit/Shared/LoadParameters.cpp
+++ b/Source/WebKit/Shared/LoadParameters.cpp
@@ -38,6 +38,7 @@ void LoadParameters::encode(IPC::Encoder& encoder) const
     encoder << host;
 #endif
     encoder << navigationID;
+    encoder << frameIdentifier;
     encoder << request;
 
     encoder << static_cast<bool>(request.httpBody());
@@ -81,6 +82,9 @@ bool LoadParameters::decode(IPC::Decoder& decoder, LoadParameters& data)
 #endif
 
     if (!decoder.decode(data.navigationID))
+        return false;
+
+    if (!decoder.decode(data.frameIdentifier))
         return false;
 
     if (!decoder.decode(data.request))

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -31,6 +31,7 @@
 #include "SandboxExtension.h"
 #include "UserData.h"
 #include "WebsitePoliciesData.h"
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ShouldTreatAsContinuingLoad.h>
@@ -62,6 +63,7 @@ struct LoadParameters {
 #endif
 
     uint64_t navigationID { 0 };
+    std::optional<WebCore::FrameIdentifier> frameIdentifier;
 
     WebCore::ResourceRequest request;
     SandboxExtension::Handle sandboxExtensionHandle;

--- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
@@ -200,9 +200,7 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
 #endif
 
     encoder << contentSecurityPolicyModeForExtension;
-    encoder << mainFrameIdentifier;
-    encoder << mainFrameCreationParameters;
-    encoder << layerHostingContextIdentifier;
+    encoder << subframeProcessFrameTreeInitializationParameters;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
     encoder << lookalikeCharacterStrings;
@@ -648,13 +646,7 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
     if (!decoder.decode(parameters.contentSecurityPolicyModeForExtension))
         return std::nullopt;
 
-    if (!decoder.decode(parameters.mainFrameIdentifier))
-        return std::nullopt;
-
-    if (!decoder.decode(parameters.mainFrameCreationParameters))
-        return std::nullopt;
-
-    if (!decoder.decode(parameters.layerHostingContextIdentifier))
+    if (!decoder.decode(parameters.subframeProcessFrameTreeInitializationParameters))
         return std::nullopt;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
@@ -680,6 +672,34 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
 #endif
 
     return { WTFMove(parameters) };
+}
+
+void WebPageCreationParameters::SubframeProcessFrameTreeInitializationParameters::encode(IPC::Encoder& encoder) const
+{
+    encoder << localFrameIdentifier;
+    encoder << treeCreationParameters;
+    encoder << layerHostingContextIdentifier;
+}
+
+auto WebPageCreationParameters::SubframeProcessFrameTreeInitializationParameters::decode(IPC::Decoder& decoder) -> std::optional<SubframeProcessFrameTreeInitializationParameters>
+{
+    auto localFrameIdentifier = decoder.decode<WebCore::FrameIdentifier>();
+    if (!localFrameIdentifier)
+        return std::nullopt;
+
+    auto treeCreationParameters = decoder.decode<FrameTreeCreationParameters>();
+    if (!treeCreationParameters)
+        return std::nullopt;
+
+    auto layerHostingContextIdentifier = decoder.decode<WebCore::LayerHostingContextIdentifier>();
+    if (!layerHostingContextIdentifier)
+        return std::nullopt;
+
+    return { {
+        WTFMove(*localFrameIdentifier),
+        WTFMove(*treeCreationParameters),
+        WTFMove(*layerHostingContextIdentifier)
+    } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -289,9 +289,15 @@ struct WebPageCreationParameters {
 
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
 
-    std::optional<WebCore::FrameIdentifier> mainFrameIdentifier;
-    Markable<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier; // FIXME: Move to frame.
-    std::optional<FrameTreeCreationParameters> mainFrameCreationParameters;
+    struct SubframeProcessFrameTreeInitializationParameters {
+        WebCore::FrameIdentifier localFrameIdentifier;
+        FrameTreeCreationParameters treeCreationParameters;
+        WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier;
+
+        void encode(IPC::Encoder&) const;
+        static std::optional<SubframeProcessFrameTreeInitializationParameters> decode(IPC::Decoder&);
+    };
+    std::optional<SubframeProcessFrameTreeInitializationParameters> subframeProcessFrameTreeInitializationParameters;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
     Vector<String> lookalikeCharacterStrings;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -114,7 +114,8 @@ private:
     // Message handlers
     virtual void setPreferredFramesPerSecond(WebCore::FramesPerSecond) { }
     void willCommitLayerTree(TransactionID);
-    void commitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&);
+    void commitLayerTree(IPC::Connection&, const Vector<std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>>&);
+    void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&);
     virtual void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) { }
 
     void asyncSetLayerContents(WebCore::PlatformLayerIdentifier, ImageBufferBackendHandle&&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
@@ -23,6 +23,6 @@
 messages -> RemoteLayerTreeDrawingAreaProxy : DrawingAreaProxy NotRefCounted {
     void SetPreferredFramesPerSecond(unsigned preferredFramesPerSecond)
     void WillCommitLayerTree(WebKit::TransactionID transactionID)
-    void CommitLayerTree(WebKit::RemoteLayerTreeTransaction layerTreeTransaction, WebKit::RemoteScrollingCoordinatorTransaction scrollingTreeTransaction)
+    void CommitLayerTree(Vector<std::pair<WebKit::RemoteLayerTreeTransaction, WebKit::RemoteScrollingCoordinatorTransaction>> transactions)
     void AsyncSetLayerContents(WebCore::PlatformLayerIdentifier layer, WebKit::ImageBufferBackendHandle handle)
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -137,7 +137,13 @@ void RemoteLayerTreeDrawingAreaProxy::willCommitLayerTree(TransactionID transact
     m_pendingLayerTreeTransactionID = transactionID;
 }
 
-void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connection, const RemoteLayerTreeTransaction& layerTreeTransaction, const RemoteScrollingCoordinatorTransaction& scrollingTreeTransaction)
+void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connection, const Vector<std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>>& transactions)
+{
+    for (auto& transaction : transactions)
+        commitLayerTreeTransaction(connection, transaction.first, transaction.second);
+}
+
+void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection& connection, const RemoteLayerTreeTransaction& layerTreeTransaction, const RemoteScrollingCoordinatorTransaction& scrollingTreeTransaction)
 {
     TraceScope tracingScope(CommitLayerTreeStart, CommitLayerTreeEnd);
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -125,7 +125,7 @@ public:
     void didReceiveServerRedirectForProvisionalLoad(const URL&);
     void didFailProvisionalLoad();
     void didCommitLoad(const String& contentType, const WebCore::CertificateInfo&, bool containsPluginDocument);
-    void didFinishLoad(bool isAboutBlank);
+    void didFinishLoad();
     void didFailLoad();
     void didSameDocumentNavigation(const URL&); // eg. anchor navigation, session state change.
     void didChangeTitle(const String&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5339,7 +5339,7 @@ void WebPageProxy::didFinishLoadForFrame(FrameIdentifier frameID, FrameInfoData&
                 automationSession->navigationOccurredForFrame(*frame);
         }
 
-        frame->didFinishLoad(request.url().isAboutBlank());
+        frame->didFinishLoad();
 
         m_pageLoadState.commitChanges();
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -982,12 +982,12 @@ RefPtr<PAL::WebGPU::GPU> WebChromeClient::createGPUForWebGPU() const
 #endif
 }
 
-void WebChromeClient::attachRootGraphicsLayer(LocalFrame&, GraphicsLayer* layer)
+void WebChromeClient::attachRootGraphicsLayer(LocalFrame& frame, GraphicsLayer* layer)
 {
     if (layer)
-        m_page.enterAcceleratedCompositingMode(layer);
+        m_page.enterAcceleratedCompositingMode(frame, layer);
     else
-        m_page.exitAcceleratedCompositingMode();
+        m_page.exitAcceleratedCompositingMode(frame);
 }
 
 void WebChromeClient::attachViewOverlayGraphicsLayer(GraphicsLayer* graphicsLayer)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -838,7 +838,7 @@ void WebFrameLoaderClient::dispatchDidReachVisuallyNonEmptyState()
 {
     if (!m_frame->page() || m_frame->page()->corePage()->settings().suppressesIncrementalRendering())
         return;
-    ASSERT(m_frame->isMainFrame());
+    ASSERT(m_frame->isRootFrame());
     completePageTransitionIfNeeded();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -327,7 +327,7 @@ GraphicsLayerFactory* DrawingAreaCoordinatedGraphics::graphicsLayerFactory()
     return m_layerTreeHost ? m_layerTreeHost->graphicsLayerFactory() : nullptr;
 }
 
-void DrawingAreaCoordinatedGraphics::setRootCompositingLayer(GraphicsLayer* graphicsLayer)
+void DrawingAreaCoordinatedGraphics::setRootCompositingLayer(WebCore::Frame&, GraphicsLayer* graphicsLayer)
 {
     if (m_layerTreeHost) {
         if (graphicsLayer) {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -70,7 +70,7 @@ private:
     void unregisterScrollingTree() override;
 
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() override;
-    void setRootCompositingLayer(WebCore::GraphicsLayer*) override;
+    void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void triggerRenderingUpdate() override;
 
 #if USE(COORDINATED_GRAPHICS) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -33,6 +33,7 @@
 #include <WebCore/ActivityState.h>
 #include <WebCore/DisplayRefreshMonitorFactory.h>
 #include <WebCore/FloatRect.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/LayoutMilestone.h>
 #include <WebCore/PlatformScreen.h>
@@ -122,7 +123,8 @@ public:
     virtual bool shouldUseTiledBackingForFrameView(const WebCore::LocalFrameView&) const { return false; }
 
     virtual WebCore::GraphicsLayerFactory* graphicsLayerFactory() { return nullptr; }
-    virtual void setRootCompositingLayer(WebCore::GraphicsLayer*) = 0;
+    virtual void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) = 0;
+    virtual void attachToInitialRootFrame(WebCore::FrameIdentifier) { }
     virtual void triggerRenderingUpdate() = 0;
 
     virtual void willStartRenderingUpdateDisplay();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -40,6 +40,7 @@ namespace WebKit {
 class GraphicsLayerCARemote;
 class PlatformCALayerRemote;
 class RemoteRenderingBackendProxy;
+class WebFrame;
 class WebPage;
 
 // FIXME: This class doesn't do much now. Roll into RemoteLayerTreeDrawingArea?
@@ -67,7 +68,7 @@ public:
 
     DrawingAreaIdentifier drawingAreaIdentifier() const;
 
-    void buildTransaction(RemoteLayerTreeTransaction&, WebCore::PlatformCALayer& rootLayer);
+    void buildTransaction(RemoteLayerTreeTransaction&, WebCore::PlatformCALayer& rootLayer, WebFrame* rootFrame);
 
     void layerPropertyChangedWhileBuildingTransaction(PlatformCALayerRemote&);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -174,13 +174,14 @@ Ref<GraphicsLayer> RemoteLayerTreeContext::createGraphicsLayer(WebCore::Graphics
     return adoptRef(*new GraphicsLayerCARemote(layerType, client, *this));
 }
 
-void RemoteLayerTreeContext::buildTransaction(RemoteLayerTreeTransaction& transaction, PlatformCALayer& rootLayer)
+void RemoteLayerTreeContext::buildTransaction(RemoteLayerTreeTransaction& transaction, PlatformCALayer& rootLayer, WebFrame* rootFrame)
 {
     TraceScope tracingScope(BuildTransactionStart, BuildTransactionEnd);
 
     PlatformCALayerRemote& rootLayerRemote = downcast<PlatformCALayerRemote>(rootLayer);
     transaction.setRootLayerID(rootLayerRemote.layerID());
-    transaction.setRemoteContextHostedIdentifier(m_webPage.layerHostingContextIdentifier());
+    if (rootFrame)
+        transaction.setRemoteContextHostedIdentifier(rootFrame->layerHostingContextIdentifier());
 
     m_currentTransaction = &transaction;
     rootLayerRemote.recursiveBuildTransaction(*this, transaction);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -70,7 +70,8 @@ private:
     void adoptDisplayRefreshMonitorsFromDrawingArea(DrawingArea&) override;
 
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() override;
-    void setRootCompositingLayer(WebCore::GraphicsLayer*) override;
+    void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
+    void attachToInitialRootFrame(WebCore::FrameIdentifier) final;
     void triggerRenderingUpdate() override;
     void attachViewOverlayGraphicsLayer(WebCore::GraphicsLayer*) override;
 
@@ -144,7 +145,15 @@ private:
     };
 
     std::unique_ptr<RemoteLayerTreeContext> m_remoteLayerTreeContext;
-    Ref<WebCore::GraphicsLayer> m_rootLayer;
+    
+    struct RootLayerInfo {
+        Ref<WebCore::GraphicsLayer> layer;
+        RefPtr<WebCore::GraphicsLayer> contentLayer;
+        RefPtr<WebCore::GraphicsLayer> viewOverlayRootLayer;
+        WeakPtr<WebFrame> frame;
+    };
+
+    Vector<RootLayerInfo> m_rootLayers;
 
     std::optional<WebCore::FloatRect> m_viewExposedRect;
 
@@ -168,9 +177,6 @@ private:
     ActivityStateChangeID m_activityStateChangeID { ActivityStateChangeAsynchronous };
 
     OptionSet<WebCore::LayoutMilestone> m_pendingNewlyReachedPaintingMilestones;
-
-    RefPtr<WebCore::GraphicsLayer> m_contentLayer;
-    RefPtr<WebCore::GraphicsLayer> m_viewOverlayRootLayer;
 };
 
 inline bool RemoteLayerTreeDrawingArea::addMilestonesToDispatch(OptionSet<WebCore::LayoutMilestone> paintMilestones)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -35,6 +35,7 @@
 #import "RemoteLayerTreeDrawingAreaProxyMessages.h"
 #import "RemoteScrollingCoordinator.h"
 #import "RemoteScrollingCoordinatorTransaction.h"
+#import "WebFrame.h"
 #import "WebPage.h"
 #import "WebPageCreationParameters.h"
 #import "WebPageProxyMessages.h"
@@ -58,14 +59,24 @@
 namespace WebKit {
 using namespace WebCore;
 
+static WeakPtr<WebFrame> initialRootFrame(WebPage& page, const WebPageCreationParameters& parameters)
+{
+    if (parameters.subframeProcessFrameTreeInitializationParameters) {
+        // attachToInitialRootFrame will be called once the frame exists.
+        ASSERT(!WebProcess::singleton().webFrame(parameters.subframeProcessFrameTreeInitializationParameters->localFrameIdentifier));
+        return nullptr;
+    }
+    return page.mainWebFrame();
+}
+
 RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea(WebPage& webPage, const WebPageCreationParameters& parameters)
     : DrawingArea(DrawingAreaType::RemoteLayerTree, parameters.drawingAreaIdentifier, webPage)
     , m_remoteLayerTreeContext(makeUnique<RemoteLayerTreeContext>(webPage))
-    , m_rootLayer(GraphicsLayer::create(graphicsLayerFactory(), *this))
+    , m_rootLayers({ RootLayerInfo { GraphicsLayer::create(graphicsLayerFactory(), *this), nullptr, nullptr, initialRootFrame(webPage, parameters) } })
     , m_updateRenderingTimer(*this, &RemoteLayerTreeDrawingArea::updateRendering)
 {
     webPage.corePage()->settings().setForceCompositingMode(true);
-    m_rootLayer->setName(MAKE_STATIC_STRING_IMPL("drawing area root"));
+    m_rootLayers[0].layer->setName(MAKE_STATIC_STRING_IMPL("drawing area root"));
 
     m_commitQueue = adoptOSObject(dispatch_queue_create("com.apple.WebKit.WebContent.RemoteLayerTreeDrawingArea.CommitQueue", nullptr));
 
@@ -125,25 +136,36 @@ void RemoteLayerTreeDrawingArea::setPreferredFramesPerSecond(FramesPerSecond pre
 
 void RemoteLayerTreeDrawingArea::updateRootLayers()
 {
-    Vector<Ref<GraphicsLayer>> children;
-    if (m_contentLayer) {
-        children.append(*m_contentLayer);
-        if (m_viewOverlayRootLayer)
-            children.append(*m_viewOverlayRootLayer);
+    for (auto& rootLayer : m_rootLayers) {
+        Vector<Ref<GraphicsLayer>> children;
+        if (rootLayer.contentLayer) {
+            children.append(*rootLayer.contentLayer);
+            if (rootLayer.viewOverlayRootLayer)
+                children.append(*rootLayer.viewOverlayRootLayer);
+        }
+        rootLayer.layer->setChildren(WTFMove(children));
     }
-
-    m_rootLayer->setChildren(WTFMove(children));
 }
 
 void RemoteLayerTreeDrawingArea::attachViewOverlayGraphicsLayer(GraphicsLayer* viewOverlayRootLayer)
 {
-    m_viewOverlayRootLayer = viewOverlayRootLayer;
+    // FIXME: Support view overlays in iframe processes.
+    m_rootLayers[0].viewOverlayRootLayer = viewOverlayRootLayer;
     updateRootLayers();
 }
 
-void RemoteLayerTreeDrawingArea::setRootCompositingLayer(GraphicsLayer* rootLayer)
+void RemoteLayerTreeDrawingArea::attachToInitialRootFrame(WebCore::FrameIdentifier frameID)
 {
-    m_contentLayer = rootLayer;
+    m_rootLayers[0].frame = WebProcess::singleton().webFrame(frameID);
+    ASSERT(m_rootLayers[0].frame);
+}
+
+void RemoteLayerTreeDrawingArea::setRootCompositingLayer(WebCore::Frame& frame, GraphicsLayer* rootGraphicsLayer)
+{
+    for (auto& rootLayer : m_rootLayers) {
+        if (rootLayer.frame && rootLayer.frame->coreFrame() == &frame)
+            rootLayer.contentLayer = rootGraphicsLayer;
+    }
     updateRootLayers();
     triggerRenderingUpdate();
 }
@@ -174,8 +196,7 @@ void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, bool fl
 
 bool RemoteLayerTreeDrawingArea::shouldUseTiledBackingForFrameView(const LocalFrameView& frameView) const
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(frameView.frame());
-    return (localFrame && localFrame->isMainFrame())
+    return frameView.frame().isRootFrame()
         || m_webPage.corePage()->settings().asyncFrameScrollingEnabled();
 }
 
@@ -187,7 +208,8 @@ void RemoteLayerTreeDrawingArea::updatePreferences(const WebPreferencesStore& pr
     // in order to be scrolled by the ScrollingCoordinator.
     settings.setAcceleratedCompositingForFixedPositionEnabled(true);
 
-    m_rootLayer->setShowDebugBorder(settings.showDebugBorders());
+    for (auto& rootLayer : m_rootLayers)
+        rootLayer.layer->setShowDebugBorder(settings.showDebugBorders());
 
     m_remoteLayerTreeContext->setUseCGDisplayListsForDOMRendering(preferences.getBoolValueForKey(WebPreferencesKey::useCGDisplayListsForDOMRenderingKey()));
     m_remoteLayerTreeContext->setUseCGDisplayListImageCache(preferences.getBoolValueForKey(WebPreferencesKey::useCGDisplayListImageCacheKey()) && !preferences.getBoolValueForKey(WebPreferencesKey::replayCGDisplayListsIntoBackingStoreKey()));
@@ -329,49 +351,58 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     willStartRenderingUpdateDisplay();
 
     // Because our view-relative overlay root layer is not attached to the FrameView's GraphicsLayer tree, we need to flush it manually.
-    if (m_viewOverlayRootLayer)
-        m_viewOverlayRootLayer->flushCompositingState(visibleRect);
+    for (auto& rootLayer : m_rootLayers) {
+        if (rootLayer.viewOverlayRootLayer)
+            rootLayer.viewOverlayRootLayer->flushCompositingState(visibleRect);
+    }
 
     RELEASE_ASSERT(!m_pendingBackingStoreFlusher || m_pendingBackingStoreFlusher->hasFlushed());
 
     RemoteLayerBackingStoreCollection& backingStoreCollection = m_remoteLayerTreeContext->backingStoreCollection();
     backingStoreCollection.willFlushLayers();
 
-    m_rootLayer->flushCompositingStateForThisLayerOnly();
-
     // FIXME: Minimize these transactions if nothing changed.
-    RemoteLayerTreeTransaction layerTransaction;
-    layerTransaction.setTransactionID(takeNextTransactionID());
-    layerTransaction.setCallbackIDs(WTFMove(m_pendingCallbackIDs));
+    Vector<std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>> transactions;
+    transactions.reserveInitialCapacity(m_rootLayers.size());
+    for (auto& rootLayer : m_rootLayers) {
+        rootLayer.layer->flushCompositingStateForThisLayerOnly();
+        
+        RemoteLayerTreeTransaction layerTransaction;
+        layerTransaction.setTransactionID(takeNextTransactionID());
+        layerTransaction.setCallbackIDs(WTFMove(m_pendingCallbackIDs));
+        
+        m_remoteLayerTreeContext->setNextRenderingUpdateRequiresSynchronousImageDecoding(m_nextRenderingUpdateRequiresSynchronousImageDecoding);
+        m_remoteLayerTreeContext->buildTransaction(layerTransaction, *downcast<GraphicsLayerCARemote>(rootLayer.layer.get()).platformCALayer(), rootLayer.frame.get());
+        m_remoteLayerTreeContext->setNextRenderingUpdateRequiresSynchronousImageDecoding(false);
+        
+        backingStoreCollection.willCommitLayerTree(layerTransaction);
+        m_webPage.willCommitLayerTree(layerTransaction, rootLayer.frame.get());
+        
+        layerTransaction.setNewlyReachedPaintingMilestones(std::exchange(m_pendingNewlyReachedPaintingMilestones, { }));
+        layerTransaction.setActivityStateChangeID(std::exchange(m_activityStateChangeID, ActivityStateChangeAsynchronous));
+        
+        willCommitLayerTree(layerTransaction);
+        
+        m_nextRenderingUpdateRequiresSynchronousImageDecoding = false;
+        m_waitingForBackingStoreSwap = true;
+        
+        send(Messages::RemoteLayerTreeDrawingAreaProxy::WillCommitLayerTree(layerTransaction.transactionID()));
 
-    m_remoteLayerTreeContext->setNextRenderingUpdateRequiresSynchronousImageDecoding(m_nextRenderingUpdateRequiresSynchronousImageDecoding);
-    m_remoteLayerTreeContext->buildTransaction(layerTransaction, *downcast<GraphicsLayerCARemote>(m_rootLayer.get()).platformCALayer());
-    m_remoteLayerTreeContext->setNextRenderingUpdateRequiresSynchronousImageDecoding(false);
-
-    backingStoreCollection.willCommitLayerTree(layerTransaction);
-    m_webPage.willCommitLayerTree(layerTransaction);
-
-    layerTransaction.setNewlyReachedPaintingMilestones(std::exchange(m_pendingNewlyReachedPaintingMilestones, { }));
-    layerTransaction.setActivityStateChangeID(std::exchange(m_activityStateChangeID, ActivityStateChangeAsynchronous));
-
-    RemoteScrollingCoordinatorTransaction scrollingTransaction;
+        RemoteScrollingCoordinatorTransaction scrollingTransaction;
 #if ENABLE(ASYNC_SCROLLING)
-    if (m_webPage.scrollingCoordinator())
-        downcast<RemoteScrollingCoordinator>(*m_webPage.scrollingCoordinator()).buildTransaction(scrollingTransaction);
+        if (m_webPage.scrollingCoordinator())
+            downcast<RemoteScrollingCoordinator>(*m_webPage.scrollingCoordinator()).buildTransaction(scrollingTransaction);
 #endif
+        transactions.uncheckedAppend({ WTFMove(layerTransaction), WTFMove(scrollingTransaction) });
+    }
 
-    willCommitLayerTree(layerTransaction);
-
-    m_nextRenderingUpdateRequiresSynchronousImageDecoding = false;
-    m_waitingForBackingStoreSwap = true;
-
-    send(Messages::RemoteLayerTreeDrawingAreaProxy::WillCommitLayerTree(layerTransaction.transactionID()));
-
-    Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree message(layerTransaction, scrollingTransaction);
+    Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree message(transactions);
     auto commitEncoder = makeUniqueRef<IPC::Encoder>(Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree::name(), m_identifier.toUInt64());
     commitEncoder.get() << WTFMove(message).arguments();
 
-    auto flushers = backingStoreCollection.didFlushLayers(layerTransaction);
+    Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>> flushers;
+    for (auto& transactions : transactions)
+        flushers.appendVector(backingStoreCollection.didFlushLayers(transactions.first));
     bool haveFlushers = flushers.size();
     RefPtr<BackingStoreFlusher> backingStoreFlusher = BackingStoreFlusher::create(WebProcess::singleton().parentProcessConnection(), WTFMove(commitEncoder), WTFMove(flushers));
     m_pendingBackingStoreFlusher = backingStoreFlusher;
@@ -428,7 +459,8 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh()
 
 void RemoteLayerTreeDrawingArea::mainFrameContentSizeChanged(const IntSize& contentsSize)
 {
-    m_rootLayer->setSize(contentsSize);
+    // FIXME: Make this more aware of subframe processes where the root frame isn't always the main frame.
+    m_rootLayers[0].layer->setSize(contentsSize);
 }
 
 void RemoteLayerTreeDrawingArea::tryMarkLayersVolatile(CompletionHandler<void(bool)>&& completionFunction)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -441,7 +441,7 @@ public:
 #endif
 
 #if PLATFORM(COCOA)
-    void willCommitLayerTree(RemoteLayerTreeTransaction&);
+    void willCommitLayerTree(RemoteLayerTreeTransaction&, WebFrame*);
     void didFlushLayerTreeAtTime(MonotonicTime);
 #endif
 
@@ -676,8 +676,8 @@ public:
     bool defersLoading() const;
     void setDefersLoading(bool deferLoading);
 
-    void enterAcceleratedCompositingMode(WebCore::GraphicsLayer*);
-    void exitAcceleratedCompositingMode();
+    void enterAcceleratedCompositingMode(WebCore::Frame&, WebCore::GraphicsLayer*);
+    void exitAcceleratedCompositingMode(WebCore::Frame&);
 
 #if ENABLE(PDFKIT_PLUGIN)
     void addPluginView(PluginView*);
@@ -922,6 +922,8 @@ public:
     };
     void freezeLayerTree(LayerTreeFreezeReason);
     void unfreezeLayerTree(LayerTreeFreezeReason);
+    
+    void updateFrameSize(WebCore::FrameIdentifier, WebCore::IntSize);
 
     void isLayerTreeFrozen(CompletionHandler<void(bool)>&&);
 
@@ -1625,10 +1627,10 @@ public:
     bool shouldSkipDecidePolicyForResponse(const WebCore::ResourceResponse&, const WebCore::ResourceRequest&) const;
     void setSkipDecidePolicyForResponseIfPossible(bool value) { m_skipDecidePolicyForResponseIfPossible = value; }
 
-    Markable<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
-
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
+
+    void constructFrameTree(WebFrame& parent, WebCore::FrameIdentifier localFrameIdentifier, WebCore::LayerHostingContextIdentifier localFrameHostLayerIdentifier, const FrameTreeCreationParameters&);
 
     void updateThrottleState();
 
@@ -2557,7 +2559,6 @@ private:
     Vector<String> m_corsDisablingPatterns;
 
     std::unique_ptr<WebCore::CachedPage> m_cachedPage;
-    Markable<WebCore::LayerHostingContextIdentifier> m_layerHostingContextIdentifier;
 
 #if ENABLE(IPC_TESTING_API)
     bool m_ipcTestingAPIEnabled { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -720,4 +720,6 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     PauseAllAnimations() -> ()
     PlayAllAnimations() -> ()
 #endif
+
+    UpdateFrameSize(WebCore::FrameIdentifier frame, WebCore::IntSize newSize)
 }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4035,7 +4035,13 @@ void WebPage::viewportConfigurationChanged(ZoomToInitialScale zoomToInitialScale
     updateSizeForCSSSmallViewportUnits();
     updateSizeForCSSLargeViewportUnits();
 
-    auto& frameView = *mainFrameView();
+    auto* mainFrameView = this->mainFrameView();
+    if (!mainFrameView) {
+        // FIXME: This is hit in some site isolation tests on iOS. Investigate and fix.
+        return;
+    }
+
+    auto& frameView = *mainFrameView;
     IntPoint scrollPosition = frameView.scrollPosition();
     if (!m_hasReceivedVisibleContentRectsAfterDidCommitLoad) {
         FloatSize minimumLayoutSizeInScrollViewCoordinates = m_viewportConfiguration.viewLayoutSize();
@@ -4464,7 +4470,13 @@ String WebPage::platformUserAgent(const URL&) const
     if (!m_page->settings().needsSiteSpecificQuirks())
         return String();
 
-    auto document = m_mainFrame->coreFrame()->document();
+    auto* mainFrame = m_mainFrame->coreFrame();
+    if (!mainFrame) {
+        // FIXME: Add a user agent for loads from iframe processes.
+        return { };
+    }
+
+    auto document = mainFrame->document();
     if (!document)
         return String();
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -64,7 +64,7 @@ private:
     void forceRepaintAsync(WebPage&, CompletionHandler<void()>&&) override;
     void setLayerTreeStateIsFrozen(bool) override;
     bool layerTreeStateIsFrozen() const override;
-    void setRootCompositingLayer(WebCore::GraphicsLayer*) override;
+    void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void triggerRenderingUpdate() override;
 
     void updatePreferences(const WebPreferencesStore&) override;

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -160,7 +160,7 @@ void TiledCoreAnimationDrawingArea::setNeedsDisplayInRect(const IntRect& rect)
 {
 }
 
-void TiledCoreAnimationDrawingArea::setRootCompositingLayer(GraphicsLayer* graphicsLayer)
+void TiledCoreAnimationDrawingArea::setRootCompositingLayer(WebCore::Frame&, GraphicsLayer* graphicsLayer)
 {
     CALayer *rootLayer = graphicsLayer ? graphicsLayer->platformLayer() : nil;
 

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -82,7 +82,7 @@ void DrawingAreaWC::updateRootLayers()
     triggerRenderingUpdate();
 }
 
-void DrawingAreaWC::setRootCompositingLayer(GraphicsLayer* rootLayer)
+void DrawingAreaWC::setRootCompositingLayer(WebCore::Frame&, GraphicsLayer* rootLayer)
 {
     m_contentLayer = rootLayer;
     if (rootLayer)

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -56,7 +56,7 @@ private:
     void setLayerTreeStateIsFrozen(bool) override;
     bool layerTreeStateIsFrozen() const override { return m_isRenderingSuspended; }
     void updateGeometry(uint64_t, WebCore::IntSize) override;
-    void setRootCompositingLayer(WebCore::GraphicsLayer*) override;
+    void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void attachViewOverlayGraphicsLayer(WebCore::GraphicsLayer*) override;
     void updatePreferences(const WebPreferencesStore&) override;
     bool shouldUseTiledBackingForFrameView(const WebCore::LocalFrameView&) const override;

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -762,6 +762,8 @@ void InjectedBundlePage::dump()
 
     WKBundleFrameRef frame = WKBundlePageGetMainFrame(m_page);
     auto urlRef = adoptWK(WKBundleFrameCopyURL(frame));
+    if (!urlRef)
+        return;
     String url = toWTFString(adoptWK(WKURLCopyString(urlRef.get())));
     auto mimeType = adoptWK(WKBundleFrameCopyMIMETypeForResourceWithURL(frame, urlRef.get()));
     if (url.find("dumpAsText/"_s) != notFound || WKStringIsEqualToUTF8CString(mimeType.get(), "text/plain"))


### PR DESCRIPTION
#### 93cc4767ec04fbe1027cda51ccb2ad1d47fa879f
<pre>
Create entire frame tree in iframe processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=254126">https://bugs.webkit.org/show_bug.cgi?id=254126</a>

Reviewed by Chris Dumez.

This makes it so that in a subframe process, we make the entire frame tree with a RemoteFrame as the main frame.
The next step will be to broadcast frame tree changes to all processes when an iframe is made in one process.
In order to get the pixels from the iframe to still draw to the screen, we had to introduce the concept of
root frames, which are the topmost LocalFrames in a particular process, and those are the frames that have a root
layer that is sent to the UI process in a RemoteLayerTreeTransaction.  In places where we used to tell the main
frame to draw, we now need to iterate all the root layers and tell each of them to draw.  We currently only have
unit tests that have one root layer per process, but this is a step towards having the ability to have multiple,
such as if a.com has two iframes, each of which is showing b.com.

Instead of using the DrawingArea::UpdateGeometry message to update the size of iframes, we make a new message
WebPage::UpdateFrameSize for that purpose that does many of the same things, importantly calling FrameView::resize
to make iframes draw their content into Widgets that are the right size to composite into another process&apos;s content.

I remove a hack I introduced for WebFrameProxy::didFinishLoad to ignore about:blank when considering whether to send
WebFrame::DidFinishLoadInAnotherProcess.  The hack is no longer necessary.

The ProvisionalFrameProxy constructor sent WebPage::LoadRequest messages twice.  That was a mistake that wasn&apos;t making
any tests fail yet, but we only need to send it once.

WebKitTestRunner needed a null check to not crash in the test http/tests/site-isolation/basic-iframe.html because
WKBundlePageGetMainFrame returns a WebFrame wrapping a RemoteFrame.  It&apos;s fine to just early return because we aren&apos;t
getting render tree output in any site isolation tests yet, but we will likely need to revisit that change when we do.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didReachVisuallyNonEmptyState):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::isRootFrame const):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::checkAndDispatchDidReachVisuallyNonEmptyState):
* Source/WebCore/page/Page.cpp:
(WebCore::createMainFrame):
(WebCore::Page::finalizeRenderingUpdate):
(WebCore::Page::finalizeRenderingUpdateForRootFrame):
* Source/WebCore/page/Page.h:
(WebCore::Page::rootFrames const):
(WebCore::Page::addRootFrame):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::LayerRepresentation::operator PlatformLayer* const):
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::repositionScrollingLayers):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::isMainFrameCompositor const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::~RenderObject):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::flushAccumulatedRepaintRegion const):
* Source/WebKit/Shared/LoadParameters.cpp:
(WebKit::LoadParameters::encode const):
(WebKit::LoadParameters::decode):
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.cpp:
(WebKit::WebPageCreationParameters::encode const):
(WebKit::WebPageCreationParameters::decode):
(WebKit::WebPageCreationParameters::SubframeProcessFrameTreeInitializationParameters::encode const):
(WebKit::WebPageCreationParameters::SubframeProcessFrameTreeInitializationParameters::decode):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didFinishLoad):
(WebKit::WebFrameProxy::updateRemoteFrameSize):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::attachRootGraphicsLayer):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDidReachVisuallyNonEmptyState):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::attachToInitialRootFrame):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::buildTransaction):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::initialRootFrame):
(WebKit::RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea):
(WebKit::m_updateRenderingTimer):
(WebKit::RemoteLayerTreeDrawingArea::updateRootLayers):
(WebKit::RemoteLayerTreeDrawingArea::attachViewOverlayGraphicsLayer):
(WebKit::RemoteLayerTreeDrawingArea::attachToInitialRootFrame):
(WebKit::RemoteLayerTreeDrawingArea::setRootCompositingLayer):
(WebKit::RemoteLayerTreeDrawingArea::shouldUseTiledBackingForFrameView const):
(WebKit::RemoteLayerTreeDrawingArea::updatePreferences):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::mainFrameContentSizeChanged):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createLocalSubframeHostedInAnotherProcess):
(WebKit::WebFrame::createRemoteSubframe):
(WebKit::WebFrame::coreAbstractFrame const):
(WebKit::WebFrame::didCommitLoadInAnotherProcess):
(WebKit::WebFrame::isRootFrame const):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
(WebKit::WebFrame::layerHostingContextIdentifier):
(WebKit::WebFrame::setLayerHostingContextIdentifier):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::clientForMainFrame):
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::constructFrameTree):
(WebKit::WebPage::enterAcceleratedCompositingMode):
(WebKit::WebPage::exitAcceleratedCompositingMode):
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::updateFrameSize):
(WebKit::WebPage::willCommitLayerTree):
(WebKit::WebPage::SandboxExtensionTracker::beginLoad):
(WebKit::WebPage::didCommitLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::layerHostingContextIdentifier const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::setRootCompositingLayer):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::dump):

Canonical link: <a href="https://commits.webkit.org/261930@main">https://commits.webkit.org/261930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c907c819e5e59aece2c0217a430b4d5618a28c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/22454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4553 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->