### PR TITLE
REGRESSION iOS 16.4 beta selects ultra-wide for facingMode: environment

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -120,6 +120,9 @@ private:
     void updateVerifyCapturingTimer();
     void verifyIsCapturing();
 
+    std::optional<double> computeMinZoom() const;
+    std::optional<double> computeMaxZoom(AVCaptureDeviceFormat*) const;
+
     RefPtr<VideoFrame> m_buffer;
     RetainPtr<AVCaptureVideoDataOutput> m_videoOutput;
     std::unique_ptr<ImageTransferSessionVT> m_imageTransferSession;
@@ -141,6 +144,7 @@ private:
 
     double m_currentFrameRate;
     double m_currentZoom { 1 };
+    double m_zoomScaleFactor { 1 };
     bool m_interrupted { false };
     bool m_isRunning { false };
 


### PR DESCRIPTION
#### 1ed9893d37379f00ccdfb1da94c568bf4be79ef6
<pre>
REGRESSION iOS 16.4 beta selects ultra-wide for facingMode: environment
<a href="https://bugs.webkit.org/show_bug.cgi?id=253186">https://bugs.webkit.org/show_bug.cgi?id=253186</a>
rdar://problem/106142457

Reviewed by Jer Noble.

For ultra wide back cameras, add a zoomn factor of 2 so that a zoom of 1 corresponds to a standard FOV.
We compute this factor once and we then divide by this factor for capabilities and multiply by this factor for settings.
Manually tested on device.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::computeMinZoom const):
(WebCore::AVVideoCaptureSource::computeMaxZoom const):
(WebCore::cameraZoomScaleFactor):
(WebCore::AVVideoCaptureSource::AVVideoCaptureSource):
(WebCore::AVVideoCaptureSource::setFrameRateAndZoomWithPreset):
(WebCore::AVVideoCaptureSource::generatePresets):
(WebCore::computeMaxZoom): Deleted.

Canonical link: <a href="https://commits.webkit.org/261877@main">https://commits.webkit.org/261877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/004b11030320b0bd25626197335d5c6114e0cc4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6121 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106189 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46567 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14542 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1384 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10716 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53375 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8295 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17103 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->