### PR TITLE
[JSC] Add WasmBBQDisassembler

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1139,7 +1139,6 @@
 		53F6BF6D1C3F060A00F41E5D /* InternalFunctionAllocationProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 53F6BF6C1C3F060A00F41E5D /* InternalFunctionAllocationProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53FA2AE11CF37F3F0022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 53FA2AE01CF37F3F0022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53FD04D41D7AB291003287D3 /* WasmCallingConvention.h in Headers */ = {isa = PBXBuildFile; fileRef = 53FD04D21D7AB187003287D3 /* WasmCallingConvention.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		554C418729B14CA5003C9F71 /* WebAssemblyGCObjectBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 554C418529B14CA5003C9F71 /* WebAssemblyGCObjectBase.cpp */; };
 		554C418829B14CA5003C9F71 /* WebAssemblyGCObjectBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 554C418629B14CA5003C9F71 /* WebAssemblyGCObjectBase.h */; };
 		55579D9028DD641000153DAE /* WebAssemblyArrayPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 55579D8D28DD640F00153DAE /* WebAssemblyArrayPrototype.h */; };
 		55579D9128DD641000153DAE /* WebAssemblyArrayConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 55579D8E28DD641000153DAE /* WebAssemblyArrayConstructor.h */; };
@@ -1870,6 +1869,7 @@
 		E307178E24C7829D00DF0644 /* IntlLocale.h in Headers */ = {isa = PBXBuildFile; fileRef = A3AFF92B245A3CF900C9BA3B /* IntlLocale.h */; };
 		E30873E7272559410053B601 /* IntlPluralRules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7D5FB18F20744BF1005DDF64 /* IntlPluralRules.cpp */; };
 		E308A80E294D39340044A109 /* WasmLLIntBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = E308A80D294D39330044A109 /* WasmLLIntBuiltin.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E30D06B829C6C3EE0014CCE7 /* WasmBBQDisassembler.h in Headers */ = {isa = PBXBuildFile; fileRef = E30D06B729C6C3E80014CCE7 /* WasmBBQDisassembler.h */; };
 		E30D903A28B77F28008B2CDC /* ProxyObjectAccessCase.h in Headers */ = {isa = PBXBuildFile; fileRef = E30D903828B77F28008B2CDC /* ProxyObjectAccessCase.h */; };
 		E30E8A5426DE2E4800DA4915 /* TemporalTimeZonePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E8A4E26DE2E4700DA4915 /* TemporalTimeZonePrototype.h */; };
 		E30E8A5626DE2E4800DA4915 /* TemporalTimeZone.h in Headers */ = {isa = PBXBuildFile; fileRef = E30E8A5026DE2E4800DA4915 /* TemporalTimeZone.h */; };
@@ -5352,6 +5352,8 @@
 		E307178124C7824700DF0644 /* IntlSegmenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntlSegmenter.h; sourceTree = "<group>"; };
 		E307178224C7824700DF0644 /* IntlSegmenterConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IntlSegmenterConstructor.cpp; sourceTree = "<group>"; };
 		E308A80D294D39330044A109 /* WasmLLIntBuiltin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmLLIntBuiltin.h; sourceTree = "<group>"; };
+		E30D06B629C6C3E80014CCE7 /* WasmBBQDisassembler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmBBQDisassembler.cpp; sourceTree = "<group>"; };
+		E30D06B729C6C3E80014CCE7 /* WasmBBQDisassembler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmBBQDisassembler.h; sourceTree = "<group>"; };
 		E30D903728B77F27008B2CDC /* ProxyObjectAccessCase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyObjectAccessCase.cpp; sourceTree = "<group>"; };
 		E30D903828B77F28008B2CDC /* ProxyObjectAccessCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyObjectAccessCase.h; sourceTree = "<group>"; };
 		E30E8A4C26DE2E4700DA4915 /* TemporalTimeZonePrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalTimeZonePrototype.cpp; sourceTree = "<group>"; };
@@ -7500,6 +7502,8 @@
 				467DC2ED2906EE3600726988 /* WasmAirIRGeneratorBase.h */,
 				53F40E8E1D5902820099A1B6 /* WasmB3IRGenerator.cpp */,
 				53F40E921D5A4AB30099A1B6 /* WasmB3IRGenerator.h */,
