### PR TITLE
Fullscreen window size is incorrect for non-video elements

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -564,12 +564,12 @@ static constexpr CGFloat kFullScreenWindowCornerRadius = 12;
     auto screenSize = page->overrideScreenSize();
     CGFloat preferredWidth = screenSize.width();
     CGFloat preferredHeight = screenSize.height();
-    CGFloat preferredAspectRatio = preferredWidth / preferredHeight;
-    CGFloat videoAspectRatio = videoDimensions.height ? (videoDimensions.width / videoDimensions.height) : preferredAspectRatio;
 
     CGFloat targetWidth = preferredWidth;
     CGFloat targetHeight = preferredHeight;
     if (videoDimensions.height && videoDimensions.width) {
+        CGFloat preferredAspectRatio = preferredWidth / preferredHeight;
+        CGFloat videoAspectRatio = videoDimensions.height ? (videoDimensions.width / videoDimensions.height) : preferredAspectRatio;
         if (videoAspectRatio > preferredAspectRatio)
             targetHeight = videoDimensions.height * preferredWidth / videoDimensions.width;
         else

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -204,11 +204,12 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element)
 #endif
 
     m_initialFrame = screenRectOfContents(m_element.get());
+
+    FloatSize videoDimensions;
 #if ENABLE(VIDEO)
     updateMainVideoElement();
-    auto videoDimensions = m_mainVideoElement ? FloatSize(m_mainVideoElement->videoWidth(), m_mainVideoElement->videoHeight()) : FloatSize(m_initialFrame.width(), m_initialFrame.height());
-#else
-    FloatSize videoDimensions;
+    if (m_mainVideoElement)
+        videoDimensions = FloatSize(m_mainVideoElement->videoWidth(), m_mainVideoElement->videoHeight());
 #endif
     m_page->injectedBundleFullScreenClient().enterFullScreenForElement(m_page.get(), element, m_element->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk(), isVideoElementWithControls, videoDimensions);
 }


### PR DESCRIPTION
#### 8b8e7c2006e19750c16fbb984e54083736cfee08
<pre>
Fullscreen window size is incorrect for non-video elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=254166">https://bugs.webkit.org/show_bug.cgi?id=254166</a>
rdar://102998286

Reviewed by Tim Horton.

254528@main added logic to adjust the fullscreen window size based on an
element&apos;s aspect ratio. However, this should only apply to video elements
(and elements containing a video element), as the aspect ratio of other
elements can be unsuitable for the fullscreen window size.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):

Fallback to a default when the size is zero. Move some logic that is only
necessary when the size is non-zero.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):

Pass in a zero size for non-video elements.

Canonical link: <a href="https://commits.webkit.org/261904@main">https://commits.webkit.org/261904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfcf8d79e907a41e36d0bf849d1333f9ca67caeb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121614 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6162 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106236 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46602 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14587 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1403 "7 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/98852 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10743 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53393 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8314 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17148 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->