### PR TITLE
[ManagedMSE] network transfer should be tagged as media between startstreaming/endstreaming events

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -54,8 +54,7 @@ private:
     explicit ManagedMediaSource(ScriptExecutionContext&);
     void monitorSourceBuffers() final;
     bool isBuffered(const PlatformTimeRanges&) const;
-    void startStreaming();
-    void endStreaming();
+    void setStreaming(bool);
     bool m_streaming { false };
     std::optional<double> m_lowThreshold;
     std::optional<double> m_highThreshold;

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -525,6 +525,9 @@ ExceptionOr<void> MediaSource::setDurationInternal(const MediaTime& duration)
     // 6. Update the media duration to new duration and run the HTMLMediaElement duration change algorithm.
     m_private->durationChanged(newDuration);
 
+    // Changing the duration affects the buffered range.
+    monitorSourceBuffers();
+
     return { };
 }
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -135,6 +135,7 @@ protected:
     bool hasFutureTime();
 
     void scheduleEvent(const AtomString& eventName);
+    void notifyElementUpdateMediaState() const;
 
     std::unique_ptr<PlatformTimeRanges> m_buffered;
 
@@ -163,7 +164,6 @@ private:
 
     void regenerateActiveSourceBuffers();
     void updateBufferedIfNeeded();
-    void notifyElementUpdateMediaState() const;
 
     void completeSeek();
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -156,7 +156,11 @@
 
 #if ENABLE(MEDIA_SOURCE)
 #include "LocalDOMWindow.h"
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+#include "ManagedMediaSource.h"
+#else
 #include "MediaSource.h"
+#endif
 #include "SourceBufferList.h"
 #endif
 
@@ -8516,8 +8520,18 @@ MediaProducerMediaStateFlags HTMLMediaElement::mediaState() const
 #endif
 
 #if ENABLE(MEDIA_SOURCE)
+    bool streaming = false;
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+    RefPtr managedMediasource = is<ManagedMediaSource>(m_mediaSource) ? downcast<ManagedMediaSource>(m_mediaSource.get()) : nullptr;
+    streaming |= managedMediasource && managedMediasource->streaming();
+    if (!managedMediasource) {
+#endif
     // We can assume that if we have active source buffers, later networking activity (such as stream or XHR requests) will be media related.
-    if (m_mediaSource && m_mediaSource->activeSourceBuffers() && m_mediaSource->activeSourceBuffers()->length())
+    streaming |= m_mediaSource && m_mediaSource->activeSourceBuffers() && m_mediaSource->activeSourceBuffers()->length();
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+    }
+#endif
+    if (streaming)
         state.add(MediaProducerMediaState::HasStreamingActivity);
 #endif
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1003,6 +1003,7 @@
 		CD577799211CE0E4001B371E /* web-audio-only.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD577798211CDE8F001B371E /* web-audio-only.html */; };
 		CD57779C211CE91F001B371E /* audio-with-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779A211CE6B7001B371E /* audio-with-web-audio.html */; };
 		CD57779D211CE91F001B371E /* video-with-audio-and-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */; };
+		51E1007929C6D947009CEE99 /* file-with-managedmse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E1007129C6D891009CEE99 /* file-with-managedmse.html */; };
 		CD59F53419E9110D00CF1835 /* file-with-mse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53219E910AA00CF1835 /* file-with-mse.html */; };
 		CD59F53519E9110D00CF1835 /* test-mse.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53319E910BC00CF1835 /* test-mse.mp4 */; };
 		CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5FF4962162E27E004BD86F /* ISOBox.cpp */; };
@@ -1573,6 +1574,7 @@
 				F41AB9A31EF4696B0083FA08 /* file-uploading.html in Copy Resources */,
 				BC2D006412AA04CE00E732A3 /* file-with-anchor.html in Copy Resources */,
 				49D2E5C22731E3BC00BCCAED /* file-with-iframe.html in Copy Resources */,
+				51E1007929C6D947009CEE99 /* file-with-managedmse.html in Copy Resources */,
 				CD59F53419E9110D00CF1835 /* file-with-mse.html in Copy Resources */,
 				524BBC9E19DF72C0002F1AF1 /* file-with-video.html in Copy Resources */,
 				1A02C870125D4CFD00E3F4BD /* find.html in Copy Resources */,
