### PR TITLE
[WGSL] Temporarily disable early compilation

### DIFF
--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -131,7 +131,7 @@ void EntryPointRewriter::collectParameters()
     while (m_function.parameters().size()) {
         auto parameter = m_shaderModule.takeLast(m_function.parameters());
         Vector<String> path;
-        visit(path, MemberOrParameter { parameter->name(), parameter->typeName(), WTFMove(parameter->attributes()) });
+        visit(path, MemberOrParameter { parameter->name(), parameter->typeName(), parameter->attributes() });
     }
 }
 

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -112,8 +112,9 @@ Ref<ShaderModule> Device::createShaderModule(const WGPUShaderModuleDescriptor& d
     auto checkResult = WGSL::staticCheck(fromAPI(shaderModuleParameters->wgsl.code), std::nullopt, { maxBuffersPlusVertexBuffersForVertexStage() });
 
     if (std::holds_alternative<WGSL::SuccessfulCheck>(checkResult) && shaderModuleParameters->hints && descriptor.hintCount) {
-        if (auto result = earlyCompileShaderModule(*this, WTFMove(checkResult), descriptor, fromAPI(descriptor.label)))
-            return result.releaseNonNull();
+        // FIXME: re-enable early compilation later on once deferred compilation is fully implemented
+        // https://bugs.webkit.org/show_bug.cgi?id=254258
+        UNUSED_PARAM(earlyCompileShaderModule);
     } else {
         // FIXME: remove shader library generation from MSL after compiler bringup
         auto library = ShaderModule::createLibrary(device(), String::fromUTF8(shaderModuleParameters->wgsl.code), fromAPI(descriptor.label));


### PR DESCRIPTION
#### 54c0a441a4a1db892ba3f87e4c5048608058b31d
<pre>
[WGSL] Temporarily disable early compilation
<a href="https://bugs.webkit.org/show_bug.cgi?id=254224">https://bugs.webkit.org/show_bug.cgi?id=254224</a>
&lt;rdar://problem/107008408&gt;

Reviewed by Myles C. Maxfield and Mike Wyrzykowski.

Since early compilation is an optimization, and using deferred compilation can be
helpful for catching bugs where we make irreversible changes to the AST (such as
the one in EntryPointRewriter fixed in this patch), temporarily disable it until
we have deferred compilation fully working. The plan is to refactor the API to make
the AST immutable, but this is helpful in the meantime.

* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::collectParameters):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::Device::createShaderModule):

Canonical link: <a href="https://commits.webkit.org/261979@main">https://commits.webkit.org/261979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6c0d68bc55199d9b36684426625880aafcb1dd1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/105 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/182 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/91 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/100 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/91 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/95 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/112 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->