### PR TITLE
[media controls] overflow button appears clipped on Google Research page

### DIFF
--- a/LayoutTests/media/modern-media-controls/overflow-support/dropped-when-narrow-expected.txt
+++ b/LayoutTests/media/modern-media-controls/overflow-support/dropped-when-narrow-expected.txt
@@ -1,0 +1,12 @@
+Testing the OverflowSupport button does not appear when controls are narrow.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS shadowRoot.querySelector('button.overflow') became different from null
+PASS shadowRoot.querySelector('button.overflow').getBoundingClientRect().width became different from 0
+PASS shadowRoot.querySelector('button.overflow') became null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/overflow-support/dropped-when-narrow.html
+++ b/LayoutTests/media/modern-media-controls/overflow-support/dropped-when-narrow.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<meta name="viewport" content="width=device-width">
+<script src="../resources/media-controls-utils.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test-pre.js"></script>
+<body>
+<audio src="../../content/test.mp4" style="position: absolute; left: 0; top: 0; width: 600px;" controls autoplay></video>
+<script type="text/javascript">
+
+window.jsTestIsAsync = true;
+
+description("Testing the <code>OverflowSupport</code> button does not appear when controls are narrow.");
+
+const media = document.querySelector("audio");
+const shadowRoot = window.internals.shadowRoot(media);
+
+media.addEventListener("play", function() {
+    media.pause();
+
+    shouldBecomeDifferent("shadowRoot.querySelector('button.overflow')", "null", () => {
+        shouldBecomeDifferent("shadowRoot.querySelector('button.overflow').getBoundingClientRect().width", "0", async () => {
+            media.style.width = "200px";
+            shouldBecomeEqual("shadowRoot.querySelector('button.overflow')", "null", async () => {
+                media.remove();
+                finishJSTest();
+            });
+        });
+    });
+});
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.js
@@ -208,8 +208,12 @@ class InlineMediaControls extends MediaControls
         this.leftContainer.layout();
         this.rightContainer.layout();
 
+        // Get the definitive list of shown buttons in the right container since we may have dropped some of
+        // the buttons and associated them with the overflow button.
+        const visibleRightContainerButtons = this.rightContainer.children.filter(button => button.visible);
+
         const widthLeftOfTimeControl = this.leftContainer.children.length > 0 ? this.leftContainer.width : this.leftContainer.leftMargin;
-        const widthRightOfTimeControl = this.rightContainer.children.length > 0 ? this.rightContainer.width : this.rightContainer.rightMargin;
+        const widthRightOfTimeControl = visibleRightContainerButtons.length > 0 ? this.rightContainer.width : this.rightContainer.rightMargin;
         centerControl.x = widthLeftOfTimeControl;
         centerControl.width = this.bottomControlsBar.width - widthLeftOfTimeControl - widthRightOfTimeControl;
         centerControl.layout();
@@ -219,7 +223,7 @@ class InlineMediaControls extends MediaControls
         if (this.leftContainer.children.length)
             controlsBarChildren.push(this.leftContainer);
         controlsBarChildren.push(centerControl);
-        if (this.rightContainer.children.length) {
+        if (visibleRightContainerButtons.length) {
             controlsBarChildren.push(this.rightContainer);
             this.rightContainer.x = this.bottomControlsBar.width - this.rightContainer.width;
         }


### PR DESCRIPTION
#### 2972c6591e214a15e9bec189e9c679ff44bbc8c5
<pre>
[media controls] overflow button appears clipped on Google Research page
<a href="https://bugs.webkit.org/show_bug.cgi?id=254165">https://bugs.webkit.org/show_bug.cgi?id=254165</a>
rdar://104744690

Reviewed by Devin Rousso.

We must account for _visible_ children when determining whether the right bar container should be shown.

* LayoutTests/media/modern-media-controls/overflow-support/dropped-when-narrow-expected.txt: Added.
* LayoutTests/media/modern-media-controls/overflow-support/dropped-when-narrow.html: Added.
* Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.js:
(InlineMediaControls.prototype.layout):

Canonical link: <a href="https://commits.webkit.org/261912@main">https://commits.webkit.org/261912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e1d878c686d7aeee2ef75183bbb04bd642e301a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/5015 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13546 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/6239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/119027 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/100902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106335 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/1443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14672 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/1482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/98938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15382 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20674 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/53473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17234 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4546 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->