### PR TITLE
[CSS Fonts] Implement two-value syntax of font-size-adjust

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3726,11 +3726,6 @@ webkit.org/b/86071 imported/w3c/web-platform-tests/css/css-fonts/font-kerning-05
 webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-13.html [ ImageOnlyFailure ]
 webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-14.html [ ImageOnlyFailure ]
 
-# font-size-adjust CSS Fonts Module level 5 (current implementation is at level 4)
-webkit.org/b/15257 imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-009.html [ ImageOnlyFailure ]
-webkit.org/b/15257 imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-010.html [ ImageOnlyFailure ]
-webkit.org/b/15257 imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-011.html [ ImageOnlyFailure ]
-
 # @font-face: ascent-override, descent-override, and line-gap-override
 webkit.org/b/219735 imported/w3c/web-platform-tests/css/css-fonts/ascent-descent-override.html [ ImageOnlyFailure ]
 webkit.org/b/219735 imported/w3c/web-platform-tests/css/css-fonts/line-gap-override.html [ ImageOnlyFailure ]

--- a/LayoutTests/http/tests/incremental/stylesheet-body-incremental-rendering.html
+++ b/LayoutTests/http/tests/incremental/stylesheet-body-incremental-rendering.html
@@ -7,18 +7,19 @@ let initialRects;
 setTimeout(() => {
    initialRects = internals.repaintRectsAsText();
    internals.stopTrackingRepaints();
-   internals.startTrackingRepaints();
 }, 0);
-
-document.body.onload = () => {
-    let finalRects = internals.repaintRectsAsText();
-    internals.stopTrackingRepaints();
-    document.body.innerHTML += `<p>
-        Before stylesheet load: ${initialRects}<br>
-        After stylesheet load: ${finalRects}<br>
-    </p>`;
-};
 </script>
 <div style="width:100px; height:100px; background-color:green"></div>
 <link rel="stylesheet" href="resources/delayed-css.py?delay=300">
+<script>
+internals.startTrackingRepaints();
+</script>
 <div class=delayed style="width:100px; height:100px; background-color:red"></div>
+<script>
+let finalRects = internals.repaintRectsAsText();
+internals.stopTrackingRepaints();
+document.body.innerHTML += `<p>
+    Before stylesheet load: ${initialRects}<br>
+    After stylesheet load: ${finalRects}<br>
+</p>`;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override-expected.txt
@@ -2,5 +2,5 @@
 PASS @counter-style unlayered overrides layered
 PASS @counter-style override between layers
 PASS @counter-style override update with appended sheet 1
-FAIL @counter-style override update with appended sheet 2 assert_equals: expected "31.21875px" but got "23.40625px"
+PASS @counter-style override update with appended sheet 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-size-adjust-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-size-adjust-interpolation-expected.txt
@@ -55,34 +55,34 @@ PASS Web Animations: property <font-size-adjust> from [initial] to [2] at (0.5) 
 PASS Web Animations: property <font-size-adjust> from [initial] to [2] at (0.6) should be [2]
 PASS Web Animations: property <font-size-adjust> from [initial] to [2] at (1) should be [2]
 PASS Web Animations: property <font-size-adjust> from [initial] to [2] at (1.5) should be [2]
-FAIL CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (-0.3) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (0) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (0.3) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (0.5) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (0.6) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (1) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (1.5) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (-0.3) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (0) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (0.3) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (0.5) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (0.6) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (1) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (1.5) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (-0.3) should be [initial] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0) should be [initial] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.3) should be [initial] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.5) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.6) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (1) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (1.5) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (-0.3) should be [initial] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0) should be [initial] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.3) should be [initial] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.5) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.6) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (1) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (1.5) should be [cap-height 2] assert_true: 'to' value should be supported expected true got false
+PASS CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (-0.3) should be [cap-height 2]
+PASS CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (0) should be [cap-height 2]
+PASS CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (0.3) should be [cap-height 2]
+PASS CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (0.5) should be [cap-height 2]
+PASS CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (0.6) should be [cap-height 2]
+PASS CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (1) should be [cap-height 2]
+PASS CSS Transitions: property <font-size-adjust> from [initial] to [cap-height 2] at (1.5) should be [cap-height 2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (-0.3) should be [cap-height 2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (0) should be [cap-height 2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (0.3) should be [cap-height 2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (0.5) should be [cap-height 2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (0.6) should be [cap-height 2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (1) should be [cap-height 2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [initial] to [cap-height 2] at (1.5) should be [cap-height 2]
+PASS CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (-0.3) should be [initial]
+PASS CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0) should be [initial]
+PASS CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.3) should be [initial]
+PASS CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.5) should be [cap-height 2]
+PASS CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.6) should be [cap-height 2]
+PASS CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (1) should be [cap-height 2]
+PASS CSS Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (1.5) should be [cap-height 2]
+PASS Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (-0.3) should be [initial]
+PASS Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0) should be [initial]
+PASS Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.3) should be [initial]
+PASS Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.5) should be [cap-height 2]
+PASS Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (0.6) should be [cap-height 2]
+PASS Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (1) should be [cap-height 2]
+PASS Web Animations: property <font-size-adjust> from [initial] to [cap-height 2] at (1.5) should be [cap-height 2]
 PASS CSS Transitions: property <font-size-adjust> from [inherit] to [2] at (-2) should be [5]
 PASS CSS Transitions: property <font-size-adjust> from [inherit] to [2] at (-0.3) should be [3.3]
 PASS CSS Transitions: property <font-size-adjust> from [inherit] to [2] at (0) should be [3]
