### PR TITLE
Trimmed inline-start margins for flex items in horizontal writing mode should be reflected in computed style.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-inline-start-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-inline-start-expected.txt
@@ -1,0 +1,5 @@
+
+PASS flexbox > item 1
+PASS flexbox > item 2
+PASS flexbox > item 3
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-inline-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-inline-start.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="trimmed inline-start margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    width: min-content;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+item:nth-child(1) {
+    margin-inline-start: 10px;
+}
+item:nth-child(2) {
+    margin-inline-start: -10px;
+}
+item:nth-child(3) {
+    margin-inline-start: 30%;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-expected-margin-left="0" data-offset-x="8"></item>
+    <item data-expected-margin-left="0" data-offset-x="8"></item>
+    <item data-expected-margin-left="0" data-offset-x="8"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-inline-start-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-inline-start-expected.txt
@@ -1,0 +1,6 @@
+
+PASS flexbox > item 1
+PASS flexbox > item 2
+PASS flexbox > item 3
+PASS flexbox > item 4
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-inline-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-inline-start.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="trimmed inline-start margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    width: min-content;
+    height: 100px;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline-start: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-offset-x="8" data-expected-margin-left="0"></item>
+    <item data-offset-x="8" data-expected-margin-left="0"></item>
+    <item data-offset-x="68" data-expected-margin-left="10"></item>
+    <item data-offset-x="68" data-expected-margin-left="10"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-inline-start-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-inline-start-expected.txt
@@ -1,0 +1,5 @@
+
+PASS flexbox > item 1
+PASS flexbox > item 2
+PASS flexbox > item 3
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-inline-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-inline-start.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="trimmed inline-start margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline-start: 20px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-expected-margin-left="0" data-offset-x="8"></item>
+    <item data-expected-margin-left="20" data-offset-x="78"></item>
+    <item data-expected-margin-left="20" data-offset-x="148"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-inline-start-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-inline-start-expected.txt
@@ -1,0 +1,6 @@
+
+PASS flexbox > item 1
+PASS flexbox > item 2
+PASS flexbox > item 3
+PASS flexbox > item 4
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-inline-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-inline-start.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="trimmed inline-start margins should be reflected in computed style">
+<style>
+flexbox {
+    display: flex;
+    width: 110px;
+    flex-wrap: wrap;
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+item:nth-child(1) {
+    margin-inline-start: 10px;
+}
+item:nth-child(2) {
+    margin-inline-start: -10px;
+}
+item:nth-child(3) {
+    margin-inline-start: 50%;
+}
+item:nth-child(4) {
+    margin-inline-start: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('flexbox > item')">
+<div id="target">
+<flexbox>
+    <item data-expected-margin-left="0" data-offset-x="8"></item>
+    <item data-expected-margin-left="-10" data-offset-x="48"></item>
+    <item data-expected-margin-left="0" data-offset-x="8"></item>
+    <item data-expected-margin-left="10" data-offset-x="68"></item>
+</flexbox>
+</div>
+</body>
+</html>

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2309,7 +2309,7 @@ static bool rendererCanHaveTrimmedMargin(const RenderBox& renderer, std::optiona
 
     if (containingBlock->isFlexibleBox()) {
         if (!marginTrimType)
-            return containingBlock->style().marginTrim().containsAny({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd, MarginTrimType::InlineEnd });
+            return !containingBlock->style().marginTrim().isEmpty();
         return containingBlock->style().marginTrim().contains(marginTrimType.value());
     }
     return false;
@@ -2354,7 +2354,7 @@ static bool isLayoutDependent(CSSPropertyID propertyID, const RenderStyle* style
     case CSSPropertyMarginBottom:
         return paddingOrMarginIsRendererDependent<&RenderStyle::marginBottom>(style, renderer) || (isFlexItem(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::BlockEnd));
     case CSSPropertyMarginLeft:
-        return paddingOrMarginIsRendererDependent<&RenderStyle::marginLeft>(style, renderer);
+        return paddingOrMarginIsRendererDependent<&RenderStyle::marginLeft>(style, renderer) || (isFlexItem(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::InlineStart));
     case CSSPropertyPadding: {
         if (!renderer || !renderer->isBox())
             return false;
@@ -3312,6 +3312,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             return zoomAdjustedPixelValue(box->marginBottom(), style);
         return zoomAdjustedPaddingOrMarginPixelValue<&RenderStyle::marginBottom, &RenderBoxModelObject::marginBottom>(style, renderer);
     case CSSPropertyMarginLeft:
+        if (auto* box = dynamicDowncast<RenderBox>(renderer); box && box->isFlexItem() && box->hasTrimmedMargin(PhysicalDirection::Left))
+            return zoomAdjustedPixelValue(box->marginLeft(), style);
         return zoomAdjustedPaddingOrMarginPixelValue<&RenderStyle::marginLeft, &RenderBoxModelObject::marginLeft>(style, renderer);
     case CSSPropertyMarginTrim: {
         auto marginTrim = style.marginTrim();

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3048,6 +3048,10 @@ void RenderBlock::setTrimmedMarginForChild(RenderBox &child, MarginTrimType marg
         setMarginAfterForChild(child, 0_lu);
         child.markMarginAsTrimmed(MarginTrimType::BlockEnd);
         break;
+    case MarginTrimType::InlineStart:
+        setMarginStartForChild(child, 0_lu);
+        child.markMarginAsTrimmed(MarginTrimType::InlineStart);
+        break;
     case MarginTrimType::InlineEnd:
         setMarginEndForChild(child, 0_lu);
         child.markMarginAsTrimmed(MarginTrimType::InlineEnd);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1417,6 +1417,10 @@ FlowRelativeDirection RenderBox::physicalToFlowRelativeDirectionMapping(Physical
             if (isHorizontalWritingMode)
                 return FlowRelativeDirection::BlockEnd;
             return isLeftToRightDirection ? FlowRelativeDirection::InlineEnd : FlowRelativeDirection::InlineStart;
+        case PhysicalDirection::Left:
+            if (isHorizontalWritingMode)
+                return isLeftToRightDirection ? FlowRelativeDirection::InlineStart : FlowRelativeDirection::InlineEnd;
+            return isFlippedBlocksWritingMode ? FlowRelativeDirection::BlockEnd : FlowRelativeDirection::BlockStart;
         default:
             ASSERT_NOT_IMPLEMENTED_YET();
         } 
@@ -1469,8 +1473,6 @@ bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) c
         ASSERT_NOT_IMPLEMENTED_YET();
         return false;
     }
-    if (containingBlock && containingBlock->isFlexibleBox())
-        ASSERT(!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart || marginTrimType.value() == MarginTrimType::InlineEnd || marginTrimType.value() == MarginTrimType::BlockEnd);
 #endif
     if (!hasRareData())
         return false;
@@ -1480,11 +1482,7 @@ bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) c
 bool RenderBox::hasTrimmedMargin(PhysicalDirection physicalDirection) const
 {
     ASSERT(!needsLayout());
-
-    if (physicalDirection == PhysicalDirection::Top || physicalDirection == PhysicalDirection::Right || physicalDirection == PhysicalDirection::Bottom)
-        return hasTrimmedMargin(flowRelativeDirectionToMarginTrimType(physicalToFlowRelativeDirectionMapping(physicalDirection)));
-    ASSERT_NOT_IMPLEMENTED_YET();
-    return false;
+    return hasTrimmedMargin(flowRelativeDirectionToMarginTrimType(physicalToFlowRelativeDirectionMapping(physicalDirection)));
 }
 
 LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(const Length& logicalWidth) const

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -972,8 +972,8 @@ void RenderFlexibleBox::trimMainAxisMarginStart(const FlexItem& flexItem)
 {
     auto horizontalFlow = isHorizontalFlow();
     flexItem.mainAxisMargin -= horizontalFlow ? flexItem.box.marginStart(&style()) : flexItem.box.marginBefore(&style());
-    if (horizontalFlow) 
-        flexItem.box.setMarginStart(0_lu, &style());
+    if (horizontalFlow)
+        setTrimmedMarginForChild(flexItem.box, MarginTrimType::InlineStart);
     else
         setTrimmedMarginForChild(flexItem.box, MarginTrimType::BlockStart);
     m_marginTrimItems.m_itemsAtFlexLineStart.add(&flexItem.box);
@@ -995,7 +995,7 @@ void RenderFlexibleBox::trimCrossAxisMarginStart(const FlexItem& flexItem)
     if (isHorizontalFlow())
         setTrimmedMarginForChild(flexItem.box, MarginTrimType::BlockStart);
     else
-        flexItem.box.setMarginStart(0_lu, &style());
+        setTrimmedMarginForChild(flexItem.box, MarginTrimType::InlineStart);
     m_marginTrimItems.m_itemsOnFirstFlexLine.add(&flexItem.box);
 }
 


### PR DESCRIPTION
#### c69be377e17c2977681fef9113d13d91b62d1ee4
<pre>
Trimmed inline-start margins for flex items in horizontal writing mode should be reflected in computed style.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253714">https://bugs.webkit.org/show_bug.cgi?id=253714</a>
rdar://106559056

Reviewed by Alan Baradlay.

Currently, we trim the inline-start margin of a flex item when we call
flexItem.box.setMarginStart inside either RenderFlexibleBox::trimCrossAxisMarginStart
or RenderFlexibleBox::trimMainAxisMarginStart. Instead, we can replace
these calls with setTrimmedMarginForChild with an argument of
MarginTrimType::InlineStart to both trim the margin and set the
appropriate bit in the rare data object. In horizontal writing-mode
this bit should correspond to margin-left. Once layout has finished,
this bit can be used to determine if the box has a trimmed inline-start
margin.

When ComputedStyleExtractor tries to obtain the &quot;margin-left,&quot; value, it
will first need to check if this margin has been trimmed. This can be
done by calling box-&gt;hasTrimedMargin(PhysicalDirection::Left).
hasTrimmedMargin will first map this PhysicalDirection to a MarginTrimType
and then check if the appropriate rare data bit has been set. If this
returns true, then the box should have a trimmed inline-start (left)
margin and ComputedStyleExtractor should consult the box&apos;s m_marginBox
to get the trimmed value.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-inline-start-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-inline-start.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-inline-start-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-multi-line-inline-start.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-inline-start-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-inline-start.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-inline-start-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-multi-line-inline-start.html: Added.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::rendererContainingBlockHasMarginTrim):
(WebCore::isLayoutDependent):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::setTrimmedMarginForChild):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::physicalToFlowRelativeDirectionMapping const):
(WebCore::RenderBox::hasTrimmedMargin const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::trimMainAxisMarginStart):
(WebCore::RenderFlexibleBox::trimCrossAxisMarginStart):

Canonical link: <a href="https://commits.webkit.org/262708@main">https://commits.webkit.org/262708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e982307d85b768e55e47d59b1a509376cfe2c07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2350 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2089 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3147 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/42 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2075 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1952 "147 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2154 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3266 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2123 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1913 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2081 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/585 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->