### PR TITLE
[WGSL] Generate auto pipeline layout

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.h
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.h
@@ -31,7 +31,8 @@ namespace WGSL {
 
 class CallGraph;
 struct PipelineLayout;
+struct PrepareResult;
 
-void rewriteGlobalVariables(CallGraph&, const HashMap<String, PipelineLayout>&);
+void rewriteGlobalVariables(CallGraph&, const HashMap<String, PipelineLayout>&, PrepareResult&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -103,7 +103,7 @@ inline PrepareResult prepareImpl(ShaderModule& ast, const HashMap<String, Pipeli
 
         RUN_PASS_WITH_RESULT(callGraph, buildCallGraph, ast);
         RUN_PASS(rewriteEntryPoints, callGraph, result);
-        RUN_PASS(rewriteGlobalVariables, callGraph, pipelineLayouts);
+        RUN_PASS(rewriteGlobalVariables, callGraph, pipelineLayouts, result);
         RUN_PASS(mangleNames, callGraph, result);
 
         dumpASTAtEndIfNeeded(ast);


### PR DESCRIPTION
#### f28b77f3e56ffa86903def9fa4c860af0f2d5eef
<pre>
[WGSL] Generate auto pipeline layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=254160">https://bugs.webkit.org/show_bug.cgi?id=254160</a>
rdar://106948771

Reviewed by Mike Wyrzykowski and Myles C. Maxfield.

When no pipeline layout is passed in, the compiler should generate a layout
according to <a href="https://www.w3.org/TR/webgpu/#default-pipeline-layout.">https://www.w3.org/TR/webgpu/#default-pipeline-layout.</a>

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::RewriteGlobalVariables):
(WGSL::RewriteGlobalVariables::run):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::visitEntryPoint):
(WGSL::RewriteGlobalVariables::requiredGroups):
(WGSL::rewriteGlobalVariables):
* Source/WebGPU/WGSL/GlobalVariableRewriter.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):

Canonical link: <a href="https://commits.webkit.org/261927@main">https://commits.webkit.org/261927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b513578e4a03e6223323e7788e3345dbf7592fee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22428 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121748 "Built successfully") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/23789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/119081 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/23789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106391 "Failed to checkout and rebase branch from PR 11713") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/23789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/106391 "Failed to checkout and rebase branch from PR 11713") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14728 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/106391 "Failed to checkout and rebase branch from PR 11713") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/15436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20730 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8337 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17291 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->