@@ -167,34 +167,34 @@ PASS Web Animations: property <font-size-adjust> from [0] to [1.2] at (0.3) shou
 PASS Web Animations: property <font-size-adjust> from [0] to [1.2] at (0.6) should be [0.72]
 PASS Web Animations: property <font-size-adjust> from [0] to [1.2] at (1) should be [1.2]
 PASS Web Animations: property <font-size-adjust> from [0] to [1.2] at (1.5) should be [1.8]
-FAIL CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-2) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-0.3) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.3) should be [cap-height 0.36] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.6) should be [cap-height 0.72] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1.5) should be [cap-height 1.8] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-2) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-0.3) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.3) should be [cap-height 0.36] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.6) should be [cap-height 0.72] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1.5) should be [cap-height 1.8] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-2) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-0.3) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.3) should be [cap-height 0.36] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.6) should be [cap-height 0.72] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1.5) should be [cap-height 1.8] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-2) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-0.3) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0) should be [cap-height 0] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.3) should be [cap-height 0.36] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.6) should be [cap-height 0.72] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1.5) should be [cap-height 1.8] assert_true: 'from' value should be supported expected true got false
+PASS CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-2) should be [cap-height 0]
+PASS CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-0.3) should be [cap-height 0]
+PASS CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0) should be [cap-height 0]
+PASS CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.3) should be [cap-height 0.36]
+PASS CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.6) should be [cap-height 0.72]
+PASS CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1.5) should be [cap-height 1.8]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-2) should be [cap-height 0]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-0.3) should be [cap-height 0]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0) should be [cap-height 0]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.3) should be [cap-height 0.36]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.6) should be [cap-height 0.72]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1.5) should be [cap-height 1.8]
+PASS CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-2) should be [cap-height 0]
+PASS CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-0.3) should be [cap-height 0]
+PASS CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0) should be [cap-height 0]
+PASS CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.3) should be [cap-height 0.36]
+PASS CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.6) should be [cap-height 0.72]
+PASS CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS CSS Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1.5) should be [cap-height 1.8]
+PASS Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-2) should be [cap-height 0]
+PASS Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (-0.3) should be [cap-height 0]
+PASS Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0) should be [cap-height 0]
+PASS Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.3) should be [cap-height 0.36]
+PASS Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (0.6) should be [cap-height 0.72]
+PASS Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS Web Animations: property <font-size-adjust> from [cap-height 0] to [cap-height 1.2] at (1.5) should be [cap-height 1.8]
 PASS CSS Transitions: property <font-size-adjust> from [none] to [1.2] at (-0.3) should be [1.2]
 PASS CSS Transitions: property <font-size-adjust> from [none] to [1.2] at (0) should be [1.2]
 PASS CSS Transitions: property <font-size-adjust> from [none] to [1.2] at (0.3) should be [1.2]
@@ -223,34 +223,34 @@ PASS Web Animations: property <font-size-adjust> from [none] to [1.2] at (0.5) s
 PASS Web Animations: property <font-size-adjust> from [none] to [1.2] at (0.6) should be [1.2]
 PASS Web Animations: property <font-size-adjust> from [none] to [1.2] at (1) should be [1.2]
 PASS Web Animations: property <font-size-adjust> from [none] to [1.2] at (1.5) should be [1.2]
-FAIL CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (0) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.3) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (0) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.3) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (-0.3) should be [none] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0) should be [none] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.3) should be [none] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (-0.3) should be [none] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0) should be [none] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.3) should be [none] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_true: 'to' value should be supported expected true got false
+PASS CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (0) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.3) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.5) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.6) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [none] to [cap-height 1.2] at (1.5) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (0) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.3) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.5) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.6) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [none] to [cap-height 1.2] at (1.5) should be [cap-height 1.2]
+PASS CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (-0.3) should be [none]
+PASS CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0) should be [none]
+PASS CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.3) should be [none]
+PASS CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.5) should be [cap-height 1.2]
+PASS CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.6) should be [cap-height 1.2]
+PASS CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS CSS Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (1.5) should be [cap-height 1.2]
+PASS Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (-0.3) should be [none]
+PASS Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0) should be [none]
+PASS Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.3) should be [none]
+PASS Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.5) should be [cap-height 1.2]
+PASS Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (0.6) should be [cap-height 1.2]
+PASS Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS Web Animations: property <font-size-adjust> from [none] to [cap-height 1.2] at (1.5) should be [cap-height 1.2]
 PASS CSS Transitions: property <font-size-adjust> from [0.2] to [1.2] at (-2) should be [0]
 PASS CSS Transitions: property <font-size-adjust> from [0.2] to [1.2] at (-0.3) should be [0]
 PASS CSS Transitions: property <font-size-adjust> from [0.2] to [1.2] at (0) should be [0.2]
