### PR TITLE
[MSE] readyState should change back to HAVE_METADATA when removing sample at current playtime

### DIFF
--- a/LayoutTests/media/media-source/media-source-monitor-playing-event.html
+++ b/LayoutTests/media/media-source/media-source-monitor-playing-event.html
@@ -67,8 +67,6 @@
         run('sourceBuffer.remove(0,10)');
         await waitFor(sourceBuffer, 'updateend');
 
-        await sleepFor(1000);
-
         consoleWrite('video.readyState : ' + readyStateString[video.readyState]);
         sample = makeASample(0, 0, 1, 1, 1, SAMPLE_FLAG.SYNC, 1);
         run('sourceBuffer.appendBuffer(sample)');

--- a/LayoutTests/media/media-source/media-source-remove-readystate-expected.txt
+++ b/LayoutTests/media/media-source/media-source-remove-readystate-expected.txt
@@ -1,0 +1,20 @@
+
+RUN(source = new MediaSource())
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+Appending 10s Data
+EXPECTED (video.readyState > '1') OK
+RUN(video.currentTime = 2.5)
+EVENT(seeked)
+RUN(source.endOfStream())
+EVENT(sourceended)
+RUN(video.play())
+RUN(sourceBuffer.remove(video.currentTime - 1, video.currentTime + 5))
+EVENT(waiting)
+EVENT(update)
+EXPECTED (video.readyState == '1') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-remove-readystate.html
+++ b/LayoutTests/media/media-source/media-source-remove-readystate.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>managedmediasource-streaming</title>
+    <script src="../../media/media-source/media-source-loader.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script src="../../media/utilities.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        try {
+            findMediaElement();
+
+            let manifests = [ 'content/test-opus-manifest.json', 'content/test-vorbis-manifest.json', 'content/test-48khz-manifest.json', 'content/test-xhe-aac-manifest.json' ];
+            for (const manifest of manifests) {
+                loader = new MediaSourceLoader(manifest);
+                await loaderPromise(loader);
+                if (MediaSource.isTypeSupported(loader.type()))
+                    break;
+            }
+
+            waitFor(video, 'error').then(failTest);
+
+            run('source = new MediaSource()');
+            run('video.src = URL.createObjectURL(source)');
+
+            await waitFor(source, 'sourceopen');
+
+            run('sourceBuffer = source.addSourceBuffer(loader.type())');
+
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+
+            consoleWrite('Appending 10s Data');
+            do {
+                sourceBuffer.appendBuffer(loader.mediaSegment(0));
+                await once(sourceBuffer, 'update');
+                sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1);
+            } while (sourceBuffer.buffered.end(sourceBuffer.buffered.length-1) < 10);
+            testExpected('video.readyState', 1, '>');
+            run('video.currentTime = 2.5');
+            await waitFor(video, 'seeked');
+            run('source.endOfStream()');
+            await waitFor(source, 'sourceended');
+            run('video.play()');
+            run('sourceBuffer.remove(video.currentTime - 1, video.currentTime + 5)');
+            await Promise.all([waitFor(video, 'waiting'), waitFor(sourceBuffer, 'update')]);
+
+            testExpected('video.readyState', 1);
+
+            endTest();
+        } catch (e) {
+            failTest(`Caught exception: "${e}"`);
+        }
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2900,6 +2900,8 @@ webkit.org/b/143702 media/progress-events-generated-correctly.html [ Failure ]
 webkit.org/b/198830 media/context-menu-actions.html [ Failure ]
 webkit.org/b/193638 media/video-webkit-playsinline.html [ Failure ]
 webkit.org/b/224067 media/media-source/media-source-timestampoffset-trim.html [ Failure ]
+webkit.org/b/254207 media/media-source/media-source-remove-readystate.html [ Failure ]
+webkit.org/b/254207 media/media-source/media-source-monitor-playing-event.html [ Failure ]
 webkit.org/b/160119 media/video-object-fit-change.html [ Pass Crash ImageOnlyFailure ]
 
 webkit.org/b/61487 http/tests/media/video-cross-site.html [ Failure Timeout ]

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -626,6 +626,9 @@ void SourceBuffer::removeTimerFired()
     // 6. Run the coded frame removal algorithm with start and end as the start and end of the removal range.
 
     m_private->removeCodedFrames(m_pendingRemoveStart, m_pendingRemoveEnd, m_source->currentTime(), m_source->isEnded(), [this, protectedThis = Ref { *this }] {
+        if (isRemoved())
+            return;
+
         // 7. Set the updating attribute to false.
         m_updating = false;
         m_pendingRemoveStart = MediaTime::invalidTime();


### PR DESCRIPTION
#### 20053bdeedfdba913322e589de7b2f3f257be790
<pre>
[MSE] readyState should change back to HAVE_METADATA when removing sample at current playtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=254198">https://bugs.webkit.org/show_bug.cgi?id=254198</a>
rdar://106979551

Reviewed by Youenn Fablet.

Ensure that we only run the removeCodedFrames&apos;s completionHandler after
we&apos;ve updated the readyState in the content process.

Fly-by fix: We must ensure that the SourceBuffer hasn&apos;t been deleted by
time the removeCodedFrames operation completes.

* LayoutTests/media/media-source/media-source-remove-readystate-expected.txt: Added.
* LayoutTests/media/media-source/media-source-remove-readystate.html: Added.
* LayoutTests/media/media-source/media-source-monitor-playing-event.html: remove sleep(1s) as it is no longer required.
* LayoutTests/platform/glib/TestExpectations: Mark test as failine, GStreamer doesn&apos;t handle readyState as it should.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::removeCodedFrames):
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::removeTimerFired):

Canonical link: <a href="https://commits.webkit.org/261955@main">https://commits.webkit.org/261955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba31a322c3563d4b1aca4c087b12643d39c252b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/86 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/98 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/97 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/82 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/78 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/99 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/87 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/82 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/94 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/92 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/91 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/78 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/77 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/95 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->