### PR TITLE
[WGSL] Make AST::Structure::role changes reversible

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -57,6 +57,7 @@ public:
 
     NodeKind kind() const override;
     StructureRole role() const { return m_role; }
+    StructureRole& role() { return m_role; }
     Identifier& name() { return m_name; }
     Attribute::List& attributes() { return m_attributes; }
     StructureMember::List& members() { return m_members; }

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -144,7 +144,7 @@ void EntryPointRewriter::checkReturnType()
     if (auto* maybeReturnType = m_function.maybeReturnType()) {
         if (auto* structType = std::get_if<Types::Struct>(maybeReturnType->resolvedType())) {
             ASSERT(structType->structure.role() == AST::StructureRole::UserDefined);
-            structType->structure.setRole(AST::StructureRole::VertexOutput);
+            m_shaderModule.replace(&structType->structure.role(), AST::StructureRole::VertexOutput);
         }
     }
 }


### PR DESCRIPTION
#### acf07e068d0b4cbe03258bc2da8012db6d0c76dc
<pre>
[WGSL] Make AST::Structure::role changes reversible
<a href="https://bugs.webkit.org/show_bug.cgi?id=254223">https://bugs.webkit.org/show_bug.cgi?id=254223</a>
&lt;rdar://problem/107008054&gt;

Reviewed by Myles C. Maxfield.

This is one of the last modifications that is not currently reversible. As with the similar
changes, the goal is to allow multiple compilations using the same AST, which requires that
every AST modification be reversible.

* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::checkReturnType):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::replace):

Canonical link: <a href="https://commits.webkit.org/261950@main">https://commits.webkit.org/261950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36ff871053f904e6812d820e7795c75d82515d8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/93 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/94 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/74 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/87 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/86 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/70 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/77 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/69 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/71 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/84 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/80 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/70 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/66 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/84 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->