@@ -279,60 +279,60 @@ PASS Web Animations: property <font-size-adjust> from [0.2] to [1.2] at (0.3) sh
 PASS Web Animations: property <font-size-adjust> from [0.2] to [1.2] at (0.6) should be [0.8]
 PASS Web Animations: property <font-size-adjust> from [0.2] to [1.2] at (1) should be [1.2]
 PASS Web Animations: property <font-size-adjust> from [0.2] to [1.2] at (1.5) should be [1.7]
-FAIL CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-2) should be [ch-width 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-0.3) should be [ch-width 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0) should be [ch-width 0.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.3) should be [ch-width 0.5] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.6) should be [ch-width 0.8] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1) should be [ch-width 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1.5) should be [ch-width 1.7] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-2) should be [ch-width 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-0.3) should be [ch-width 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0) should be [ch-width 0.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.3) should be [ch-width 0.5] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.6) should be [ch-width 0.8] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1) should be [ch-width 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1.5) should be [ch-width 1.7] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-2) should be [ch-width 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-0.3) should be [ch-width 0] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0) should be [ch-width 0.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.3) should be [ch-width 0.5] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.6) should be [ch-width 0.8] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1) should be [ch-width 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1.5) should be [ch-width 1.7] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-2) should be [ch-width 0] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-0.3) should be [ch-width 0] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0) should be [ch-width 0.2] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.3) should be [ch-width 0.5] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.6) should be [ch-width 0.8] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1) should be [ch-width 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1.5) should be [ch-width 1.7] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [ex-height 0.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [ex-height 0.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [ex-height 0.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [ex-height 0.2] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [ex-height 0.2] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [ex-height 0.2] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_true: 'from' value should be supported expected true got false
+PASS CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-2) should be [ch-width 0]
+PASS CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-0.3) should be [ch-width 0]
+PASS CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0) should be [ch-width 0.2]
+PASS CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.3) should be [ch-width 0.5]
+PASS CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.6) should be [ch-width 0.8]
+PASS CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1) should be [ch-width 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1.5) should be [ch-width 1.7]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-2) should be [ch-width 0]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-0.3) should be [ch-width 0]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0) should be [ch-width 0.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.3) should be [ch-width 0.5]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.6) should be [ch-width 0.8]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1) should be [ch-width 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1.5) should be [ch-width 1.7]
+PASS CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-2) should be [ch-width 0]
+PASS CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-0.3) should be [ch-width 0]
+PASS CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0) should be [ch-width 0.2]
+PASS CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.3) should be [ch-width 0.5]
+PASS CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.6) should be [ch-width 0.8]
+PASS CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1) should be [ch-width 1.2]
+PASS CSS Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1.5) should be [ch-width 1.7]
+PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-2) should be [ch-width 0]
+PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (-0.3) should be [ch-width 0]
+PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0) should be [ch-width 0.2]
+PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.3) should be [ch-width 0.5]
+PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.6) should be [ch-width 0.8]
+PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1) should be [ch-width 1.2]
+PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1.5) should be [ch-width 1.7]
+FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0 "
+FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.2 "
+FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.5 "
+FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.7 "
+FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.8 "
+FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.2 "
+FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.7 "
+FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0 "
+FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.2 "
+FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.5 "
+FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.7 "
+FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.8 "
+FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.2 "
+FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.7 "
+FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [ex-height 0.2] assert_equals: expected "0.2 " but got "0 "
+PASS CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [ex-height 0.2]
+FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [ex-height 0.2] assert_equals: expected "0.2 " but got "0.5 "
+FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.7 "
+FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.8 "
+FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.2 "
+FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.7 "
+FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [ex-height 0.2] assert_equals: expected "0.2 " but got "0 "
+PASS Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [ex-height 0.2]
+FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [ex-height 0.2] assert_equals: expected "0.2 " but got "0.5 "
+FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.7 "
+FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.8 "
+FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.2 "
+FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.7 "
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-size-adjust-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-size-adjust-computed-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Property font-size-adjust value 'none'
 PASS Property font-size-adjust value '0.5'
-FAIL Property font-size-adjust value 'ex-height 0.5' assert_true: 'ex-height 0.5' is a supported value for font-size-adjust. expected true got false
-FAIL Property font-size-adjust value 'cap-height 0.8' assert_true: 'cap-height 0.8' is a supported value for font-size-adjust. expected true got false
-FAIL Property font-size-adjust value 'ch-width 0.4' assert_true: 'ch-width 0.4' is a supported value for font-size-adjust. expected true got false
-FAIL Property font-size-adjust value 'ic-width 0.9' assert_true: 'ic-width 0.9' is a supported value for font-size-adjust. expected true got false
-FAIL Property font-size-adjust value 'ic-height 1.1' assert_true: 'ic-height 1.1' is a supported value for font-size-adjust. expected true got false
+PASS Property font-size-adjust value 'ex-height 0.5'
+PASS Property font-size-adjust value 'cap-height 0.8'
+PASS Property font-size-adjust value 'ch-width 0.4'
+PASS Property font-size-adjust value 'ic-width 0.9'
+PASS Property font-size-adjust value 'ic-height 1.1'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-size-adjust-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-size-adjust-valid-expected.txt
@@ -1,9 +1,9 @@
 
 PASS e.style['font-size-adjust'] = "none" should set the property value
 PASS e.style['font-size-adjust'] = "0.5" should set the property value
