### PR TITLE
[Gstreamer][WebRTC] webrtc/video-disabled-black.html fails

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1765,7 +1765,6 @@ imported/w3c/web-platform-tests/webrtc/ [ Skip ]
 
 # Pending investigation.
 webkit.org/b/187064 webrtc/video-addTrack.html [ Failure ]
-webkit.org/b/187064 webkit.org/b/235885 webrtc/video-disabled-black.html [ Failure ]
 webkit.org/b/187064 webrtc/video-rotation.html [ Failure ]
 webkit.org/b/187064 webrtc/video-with-data-channel.html [ Failure ]
 webkit.org/b/187064 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https.html [ Failure Pass ]

--- a/LayoutTests/webrtc/routines.js
+++ b/LayoutTests/webrtc/routines.js
@@ -226,6 +226,20 @@ async function checkVideoBlack(expected, canvas, video, errorMessage, counter)
     return checkVideoBlack(expected, canvas, video, errorMessage, --counter);
 }
 
+async function checkVideoIsEntirelyBlack(canvas, video, counter)
+{
+    if (counter === undefined)
+        counter = 200;
+    if (counter === 0)
+        return Promise.reject("Remote video frame was not black as expected");
+
+    if (video.videoWidth && video.videoHeight && isVideoBlack(canvas, video, 0, 0, video.videoWidth, video.videoHeight))
+        return Promise.resolve();
+
+    await waitFor(50);
+    return checkVideoIsEntirelyBlack(canvas, video, --counter);
+}
+
 function setCodec(sdp, codec)
 {
     return sdp.split('\r\n').filter(line => {

--- a/LayoutTests/webrtc/video-disabled-black.html
+++ b/LayoutTests/webrtc/video-disabled-black.html
@@ -18,35 +18,12 @@ video = document.getElementById("video");
 canvas = document.getElementById("canvas");
 // FIXME: We should use tracks
 
-function testImage()
-{
-    try {
-        if (!video.videoWidth || !video.videoHeight)
-            throw `Video size invalid: ${video.videoWidth}x${video.videoHeight}`;
-
-        canvas.width = video.videoWidth;
-        canvas.height = video.videoHeight;
-        canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
-
-        imageData = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height);
-        assert_true(imageData.data.every( (pixel, index) => {
-            return pixel === 0 || (index % 4) === 3;
-        }));
-
-        finishTest();
-    } catch(e) {
-        errorTest(e);
-    }
-}
-
 function testStream(stream)
 {
     video.srcObject = stream;
     video.onplay = setTimeout(() => {
         stream.getTracks()[0].enabled = false;
-        setTimeout(() => {
-            testImage();
-        }, 0);
+        checkVideoIsEntirelyBlack(canvas, video).then(finishTest, errorTest);
     }, 2000);
 }
 


### PR DESCRIPTION
#### aff28bc50d0e283250350647403aba6131fbd8fb
<pre>
[Gstreamer][WebRTC] webrtc/video-disabled-black.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=254212">https://bugs.webkit.org/show_bug.cgi?id=254212</a>

Reviewed by Xabier Rodriguez-Calvar.

Flushing a disabled video track would lead to a caps negotiation failure afterwards, so flush only
if the track is being re-enabled.

The webrtc/video-disabled-black.html test was also rewritten in order to avoid flakiness, we now
check the video at most 200 times instead of one, before failing the test.

Also drive-by in MediaStreamSource, rebuild black frame caps when needed, instead of attempting to
update caps that are not writable.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/webrtc/routines.js:
* LayoutTests/webrtc/video-disabled-black.html:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:

Canonical link: <a href="https://commits.webkit.org/261951@main">https://commits.webkit.org/261951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f8b6ee815cdaea5bd08ac75e50e15612189adbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/113278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/22411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/90/builds/1950 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/121732 "Built successfully") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/23779 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/119065 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/100935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/106376 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/88/builds/1475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/46725 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/14711 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/89/builds/1514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/98980 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/15419 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/20713 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/53505 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/17274 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->