### PR TITLE
[EGL] Move image API helpers from GLContext to PlatformDisplay

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -30,7 +30,12 @@
 #include <wtf/text/WTFString.h>
 
 #if USE(EGL)
+typedef intptr_t EGLAttrib;
+typedef void *EGLClientBuffer;
+typedef void *EGLContext;
 typedef void *EGLDisplay;
+typedef void *EGLImage;
+typedef unsigned EGLenum;
 #endif
 
 #if PLATFORM(GTK)
@@ -93,6 +98,9 @@ public:
         bool EXT_image_dma_buf_import_modifiers { false };
     };
     const EGLExtensions& eglExtensions() const;
+
+    EGLImage createEGLImage(EGLContext, EGLenum target, EGLClientBuffer, const Vector<EGLAttrib>&) const;
+    bool destroyEGLImage(EGLImage) const;
 #endif
 
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)

--- a/Source/WebCore/platform/graphics/egl/GLContextEGL.h
+++ b/Source/WebCore/platform/graphics/egl/GLContextEGL.h
@@ -36,30 +36,10 @@ struct wl_egl_window;
 struct wpe_renderer_backend_egl_offscreen_target;
 #endif
 
-typedef intptr_t EGLAttrib;
-typedef unsigned EGLBoolean;
-typedef void *EGLClientBuffer;
 typedef void *EGLConfig;
 typedef void *EGLContext;
 typedef void *EGLDisplay;
-typedef void *EGLImage;
-typedef void *EGLImageKHR;
 typedef void *EGLSurface;
