### PR TITLE
Have RemoteMediaSourceProxy keep a mirror of the MediaSource's buffered range.

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1166,6 +1166,7 @@ void MediaSource::updateBufferedIfNeeded(bool force)
     auto updatePrivate = makeScopeExit([&] {
         if (!m_private || buffered.get() == m_buffered.get())
             return;
+        m_private->bufferedChanged(m_buffered);
         monitorSourceBuffers();
     });
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -70,8 +70,7 @@ MediaTime RemoteMediaSourceProxy::duration() const
 
 std::unique_ptr<PlatformTimeRanges> RemoteMediaSourceProxy::buffered() const
 {
-    notImplemented();
-    return nullptr;
+    return makeUnique<PlatformTimeRanges>(m_buffered);
 }
 
 void RemoteMediaSourceProxy::seekToTime(const MediaTime& time)
@@ -126,6 +125,13 @@ void RemoteMediaSourceProxy::durationChanged(const MediaTime& duration)
     m_duration = duration;
     if (m_private)
         m_private->durationChanged(duration);
+}
+
+void RemoteMediaSourceProxy::bufferedChanged(WebCore::PlatformTimeRanges&& buffered)
+{
+    m_buffered = WTFMove(buffered);
+    if (m_private)
+        m_private->bufferedChanged(m_buffered);
 }
 
 void RemoteMediaSourceProxy::setReadyState(WebCore::MediaPlayerEnums::ReadyState readyState)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -82,6 +82,7 @@ private:
     using AddSourceBufferCallback = CompletionHandler<void(WebCore::MediaSourcePrivate::AddStatus, std::optional<RemoteSourceBufferIdentifier>)>;
     void addSourceBuffer(const WebCore::ContentType&, AddSourceBufferCallback&&);
     void durationChanged(const MediaTime&);
+    void bufferedChanged(WebCore::PlatformTimeRanges&&);
     void setReadyState(WebCore::MediaPlayerEnums::ReadyState);
     void setIsSeeking(bool);
     void waitForSeekCompleted();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
@@ -28,6 +28,7 @@
 messages -> RemoteMediaSourceProxy NotRefCounted {
     AddSourceBuffer(WebCore::ContentType contentType) -> (enum:uint8_t WebCore::MediaSourcePrivate::AddStatus status, std::optional<WebKit::RemoteSourceBufferIdentifier> remoteSourceBufferIdentifier) Synchronous
     DurationChanged(MediaTime duration)
+    BufferedChanged(WebCore::PlatformTimeRanges buffered)
     SetReadyState(WebCore::MediaPlayerEnums::ReadyState readyState)
     SetIsSeeking(bool isSeeking)
     WaitForSeekCompleted()

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -117,6 +117,14 @@ void MediaSourcePrivateRemote::durationChanged(const MediaTime& duration)
     m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::DurationChanged(duration), m_identifier);
 }
 
+void MediaSourcePrivateRemote::bufferedChanged(const PlatformTimeRanges& buffered)
+{
+    if (!m_gpuProcessConnection)
+        return;
+
+    m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::BufferedChanged(buffered), m_identifier);
+}
+
 void MediaSourcePrivateRemote::markEndOfStream(EndOfStreamStatus)
 {
     notImplemented();

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -63,6 +63,7 @@ public:
     // MediaSourcePrivate overrides
     AddStatus addSourceBuffer(const WebCore::ContentType&, bool webMParserEnabled, RefPtr<WebCore::SourceBufferPrivate>&) final;
     void durationChanged(const MediaTime&) final;
+    void bufferedChanged(const WebCore::PlatformTimeRanges&) final;
     void markEndOfStream(EndOfStreamStatus) final;
     void unmarkEndOfStream() final;
     bool isEnded() const final;


### PR DESCRIPTION
#### 6daa61939b71b1f8dba57c58442c831c82368995
<pre>
Have RemoteMediaSourceProxy keep a mirror of the MediaSource&apos;s buffered range.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254209">https://bugs.webkit.org/show_bug.cgi?id=254209</a>
rdar://106990497

Reviewed by Youenn Fablet.

When enabling the MockMediaPlayerMediaSource to run in the GPU process,
it requires to access the MediaSource&apos;s buffered range that is maintained
and live in the content process.
Actual use to come in a follow-up change.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::updateBufferedIfNeeded):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::buffered const):
(WebKit::RemoteMediaSourceProxy::bufferedChanged):
(WebKit::RemoteMediaSourceProxy::setReadyState):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::bufferedChanged):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/261957@main">https://commits.webkit.org/261957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21584aa66510f4cc417e096d57c589d24a913ded

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/93 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/104 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/85 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/98 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/89 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/98 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/85 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/84 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/102 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->