### PR TITLE
[PlayStation] Port pthread mutex implementation to libpas.

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -99,7 +99,7 @@
 
 #define PAS_ALLOCATOR_INDEX_BYTES        4
 
-#if PAS_OS(DARWIN)
+#if PAS_OS(DARWIN) || PAS_PLATFORM(PLAYSTATION)
 #define PAS_USE_SPINLOCKS                0
 #else
 #define PAS_USE_SPINLOCKS                1

--- a/Source/bmalloc/libpas/src/libpas/pas_lock.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_lock.h
@@ -115,7 +115,7 @@ static inline void pas_lock_testing_assert_held(pas_lock* lock)
 
 PAS_END_EXTERN_C;
 
-#else /* !PAS_USE_SPINLOCKS */
+#elif PAS_OS(DARWIN) /* !PAS_USE_SPINLOCKS */
 
 #if defined(__has_include) && __has_include(<os/lock_private.h>) && (defined(LIBPAS) || defined(PAS_BMALLOC)) && (!defined(OS_UNFAIR_LOCK_INLINE) || OS_UNFAIR_LOCK_INLINE)
 #ifndef OS_UNFAIR_LOCK_INLINE
@@ -192,6 +192,92 @@ static inline void pas_lock_testing_assert_held(pas_lock* lock)
 
 PAS_END_EXTERN_C;
 
+#elif PAS_PLATFORM(PLAYSTATION) /* !PAS_USE_SPINLOCKS */
+
+#include <errno.h>
+#include <pthread_np.h>
+
+PAS_BEGIN_EXTERN_C;
+
+struct pas_lock;
+typedef struct pas_lock pas_lock;
+
+struct pas_lock {
+    pthread_mutex_t mutex;
+};
+
+#define PAS_LOCK_INITIALIZER ((pas_lock){ .mutex = PTHREAD_MUTEX_INITIALIZER })
+
+static inline void pas_lock_construct(pas_lock* lock)
+{
+    *lock = PAS_LOCK_INITIALIZER;
+}
+
+static inline void pas_lock_construct_disabled(pas_lock* lock)
+{
+    pthread_mutex_destroy(&lock->mutex);
+    pas_zero_memory(lock, sizeof(pas_lock));
+}
+
+static inline void pas_lock_mutex_setname(pas_lock* lock)
+{
+    pthread_mutex_setname_np(&lock->mutex, "SceNKLibpas");
+}
+
+static inline void pas_lock_lock(pas_lock* lock)
+{
+    bool unnamed;
+    unnamed = (lock->mutex == PTHREAD_MUTEX_INITIALIZER);
+    pas_race_test_will_lock(lock);
+    pthread_mutex_lock(&lock->mutex);
+    pas_race_test_did_lock(lock);
+    if (PAS_UNLIKELY(unnamed))
+        pas_lock_mutex_setname(lock);
+}
+
+static inline bool pas_lock_try_lock(pas_lock* lock)
+{
+    int error;
+    bool unnamed;
+    unnamed = (lock->mutex == PTHREAD_MUTEX_INITIALIZER);
+    error = pthread_mutex_trylock(&lock->mutex);
+    PAS_ASSERT(!error || errno == EBUSY);
+    if (!error) {
+        pas_race_test_did_try_lock(lock);
+        if (PAS_UNLIKELY(unnamed))
+            pas_lock_mutex_setname(lock);
+    }
+    return !error;
+}
+
+static inline void pas_lock_unlock(pas_lock* lock)
+{
+    pas_race_test_will_unlock(lock);
+    pthread_mutex_unlock(&lock->mutex);
+}
+
+static inline bool pas_lock_test_held(pas_lock* lock)
+{
+    if (pthread_mutex_trylock(&lock->mutex))
+        return true;
+    pthread_mutex_unlock(&lock->mutex);
+    return false;
+}
+
+static inline void pas_lock_assert_held(pas_lock* lock)
+{
+    PAS_ASSERT(pas_lock_test_held(lock));
+}
+
+static inline void pas_lock_testing_assert_held(pas_lock* lock)
+{
+    PAS_TESTING_ASSERT(pas_lock_test_held(lock));
+}
+
+PAS_END_EXTERN_C;
+
+#else /* !PAS_USE_SPINLOCKS */
+#error "No pas_lock implementation found"
 #endif /* !PAS_USE_SPINLOCKS */
 
 PAS_BEGIN_EXTERN_C;


### PR DESCRIPTION
#### f24f304431b72fcb29dabdc0e8501e100e7892e3
<pre>
[PlayStation] Port pthread mutex implementation to libpas.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254182">https://bugs.webkit.org/show_bug.cgi?id=254182</a>

Reviewed by Yusuke Suzuki.

Added pthread mutex implementation for PlayStation port.

* Source/bmalloc/libpas/src/libpas/pas_config.h:
* Source/bmalloc/libpas/src/libpas/pas_lock.h:
(pas_lock_construct):
(pas_lock_construct_disabled):
(pas_lock_mutex_setname):
(pas_lock_lock):
(pas_lock_try_lock):
(pas_lock_unlock):
(pas_lock_test_held):
(pas_lock_assert_held):
(pas_lock_testing_assert_held):

Canonical link: <a href="https://commits.webkit.org/261931@main">https://commits.webkit.org/261931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92defd17ffbec3c4811810bc9fe3ca4686f5c74d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113173 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/4948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121634 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6189 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/118960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46620 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/101406 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14607 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/98872 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/12765 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15319 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10760 "1 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/102966 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53418 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/32110 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8341 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17168 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/111018 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/27410 "Passed tests") | 
<!--EWS-Status-Bubble-End-->