### PR TITLE
[UI-side compositing] fast/repaint/canvas-object-fit.html fails on macOS due to a missing repaint rect

### DIFF
--- a/LayoutTests/fast/repaint/canvas-object-fit.html
+++ b/LayoutTests/fast/repaint/canvas-object-fit.html
@@ -10,7 +10,7 @@
 </head>
 <body>
     <canvas id="canvas" width="200" height="200"></canvas> 
-<pre id="layers"></pre>
+    <pre id="layers"></pre>
     <script>
         if (window.testRunner) {
             testRunner.dumpAsText();
@@ -33,19 +33,24 @@
             if (window.testRunner)
                 testRunner.notifyDone();
         }
-        
+
         function startTest()
         {
-            var canvas = document.getElementById('canvas');
-            ctx = canvas.getContext('2d');
-
-            ctx.fillStyle = "rgb(0, 128, 0)";
-            ctx.fillRect(0, 0, 200, 200);
-            
             requestAnimationFrame(() => {
-                repaintTest();
+                requestAnimationFrame(() => {
+                    var canvas = document.getElementById('canvas');
+                    ctx = canvas.getContext('2d');
+
+                    ctx.fillStyle = "rgb(0, 128, 0)";
+                    ctx.fillRect(0, 0, 200, 200);
+            
+                    requestAnimationFrame(() => {
+                        repaintTest();
+                    });
+                });
             });
         }
+
         window.addEventListener('load', startTest, false);
     </script>
 </body>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2079,8 +2079,6 @@ webkit.org/b/223193 [ BigSur ] imported/w3c/web-platform-tests/html/canvas/eleme
 
 webkit.org/b/223271 [ BigSur Debug ] imported/w3c/web-platform-tests/xhr/send-response-event-order.htm [ Pass Failure ]
 
-webkit.org/b/223283 fast/repaint/canvas-object-fit.html [ Pass Failure ]
-
 webkit.org/b/222686 imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-repeat-max-size-001.html [ Pass Failure ]
 
 webkit.org/b/223944 [ BigSur Debug ] imported/w3c/web-platform-tests/xhr/event-upload-progress.any.html [ Pass Failure ]


### PR DESCRIPTION
#### 9eeb1f044a729b3ccdaf67578a0337cea9116d3a
<pre>
[UI-side compositing] fast/repaint/canvas-object-fit.html fails on macOS due to a missing repaint rect
<a href="https://bugs.webkit.org/show_bug.cgi?id=254200">https://bugs.webkit.org/show_bug.cgi?id=254200</a>
rdar://103582615

Reviewed by Simon Fraser.

With UI-side compositing, the two JS functions in the test are combined in one
updateRendering(). So we report one repaint rect which the entire canvas rect.
There is no user problem here but the test does not generate exactly the expected
output.

The fix is to make the first JS function run in the first updateRendering() loop
instead of running it onload. To fix the test for WK1, two requestAnimationFrame()
need to be scheduled before runing the first JS function.

* LayoutTests/fast/repaint/canvas-object-fit.html:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/261933@main">https://commits.webkit.org/261933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccc02cf5e7e7bbb1b6da27ad4bfb822a1c7c8be3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/113314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/22447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/119100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/106410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/14747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/15455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8340 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/17310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->