### PR TITLE
Let siblings layout if an adjacent float may no longer affect them

### DIFF
--- a/LayoutTests/fast/block/float/margin-top-changes-expected.txt
+++ b/LayoutTests/fast/block/float/margin-top-changes-expected.txt
@@ -1,0 +1,2 @@
+
+PASS crbug.com/711938: Sibling elements notice when a float no longer overlaps due to margin top changing.

--- a/LayoutTests/fast/block/float/margin-top-changes.html
+++ b/LayoutTests/fast/block/float/margin-top-changes.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<style>
+body
+{
+  margin: 0;
+  padding: 0;
+}
+.div
+{
+  width: 100px;
+  height: 50px;
+}
+#float
+{
+  float: left;
+}
+#inline
+{
+  display: inline-block;
+  background-color:green;
+}
+#positioned
+{
+  position: absolute;
+  background-color: red;
+  z-index: -1;
+}
+</style>
+<div id="positioned" class="div"></div>
+<div id="float" class="div"></div>
+<div id="test">
+  <div id="inline" class="div"></div>
+</div>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+  document.body.offsetTop;
+  float.style["margin-top"] = "-50px";
+    test(() => {
+        assert_equals(document.getElementById("inline").offsetLeft, 0);
+    }, "crbug.com/711938: Sibling elements notice when a float no longer overlaps due to margin top changing.");
+</script>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2007 David Smith (catfish.man@gmail.com)
  * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2014-2015 Google Inc. All rights reserved.
+ * Copyright (C) 2014-2017 Google Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -966,6 +966,7 @@ void RenderBlockFlow::layoutBlockChild(RenderBox& child, MarginInfo& marginInfo,
         // If an element might be affected by the presence of floats, then always mark it for
         // layout.
         LayoutUnit fb = std::max(previousFloatLogicalBottom, lowestFloatLogicalBottom());
+        fb = std::max(fb, childBlockFlow->lowestFloatLogicalBottom());
         if (fb > logicalTopEstimate)
             markDescendantsWithFloats = true;
     }


### PR DESCRIPTION
<pre>
Let siblings layout if an adjacent float may no longer affect them
<a href="https://bugs.webkit.org/show_bug.cgi?id=254183">https://bugs.webkit.org/show_bug.cgi?id=254183</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/789b5e528fb3bd9ca44341de46547c45355652ab">https://chromium.googlesource.com/chromium/src.git/+/789b5e528fb3bd9ca44341de46547c45355652ab</a>

Negative margin top can move a float up out of the way of siblings/descendants
that are currently avoiding them. We need to account for the position of the child's
current lowest float so that it can try laying out again.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(RenderBlockFlow::layoutBlockChild):
* LayoutTests/fast/block/float/margin-top-changes.html: Add Test Case
* LayoutTests/fast/block/float/margin-top-changes-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54a783980f0f78950814eac27358f022cf1ba5f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4942 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13482 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6180 "6 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118957 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100839 "2 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106254 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1378 "4 flakes 4 failures") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14604 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1420 "10 flakes 7 failures") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/98869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15316 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53411 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17165 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->