### PR TITLE
Blob range request test failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any-expected.txt
@@ -14,4 +14,27 @@ PASS Preflight for {"content-type":"application/www-form-urlencoded"}
 PASS Preflight for {"content-type":"application/x-www-form-urlencoded;"}
 PASS No preflight for {"content-type":"multipart/form-data"}
 PASS Preflight for {"content-type":"multipart/form-data;\""}
+PASS Preflight for {"range":"100-200"}
+PASS Preflight for {"range":"MB=100-200"}
+PASS No preflight for {"range":"bytes=100-200"}
+PASS Preflight for {"range":"bytes =100-200"}
+PASS Preflight for {"range":"bytes\t=100-200"}
+PASS Preflight for {"range":"bytes=  100-200"}
+PASS Preflight for {"range":"bytes=\t\t100-200"}
+PASS Preflight for {"range":"bytes= \t100-200"}
+PASS Preflight for {"range":"bytes=100 -200"}
+PASS Preflight for {"range":"bytes=100\t-200"}
+PASS Preflight for {"range":"bytes=100- 200"}
+PASS Preflight for {"range":"bytes=100-\t200"}
+PASS Preflight for {"range":"bytes=100-200hello"}
+PASS Preflight for {"range":"bytes=abc-def"}
+PASS Preflight for {"range":"bytes=100-200,300-400"}
+PASS Preflight for {"range":"bytes=-200"}
+PASS No preflight for {"range":"bytes=200-"}
+PASS Preflight for {"range":"bytes=200-100"}
+PASS Preflight for {"range":"bytes=1000000000000000000000000000000000000000000000000000000000000-2000000000000000000000000000000000000000000000000000000000000"}
+PASS Preflight for {"range":"bytes 100-200"}
+PASS Preflight for {"range":"bytes = 100-200"}
+PASS Preflight for {"range":",bytes=100-200"}
+PASS Preflight for {"range":"bytes=,100-200"}
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any.js
@@ -40,4 +40,32 @@ function safelist(headers, expectPreflight = false) {
   ["multipart/form-data;\"", true]
 ].forEach(([mimeType, preflight = false]) => {
   safelist({"content-type": mimeType}, preflight);
-})
+});
+
+[
+  ["100-200", true],
+  ["MB=100-200", true],
+  ["bytes=100-200"],
+  ["bytes =100-200", true],
+  ["bytes\t=100-200", true],
+  ["bytes=  100-200", true],
+  ["bytes=\t\t100-200", true],
+  ["bytes= \t100-200", true],
+  ["bytes=100 -200", true],
+  ["bytes=100\t-200", true],
+  ["bytes=100- 200", true],
+  ["bytes=100-\t200", true],
+  ["bytes=100-200hello", true],
+  ["bytes=abc-def", true],
+  ["bytes=100-200,300-400", true],
+  ["bytes=-200", true],
+  ["bytes=200-"],
+  ["bytes=200-100", true],
+  [`bytes=1${'0'.repeat(60)}-2${'0'.repeat(60)}`, true],
+  ["bytes 100-200", true],
+  ["bytes = 100-200", true],
+  [",bytes=100-200", true],
+  ["bytes=,100-200", true],
+].forEach(([value, preflight = false]) => {
+  safelist({"range": value}, preflight);
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any.worker-expected.txt
@@ -14,4 +14,27 @@ PASS Preflight for {"content-type":"application/www-form-urlencoded"}
 PASS Preflight for {"content-type":"application/x-www-form-urlencoded;"}
 PASS No preflight for {"content-type":"multipart/form-data"}
 PASS Preflight for {"content-type":"multipart/form-data;\""}
+PASS Preflight for {"range":"100-200"}
+PASS Preflight for {"range":"MB=100-200"}
+PASS No preflight for {"range":"bytes=100-200"}
+PASS Preflight for {"range":"bytes =100-200"}
+PASS Preflight for {"range":"bytes\t=100-200"}
+PASS Preflight for {"range":"bytes=  100-200"}
+PASS Preflight for {"range":"bytes=\t\t100-200"}
+PASS Preflight for {"range":"bytes= \t100-200"}
+PASS Preflight for {"range":"bytes=100 -200"}
+PASS Preflight for {"range":"bytes=100\t-200"}
+PASS Preflight for {"range":"bytes=100- 200"}
+PASS Preflight for {"range":"bytes=100-\t200"}
+PASS Preflight for {"range":"bytes=100-200hello"}
+PASS Preflight for {"range":"bytes=abc-def"}
+PASS Preflight for {"range":"bytes=100-200,300-400"}
+PASS Preflight for {"range":"bytes=-200"}
+PASS No preflight for {"range":"bytes=200-"}
+PASS Preflight for {"range":"bytes=200-100"}
+PASS Preflight for {"range":"bytes=1000000000000000000000000000000000000000000000000000000000000-2000000000000000000000000000000000000000000000000000000000000"}
+PASS Preflight for {"range":"bytes 100-200"}
+PASS Preflight for {"range":"bytes = 100-200"}
+PASS Preflight for {"range":",bytes=100-200"}
+PASS Preflight for {"range":"bytes=,100-200"}
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any-expected.txt
@@ -1,0 +1,28 @@
+
+PASS A simple blob range request.
+PASS A blob range request with no end.
+PASS A blob range request with no start.
+PASS A simple blob range request with whitespace.
+PASS Blob content with short content and a large range end
+PASS Blob content with short content and a range end matching content length
+PASS Blob range with whitespace before and after hyphen
+PASS Blob range with whitespace after hyphen
+PASS Blob range with whitespace around equals sign
+PASS Blob range with no value
+PASS Blob range with incorrect range header
+PASS Blob range with incorrect range header #2
+PASS Blob range with incorrect range header #3
+PASS Blob range request with multiple range values
+PASS Blob range request with multiple range values and whitespace
+PASS Blob range request with trailing comma
+PASS Blob range with no start or end
+PASS Blob range request with short range end
+PASS Blob range start should be an ASCII digit
+PASS Blob range should have a dash
+PASS Blob range end should be an ASCII digit
+PASS Blob range should include '-'
+PASS Blob range should include '='
+PASS Blob range should include 'bytes='
+PASS Blob content with short content and a large range start
+PASS Blob content with short content and a range start matching the content length
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.js
@@ -1,0 +1,224 @@
+// META: script=/common/utils.js
+
+const supportedBlobRange = [
+  {
+    name: "A simple blob range request.",
+    data: ["A simple Hello, World! example"],
+    type: "text/plain",
+    range: "bytes=9-21",
+    content_length: 13,
+    content_range: "bytes 9-21/30",
+    result: "Hello, World!",
+  },
+  {
+    name: "A blob range request with no end.",
+    data: ["Range with no end"],
+    type: "text/plain",
+    range: "bytes=11-",
+    content_length: 6,
+    content_range: "bytes 11-16/17",
+    result: "no end",
+  },
+  {
+    name: "A blob range request with no start.",
+    data: ["Range with no start"],
+    type: "text/plain",
+    range: "bytes=-8",
+    content_length: 8,
+    content_range: "bytes 11-18/19",
+    result: "no start",
+  },
+  {
+    name: "A simple blob range request with whitespace.",
+    data: ["A simple Hello, World! example"],
+    type: "text/plain",
+    range: "bytes= \t9-21",
+    content_length: 13,
+    content_range: "bytes 9-21/30",
+    result: "Hello, World!",
+  },
+  {
+    name: "Blob content with short content and a large range end",
+    data: ["Not much here"],
+    type: "text/plain",
+    range: "bytes=4-100000000000",
+    content_length: 9,
+    content_range: "bytes 4-12/13",
+    result: "much here",
+  },
+  {
+    name: "Blob content with short content and a range end matching content length",
+    data: ["Not much here"],
+    type: "text/plain",
+    range: "bytes=4-13",
+    content_length: 9,
+    content_range: "bytes 4-12/13",
+    result: "much here",
+  },
+  {
+    name: "Blob range with whitespace before and after hyphen",
+    data: ["Valid whitespace #1"],
+    type: "text/plain",
+    range: "bytes=5 - 10",
+    content_length: 6,
+    content_range: "bytes 5-10/19",
+    result: " white",
+  },
+  {
+    name: "Blob range with whitespace after hyphen",
+    data: ["Valid whitespace #2"],
+    type: "text/plain",
+    range: "bytes=-\t 5",
+    content_length: 5,
+    content_range: "bytes 14-18/19",
+    result: "ce #2",
+  },
+  {
+    name: "Blob range with whitespace around equals sign",
+    data: ["Valid whitespace #3"],
+    type: "text/plain",
+    range: "bytes \t =\t 6-",
+    content_length: 13,
+    content_range: "bytes 6-18/19",
+    result: "whitespace #3",
+  },
+];
+
+const unsupportedBlobRange = [
+  {
+    name: "Blob range with no value",
+    data: ["Blob range should have a value"],
+    type: "text/plain",
+    range: "",
+  },
+  {
+    name: "Blob range with incorrect range header",
+    data: ["A"],
+    type: "text/plain",
+    range: "byte=0-"
+  },
+  {
+    name: "Blob range with incorrect range header #2",
+    data: ["A"],
+    type: "text/plain",
+    range: "bytes"
+  },
+  {
+    name: "Blob range with incorrect range header #3",
+    data: ["A"],
+    type: "text/plain",
+    range: "bytes\t \t"
+  },
+  {
+    name: "Blob range request with multiple range values",
+    data: ["Multiple ranges are not currently supported"],
+    type: "text/plain",
+    range: "bytes=0-5,15-",
+  },
+  {
+    name: "Blob range request with multiple range values and whitespace",
+    data: ["Multiple ranges are not currently supported"],
+    type: "text/plain",
+    range: "bytes=0-5, 15-",
+  },
+  {
+    name: "Blob range request with trailing comma",
+    data: ["Range with invalid trailing comma"],
+    type: "text/plain",
+    range: "bytes=0-5,",
+  },
+  {
+    name: "Blob range with no start or end",
+    data: ["Range with no start or end"],
+    type: "text/plain",
+    range: "bytes=-",
+  },
+  {
+    name: "Blob range request with short range end",
+    data: ["Range end should be greater than range start"],
+    type: "text/plain",
+    range: "bytes=10-5",
+  },
+  {
+    name: "Blob range start should be an ASCII digit",
+    data: ["Range start must be an ASCII digit"],
+    type: "text/plain",
+    range: "bytes=x-5",
+  },
+  {
+    name: "Blob range should have a dash",
+    data: ["Blob range should have a dash"],
+    type: "text/plain",
+    range: "bytes=5",
+  },
+  {
+    name: "Blob range end should be an ASCII digit",
+    data: ["Range end must be an ASCII digit"],
+    type: "text/plain",
+    range: "bytes=5-x",
+  },
+  {
+    name: "Blob range should include '-'",
+    data: ["Range end must include '-'"],
+    type: "text/plain",
+    range: "bytes=x",
+  },
+  {
+    name: "Blob range should include '='",
+    data: ["Range end must include '='"],
+    type: "text/plain",
+    range: "bytes 5-",
+  },
+  {
+    name: "Blob range should include 'bytes='",
+    data: ["Range end must include 'bytes='"],
+    type: "text/plain",
+    range: "5-",
+  },
+  {
+    name: "Blob content with short content and a large range start",
+    data: ["Not much here"],
+    type: "text/plain",
+    range: "bytes=100000-",
+  },
+  {
+    name: "Blob content with short content and a range start matching the content length",
+    data: ["Not much here"],
+    type: "text/plain",
+    range: "bytes=13-",
+  },
+];
+
+supportedBlobRange.forEach(({ name, data, type, range, content_length, content_range, result }) => {
+  promise_test(async t => {
+    const blob = new Blob(data, { "type" : type });
+    const blobURL = URL.createObjectURL(blob);
+    t.add_cleanup(() => URL.revokeObjectURL(blobURL));
+    const resp = await fetch(blobURL, {
+      "headers": {
+        "Range": range
+      }
+    });
+    assert_equals(resp.status, 206, "HTTP status is 206");
+    assert_equals(resp.type, "basic", "response type is basic");
+    assert_equals(resp.headers.get("Content-Type"), type, "Content-Type is " + resp.headers.get("Content-Type"));
+    assert_equals(resp.headers.get("Content-Length"), content_length.toString(), "Content-Length is " + resp.headers.get("Content-Length"));
+    assert_equals(resp.headers.get("Content-Range"), content_range, "Content-Range is " + resp.headers.get("Content-Range"));
+    const text = await resp.text();
+    assert_equals(text, result, "Response's body is correct");
+  }, name);
+});
+
+unsupportedBlobRange.forEach(({ name, data, type, range }) => {
+  promise_test(t => {
+    const blob = new Blob(data, { "type" : type });
+    const blobURL = URL.createObjectURL(blob);
+    t.add_cleanup(() => URL.revokeObjectURL(blobURL));
+    const promise = fetch(blobURL, {
+      "headers": {
+        "Range": range
+      }
+    });
+    return promise_rejects_js(t, TypeError, promise);
+  }, name);
+});

--- a/Source/WebCore/platform/network/BlobResourceHandle.h
+++ b/Source/WebCore/platform/network/BlobResourceHandle.h
@@ -108,9 +108,9 @@ private:
     Vector<long long> m_itemLengthList;
     Error m_errorCode { Error::NoError };
     bool m_aborted { false };
-    long long m_rangeOffset { kPositionNotSpecified };
+    bool m_isRangeRequest { false };
+    long long m_rangeStart { kPositionNotSpecified };
     long long m_rangeEnd { kPositionNotSpecified };
-    long long m_rangeSuffixLength { kPositionNotSpecified };
     long long m_totalSize { 0 };
     long long m_totalRemainingSize { 0 };
     long long m_currentItemReadSize { 0 };

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -10,13 +10,13 @@
  * are met:
  *
  * 1.  Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer. 
+ *     notice, this list of conditions and the following disclaimer.
  * 2.  Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution. 
+ *     documentation and/or other materials provided with the distribution.
  * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
  *     its contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission. 
+ *     from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -156,7 +156,7 @@ bool isValidAcceptHeaderValue(const String& value)
         if (RFC7230::isDelimiter(c))
             return false;
     }
-    
+
     return true;
 }
 
