### PR TITLE
WebRTC: Camera input is rotated by 90 degrees

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -164,6 +164,7 @@ struct PerWebProcessState {
 
     std::optional<WebCore::FloatSize> lastSentViewLayoutSize;
     std::optional<WebCore::IntDegrees> lastSentDeviceOrientation;
+    std::optional<WebCore::IntDegrees> lastSentOrientationForMediaCapture;
     std::optional<CGFloat> lastSentMinimumEffectiveDeviceWidth;
 
     std::optional<CGRect> frozenVisibleContentRect;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -180,7 +180,7 @@ enum class TapHandlingResult : uint8_t;
 @property (nonatomic, readonly) UIEdgeInsets _computedObscuredInset;
 @property (nonatomic, readonly) UIEdgeInsets _computedUnobscuredSafeAreaInset;
 @property (nonatomic, readonly, getter=_isRetainingActiveFocusedState) BOOL _retainingActiveFocusedState;
-@property (nonatomic, readonly) WebCore::IntDegrees _deviceOrientation;
+@property (nonatomic, readonly) WebCore::IntDegrees _deviceOrientationIgnoringOverrides;
 
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
 @property (nonatomic, readonly) BOOL _isWindowResizingEnabled;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9159,7 +9159,7 @@ void WebPageProxy::willStartCapture(const UserMediaPermissionRequestProxy& reque
     gpuProcess.updateCaptureAccess(request.requiresAudioCapture(), request.requiresVideoCapture(), request.requiresDisplayCapture(), m_process->coreProcessIdentifier(), WTFMove(callback));
     gpuProcess.updateCaptureOrigin(request.topLevelDocumentSecurityOrigin().data(), m_process->coreProcessIdentifier());
 #if PLATFORM(IOS_FAMILY)
-    gpuProcess.setOrientationForMediaCapture(m_deviceOrientation);
+    gpuProcess.setOrientationForMediaCapture(m_orientationForMediaCapture);
 #endif
 #else
     callback();
@@ -11436,6 +11436,10 @@ void WebPageProxy::getProcessDisplayName(CompletionHandler<void(String&&)>&& com
 
 void WebPageProxy::setOrientationForMediaCapture(WebCore::IntDegrees orientation)
 {
+    m_orientationForMediaCapture = orientation;
+    if (!hasRunningProcess())
+        return;
+
 #if ENABLE(MEDIA_STREAM)
 #if PLATFORM(COCOA)
     if (auto* proxy = m_process->userMediaCaptureManagerProxy())
@@ -11491,7 +11495,7 @@ void WebPageProxy::gpuProcessExited(ProcessTerminationReason)
         auto& gpuProcess = process().processPool().ensureGPUProcess();
         gpuProcess.updateCaptureAccess(activeAudioCapture, activeVideoCapture, activeDisplayCapture, m_process->coreProcessIdentifier(), [] { });
 #if PLATFORM(IOS_FAMILY)
-        gpuProcess.setOrientationForMediaCapture(m_deviceOrientation);
+        gpuProcess.setOrientationForMediaCapture(m_orientationForMediaCapture);
 #endif
     }
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3251,6 +3251,8 @@ private:
     static constexpr Seconds DefaultMediaCaptureReportingDelay { 3_s };
     Seconds m_mediaCaptureReportingDelay { DefaultMediaCaptureReportingDelay };
 
+    WebCore::IntDegrees m_orientationForMediaCapture { 0 };
+
     bool m_hasHadSelectionChangesFromUserInteraction { false };
 
 #if HAVE(TOUCH_BAR)

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -313,10 +313,8 @@ void WebPageProxy::setDeviceOrientation(IntDegrees deviceOrientation)
 {
     if (deviceOrientation != m_deviceOrientation) {
         m_deviceOrientation = deviceOrientation;
-        if (hasRunningProcess()) {
+        if (hasRunningProcess())
             m_process->send(Messages::WebPage::SetDeviceOrientation(deviceOrientation), m_webPageID);
-            setOrientationForMediaCapture(deviceOrientation);
-        }
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/getUserMedia.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/getUserMedia.html
@@ -217,6 +217,12 @@
                 });
             }
 
+
+            function captureOrientation() {
+                let settings = stream.getVideoTracks()[0].getSettings();
+                return (settings.width > settings.height) ? "landscape" : "portrait";
+            }
+
             function checkConstraintsStatus() {
                 async function doCheckConstraints() {
                     video2.srcObject = stream;


### PR DESCRIPTION
#### 18a0a5b45375c7795a80ee132c23f04d2c49ba74
<pre>
WebRTC: Camera input is rotated by 90 degrees
<a href="https://bugs.webkit.org/show_bug.cgi?id=254185">https://bugs.webkit.org/show_bug.cgi?id=254185</a>
rdar://106396515

Reviewed by Youenn Fablet.

If a client overrides the device orientation (as exposed to CSS), it currently
also overrides the capture orientation, resulting in sideways video.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setupScrollAndContentViews]):
(-[WKWebView _deviceOrientationIgnoringOverrides]):
(-[WKWebView didMoveToWindow]):
(-[WKWebView _dispatchSetOrientationForMediaCapture:]):
(-[WKWebView _windowDidRotate:]):
(-[WKWebView _deviceOrientation]): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::willStartCapture):
(WebKit::WebPageProxy::setOrientationForMediaCapture):
(WebKit::WebPageProxy::gpuProcessExited):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::setDeviceOrientation):
Separate the device orientation from the capture orientation, and make the
overrides not apply to capture orientation (which already has e.g.
WKPageSetMockCameraOrientation to override it).

The new bit is not transmitted in the DynamicViewportSizeUpdate because it
can&apos;t be changed synchronously, so there is no value to moving it there.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setOrientationForMediaCapture):
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
* Tools/TestWebKitAPI/Tests/WebKit/getUserMedia.html:
Add a test ensuring that the override doesn&apos;t affect capture orientation.

Canonical link: <a href="https://commits.webkit.org/261972@main">https://commits.webkit.org/261972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31b587fd61ab3243b09a360ae51ebad51bf84520

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->