@@ -3213,6 +3215,7 @@
 		CD577798211CDE8F001B371E /* web-audio-only.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "web-audio-only.html"; sourceTree = "<group>"; };
 		CD57779A211CE6B7001B371E /* audio-with-web-audio.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "audio-with-web-audio.html"; sourceTree = "<group>"; };
 		CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "video-with-audio-and-web-audio.html"; sourceTree = "<group>"; };
+		51E1007129C6D891009CEE99 /* file-with-managedmse.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "file-with-managedmse.html"; sourceTree = "<group>"; };
 		CD59F53219E910AA00CF1835 /* file-with-mse.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "file-with-mse.html"; sourceTree = "<group>"; };
 		CD59F53319E910BC00CF1835 /* test-mse.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse.mp4"; sourceTree = "<group>"; };
 		CD5FF4962162E27E004BD86F /* ISOBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISOBox.cpp; sourceTree = "<group>"; };
@@ -5248,6 +5251,7 @@
 				07492B391DF8ADA400633DE1 /* enumerateMediaDevices.html */,
 				C5E1AFFD16B22179006CC1F2 /* execCopy.html */,
 				BC2D004A12A9FEB300E732A3 /* file-with-anchor.html */,
+				51E1007129C6D891009CEE99 /* file-with-managedmse.html */,
 				CD59F53219E910AA00CF1835 /* file-with-mse.html */,
 				524BBC9B19DF3714002F1AF1 /* file-with-video.html */,
 				1A02C84B125D4A5E00E3F4BD /* find.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script>
+      var video;
+      var source;
+      var sourceBuffer;
+      var request;
+
+      function isMP4Supported()
+      {
+        return MediaSource.isTypeSupported('video/mp4;codecs="avc1.4D4001,mp4a.40.2"');
+      }
+      function isWebMVP9Supported()
+      {
+        return MediaSource.isTypeSupported('video/webm;codecs="vp9,opus"');
+      }
+      function isWebMOpusSupported()
+      {
+        return MediaSource.isTypeSupported('video/webm;codecs="opus"');
+      }
+      function loadVideo()
+      {
+          video = document.getElementById('test-video');
+          request = new XMLHttpRequest();
+          request.responseType = 'arraybuffer';
+          request.open('GET', isMP4Supported() ? 'test-mse.mp4' : isWebMVP9Supported() ? 'test-mse.webm' : 'test-mse-audio.webm', true);
+          request.addEventListener('load', load);
+          request.send();
+      }
+
+      function load(event)
+      {
+          source = new ManagedMediaSource();
+          source.addEventListener('sourceopen', sourceopen);
+          video.src = URL.createObjectURL(source);
+      }
+
+      function sourceopen(event)
+      {
+          sourceBuffer = source.addSourceBuffer(isMP4Supported() ? 'video/mp4;codecs="avc1.4D4001,mp4a.40.2"' : isWebMVP9Supported() ? 'video/webm;codecs="vp9,opus"' : 'video/webm;codecs="opus"');
+      }
+
+      function startStreaming(event)
+      {
+          sourceBuffer.addEventListener('updateend', updateend);
+          sourceBuffer.appendBuffer(request.response);
+      }
+
+      function updateend(event)
+      {
+          // enstreaming event will be fired.
+          source.endOfStream();
+      }
+</script>
+</head>
+<body>
+    <p>
+        <video id="test-video" controls></video>
+    </p>
+    <p>
+        <button onclick="loadVideo()">load video</button>
+        <button onclick="startStreaming()">Stream video</button>
+    </p>
+</body>
+</html>


### PR DESCRIPTION
#### d55ce0bd5ffa26e832da01f2e8d81724311aedd8
<pre>
[ManagedMSE] network transfer should be tagged as media between startstreaming/endstreaming events
<a href="https://bugs.webkit.org/show_bug.cgi?id=253996">https://bugs.webkit.org/show_bug.cgi?id=253996</a>
rdar://106783581

Reviewed by Jer Noble.

Narrow detection of media related streaming activity to only be set
while the ManagedMediaSource&apos;s streaming activity is true.
With plain MSE we keep the existing behaviour.

Fly-by fix: when the MediaSource was ended, `endstreaming` wasn&apos;t fired
even if the entire file content had been buffered already.

API test added.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::setStreaming):
(WebCore::ManagedMediaSource::monitorSourceBuffers):
(WebCore::ManagedMediaSource::startStreaming): Deleted.
(WebCore::ManagedMediaSource::endStreaming): Deleted.
* Source/WebCore/Modules/mediasource/ManagedMediaSource.h:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::setDurationInternal):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaState const):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/261850@main">https://commits.webkit.org/261850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/426291db7180c39206810a48d2d5922f7d5c8df6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121549 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13402 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/6097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118873 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106168 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1326 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14521 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1368 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10703 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53360 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8274 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17082 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->