-typedef unsigned EGLenum;
-typedef int32_t EGLint;
-
-#if !defined(PFNEGLCREATEIMAGEPROC)
-typedef EGLImage (*PFNEGLCREATEIMAGEPROC) (EGLDisplay, EGLContext, EGLenum, EGLClientBuffer, const EGLAttrib*);
-#endif
-#if !defined(PFNEGLDESTROYIMAGEPROC)
-typedef EGLBoolean (*PFNEGLDESTROYIMAGEPROC) (EGLDisplay, EGLImage);
-#endif
-#if !defined(PFNEGLCREATEIMAGEKHRPROC)
-typedef EGLImageKHR (*PFNEGLCREATEIMAGEKHRPROC) (EGLDisplay, EGLContext, EGLenum target, EGLClientBuffer, const EGLint* attribList);
-#endif
-#if !defined(PFNEGLDESTROYIMAGEKHRPROC)
-typedef EGLBoolean (*PFNEGLDESTROYIMAGEKHRPROC) (EGLDisplay, EGLImageKHR);
-#endif
 
 namespace WebCore {
 
@@ -73,8 +53,6 @@ public:
     static const char* lastErrorString();
 
     EGLConfig config() const { return m_config; }
-    EGLImage createImage(EGLenum target, EGLClientBuffer, const Vector<EGLAttrib>&) const;
-    bool destroyImage(EGLImage) const;
 
     virtual ~GLContextEGL();
 
@@ -128,10 +106,6 @@ private:
     EGLSurface m_surface { nullptr };
     EGLConfig m_config { nullptr };
     EGLSurfaceType m_type;
-    PFNEGLCREATEIMAGEPROC m_eglCreateImage { nullptr };
-    PFNEGLDESTROYIMAGEPROC m_eglDestroyImage { nullptr };
-    PFNEGLCREATEIMAGEKHRPROC m_eglCreateImageKHR { nullptr };
-    PFNEGLDESTROYIMAGEKHRPROC m_eglDestroyImageKHR { nullptr };
 #if PLATFORM(X11)
     XUniquePixmap m_pixmap;
 #endif

--- a/Source/WebCore/platform/graphics/gbm/DMABufEGLUtilities.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufEGLUtilities.h
@@ -43,12 +43,12 @@ enum class PlaneModifiersUsage : bool {
     DoNotUse = false,
 };
 
-static inline Vector<EGLint> constructEGLCreateImageAttributes(const DMABufObject& object, unsigned planeIndex, PlaneModifiersUsage planeModifiersUsage)
+static inline Vector<EGLAttrib> constructEGLCreateImageAttributes(const DMABufObject& object, unsigned planeIndex, PlaneModifiersUsage planeModifiersUsage)
 {
-    Vector<EGLint> attributes;
+    Vector<EGLAttrib> attributes;
     attributes.reserveInitialCapacity(12 + 4 + 1);
 
-    attributes.uncheckedAppend(Span<const EGLint>({
+    attributes.uncheckedAppend(Span<const EGLAttrib>({
         EGL_WIDTH, EGLint(object.format.planeWidth(planeIndex, object.width)),
         EGL_HEIGHT, EGLint(object.format.planeHeight(planeIndex, object.height)),
         EGL_LINUX_DRM_FOURCC_EXT, EGLint(object.format.planes[planeIndex].fourcc),
@@ -58,7 +58,7 @@ static inline Vector<EGLint> constructEGLCreateImageAttributes(const DMABufObjec
     }));
 
     if (planeModifiersUsage == PlaneModifiersUsage::Use && object.modifierPresent[planeIndex]) {
-        attributes.uncheckedAppend(Span<const EGLint>({
+        attributes.uncheckedAppend(Span<const EGLAttrib>({
             EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, EGLint(object.modifierValue[planeIndex] >> 32),
             EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, EGLint(object.modifierValue[planeIndex] & 0xffffffff),
         }));

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -307,7 +307,10 @@ void GraphicsContextGLGBM::allocateDrawBufferObject()
             auto dmabufObject = m_swapchain.drawBO->createDMABufObject(0);
             auto attributes = DMABufEGLUtilities::constructEGLCreateImageAttributes(dmabufObject, 0,
                 DMABufEGLUtilities::PlaneModifiersUsage { static_cast<GraphicsContextGLGBM&>(*this).eglExtensions().EXT_image_dma_buf_import_modifiers });
-            return EGL_CreateImageKHR(m_swapchain.platformDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, (EGLClientBuffer)nullptr, attributes.data());
+            auto intAttributes = attributes.map<Vector<EGLint>>([] (EGLAttrib value) {
+                return value;
+            });
+            return EGL_CreateImageKHR(m_swapchain.platformDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, (EGLClientBuffer)nullptr, intAttributes.isEmpty() ? nullptr : intAttributes.data());
         });
 
     GL_BindTexture(textureTarget, m_texture);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerDmabuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerDmabuf.cpp
@@ -85,6 +85,7 @@ void TextureMapperPlatformLayerDmabuf::validateTexture()
 
     auto* context = GLContext::current();
     ASSERT(context->isEGLContext());
+    auto& display = context->display();
 
     context->makeContextCurrent();
 
@@ -98,7 +99,7 @@ void TextureMapperPlatformLayerDmabuf::validateTexture()
         EGL_DMA_BUF_PLANE0_OFFSET_EXT, 0,
         EGL_NONE
     };
-    auto image = downcast<GLContextEGL>(*context).createImage(EGL_LINUX_DMA_BUF_EXT, (EGLClientBuffer)nullptr, imageAttributes);
+    auto image = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, imageAttributes);
     if (!image)
         return;
 
@@ -108,7 +109,7 @@ void TextureMapperPlatformLayerDmabuf::validateTexture()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-    RELEASE_ASSERT(downcast<GLContextEGL>(*context).destroyImage(image));
+    RELEASE_ASSERT(display.destroyEGLImage(image));
 }
 
 void TextureMapperPlatformLayerDmabuf::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -49,39 +49,18 @@
 
 namespace WebCore {
 
-static PFNEGLCREATEIMAGEKHRPROC createImageKHR()
-{
-    static PFNEGLCREATEIMAGEKHRPROC s_createImageKHR;
-    static std::once_flag s_flag;
-    std::call_once(s_flag,
-        [&] {
-            s_createImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"));
-        });
-    return s_createImageKHR;
-}
-
-static PFNEGLDESTROYIMAGEKHRPROC destroyImageKHR()
-{
-    static PFNEGLDESTROYIMAGEKHRPROC s_destroyImageKHR;
-    static std::once_flag s_flag;
-    std::call_once(s_flag,
-        [&] {
-            s_destroyImageKHR = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(eglGetProcAddress("eglDestroyImageKHR"));
-        });
-    return s_destroyImageKHR;
-}
-
 struct TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::EGLImageData {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     ~EGLImageData()
     {
         if (numImages) {
+            auto& platformDisplay = PlatformDisplay::sharedDisplayForCompositing();
             glDeleteTextures(numImages, texture.data());
 
             for (unsigned i = 0; i < numImages; ++i) {
                 if (image[i] != EGL_NO_IMAGE_KHR)
-                    destroyImageKHR()(PlatformDisplay::sharedDisplayForCompositing().eglDisplay(), image[i]);
+                    platformDisplay.destroyEGLImage(image[i]);
             }
         }
     }
@@ -297,13 +276,12 @@ std::unique_ptr<TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::EGLImageData
     using EGLImageData = TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::EGLImageData;
 
     auto& platformDisplay = PlatformDisplay::sharedDisplayForCompositing();
-    EGLDisplay eglDisplay = platformDisplay.eglDisplay();
 
     EGLImageKHR image[DMABufFormat::c_maxPlanes];
     for (unsigned i = 0; i < object.format.numPlanes; ++i) {
         auto attributes = DMABufEGLUtilities::constructEGLCreateImageAttributes(object, i,
             DMABufEGLUtilities::PlaneModifiersUsage { platformDisplay.eglExtensions().EXT_image_dma_buf_import_modifiers });
-        image[i] = createImageKHR()(eglDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes.data());
+        image[i] = platformDisplay.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
     }
 
     auto imageData = makeUnique<EGLImageData>();


### PR DESCRIPTION
#### 1bce9ee5245c33c2b02a5ce3de321b9660c13883
<pre>
[EGL] Move image API helpers from GLContext to PlatformDisplay
<a href="https://bugs.webkit.org/show_bug.cgi?id=254206">https://bugs.webkit.org/show_bug.cgi?id=254206</a>

Reviewed by Žan Doberšek.

It&apos;s not context API, but display API.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::createEGLImage const):
(WebCore::PlatformDisplay::destroyEGLImage const):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/egl/GLContextEGL.cpp:
(WebCore::GLContextEGL::GLContextEGL):
(WebCore::GLContextEGL::~GLContextEGL):
(WebCore::GLContextEGL::createImage const): Deleted.
(WebCore::GLContextEGL::destroyImage const): Deleted.
* Source/WebCore/platform/graphics/egl/GLContextEGL.h:
* Source/WebCore/platform/graphics/gbm/DMABufEGLUtilities.h:
(WebCore::DMABufEGLUtilities::constructEGLCreateImageAttributes):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::allocateDrawBufferObject):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerDmabuf.cpp:
(WebCore::TextureMapperPlatformLayerDmabuf::validateTexture):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::EGLImageData::~EGLImageData):
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::createEGLImageData):
(WebCore::createImageKHR): Deleted.
(WebCore::destroyImageKHR): Deleted.

Canonical link: <a href="https://commits.webkit.org/261958@main">https://commits.webkit.org/261958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e32386399f9c2b212f896a8de0e39ee643b6f4ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/96 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/107 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/86 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/102 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/92 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/109 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/109 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/100 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/87 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/87 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/104 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->