### PR TITLE
[GTK] Unreviewed, remove duplicated entries in API GTK test expectations after 261731@main

### DIFF
--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -150,16 +150,13 @@
                 "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug": "webkit.org/b/210635"}}
             },
             "/webkit/WebKitWebView/is-web-process-responsive": {
-                "expected": {"gtk": {"status": ["PASS"], "slow": true}}
+                "expected": {"gtk": {"status": ["PASS", "TIMEOUT"], "slow": true, "bug": "webkit.org/b/254002"}}
             },
             "/webkit/WebKitWebView/fullscreen": {
                 "expected": {
                         "gtk": {"status": ["SKIP"], "bug": "webkit.org/b/248203"},
                         "wpe": {"status": ["TIMEOUT", "PASS"]}
                 }
-            },
-            "/webkit/WebKitWebView/is-web-process-responsive": {
-                "expected": {"gtk": {"status": ["TIMEOUT"], "bug": "webkit.org/b/254002"}}
             },
             "/webkit/WebKitWebView/terminate-unresponsive-web-process": {
                 "expected": {"gtk": {"status": ["TIMEOUT"], "bug": "webkit.org/b/254002"}}
@@ -224,13 +221,10 @@
                 "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/205336"}}
             },
             "WebKit.OnDeviceChangeCrash": {
-                "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/214805"}}
+                "expected": {"gtk": {"status": ["CRASH", "TIMEOUT", "PASS"], "bug": "webkit.org/b/214805"}}
             },
             "WebKit.PrivateBrowsingPushStateNoHistoryCallback": {
                 "expected": {"gtk": {"status": ["TIMEOUT"], "bug": "webkit.org/b/254002"}}
-            },
-            "WebKit.OnDeviceChangeCrash": {
-                "expected": {"gtk": {"status": ["CRASH"], "bug": "webkit.org/b/254002"}}
             },
             "WebKit.GeolocationWatchMultiprocess": {
                 "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug": "webkit.org/b/254002"}}


### PR DESCRIPTION
#### 212eab5142710901ca363fc47f48c211957bf5b6
<pre>
[GTK] Unreviewed, remove duplicated entries in API GTK test expectations after 261731@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=254002">https://bugs.webkit.org/show_bug.cgi?id=254002</a>

Tests were failing to run because there were duplicated entries in API
GTK test expectations.

* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/261867@main">https://commits.webkit.org/261867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c6cb878228fa485d645d2acc704485092fac8ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121573 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/117223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13426 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/6127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17543 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/100809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106192 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99497 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/1346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14545 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/1388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10718 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20553 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/53379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17106 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4531 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->