+				E30D06B629C6C3E80014CCE7 /* WasmBBQDisassembler.cpp */,
+				E30D06B729C6C3E80014CCE7 /* WasmBBQDisassembler.h */,
 				FED5FA3329A0859C00798A7F /* WasmBBQJIT.cpp */,
 				FED5FA3229A0859C00798A7F /* WasmBBQJIT.h */,
 				53CA73071EA533D80076049D /* WasmBBQPlan.cpp */,
@@ -11412,6 +11416,7 @@
 				52847ADC21FFB8690061A9DB /* WasmAirIRGenerator.h in Headers */,
 				467DC2F02906EE3600726988 /* WasmAirIRGeneratorBase.h in Headers */,
 				53F40E931D5A4AB30099A1B6 /* WasmB3IRGenerator.h in Headers */,
+				E30D06B829C6C3EE0014CCE7 /* WasmBBQDisassembler.h in Headers */,
 				FED5FA3429A0859C00798A7F /* WasmBBQJIT.h in Headers */,
 				53CA730A1EA533D80076049D /* WasmBBQPlan.h in Headers */,
 				AD4B1DFA1DF244E20071AE32 /* WasmBinding.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1103,6 +1103,7 @@ tools/VMInspector.cpp
 wasm/WasmAirIRGenerator32_64.cpp @no-unify
 wasm/WasmAirIRGenerator64.cpp @no-unify
 wasm/WasmB3IRGenerator.cpp
+wasm/WasmBBQDisassembler.cpp
 wasm/WasmBBQJIT.cpp @no-unify
 wasm/WasmBBQPlan.cpp
 wasm/WasmBinding.cpp

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.h
@@ -33,6 +33,7 @@
 #include "JITCompilation.h"
 #include "JITOpaqueByproducts.h"
 #include "PCToCodeOriginMap.h"
+#include "WasmBBQDisassembler.h"
 #include "WasmCompilationMode.h"
 #include "WasmJS.h"
 #include "WasmMemory.h"
@@ -55,6 +56,7 @@ struct CompilationContext {
     std::unique_ptr<CCallHelpers> wasmEntrypointJIT;
     std::unique_ptr<OpaqueByproducts> wasmEntrypointByproducts;
     std::unique_ptr<B3::Procedure> procedure;
+    std::unique_ptr<BBQDisassembler> bbqDisassembler;
     Box<PCToCodeOriginMap> pcToCodeOriginMap;
     Box<PCToCodeOriginMapBuilder> pcToCodeOriginMapBuilder;
     Vector<CCallHelpers::Label> catchEntrypoints;

--- a/Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WasmBBQDisassembler.h"
+
+#if ENABLE(WEBASSEMBLY_B3JIT)
+
+#include "Disassembler.h"
+#include "LinkBuffer.h"
+#include <wtf/HexNumber.h>
+#include <wtf/StringPrintStream.h>
+
+namespace JSC {
+namespace Wasm {
+
+BBQDisassembler::BBQDisassembler() = default;
+
+BBQDisassembler::~BBQDisassembler() = default;
+
+void BBQDisassembler::dump(PrintStream& out, LinkBuffer& linkBuffer)
+{
+    m_codeStart = linkBuffer.entrypoint<DisassemblyPtrTag>().untaggedPtr();
+    m_codeEnd = bitwise_cast<uint8_t*>(m_codeStart) + linkBuffer.size();
+
+    dumpHeader(out, linkBuffer);
+    if (m_labels.isEmpty())
+        dumpDisassembly(out, linkBuffer, m_startOfCode, m_endOfCode);
+    else {
+        dumpDisassembly(out, linkBuffer, m_startOfCode, std::get<0>(m_labels[0]));
+        dumpForInstructions(out, linkBuffer, "    ", m_labels, m_endOfOpcode);
+        out.print("    (End Of Main Code)\n");
+        dumpDisassembly(out, linkBuffer, m_endOfOpcode, m_endOfCode);
+    }
+}
+
+void BBQDisassembler::dump(LinkBuffer& linkBuffer)
+{
+    dump(WTF::dataFile(), linkBuffer);
+}
+
+void BBQDisassembler::dumpHeader(PrintStream& out, LinkBuffer& linkBuffer)
+{
+    out.print("   Code at [", RawPointer(linkBuffer.debugAddress()), ", ", RawPointer(static_cast<char*>(linkBuffer.debugAddress()) + linkBuffer.size()), "):\n");
+}
+
+Vector<BBQDisassembler::DumpedOp> BBQDisassembler::dumpVectorForInstructions(LinkBuffer& linkBuffer, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpType, size_t>>& labels, MacroAssembler::Label endLabel)
+{
+    StringPrintStream out;
+    Vector<DumpedOp> result;
+
+    for (unsigned i = 0; i < labels.size();) {
+        out.reset();
+        auto opcode = std::get<1>(labels[i]);
+        auto offset = std::get<2>(labels[i]);
+        result.append(DumpedOp { { } });
+        out.print(prefix);
+        out.println("[", makeString(pad(' ', 8, makeString("0x", hex(offset, 0, Lowercase)))), "] ", makeString(opcode));
+        unsigned nextIndex = i + 1;
+        if (nextIndex >= labels.size()) {
+            dumpDisassembly(out, linkBuffer, std::get<0>(labels[i]), endLabel);
+            result.last().disassembly = out.toCString();
+            return result;
+        }
+        dumpDisassembly(out, linkBuffer, std::get<0>(labels[i]), std::get<0>(labels[nextIndex]));
+        result.last().disassembly = out.toCString();
+        i = nextIndex;
+    }
+
+    return result;
+}
+
+void BBQDisassembler::dumpForInstructions(PrintStream& out, LinkBuffer& linkBuffer, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpType, size_t>>& labels, MacroAssembler::Label endLabel)
+{
+    Vector<DumpedOp> dumpedOps = dumpVectorForInstructions(linkBuffer, prefix, labels, endLabel);
+
+    for (unsigned i = 0; i < dumpedOps.size(); ++i)
+        out.print(dumpedOps[i].disassembly);
+}
+
+void BBQDisassembler::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, MacroAssembler::Label from, MacroAssembler::Label to)
+{
+    CodeLocationLabel<DisassemblyPtrTag> fromLocation = linkBuffer.locationOf<DisassemblyPtrTag>(from);
+    CodeLocationLabel<DisassemblyPtrTag> toLocation = linkBuffer.locationOf<DisassemblyPtrTag>(to);
+    disassemble(fromLocation, toLocation.dataLocation<uintptr_t>() - fromLocation.dataLocation<uintptr_t>(), m_codeStart, m_codeEnd, "        ", out);
+}
+
+} // namespace Wasm
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY_B3JIT)

--- a/Source/JavaScriptCore/wasm/WasmBBQDisassembler.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQDisassembler.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY_B3JIT)
+
+#include "BytecodeIndex.h"
+#include "MacroAssembler.h"
+#include "WasmOpcodeOrigin.h"
+#include <wtf/Vector.h>
+#include <wtf/text/CString.h>
+
+namespace JSC {
+
+class LinkBuffer;
+
+namespace Wasm {
+
+class BBQCallee;
+
+class BBQDisassembler {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    BBQDisassembler();
+    ~BBQDisassembler();
+
+    void setStartOfCode(MacroAssembler::Label label) { m_startOfCode = label; }
+    void setOpcode(MacroAssembler::Label label, OpType opcode, size_t offset)
+    {
+        m_labels.append(std::tuple { label, opcode, offset });
+    }
+    void setEndOfOpcode(MacroAssembler::Label label) { m_endOfOpcode = label; }
+    void setEndOfCode(MacroAssembler::Label label) { m_endOfCode = label; }
+
+    void dump(LinkBuffer&);
+    void dump(PrintStream&, LinkBuffer&);
+
+private:
+    void dumpHeader(PrintStream&, LinkBuffer&);
+
+    struct DumpedOp {
+        CString disassembly;
+    };
+    Vector<DumpedOp> dumpVectorForInstructions(LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpType, size_t>>& labels, MacroAssembler::Label endLabel);
+
+    void dumpForInstructions(PrintStream&, LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpType, size_t>>& labels, MacroAssembler::Label endLabel);
+    void dumpDisassembly(PrintStream&, LinkBuffer&, MacroAssembler::Label from, MacroAssembler::Label to);
+
+    MacroAssembler::Label m_startOfCode;
+    Vector<std::tuple<MacroAssembler::Label, OpType, size_t>> m_labels;
+    MacroAssembler::Label m_endOfOpcode;
+    MacroAssembler::Label m_endOfCode;
+    void* m_codeStart { nullptr };
+    void* m_codeEnd { nullptr };
+};
+
+} // namespace Wasm
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY_B3JIT)

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -102,7 +102,11 @@ bool BBQPlan::prepareImpl()
 bool BBQPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& linkBuffer, unsigned functionIndex, const TypeDefinition& signature, unsigned functionIndexSpace)
 {
     if (UNLIKELY(shouldDumpDisassemblyFor(CompilationMode::BBQMode))) {
-        if (!Options::useSinglePassBBQJIT()) {
+        dataLogF("Generated BBQ code for WebAssembly BBQ function[%i] %s name %s\n", functionIndex, signature.toString().ascii().data(), makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data());
+        if (Options::useSinglePassBBQJIT()) {
+            if (context.bbqDisassembler)
+                context.bbqDisassembler->dump(linkBuffer);
+        } else {
             auto* disassembler = context.procedure->code().disassembler();
 
             const char* b3Prefix = "b3    ";
@@ -119,11 +123,10 @@ bool BBQPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& linkBuffe
                 }
             });
 
-            dataLogLn("Generated BBQ code for WebAssembly BBQ function[%i] %s name %s", functionIndex, signature.toString().ascii().data(), makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data());
             disassembler->dump(context.procedure->code(), WTF::dataFile(), linkBuffer, airPrefix, asmPrefix, forEachInst);
-            linkBuffer.didAlreadyDisassemble();
-            return true;
         }
+        linkBuffer.didAlreadyDisassemble();
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
#### 7bdb70dd637f3e6c3b6c7739d302f2b9ea5b2cc0
<pre>
[JSC] Add WasmBBQDisassembler
<a href="https://bugs.webkit.org/show_bug.cgi?id=254128">https://bugs.webkit.org/show_bug.cgi?id=254128</a>
rdar://106906971

Reviewed by Mark Lam.

This patch adds better disassembler support to new WasmBBQJIT (since previous old BBQ had good disassembler. So now it was missing).
It dumps code with Wasm Opcode information as follows.

    ...
               &lt;128&gt; 0x10d000080:    b.pl     0x10d00044c -&gt; &lt;1100&gt;
    [     0x3] Block
    [     0x5] Block
    [     0x7] GetLocal
               &lt;132&gt; 0x10d000084:    ldur     w0, [fp, #-12]
    [     0x9] I32Const
    [     0xb] I32Add
               &lt;136&gt; 0x10d000088:    add      w0, w0, #16
    [     0xc] TeeLocal
               &lt;140&gt; 0x10d00008c:    stur     w0, [fp, #-20]
               &lt;144&gt; 0x10d000090:    ldur     w0, [fp, #-20]
    [     0xe] I32Load
               &lt;148&gt; 0x10d000094:    ldr      w0, [x22, w0, uxtw]
    [    0x11] TeeLocal
               &lt;152&gt; 0x10d000098:    stur     w0, [fp, #-16]
               &lt;156&gt; 0x10d00009c:    ldur     w0, [fp, #-16]
    [    0x13] BrIf
               &lt;160&gt; 0x10d0000a0:    mov      x8, x0
               &lt;164&gt; 0x10d0000a4:    cbz      w8, 0x10d0000ac -&gt; &lt;172&gt;
               &lt;168&gt; 0x10d0000a8:    b        0x10d0000e4 -&gt; &lt;228&gt;
    ...

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.h:
* Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp: Added.
(JSC::Wasm::BBQDisassembler::dump):
(JSC::Wasm::BBQDisassembler::dumpHeader):
(JSC::Wasm::BBQDisassembler::dumpVectorForInstructions):
(JSC::Wasm::BBQDisassembler::dumpForInstructions):
(JSC::Wasm::BBQDisassembler::dumpDisassembly):
* Source/JavaScriptCore/wasm/WasmBBQDisassembler.h: Added.
(JSC::Wasm::BBQDisassembler::setStartOfCode):
(JSC::Wasm::BBQDisassembler::setOpcode):
(JSC::Wasm::BBQDisassembler::setEndOfOpcode):
(JSC::Wasm::BBQDisassembler::setEndOfCode):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJIT::endTopLevel):
(JSC::Wasm::BBQJIT::willParseOpcode):
(JSC::Wasm::BBQJIT::finalize):
(JSC::Wasm::BBQJIT::takeDisassembler):
(JSC::Wasm::parseAndCompileBBQ):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::dumpDisassembly):

Canonical link: <a href="https://commits.webkit.org/261835@main">https://commits.webkit.org/261835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1106eae6d6be83c93044e0ffb9b57539b97a49fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121507 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13342 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/6017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118809 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106113 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/1275 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/101278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14469 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1317 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12626 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15179 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102815 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53309 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/32069 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17028 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/110867 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4528 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27374 "Passed tests") | 
<!--EWS-Status-Bubble-End-->