### PR TITLE
Fix the build after 261878@main

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -342,6 +342,23 @@ typedef void(^PKCanMakePaymentsCompletion)(BOOL isValid, NSError *);
 @end
 #endif
 
+#if HAVE(PASSKIT_APPLE_PAY_LATER_MODE)
+
+// FIXME: rdar://106983272 Remove staging code.
+
+typedef NS_ENUM(NSUInteger, PKApplePayLaterMode);
+
+#define PKApplePayLaterModeEnabled 0
+#define PKApplePayLaterModeDisabledMerchantIneligible 1
+#define PKApplePayLaterModeDisabledItemIneligible 2
+#define PKApplePayLaterModeDisabledRecurringTransaction 3
+
+@interface PKPaymentRequest (Staging_105877661)
+@property (nonatomic, assign) PKApplePayLaterMode applePayLaterMode;
+@end
+
+#endif
+
 NS_ASSUME_NONNULL_END
 
 #define PAL_PASSKIT_SPI_GUARD_AGAINST_INDIRECT_INCLUSION

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -238,18 +238,19 @@ static PKShippingContactEditingMode toPKShippingContactEditingMode(WebCore::Appl
 
 static PKApplePayLaterMode toPKApplePayLaterMode(WebCore::ApplePayLaterMode applePayLaterMode)
 {
+    // FIXME: rdar://106983272 Remove staging code.
     switch (applePayLaterMode) {
     case WebCore::ApplePayLaterMode::Enabled:
-        return PKApplePayLaterModeEnabled;
+        return (PKApplePayLaterMode)PKApplePayLaterModeEnabled;
 
     case WebCore::ApplePayLaterMode::DisabledMerchantIneligible:
-        return PKApplePayLaterModeDisabledMerchantIneligible;
+        return (PKApplePayLaterMode)PKApplePayLaterModeDisabledMerchantIneligible;
 
     case WebCore::ApplePayLaterMode::DisabledItemIneligible:
-        return PKApplePayLaterModeDisabledItemIneligible;
+        return (PKApplePayLaterMode)PKApplePayLaterModeDisabledItemIneligible;
 
     case WebCore::ApplePayLaterMode::DisabledRecurringTransaction:
-        return PKApplePayLaterModeDisabledRecurringTransaction;
+        return (PKApplePayLaterMode)PKApplePayLaterModeDisabledRecurringTransaction;
     }
 }
 
@@ -360,8 +361,11 @@ RetainPtr<PKPaymentRequest> WebPaymentCoordinatorProxy::platformPaymentRequest(c
 #endif
 
 #if HAVE(PASSKIT_APPLE_PAY_LATER_MODE)
-    if (auto& applePayLaterMode = paymentRequest.applePayLaterMode())
-        [result setApplePayLaterMode:toPKApplePayLaterMode(*applePayLaterMode)];
+    if (auto& applePayLaterMode = paymentRequest.applePayLaterMode()) {
+        // FIXME: rdar://106983272 Remove staging code.
+        if ([result respondsToSelector:@selector(setApplePayLaterMode:)])
+            [result setApplePayLaterMode:toPKApplePayLaterMode(*applePayLaterMode)];
+    }
 #endif
 
 #if HAVE(PASSKIT_RECURRING_PAYMENTS)


### PR DESCRIPTION
#### d4e6a1f3f16de72d8395760a67af40395126dc00
<pre>
Fix the build after 261878@main

Unreviewed build fix.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::toPKApplePayLaterMode):
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):

Canonical link: <a href="https://commits.webkit.org/261910@main">https://commits.webkit.org/261910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f1881eec6fdb1fd3a0c71558a915b861834b323

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/5009 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13540 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/86/builds/6233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/119021 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/17633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/100896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106329 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/99587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/88/builds/1437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/46680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14666 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/89/builds/1476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/98929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15376 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/84/builds/10801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20668 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/53467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17228 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4545 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->