### PR TITLE
Offscreen Canvas does not respect size set via CSS.

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-scaling-expected.html
+++ b/LayoutTests/fast/canvas/offscreen-scaling-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<canvas id="onscreen" width="200" height="200" style="width: 100px; height: 100px"></canvas>
+<script>
+const canvas = document.getElementById('onscreen');
+
+const context = canvas.getContext('2d');
+
+const square = new Path2D();
+square.rect(50, 50, 100, 100);
+context.fillStyle = 'red';
+context.fill(square);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/offscreen-scaling.html
+++ b/LayoutTests/fast/canvas/offscreen-scaling.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<body>
+<canvas id="offscreen" width="200" height="200" style="width: 100px; height: 100px"></canvas>
+<script>
+const canvas = document.getElementById('offscreen');
+
+// Draw on the off-screen canvas
+const offscreenCanvas = canvas.transferControlToOffscreen();
+const offscreenContext = offscreenCanvas.getContext('2d');
+
+const square = new Path2D();
+square.rect(50, 50, 100, 100);
+offscreenContext.fillStyle = 'red';
+offscreenContext.fill(square);
+offscreenContext.commit();
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function finishTest() {
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+requestAnimationFrame(finishTest);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
@@ -47,7 +47,6 @@ bool GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer(ImageBuffer&
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
 
-    [m_layer setFrame:CGRectMake(0, 0, native->size().width(), native->size().height())];
     [m_layer setContents:(__bridge id)native->platformImage().get()];
 
     [CATransaction commit];


### PR DESCRIPTION
#### 2d31dae22ea7c1284f447a13c76ddeaffcf684d8
<pre>
Offscreen Canvas does not respect size set via CSS.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253821">https://bugs.webkit.org/show_bug.cgi?id=253821</a>
&lt;rdar://106941318&gt;

Reviewed by Simon Fraser.

We were previously overwriting the size of the contents layer to match the size of the buffer.
This skips that, since the size is already set during layer configuration to be desired destination size,
and then scaling the buffer to that size happens automatically.

* LayoutTests/fast/canvas/offscreen-scaling-expected.html: Added.
* LayoutTests/fast/canvas/offscreen-scaling.html: Added.
* Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm:
(WebCore::GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer):

Canonical link: <a href="https://commits.webkit.org/262039@main">https://commits.webkit.org/262039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a1d97abd309e0624e080fd7ffefbfd074d2018b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/292 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/469 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/224 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/240 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/209 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/293 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 11743") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/187 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/219 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/209 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/215 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/81 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/212 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->