-FAIL e.style['font-size-adjust'] = "ex-height 0.5" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['font-size-adjust'] = "cap-height 0.8" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['font-size-adjust'] = "ch-width 0.4" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['font-size-adjust'] = "ic-width 0.9" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['font-size-adjust'] = "ic-height 0.9" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['font-size-adjust'] = "ex-height 0.5" should set the property value
+PASS e.style['font-size-adjust'] = "cap-height 0.8" should set the property value
+PASS e.style['font-size-adjust'] = "ch-width 0.4" should set the property value
+PASS e.style['font-size-adjust'] = "ic-width 0.9" should set the property value
+PASS e.style['font-size-adjust'] = "ic-height 0.9" should set the property value
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -812,6 +812,8 @@ webkit.org/b/230926 imported/w3c/web-platform-tests/css/css-fonts/font-palette-9
 webkit.org/b/230926 imported/w3c/web-platform-tests/css/css-fonts/font-palette-add.html [ ImageOnlyFailure ]
 webkit.org/b/230926 imported/w3c/web-platform-tests/css/css-fonts/font-palette-modify.html [ ImageOnlyFailure ]
 webkit.org/b/230926 imported/w3c/web-platform-tests/css/css-fonts/font-palette-remove.html [ ImageOnlyFailure ]
+webkit.org/b/254359 imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-009.html [ ImageOnlyFailure ]
+webkit.org/b/254359 imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-010.html [ ImageOnlyFailure ]
 webkit.org/b/230926 imported/w3c/web-platform-tests/css/css-fonts/palette-values-rule-add.html [ ImageOnlyFailure ]
 webkit.org/b/230926 imported/w3c/web-platform-tests/css/css-fonts/palette-values-rule-delete.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac-ventura-wk2/imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2/imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override-expected.txt
@@ -1,0 +1,6 @@
+
+PASS @counter-style unlayered overrides layered
+PASS @counter-style override between layers
+PASS @counter-style override update with appended sheet 1
+FAIL @counter-style override update with appended sheet 2 assert_equals: expected "31.21875px" but got "23.40625px"
+

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1672,6 +1672,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/FontSelectionAlgorithm.h
     platform/graphics/FontSelector.h
     platform/graphics/FontSelectorClient.h
+    platform/graphics/FontSizeAdjust.h
     platform/graphics/FontTaggedSettings.h
     platform/graphics/FourCC.h
     platform/graphics/GCGLSpan.h

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -2490,7 +2490,7 @@ private:
     }
 };
 
