### PR TITLE
[media-controls] buffered data indicator looks wrong when scrubbing back

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/scrubbing-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/scrubbing-support.js
@@ -68,11 +68,22 @@ class ScrubbingSupport extends MediaControllerSupport
         if (isNaN(media.duration))
             return;
 
-        let buffered = 0;
-        for (let i = 0, count = media.buffered.length; i < count; ++i)
-            buffered = Math.max(media.buffered.end(i), buffered);
+        // Let's find the buffered time range containing the current time and
+        // set the scrubber's secondary value to the end of that range.
+        const endTimeForBufferedRangeContainingCurrentTime = () => {
+            const ranges = media.buffered;
+            const currentTime = media.currentTime;
+            for (let i = 0; i < ranges.length; ++i) {
+                if (currentTime < ranges.start(i))
+                    continue;
+                const end = ranges.end(i);
+                if (currentTime <= end)
+                    return end;
+            }
+            return 0;
+        }
 
-        this.control.secondaryValue = buffered / media.duration;
+        this.control.secondaryValue = endTimeForBufferedRangeContainingCurrentTime() / media.duration;
     }
 
 }


### PR DESCRIPTION
#### bc79ba5a3d3e70b9dbddb3967f2c58ff96abdfa2
<pre>
[media-controls] buffered data indicator looks wrong when scrubbing back
<a href="https://bugs.webkit.org/show_bug.cgi?id=254217">https://bugs.webkit.org/show_bug.cgi?id=254217</a>

Reviewed by Dean Jackson and Devin Rousso.

The HTMLMediaElement.buffered API provides a list of time ranges that are buffered. Until now, we would find the
highest value in all of the ranges and use that value to draw the buffered data indicator in the time scrubber.

This means that if the user would start playing a video, scrub forward, let the video play a bit to buffer some data
around that time, and then scrub backwards, the buffered data indicator would be misleading as it would indicate that
data was buffered all the way to that previous current time. Eventually, this would fix itself since the implementation
probably drops the buffered data if way past the current time.

We now only consider the buffered range that contains the current time, which means that the buffered data indicator fills
up nicely when playing linearly, but also snaps back to the current time when we scrub backwards.

* Source/WebCore/Modules/modern-media-controls/media/scrubbing-support.js:
(ScrubbingSupport.prototype.syncControl):
(ScrubbingSupport):

Canonical link: <a href="https://commits.webkit.org/261963@main">https://commits.webkit.org/261963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f544d203a90c218d1e0ecd9fa2f9fbe9b6b90437

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/90 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/83 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/94 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/86 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/101 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98 "10 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/95 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/83 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/81 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/99 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->