### PR TITLE
[GLib] No render update when seeking outside of network buffer in fullscreen

### DIFF
--- a/Source/WebCore/platform/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/UserAgentQuirks.cpp
@@ -66,6 +66,10 @@ static bool urlRequiresChromeBrowser(const String& domain, const String& baseDom
     if (baseDomain == "soundcloud.com"_s)
         return true;
 
+    // Seeking in fullscreen Youtube is broken.
+    if (baseDomain == "youtube.com"_s)
+        return true;
+
     return false;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -87,6 +87,7 @@ TEST(UserAgentTest, Quirks)
     assertUserAgentForURLHasChromeBrowserQuirk("http://auth.mayohr.com/");
     assertUserAgentForURLHasChromeBrowserQuirk("http://bankofamerica.com/");
     assertUserAgentForURLHasChromeBrowserQuirk("http://soundcloud.com/");
+    assertUserAgentForURLHasChromeBrowserQuirk("http://youtube.com/");
 
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://bugzilla.redhat.com/");
 


### PR DESCRIPTION
#### 4ad4b2d3a795edbc28cb95df43bdf187bb8f4097
<pre>
[GLib] No render update when seeking outside of network buffer in fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=253877">https://bugs.webkit.org/show_bug.cgi?id=253877</a>

Reviewed by Michael Catanzaro.

Advertize us as a Chrome UA when browsing Youtube in order to workaround broken seek handling when
playing videos in full-screen.

* Source/WebCore/platform/UserAgentQuirks.cpp:
(WebCore::urlRequiresChromeBrowser):
* Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/261839@main">https://commits.webkit.org/261839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f6283baca2833cc6a4c21768d02b25464cfa488

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6040 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118823 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106127 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99451 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1290 "1 flakes 4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46517 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14483 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1332 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10667 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53324 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8266 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17042 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->