### PR TITLE
[GPU Process] REGRESSION (261700@main): Various "css-backgrounds/background-size-" tests fail with pixel differences

### DIFF
--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -708,9 +708,6 @@ String HTMLImageElement::decoding() const
     switch (decodingMode()) {
     case DecodingMode::Auto:
         break;
-    case DecodingMode::SynchronousThumbnail:
-        ASSERT_NOT_REACHED();
-        break;
     case DecodingMode::Synchronous:
         return "sync"_s;
     case DecodingMode::Asynchronous:

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -303,9 +303,6 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
                 LOG(Images, "BitmapImage::%s - %p - url: %s [waiting for async decoding to finish]", __FUNCTION__, this, sourceURL().string().utf8().data());
             }
             return ImageDrawResult::DidRequestDecoding;
-        } else if (options.decodingMode() == DecodingMode::SynchronousThumbnail) {
-            image = frameImageAtIndexCacheIfNeeded(m_currentFrame, m_currentSubsamplingLevel, { options.decodingMode(), sizeForDrawing });
-            LOG(Images, "BitmapImage::%s - %p - url: %s [an image frame will be decoded synchronously as a thumbnail]", __FUNCTION__, this, sourceURL().string().utf8().data());
         } else {
             image = frameImageAtIndexCacheIfNeeded(m_currentFrame, m_currentSubsamplingLevel, options.decodingMode());
             LOG(Images, "BitmapImage::%s - %p - url: %s [an image frame will be decoded synchronously]", __FUNCTION__, this, sourceURL().string().utf8().data());

--- a/Source/WebCore/platform/graphics/DecodingOptions.h
+++ b/Source/WebCore/platform/graphics/DecodingOptions.h
@@ -32,7 +32,6 @@ namespace WebCore {
 
 enum class DecodingMode : uint8_t {
     Auto,
-    SynchronousThumbnail,
     Synchronous,
     Asynchronous
 };
@@ -56,7 +55,7 @@ public:
 
     DecodingMode decodingMode() const { return m_decodingMode; }
     bool isAuto() const { return m_decodingMode == DecodingMode::Auto; }
-    bool isSynchronous() const { return m_decodingMode == DecodingMode::Synchronous || m_decodingMode == DecodingMode::SynchronousThumbnail; }
+    bool isSynchronous() const { return m_decodingMode == DecodingMode::Synchronous; }
     bool isAsynchronous() const { return m_decodingMode == DecodingMode::Asynchronous; }
 
     std::optional<IntSize> sizeForDrawing() const { return m_sizeForDrawing; }

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -256,8 +256,6 @@ public:
 
     virtual bool needsCachedNativeImageInvalidationWorkaround(RenderingMode) { return true; }
 
-    virtual DecodingMode preferredImageDecodingMode() const { return DecodingMode::Synchronous; }
-
     WEBCORE_EXPORT virtual void drawSystemImage(SystemImage&, const FloatRect&);
 
     WEBCORE_EXPORT ImageDrawResult drawImage(Image&, const FloatPoint& destination, const ImagePaintingOptions& = { ImageOrientation::Orientation::FromImage });

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -523,7 +523,7 @@ PlatformImagePtr ImageDecoderCG::createFrameImageAtIndex(size_t index, Subsampli
 
     ASSERT(decodingOptions.decodingMode() != DecodingMode::Auto);
 
-    if (decodingOptions.decodingMode() == DecodingMode::Synchronous && !decodingOptions.sizeForDrawing()) {
+    if (decodingOptions.decodingMode() == DecodingMode::Synchronous) {
         // Decode an image synchronously for its native size.
         options = imageSourceOptions(subsamplingLevel);
         image = adoptCF(CGImageSourceCreateImageAtIndex(m_nativeDecoder.get(), index, options.get()));

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -300,43 +300,41 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
     if (!is<BitmapImage>(image))
         return DecodingMode::Synchronous;
 
-    auto preferredDecodingMode = paintInfo.context().preferredImageDecodingMode();
-
     const BitmapImage& bitmapImage = downcast<BitmapImage>(image);
     if (bitmapImage.canAnimate()) {
         // The DecodingMode for the current frame has to be Synchronous. The DecodingMode
         // for the next frame will be calculated in BitmapImage::internalStartAnimation().
-        return preferredDecodingMode;
+        return DecodingMode::Synchronous;
     }
 
     // Large image case.
 #if PLATFORM(IOS_FAMILY)
     if (IOSApplication::isIBooksStorytime())
-        return preferredDecodingMode;
+        return DecodingMode::Synchronous;
 #endif
     if (is<HTMLImageElement>(element())) {
         auto decodingMode = downcast<HTMLImageElement>(*element()).decodingMode();
         if (decodingMode == DecodingMode::Asynchronous)
             return DecodingMode::Asynchronous;
         if (decodingMode == DecodingMode::Synchronous)
-            return preferredDecodingMode;
+            return DecodingMode::Synchronous;
     }
     if (bitmapImage.isLargeImageAsyncDecodingEnabledForTesting())
         return DecodingMode::Asynchronous;
     if (document().isImageDocument())
-        return preferredDecodingMode;
+        return DecodingMode::Synchronous;
     if (paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting))
-        return preferredDecodingMode;
+        return DecodingMode::Synchronous;
     if (!settings().largeImageAsyncDecodingEnabled())
-        return preferredDecodingMode;
+        return DecodingMode::Synchronous;
     if (!bitmapImage.canUseAsyncDecodingForLargeImages())
-        return preferredDecodingMode;
+        return DecodingMode::Synchronous;
     if (paintInfo.paintBehavior.contains(PaintBehavior::TileFirstPaint))
         return DecodingMode::Asynchronous;
     // FIXME: isVisibleInViewport() is not cheap. Find a way to make this condition faster.
     if (!isVisibleInViewport())
         return DecodingMode::Asynchronous;
-    return preferredDecodingMode;
+    return DecodingMode::Synchronous;
 }
 
 LayoutSize RenderBoxModelObject::relativePositionOffset() const

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3629,7 +3629,6 @@ enum class WebCore::RTCPriorityType : uint8_t {
 
 [AdditionalEncoder=StreamConnectionEncoder] enum class WebCore::DecodingMode : uint8_t {
     Auto,
-    SynchronousThumbnail,
     Synchronous,
     Asynchronous
 };

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -80,18 +80,6 @@ RenderingMode RemoteDisplayListRecorderProxy::renderingMode() const
     return m_imageBuffer ? m_imageBuffer->renderingMode() : RenderingMode::Unaccelerated;
 }
 
-DecodingMode RemoteDisplayListRecorderProxy::preferredImageDecodingMode() const
-{
-    if (!m_imageBuffer)
-        return DecodingMode::Synchronous;
-
-    auto renderingPurpose = m_imageBuffer->renderingPurpose();
-    if (renderingPurpose == RenderingPurpose::DOM || renderingPurpose == RenderingPurpose::LayerBacking)
-        return DecodingMode::SynchronousThumbnail;
-
-    return DecodingMode::Synchronous;
-}
-
 void RemoteDisplayListRecorderProxy::recordSave()
 {
     send(Messages::RemoteDisplayListRecorder::Save());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -60,8 +60,6 @@ private:
 
     WebCore::RenderingMode renderingMode() const final;
 
-    WebCore::DecodingMode preferredImageDecodingMode() const final;
-
     void recordSave() final;
     void recordRestore() final;
     void recordTranslate(float x, float y) final;


### PR DESCRIPTION
#### ff57fe9af2916f68ad0bca626adc5ec8e38551b7
<pre>
[GPU Process] REGRESSION (261700@main): Various &quot;css-backgrounds/background-size-&quot; tests fail with pixel differences
<a href="https://bugs.webkit.org/show_bug.cgi?id=254202">https://bugs.webkit.org/show_bug.cgi?id=254202</a>
rdar://106952740

Reviewed by Simon Fraser.

The test page draws a tiled background-image by calling BitmapImage::drawPattern()
which ends up calling CGImageSourceCreateImageAtIndex().

The expected page draws an HTMLImageElements by calling BitmapImage::draw() which
ends up calling CGImageSourceCreateThumbnailAtIndex().

There is a slight difference between a frame decoded using CGImageSourceCreateImageAtIndex()
and a frame decode using CGImageSourceCreateThumbnailAtIndex(). A thumbnail frame
has to be decoded for a certain size which is called sizeForDrawing.

We need to switch back to use CGImageSourceCreateImageAtIndex() for small images.
This way we can ensure the image is decoded the same way for both the test and
the expected pages.

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::decoding const):
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
* Source/WebCore/platform/graphics/DecodingOptions.h:
(WebCore::DecodingOptions::isSynchronous const):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::preferredImageDecodingMode const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::createFrameImageAtIndex):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::decodingModeForImageDraw const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::preferredImageDecodingMode const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:

Canonical link: <a href="https://commits.webkit.org/261932@main">https://commits.webkit.org/261932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a608ffae5c9b4f8586c686298b963268357d79c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/87/builds/5010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121689 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/117368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/13541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/86/builds/6234 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/119022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/17634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106330 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/99588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46684 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14667 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1477 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/98935 "12 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/10802 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/8342 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17229 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->