@@ -347,7 +347,7 @@ StringView filenameFromHTTPContentDisposition(StringView value)
 
         if (key.isEmpty() || key != "filename"_s)
             continue;
-        
+
         auto value = keyValuePair.substring(valueStartPos + 1).stripWhiteSpace();
 
         // Remove quotes if there are any
@@ -610,20 +610,32 @@ OptionSet<ClearSiteDataValue> parseClearSiteDataHeader(const ResourceResponse& r
     return result;
 }
 
-bool parseRange(StringView range, long long& rangeOffset, long long& rangeEnd, long long& rangeSuffixLength)
+static bool isTabOrSpace(UChar value)
 {
-    // The format of "Range" header is defined in RFC 2616 Section 14.35.1.
-    // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35.1
-    // We don't support multiple range requests.
+    return value == '\t' || value == ' ';
+}
 
-    rangeOffset = rangeEnd = rangeSuffixLength = -1;
+// Implements <https://fetch.spec.whatwg.org/#simple-range-header-value>.
+// FIXME: this whole function could be more efficient by walking through the range value once.
+bool parseRange(StringView range, RangeAllowWhitespace allowWhitespace, long long& rangeStart, long long& rangeEnd)
+{
+    rangeStart = rangeEnd = -1;
 
-    // The "bytes" unit identifier should be present.
-    static const unsigned bytesLength = 6;
-    if (!startsWithLettersIgnoringASCIICase(range, "bytes="_s))
+    // Only 0x20 and 0x09 matter as newlines are already gone by the time we parse a header value.
+    if (allowWhitespace == RangeAllowWhitespace::No && range.find(isTabOrSpace) != notFound)
         return false;
 
-    StringView byteRange = range.substring(bytesLength);
+    // The "bytes" unit identifier should be present.
+    static const unsigned bytesLength = 5;
+    if (!startsWithLettersIgnoringASCIICase(range, "bytes"_s))
+        return false;
+
+    auto byteRange = stripLeadingAndTrailingHTTPSpaces(range.substring(bytesLength));
+
+    if (!byteRange.startsWith('='))
+        return false;
+
+    byteRange = byteRange.substring(1);
 
     // The '-' character needs to be present.
     int index = byteRange.find('-');
@@ -634,8 +646,10 @@ bool parseRange(StringView range, long long& rangeOffset, long long& rangeEnd, l
     // Example:
     //     -500
     if (!index) {
-        if (auto value = parseInteger<long long>(byteRange.substring(index + 1)))
-            rangeSuffixLength = *value;
+        auto value = parseInteger<long long>(byteRange.substring(index + 1));
+        if (!value)
+            return false;
+        rangeEnd = *value;
         return true;
     }
 
@@ -647,7 +661,7 @@ bool parseRange(StringView range, long long& rangeOffset, long long& rangeEnd, l
     if (!firstBytePos)
         return false;
 
-    auto lastBytePosStr = stripLeadingAndTrailingHTTPSpaces(byteRange.substring(index + 1));
+    auto lastBytePosStr = byteRange.substring(index + 1);
     long long lastBytePos = -1;
     if (!lastBytePosStr.isEmpty()) {
         auto value = parseInteger<long long>(lastBytePosStr);
@@ -659,7 +673,7 @@ bool parseRange(StringView range, long long& rangeOffset, long long& rangeEnd, l
     if (*firstBytePos < 0 || !(lastBytePos == -1 || lastBytePos >= *firstBytePos))
         return false;
 
-    rangeOffset = *firstBytePos;
+    rangeStart = *firstBytePos;
     rangeEnd = lastBytePos;
     return true;
 }
@@ -912,41 +926,6 @@ bool isCrossOriginSafeHeader(const String& name, const HTTPHeaderSet& accessCont
     return accessControlExposeHeaderSet.contains(name);
 }
 
-static bool isSimpleRangeHeaderValue(const String& value)
-{
-    if (!value.startsWith("bytes="_s))
-        return false;
-
-    unsigned start = 0;
-    unsigned end = 0;
-    bool hasHyphen = false;
-
-    for (size_t cptr = 6; cptr < value.length(); ++cptr) {
-        auto character = value[cptr];
-        if (character >= '0' && character <= '9') {
-            if (productOverflows<unsigned>(hasHyphen ? end : start, 10))
-                return false;
-            auto newDecimal = (hasHyphen ? end : start) * 10;
-            auto sum = Checked<unsigned, RecordOverflow>(newDecimal) + Checked<unsigned, RecordOverflow>(character - '0');
-            if (sum.hasOverflowed())
-                return false;
-
-            if (hasHyphen)
-                end = sum.value();
-            else
-                start = sum.value();
-            continue;
-        }
-        if (character == '-' && !hasHyphen) {
-            hasHyphen = true;
-            continue;
-        }
-        return false;
-    }
-
-    return hasHyphen && (!end || start < end);
-}
-
 // Implements https://fetch.spec.whatwg.org/#cors-safelisted-request-header
 bool isCrossOriginSafeRequestHeader(HTTPHeaderName name, const String& value)
 {
@@ -976,11 +955,14 @@ bool isCrossOriginSafeRequestHeader(HTTPHeaderName name, const String& value)
         break;
     }
     case HTTPHeaderName::Range:
-        if (!isSimpleRangeHeaderValue(value))
+        long long start;
+        long long end;
+        if (!parseRange(value, RangeAllowWhitespace::No, start, end))
+            return false;
+        if (start == -1)
             return false;
         break;
     default:
-        // FIXME: Should we also make safe other headers (DPR, Downlink, Save-Data...)? That would require validating their values.
         return false;
     }
     return true;

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -8,13 +8,13 @@
  * are met:
  *
  * 1.  Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer. 
+ *     notice, this list of conditions and the following disclaimer.
  * 2.  Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution. 
+ *     documentation and/or other materials provided with the distribution.
  * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
  *     its contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission. 
+ *     from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -77,6 +77,11 @@ enum class ClearSiteDataValue : uint8_t {
     Storage = 1 << 3,
 };
 
+enum class RangeAllowWhitespace : bool {
+    No,
+    Yes
+};
+
 bool isValidReasonPhrase(const String&);
 bool isValidHTTPHeaderValue(const String&);
 bool isValidAcceptHeaderValue(const String&);
@@ -96,7 +101,7 @@ WEBCORE_EXPORT XFrameOptionsDisposition parseXFrameOptionsHeader(StringView);
 WEBCORE_EXPORT OptionSet<ClearSiteDataValue> parseClearSiteDataHeader(const ResourceResponse&);
 
 // -1 could be set to one of the return parameters to indicate the value is not specified.
-WEBCORE_EXPORT bool parseRange(StringView, long long& rangeOffset, long long& rangeEnd, long long& rangeSuffixLength);
+WEBCORE_EXPORT bool parseRange(StringView, RangeAllowWhitespace, long long& rangeStart, long long& rangeEnd);
 
 ContentTypeOptionsDisposition parseContentTypeOptionsHeader(StringView header);
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -57,14 +57,8 @@ static const unsigned bufferSize = 512 * 1024;
 
 static const int httpOK = 200;
 static const int httpPartialContent = 206;
-static const int httpNotAllowed = 403;
-static const int httpRequestedRangeNotSatisfiable = 416;
-static const int httpInternalError = 500;
 static constexpr auto httpOKText = "OK"_s;
 static constexpr auto httpPartialContentText = "Partial Content"_s;
-static constexpr auto httpNotAllowedText = "Not Allowed"_s;
-static constexpr auto httpRequestedRangeNotSatisfiableText = "Requested Range Not Satisfiable"_s;
-static constexpr auto httpInternalErrorText = "Internal Server Error"_s;
 
 static constexpr auto webKitBlobResourceDomain = "WebKitBlobResource"_s;
 
@@ -132,8 +126,9 @@ void NetworkDataTaskBlob::resume()
 
         // Parse the "Range" header we care about.
         String range = m_firstRequest.httpHeaderField(HTTPHeaderName::Range);
-        if (!range.isEmpty() && !parseRange(range, m_rangeOffset, m_rangeEnd, m_rangeSuffixLength)) {
-            dispatchDidReceiveResponse(Error::RangeError);
+        m_isRangeRequest = !range.isNull();
+        if (m_isRangeRequest && !parseRange(range, RangeAllowWhitespace::Yes, m_rangeStart, m_rangeEnd)) {
+            didFail(Error::RangeError);
             return;
         }
 
@@ -223,18 +218,25 @@ void NetworkDataTaskBlob::seek()
 {
     ASSERT(RunLoop::isMain());
 
-    // Convert from the suffix length to the range.
-    if (m_rangeSuffixLength != kPositionNotSpecified) {
-        m_rangeOffset = m_totalRemainingSize - m_rangeSuffixLength;
-        m_rangeEnd = m_rangeOffset + m_rangeSuffixLength - 1;
-    }
-
     // Bail out if the range is not provided.
-    if (m_rangeOffset == kPositionNotSpecified)
+    if (!m_isRangeRequest)
         return;
 
+    // Adjust m_rangeStart / m_rangeEnd
+    if (m_rangeStart == kPositionNotSpecified) {
+        m_rangeStart = m_totalSize - m_rangeEnd;
+        m_rangeEnd = m_rangeStart + m_rangeEnd - 1;
+    } else {
+        if (m_rangeStart >= m_totalSize) {
+            didFail(Error::RangeError);
+            return;
+        }
+        if (m_rangeEnd == kPositionNotSpecified || m_rangeEnd >= m_totalSize)
+            m_rangeEnd = m_totalSize - 1;
+    }
+
     // Skip the initial items that are not in the range.
-    long long offset = m_rangeOffset;
+    long long offset = m_rangeStart;
     for (m_readItemCount = 0; m_readItemCount < m_blobData->items().size() && offset >= m_itemLengthList[m_readItemCount]; ++m_readItemCount)
         offset -= m_itemLengthList[m_readItemCount];
 
@@ -242,67 +244,37 @@ void NetworkDataTaskBlob::seek()
     m_currentItemReadSize = offset;
 
     // Adjust the total remaining size in order not to go beyond the range.
-    if (m_rangeEnd != kPositionNotSpecified) {
-        long long rangeSize = m_rangeEnd - m_rangeOffset + 1;
-        if (m_totalRemainingSize > rangeSize)
-            m_totalRemainingSize = rangeSize;
-    } else
-        m_totalRemainingSize -= m_rangeOffset;
+    long long rangeSize = m_rangeEnd - m_rangeStart + 1;
+    if (m_totalRemainingSize > rangeSize)
+        m_totalRemainingSize = rangeSize;
 }
 
-void NetworkDataTaskBlob::dispatchDidReceiveResponse(Error errorCode)
+void NetworkDataTaskBlob::dispatchDidReceiveResponse()
 {
-    LOG(NetworkSession, "%p - NetworkDataTaskBlob::dispatchDidReceiveResponse(%u)", this, static_cast<unsigned>(errorCode));
+    LOG(NetworkSession, "%p - NetworkDataTaskBlob::dispatchDidReceiveResponse()", this);
 
     Ref<NetworkDataTaskBlob> protectedThis(*this);
-    ResourceResponse response(m_firstRequest.url(), errorCode != Error::NoError ? "text/plain"_s : extractMIMETypeFromMediaType(m_blobData->contentType()), errorCode != Error::NoError ? 0 : m_totalRemainingSize, String());
-    switch (errorCode) {
-    case Error::NoError: {
-        bool isRangeRequest = m_rangeOffset != kPositionNotSpecified;
-        response.setHTTPStatusCode(isRangeRequest ? httpPartialContent : httpOK);
-        response.setHTTPStatusText(isRangeRequest ? httpPartialContentText : httpOKText);
+    ResourceResponse response(m_firstRequest.url(), extractMIMETypeFromMediaType(m_blobData->contentType()), m_totalRemainingSize, String());
+    response.setHTTPStatusCode(m_isRangeRequest ? httpPartialContent : httpOK);
+    response.setHTTPStatusText(m_isRangeRequest ? httpPartialContentText : httpOKText);
 
-        response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
-        response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toAtomString());
-        response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
-        addPolicyContainerHeaders(response, m_blobData->policyContainer());
+    response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
+    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toAtomString());
+    response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
+    addPolicyContainerHeaders(response, m_blobData->policyContainer());
 
-        if (isRangeRequest) {
-            auto rangeEnd = m_rangeEnd;
-            if (rangeEnd == kPositionNotSpecified)
-                rangeEnd = m_totalSize - 1;
+    if (m_isRangeRequest)
+        response.setHTTPHeaderField(HTTPHeaderName::ContentRange, ParsedContentRange(m_rangeStart, m_rangeEnd, m_totalSize).headerValue());
 
-            response.setHTTPHeaderField(HTTPHeaderName::ContentRange, ParsedContentRange(m_rangeOffset, rangeEnd, m_totalSize).headerValue());
-        }
-        // FIXME: If a resource identified with a blob: URL is a File object, user agents must use that file's name attribute,
-        // as if the response had a Content-Disposition header with the filename parameter set to the File's name attribute.
-        // Notably, this will affect a name suggested in "File Save As".
-        break;
-    }
-    case Error::RangeError:
-        response.setHTTPStatusCode(httpRequestedRangeNotSatisfiable);
-        response.setHTTPStatusText(httpRequestedRangeNotSatisfiableText);
-        break;
-    case Error::SecurityError:
-        response.setHTTPStatusCode(httpNotAllowed);
-        response.setHTTPStatusText(httpNotAllowedText);
-        break;
-    default:
-        response.setHTTPStatusCode(httpInternalError);
-        response.setHTTPStatusText(httpInternalErrorText);
-        break;
-    }
+    // FIXME: If a resource identified with a blob: URL is a File object, user agents must use that file's name attribute,
+    // as if the response had a Content-Disposition header with the filename parameter set to the File's name attribute.
+    // Notably, this will affect a name suggested in "File Save As".
 
-    didReceiveResponse(WTFMove(response), NegotiatedLegacyTLS::No, PrivateRelayed::No, [this, protectedThis = WTFMove(protectedThis), errorCode](PolicyAction policyAction) {
+    didReceiveResponse(WTFMove(response), NegotiatedLegacyTLS::No, PrivateRelayed::No, [this, protectedThis = WTFMove(protectedThis)](PolicyAction policyAction) {
         LOG(NetworkSession, "%p - NetworkDataTaskBlob::didReceiveResponse completionHandler (%u)", this, static_cast<unsigned>(policyAction));
 
         if (m_state == State::Canceling || m_state == State::Completed) {
             clearStream();
-            return;
-        }
-
-        if (errorCode != Error::NoError) {
-            didFinish();
             return;
         }
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
@@ -83,7 +83,7 @@ private:
 
     void clearStream();
     void getSizeForNext();
-    void dispatchDidReceiveResponse(Error = Error::NoError);
+    void dispatchDidReceiveResponse();
     void seek();
     void consumeData(const uint8_t* data, int bytesRead);
     void read();
@@ -104,9 +104,9 @@ private:
     Vector<uint8_t> m_buffer;
     Vector<long long> m_itemLengthList;
     State m_state { State::Suspended };
-    long long m_rangeOffset { kPositionNotSpecified };
+    bool m_isRangeRequest { false };
+    long long m_rangeStart { kPositionNotSpecified };
     long long m_rangeEnd { kPositionNotSpecified };
-    long long m_rangeSuffixLength { kPositionNotSpecified };
     long long m_totalSize { 0 };
     long long m_downloadBytesWritten { 0 };
     long long m_totalRemainingSize { 0 };


### PR DESCRIPTION
#### 09841b4faec73a9d1b15b37d68941a995f33cadf
<pre>
Blob range request test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=248994">https://bugs.webkit.org/show_bug.cgi?id=248994</a>
rdar://103171187

Reviewed by Youenn Fablet.

This changes the Range request header parser so it can be used by both blob: URLs and the CORS-safelisted request-header check.

It changes the error handling for blob: URLs such that it now returns network errors rather than HTTP responses.

It aligns the Range request header parser with the Fetch Standard.

* LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any.js:
(async string_appeared_here):
* LayoutTests/imported/w3c/web-platform-tests/cors/cors-safelisted-request-header.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.js: Added.
(supportedBlobRange.forEach):
(async unsupportedBlobRange):
(async unsupportedBlobRange.forEach):

These tests are from upstream web-platform-tests. <a href="https://github.com/web-platform-tests/wpt/pull/39108">https://github.com/web-platform-tests/wpt/pull/39108</a> added coverage for some of the cases discussed during review.

* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::doStart):
(WebCore::BlobResourceHandle::seek):
(WebCore::BlobResourceHandle::notifyResponse):
(WebCore::BlobResourceHandle::notifyResponseOnSuccess):
(WebCore::BlobResourceHandle::notifyResponseOnError): Deleted.
* Source/WebCore/platform/network/BlobResourceHandle.h:
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::isValidAcceptHeaderValue):
(WebCore::filenameFromHTTPContentDisposition):
(WebCore::isTabOrSpace):
(WebCore::parseRange):
(WebCore::isCrossOriginSafeRequestHeader):
(WebCore::isSimpleRangeHeaderValue): Deleted.
* Source/WebCore/platform/network/HTTPParsers.h:
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::resume):
(WebKit::NetworkDataTaskBlob::seek):
(WebKit::NetworkDataTaskBlob::dispatchDidReceiveResponse):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h:

Canonical link: <a href="https://commits.webkit.org/261968@main">https://commits.webkit.org/261968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9a11696bc0220c59124837891bb6dbbd37de4f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/132 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/125 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/129 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->