### PR TITLE
Avoid unnecessary work in DocumentTimelinesController::updateAnimationsAndSendEvents()

### DIFF
--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -435,6 +435,9 @@ void DocumentTimeline::applyPendingAcceleratedAnimations()
 
 void DocumentTimeline::enqueueAnimationEvent(AnimationEventBase& event)
 {
+    if (!event.target() || !event.target()->hasEventListeners(event.type()))
+        return;
+
     m_pendingAnimationEvents.append(event);
     if (m_shouldScheduleAnimationResolutionForNewPendingEvents)
         scheduleAnimationResolution();


### PR DESCRIPTION
#### 45604855c1c69e79b9693479fb176f84a441a3f8
<pre>
Avoid unnecessary work in DocumentTimelinesController::updateAnimationsAndSendEvents()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254180">https://bugs.webkit.org/show_bug.cgi?id=254180</a>

Reviewed by NOBODY (OOPS!).

Avoid unnecessary work in DocumentTimelinesController::updateAnimationsAndSendEvents()
when there are no listeners for those events. In many cases, there are no listeners
for those animation events and we still spend a significant amount of time in
DocumentTimelinesController::updateAnimationsAndSendEvents() dealing with these events.

* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::enqueueAnimationEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45604855c1c69e79b9693479fb176f84a441a3f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121626 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13477 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6171 "69 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118952 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100833 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1372 "5 flakes 5 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46610 "layout-tests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14599 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1414 "15 flakes 7 failures") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/98862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15311 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53404 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17160 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->