### PR TITLE
[WGSL] Fix the wgslc build

### DIFF
--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -124,7 +124,7 @@ static int runWGSL(const CommandLine& options)
     if (options.dumpASTAfterCheck())
         WGSL::AST::dumpAST(shaderModule);
 
-    String entrypointName = String::fromUTF8WithLatin1Fallback(options.entrypoint());
+    String entrypointName = String::fromLatin1(options.entrypoint());
     auto prepareResult = WGSL::prepare(shaderModule, entrypointName, std::nullopt);
     if (options.dumpASTAtEnd())
         WGSL::AST::dumpAST(shaderModule);


### PR DESCRIPTION
#### 49011a1d35b6fb9195db0e42920ceef7e21953ed
<pre>
[WGSL] Fix the wgslc build
<a href="https://bugs.webkit.org/show_bug.cgi?id=254213">https://bugs.webkit.org/show_bug.cgi?id=254213</a>
rdar://106995791

Unreviewed build fix.

Before landing I replaced `String::fromLatin1` with `String::fromUTF8WithLatin1Fallback`
without realizing that the latter takes an extra argument. For now, just revert it back
to using `fromLatin1`.

* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):

Canonical link: <a href="https://commits.webkit.org/261922@main">https://commits.webkit.org/261922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a3b136d1d7606b8e1a32ac53221c2b1f2a8ff3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/113283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/22416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/90/builds/1955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/121737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/23784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/119070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/23784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/90/builds/1955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/23784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/90/builds/1955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/106381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/14716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/90/builds/1955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/106381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/15424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/20718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/90/builds/1955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/8333 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Checked out pull request; finished (skipped); Compiled WebKit (warnings); layout-tests (exception)") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/17279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/4551 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->