### PR TITLE
[MSE] SourceBuffer.buffered should return the same object if it's not modified

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-buffered-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-buffered-expected.txt
@@ -6,4 +6,5 @@ PASS Muxed content empty buffered ranges.
 PASS Get buffered range when sourcebuffer is empty.
 PASS Get buffered range when only init segment is appended.
 PASS Get buffered range after removing sourcebuffer.
+PASS buffered return the same object over multiple calls.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-buffered.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-buffered.html
@@ -228,6 +228,17 @@
                     test.done();
                 });
             }, "Get buffered range after removing sourcebuffer.");
+
+            mediasource_test(function(test, mediaElement, mediaSource)
+            {
+                mediaElement.pause();
+                mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
+                mediaElement.addEventListener("ended", test.step_func_done());
+
+                var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_ONLY_TYPE);
+                assert_equals(mediaSource.sourceBuffers[0].buffered , mediaSource.sourceBuffers[0].buffered);
+                test.done();
+            }, "buffered return the same object over multiple calls.");
         </script>
     </body>
 </html>

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -79,7 +79,7 @@ public:
     virtual ~SourceBuffer();
 
     bool updating() const { return m_updating; }
-    ExceptionOr<Ref<TimeRanges>> buffered() const;
+    ExceptionOr<Ref<TimeRanges>> buffered();
     double timestampOffset() const;
     ExceptionOr<void> setTimestampOffset(double);
 
@@ -267,7 +267,7 @@ private:
     bool m_active { false };
     bool m_shouldGenerateTimestamps { false };
     bool m_pendingInitializationSegmentForChangeType { false };
-
+    Ref<TimeRanges> m_buffered;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
     const void* m_logIdentifier;


### PR DESCRIPTION
#### f373c652ff7f6b7fe1a00439c731a9f99dd27344
<pre>
[MSE] SourceBuffer.buffered should return the same object if it&apos;s not modified
<a href="https://bugs.webkit.org/show_bug.cgi?id=253883">https://bugs.webkit.org/show_bug.cgi?id=253883</a>
rdar://106695698

Reviewed by Eric Carlson.

Per spec <a href="https://w3c.github.io/media-source/#dom-sourcebuffer-buffered">https://w3c.github.io/media-source/#dom-sourcebuffer-buffered</a>
step 5. &quot;If intersection ranges does not contain the exact same range
information as the current value of this attribute, then update the current
value of this attribute to intersection ranges.&quot;

A change following a bug lodged in <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=27790">https://www.w3.org/Bugs/Public/show_bug.cgi?id=27790</a>

* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-buffered-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-buffered.html:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::buffered):
(WebCore::SourceBuffer::buffered const): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:

Canonical link: <a href="https://commits.webkit.org/261848@main">https://commits.webkit.org/261848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e9eb48a1784533fc92e991e6e0b12de62fdd326

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/113085 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22218 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1751 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/87/builds/4856 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/117190 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/23588 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/13401 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/87/builds/4856 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/118872 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/23588 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1751 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106167 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/23588 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1751 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/106167 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14520 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1751 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106167 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/15235 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/13401 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1751 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8273 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/17081 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->