-class PropertyWrapperFontSizeAdjust final : public PropertyWrapperGetter<std::optional<float>> {
+class PropertyWrapperFontSizeAdjust final : public PropertyWrapperGetter<FontSizeAdjust> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     PropertyWrapperFontSizeAdjust()
@@ -2501,17 +2501,18 @@ public:
 private:
     bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final
     {
-        return from.fontSizeAdjust().has_value() && to.fontSizeAdjust().has_value();
+        return from.fontSizeAdjust().value && to.fontSizeAdjust().value;
     }
 
     void blend(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const CSSPropertyBlendingContext& context) const final
     {
-        auto blendedFontSizeAdjust = [&]() -> std::optional<float> {
+        auto blendedFontSizeAdjust = [&]() -> FontSizeAdjust {
             if (context.isDiscrete)
                 return (!context.progress ? from : to).fontSizeAdjust();
-            ASSERT(from.fontSizeAdjust().has_value() && to.fontSizeAdjust().has_value());
-            auto blendedAdjust = blendFunc(from.fontSizeAdjust().value(), to.fontSizeAdjust().value(), context);
-            return std::max(blendedAdjust, 0.0f);
+            ASSERT(from.fontSizeAdjust().value && to.fontSizeAdjust().value);
+            auto blendedAdjust = blendFunc(*from.fontSizeAdjust().value, *to.fontSizeAdjust().value, context);
+            // FIXME: Handle interpolation between metrics. <http://webkit.org/b/254266>
+            return { from.fontSizeAdjust().metric, std::max(blendedAdjust, 0.0f) };
         };
 
         destination.setFontSizeAdjust(blendedFontSizeAdjust());

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -33,6 +33,7 @@
 #include "CSSPrimitiveValue.h"
 #include "CSSToLengthConversionData.h"
 #include "CSSValueKeywords.h"
+#include "FontSizeAdjust.h"
 #include "GraphicsTypes.h"
 #include "Length.h"
 #include "LineClampValue.h"
@@ -1643,6 +1644,44 @@ template<> constexpr Kerning fromCSSValueID(CSSValueID valueID)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
+
+constexpr CSSValueID toCSSValueID(FontSizeAdjust::Metric metric)
+{
+    switch (metric) {
+    case FontSizeAdjust::Metric::ExHeight:
+        return CSSValueExHeight;
+    case FontSizeAdjust::Metric::CapHeight:
+        return CSSValueCapHeight;
+    case FontSizeAdjust::Metric::ChWidth:
+        return CSSValueChWidth;
+    case FontSizeAdjust::Metric::IcWidth:
+        return CSSValueIcWidth;
+    case FontSizeAdjust::Metric::IcHeight:
+        return CSSValueIcHeight;
+    }
+    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
+    return CSSValueAuto;
+}
+
+template<> constexpr FontSizeAdjust::Metric fromCSSValueID(CSSValueID valueID)
+{
+    switch (valueID) {
+    case CSSValueExHeight:
+        return FontSizeAdjust::Metric::ExHeight;
+    case CSSValueCapHeight:
+        return FontSizeAdjust::Metric::CapHeight;
+    case CSSValueChWidth:
+        return FontSizeAdjust::Metric::ChWidth;
+    case CSSValueIcWidth:
+        return FontSizeAdjust::Metric::IcWidth;
+    case CSSValueIcHeight:
+        return FontSizeAdjust::Metric::IcHeight;
+    default:
+        break;
+    }
+    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
+    return FontSizeAdjust::Metric::ExHeight;
+}
 
 constexpr CSSValueID toCSSValueID(FontSmoothingMode smoothing)
 {

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -574,13 +574,23 @@
         "font-size-adjust": {
             "inherited": true,
             "values": [
-                "none"
+                "none",
+                "ex-height",
+                "cap-height",
+                "ch-width",
+                "ic-width",
+                "ic-height"
             ],
             "codegen-properties": {
+                "converter": "FontSizeAdjust",
                 "custom": "Value",
                 "font-property": true,
                 "high-priority": true,
-                "parser-grammar": "none | <number [0,inf]>"
+                "separator": " ",
+                "parser-function": "consumeFontSizeAdjust",
+                "parser-function-allows-number-or-integer-input": true,
+                "parser-grammar-unused": "none | [ [ ex-height | cap-height | ch-width | ic-width | ic-height ]? <number [0,inf]> ]",
+                "parser-grammar-unused-reason": "Needs support for ordered groups and optionals."
             },
             "specification": {
                 "category": "css-fonts",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -58,6 +58,14 @@ small-caption
 // This has to go after the -apple-system versions.
 status-bar
 
+// font-size-adjust:
+//
+ex-height
+cap-height
+ch-width
+ic-width
+ic-height
+
 //
 // CSS_PROP_FONT_STYLE:
 //

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -4896,6 +4896,27 @@ static std::optional<Vector<FontFamilyRaw>> consumeFontFamilyRaw(CSSParserTokenR
     return list;
 }
 
+RefPtr<CSSValue> consumeFontSizeAdjust(CSSParserTokenRange& range)
+{
+    if (range.peek().id() == CSSValueNone)
+        return consumeIdent(range);
+
+    if (auto value = consumeNumber(range, ValueRange::NonNegative))
+        return value;
+
+    auto metric = consumeIdent<CSSValueExHeight, CSSValueCapHeight, CSSValueChWidth, CSSValueIcWidth, CSSValueIcHeight>(range);
+    if (!metric)
+        return nullptr;
+
+    auto value = consumeNumber(range, ValueRange::NonNegative);
+    if (!value)
+        return nullptr;
+    if (metric->valueID() == CSSValueExHeight)
+        return value;
+
+    return CSSValuePair::create(metric.releaseNonNull(), value.releaseNonNull());
+}
+
 static std::optional<FontSizeRaw> consumeFontSizeRaw(CSSParserTokenRange& range, CSSParserMode parserMode)
 {
     // -webkit-xxx-large is a parse-time alias.

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -219,6 +219,7 @@ RefPtr<CSSValueList> consumeJustifyTracks(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeDisplay(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeWillChange(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeQuotes(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeFontSizeAdjust(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeFontVariantLigatures(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeFontVariantEastAsian(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeFontVariantAlternates(CSSParserTokenRange&);

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -43,7 +43,7 @@ namespace WebCore {
 struct FontDescriptionKeyRareData : public RefCounted<FontDescriptionKeyRareData> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<FontDescriptionKeyRareData> create(FontFeatureSettings&& featureSettings, FontVariationSettings&& variationSettings, FontVariantAlternates&& variantAlternates, FontPalette&& fontPalette, std::optional<float>&& fontSizeAdjust)
+    static Ref<FontDescriptionKeyRareData> create(FontFeatureSettings&& featureSettings, FontVariationSettings&& variationSettings, FontVariantAlternates&& variantAlternates, FontPalette&& fontPalette, FontSizeAdjust&& fontSizeAdjust)
     {
         return adoptRef(*new FontDescriptionKeyRareData(WTFMove(featureSettings), WTFMove(variationSettings), WTFMove(variantAlternates), WTFMove(fontPalette), WTFMove(fontSizeAdjust)));
     }
@@ -68,7 +68,7 @@ public:
         return m_variantAlternates;
     }
 
-    const std::optional<float>& fontSizeAdjust() const
+    const FontSizeAdjust& fontSizeAdjust() const
     {
         return m_fontSizeAdjust;
     }
@@ -83,7 +83,7 @@ public:
     }
 
 private:
-    FontDescriptionKeyRareData(FontFeatureSettings&& featureSettings, FontVariationSettings&& variationSettings, FontVariantAlternates&& variantAlternates, FontPalette&& fontPalette, std::optional<float>&& fontSizeAdjust)
+    FontDescriptionKeyRareData(FontFeatureSettings&& featureSettings, FontVariationSettings&& variationSettings, FontVariantAlternates&& variantAlternates, FontPalette&& fontPalette, FontSizeAdjust&& fontSizeAdjust)
         : m_featureSettings(WTFMove(featureSettings))
         , m_variationSettings(WTFMove(variationSettings))
         , m_variantAlternates(WTFMove(variantAlternates))
@@ -96,7 +96,7 @@ private:
     FontVariationSettings m_variationSettings;
     FontVariantAlternates m_variantAlternates;
     FontPalette m_fontPalette;
-    std::optional<float> m_fontSizeAdjust;
+    FontSizeAdjust m_fontSizeAdjust;
 };
 
 inline void add(Hasher& hasher, const FontDescriptionKeyRareData& key)
@@ -120,7 +120,7 @@ struct FontDescriptionKey {
         auto variantAlternates = description.variantAlternates();
         auto fontPalette = description.fontPalette();
         auto fontSizeAdjust = description.fontSizeAdjust();
-        if (!featureSettings.isEmpty() || !variationSettings.isEmpty() || !variantAlternates.isNormal() || fontPalette.type != FontPalette::Type::Normal || fontSizeAdjust.has_value())
+        if (!featureSettings.isEmpty() || !variationSettings.isEmpty() || !variantAlternates.isNormal() || fontPalette.type != FontPalette::Type::Normal || fontSizeAdjust.value)
             m_rareData = FontDescriptionKeyRareData::create(WTFMove(featureSettings), WTFMove(variationSettings), WTFMove(variantAlternates), WTFMove(fontPalette), WTFMove(fontSizeAdjust));
     }
 

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -42,12 +42,12 @@ struct SameSizeAsFontCascadeDescription {
     Vector<void*> vector;
     Vector<void*> vector2;
     FontPalette palette;
+    FontSizeAdjust sizeAdjust;
     FontVariantAlternates alternates;
     AtomString string;
     AtomString string2;
     int16_t fontSelectionRequest[3];
     float size;
-    Markable<float, FloatMarkableTraits> sizeAdjust;
     unsigned bitfields1;
     unsigned bitfields2 : 22;
     void* array;

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -137,7 +137,7 @@ public:
     static FontOpticalSizing initialOpticalSizing() { return FontOpticalSizing::Enabled; }
     static const AtomString& initialSpecifiedLocale() { return nullAtom(); }
     static FontPalette initialFontPalette() { return { FontPalette::Type::Normal, nullAtom() }; }
-    static std::optional<float> initialFontSizeAdjust() { return std::nullopt; }
+    static FontSizeAdjust initialFontSizeAdjust() { return { FontSizeAdjust::Metric::ExHeight, std::nullopt }; }
 
 private:
     Ref<RefCountedFixedVector<AtomString>> m_families;

--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -87,13 +87,13 @@ void FontPlatformData::updateSize(float size)
 }
 #endif
 
-void FontPlatformData::updateSizeWithFontSizeAdjust(const std::optional<float>& fontSizeAdjust)
+void FontPlatformData::updateSizeWithFontSizeAdjust(const FontSizeAdjust& fontSizeAdjust)
 {
-    if (!fontSizeAdjust.has_value())
+    if (!fontSizeAdjust.value)
         return;
 
     auto tmpFont = FontCache::forCurrentThread().fontForPlatformData(*this);
-    auto adjustedFontSize = Style::adjustedFontSize(size(), fontSizeAdjust.value(), tmpFont->fontMetrics());
+    auto adjustedFontSize = Style::adjustedFontSize(size(), fontSizeAdjust, tmpFont->fontMetrics());
 
     if (adjustedFontSize == size())
         return;

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -75,6 +75,7 @@ namespace WebCore {
 
 class FontDescription;
 struct FontCustomPlatformData;
+struct FontSizeAdjust;
 
 // This class is conceptually immutable. Once created, no instances should ever change (in an observable way).
 class FontPlatformData {
@@ -164,7 +165,7 @@ public:
     static FontPlatformData cloneWithSyntheticOblique(const FontPlatformData&, bool);
 
     static FontPlatformData cloneWithSize(const FontPlatformData&, float);
-    void updateSizeWithFontSizeAdjust(const std::optional<float>& fontSizeAdjust);
+    void updateSizeWithFontSizeAdjust(const FontSizeAdjust&);
 
 #if PLATFORM(WIN)
     HFONT hfont() const { return m_font ? m_font->get() : 0; }

--- a/Source/WebCore/platform/graphics/FontSizeAdjust.h
+++ b/Source/WebCore/platform/graphics/FontSizeAdjust.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 ChangSeok Oh <changseok@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <variant>
+#include <wtf/Markable.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+struct FloatMarkableTraits {
+    constexpr static bool isEmptyValue(float value)
+    {
+        return value != value;
+    }
+
+    constexpr static float emptyValue()
+    {
+        return std::numeric_limits<float>::quiet_NaN();
+    }
+};
+
+struct FontSizeAdjust {
+    bool operator==(const FontSizeAdjust& other) const
+    {
+        return metric == other.metric && value == other.value;
+    }
+
+    bool operator!=(const FontSizeAdjust& other) const
+    {
+        return !(*this == other);
+    }
+
+    enum class Metric : uint8_t {
+        ExHeight,
+        CapHeight,
+        ChWidth,
+        IcWidth,
+        IcHeight
+    } metric;
+    Markable<float, FloatMarkableTraits> value;
+};
+
+inline void add(Hasher& hasher, const FontSizeAdjust& fontSizeAdjust)
+{
+    add(hasher, fontSizeAdjust.metric, *fontSizeAdjust.value);
+}
+
+inline TextStream& operator<<(TextStream& ts, const FontSizeAdjust& fontSizeAdjust)
+{
+    switch (fontSizeAdjust.metric) {
+    case FontSizeAdjust::Metric::CapHeight:
+        ts << "cap-height";
+        break;
+    case FontSizeAdjust::Metric::ChWidth:
+        ts << "ch-width";
+        break;
+    case FontSizeAdjust::Metric::IcWidth:
+        ts << "ic-width";
+        break;
+    case FontSizeAdjust::Metric::IcHeight:
+        ts << "ic-height";
+        break;
+    case FontSizeAdjust::Metric::ExHeight:
+    default:
+        return ts << *fontSizeAdjust.value;
+    }
+    ts << " " << fontSizeAdjust.value;
+    return ts;
+}
+
+}

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2137,7 +2137,7 @@ void RenderStyle::setFontSize(float size)
     fontCascade().update(selector);
 }
 
-void RenderStyle::setFontSizeAdjust(std::optional<float> sizeAdjust)
+void RenderStyle::setFontSizeAdjust(FontSizeAdjust sizeAdjust)
 {
     auto selector = fontCascade().fontSelector();
     auto description = fontDescription();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -402,7 +402,6 @@ public:
     float specifiedFontSize() const;
     float computedFontSize() const;
     unsigned computedFontPixelSize() const;
-    std::optional<float> fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
     std::pair<FontOrientation, NonCJKGlyphOrientation> fontAndGlyphOrientation();
 
     FontVariationSettings fontVariationSettings() const { return fontDescription().variationSettings(); }
@@ -410,6 +409,7 @@ public:
     FontSelectionValue fontStretch() const { return fontDescription().stretch(); }
     std::optional<FontSelectionValue> fontItalic() const { return fontDescription().italic(); }
     FontPalette fontPalette() const { return fontDescription().fontPalette(); }
+    FontSizeAdjust fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
 
     const Length& textIndent() const { return m_rareInheritedData->indent; }
     TextAlignMode textAlign() const { return static_cast<TextAlignMode>(m_inheritedFlags.textAlign); }
@@ -1081,7 +1081,7 @@ public:
 
     // Only used for blending font sizes when animating, for MathML anonymous blocks, and for text autosizing.
     void setFontSize(float);
-    void setFontSizeAdjust(std::optional<float>);
+    void setFontSizeAdjust(FontSizeAdjust);
 
     void setFontVariationSettings(FontVariationSettings);
     void setFontWeight(FontSelectionValue);

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1904,13 +1904,7 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
 inline void BuilderCustom::applyValueFontSizeAdjust(BuilderState& builderState, CSSValue& value)
 {
     auto fontDescription = builderState.fontDescription();
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    if (primitiveValue.isNumber())
-        fontDescription.setFontSizeAdjust(primitiveValue.floatValue());
-    else {
-        ASSERT(primitiveValue.valueID() == CSSValueNone || CSSPropertyParserHelpers::isSystemFontShorthand(primitiveValue.valueID()));
-        fontDescription.setFontSizeAdjust(std::nullopt);
-    }
+    fontDescription.setFontSizeAdjust(BuilderConverter::convertFontSizeAdjust(builderState, value));
     builderState.setFontDescription(WTFMove(fontDescription));
 }
 

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -184,21 +184,34 @@ int legacyFontSizeForPixelSize(int pixelFontSize, bool shouldUseFixedDefaultSize
     return findNearestLegacyFontSize<float>(pixelFontSize, fontSizeFactors, mediumSize);
 }
 
-static float adjustedFontSize(float size, float sizeAdjust, float xHeight)
+static float adjustedFontSize(float size, float sizeAdjust, float metricValue)
 {
     if (!size)
         return 0;
 
-    float aspectValue = xHeight / size;
+    float aspectValue = metricValue / size;
     return size * (sizeAdjust / aspectValue);
 }
 
-float adjustedFontSize(float size, float sizeAdjust, const FontMetrics& metrics)
+float adjustedFontSize(float size, const FontSizeAdjust& sizeAdjust, const FontMetrics& metrics)
 {
-    if (!metrics.hasXHeight())
-        return size;
+    // FIXME: The behavior for missing metrics has yet to be defined.
+    // https://github.com/w3c/csswg-drafts/issues/6384
+    switch (sizeAdjust.metric) {
+    case FontSizeAdjust::Metric::CapHeight:
+        return metrics.hasCapHeight() ? adjustedFontSize(size, *sizeAdjust.value, metrics.floatCapHeight()) : size;
+    case FontSizeAdjust::Metric::ChWidth:
+        return metrics.zeroWidth() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.zeroWidth()) : size;
+    // FIXME: Are ic-height and ic-width the same? Gecko treats them the same.
+    case FontSizeAdjust::Metric::IcWidth:
+    case FontSizeAdjust::Metric::IcHeight:
+        return metrics.ideogramWidth() > 0 ? adjustedFontSize(size, *sizeAdjust.value, metrics.ideogramWidth()) : size;
+    case FontSizeAdjust::Metric::ExHeight:
+    default:
+        return metrics.hasXHeight() ? adjustedFontSize(size, *sizeAdjust.value, metrics.xHeight()) : size;
+    }
 
-    return adjustedFontSize(size, sizeAdjust, metrics.xHeight());
+    ASSERT_NOT_REACHED();
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleFontSizeFunctions.h
+++ b/Source/WebCore/style/StyleFontSizeFunctions.h
@@ -40,7 +40,7 @@ enum class MinimumFontSizeRule : uint8_t { None, Absolute, AbsoluteAndRelative }
 float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule, const Settings::Values&);
 float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const RenderStyle*, const Document&);
 float computedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document&);
-float adjustedFontSize(float size, float sizeAdjust, const FontMetrics&);
+float adjustedFontSize(float size, const FontSizeAdjust&, const FontMetrics&);
 
 // Given a CSS keyword id in the range (CSSValueXxSmall to CSSValueXxxLarge), this function will return
 // the correct font size scaled relative to the user's default (medium).


### PR DESCRIPTION
#### 2f42bab7265555901c27c9dbe5cef0b0c341ff14
<pre>
[CSS Fonts] Implement two-value syntax of font-size-adjust
<a href="https://bugs.webkit.org/show_bug.cgi?id=254191">https://bugs.webkit.org/show_bug.cgi?id=254191</a>

Reviewed by Myles C. Maxfield.

This change implements the two-value syntax of font-size-adjust specified in
the CSS Fonts Module Level 5 [1]. Five new font metrics: ex-height, cap-height
ch-width, ic-width and ic-height, are added, which clarify what font metric the
given value is for.

This change does not handle the CSS animation support and the &apos;from-font&apos; value.
Follow-up patches will cover them.

Test:
imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-009.html
imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-010.html
imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-011.html

[1] <a href="https://www.w3.org/TR/css-fonts-5/#font-size-adjust-prop">https://www.w3.org/TR/css-fonts-5/#font-size-adjust-prop</a>

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/incremental/stylesheet-body-incremental-rendering.html:
  Modified to deterministically measure repainted regions caused by style changes.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-size-adjust-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-size-adjust-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-size-adjust-valid-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-ventura-wk2/imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override-expected.txt.
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
(WebCore::fromCSSValueID):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::fontSizeAdjustFromStyle):
(WebCore::fontShorthandValue):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontSizeAdjust):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/platform/graphics/FontCascadeCache.h:
(WebCore::FontDescriptionKeyRareData::create):
(WebCore::FontDescriptionKeyRareData::fontSizeAdjust const):
(WebCore::FontDescriptionKeyRareData::FontDescriptionKeyRareData):
(WebCore::FontDescriptionKey::FontDescriptionKey):
* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
(WebCore::FontCascadeDescription::initialFontSizeAdjust):
* Source/WebCore/platform/graphics/FontDescription.h:
(WebCore::FontDescription::italic const):
(WebCore::FontDescription::fontSizeAdjust const):
(WebCore::FontDescription::setComputedSize):
(WebCore::FontDescription::setFontSizeAdjust):
(WebCore::FontDescription::decode):
(WebCore::FloatMarkableTraits::isEmptyValue): Deleted.
(WebCore::FloatMarkableTraits::emptyValue): Deleted.
* Source/WebCore/platform/graphics/FontPlatformData.cpp:
(WebCore::FontPlatformData::updateSizeWithFontSizeAdjust):
* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/FontSizeAdjust.h: Added.
(WebCore::FloatMarkableTraits::isEmptyValue):
(WebCore::FloatMarkableTraits::emptyValue):
(WebCore::FontSizeAdjust::operator== const):
(WebCore::FontSizeAdjust::operator!= const):
(WebCore::add):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setFontSizeAdjust):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::fontSizeAdjust const):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertFontSizeAdjust):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueFontSizeAdjust):
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
(WebCore::Style::adjustedFontSize):
* Source/WebCore/style/StyleFontSizeFunctions.h:

Canonical link: <a href="https://commits.webkit.org/262309@main">https://commits.webkit.org/262309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52590718050a89a3542058a0a29ee73be48efbbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1909 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1224 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1183 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1072 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1075 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2168 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1122 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1036 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1061 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1093 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/295 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1144 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->