### PR TITLE
Plumb top origin into FormData

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -38,6 +38,7 @@
 #include "JSDOMFormData.h"
 #include "JSDOMPromiseDeferred.h"
 #include "ReadableStreamSource.h"
+#include "SecurityOrigin.h"
 #include <JavaScriptCore/ArrayBufferView.h>
 
 namespace WebCore {
@@ -252,7 +253,7 @@ RefPtr<FormData> FetchBody::bodyAsFormData() const
         return FormData::create(PAL::UTF8Encoding().encode(urlSearchParamsBody().toString(), PAL::UnencodableHandling::Entities));
     if (isBlob()) {
         auto body = FormData::create();
-        body->appendBlob(blobBody().url());
+        body->appendBlob(blobBody().url(), blobBody().scriptExecutionContext() ? blobBody().scriptExecutionContext()->topOrigin().data() : SecurityOriginData::createOpaque());
         return body;
     }
     if (isArrayBuffer())
@@ -279,7 +280,7 @@ FetchBody::TakenData FetchBody::take()
 
     if (isBlob()) {
         auto body = FormData::create();
-        body->appendBlob(blobBody().url());
+        body->appendBlob(blobBody().url(), blobBody().scriptExecutionContext() ? blobBody().scriptExecutionContext()->topOrigin().data() : SecurityOriginData::createOpaque());
         return TakenData { WTFMove(body) };
     }
 

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -138,7 +138,7 @@ unsigned FormData::imageOrMediaFilesCount() const
     return imageOrMediaFilesCount;
 }
 
-uint64_t FormDataElement::lengthInBytes(const Function<uint64_t(const URL&)>& blobSize) const
+uint64_t FormDataElement::lengthInBytes(const Function<uint64_t(const URL&, const SecurityOriginData&)>& blobSize) const
 {
     return WTF::switchOn(data,
         [] (const Vector<uint8_t>& bytes) {
@@ -148,14 +148,14 @@ uint64_t FormDataElement::lengthInBytes(const Function<uint64_t(const URL&)>& bl
                 return static_cast<uint64_t>(fileData.fileLength);
             return FileSystem::fileSize(fileData.filename).value_or(0);
         }, [&blobSize] (const FormDataElement::EncodedBlobData& blobData) {
-            return blobSize(blobData.url);
+            return blobSize(blobData.url, blobData.topOrigin);
         }
     );
 }
 
 uint64_t FormDataElement::lengthInBytes() const
 {
-    return lengthInBytes([](auto& url) {
+    return lengthInBytes([](auto& url, auto&) {
         return ThreadableBlobRegistry::blobSize(url);
     });
 }
@@ -168,7 +168,7 @@ FormDataElement FormDataElement::isolatedCopy() const
         }, [] (const FormDataElement::EncodedFileData& fileData) {
             return FormDataElement(fileData.isolatedCopy());
         }, [] (const FormDataElement::EncodedBlobData& blobData) {
-            return FormDataElement(blobData.url.isolatedCopy());
+            return FormDataElement(blobData.url.isolatedCopy(), blobData.topOrigin.isolatedCopy());
         }
     );
 }
@@ -197,9 +197,9 @@ void FormData::appendFileRange(const String& filename, long long start, long lon
     m_lengthInBytes = std::nullopt;
 }
 
-void FormData::appendBlob(const URL& blobURL)
+void FormData::appendBlob(const URL& blobURL, const SecurityOriginData& topOrigin)
 {
-    m_elements.append(FormDataElement(blobURL));
+    m_elements.append(FormDataElement(blobURL, topOrigin));
     m_lengthInBytes = std::nullopt;
 }
 
@@ -208,7 +208,7 @@ static Vector<uint8_t> normalizeStringData(PAL::TextEncoding& encoding, const St
     return normalizeLineEndingsToCRLF(encoding.encode(value, PAL::UnencodableHandling::Entities, PAL::NFCNormalize::No));
 }
 
-void FormData::appendMultiPartFileValue(const File& file, Vector<char>& header, PAL::TextEncoding& encoding)
+void FormData::appendMultiPartFileValue(const File& file, Vector<char>& header, PAL::TextEncoding& encoding, const SecurityOriginData& topOrigin)
 {
     auto name = file.name();
 
@@ -229,7 +229,7 @@ void FormData::appendMultiPartFileValue(const File& file, Vector<char>& header, 
     if (!file.path().isEmpty())
         appendFile(file.path());
     else if (file.size())
-        appendBlob(file.url());
+        appendBlob(file.url(), topOrigin);
 }
 
 void FormData::appendMultiPartStringValue(const String& string, Vector<char>& header, PAL::TextEncoding& encoding)
@@ -255,7 +255,7 @@ void FormData::appendMultiPartKeyValuePairItems(const DOMFormData& formData)
         FormDataBuilder::beginMultiPartHeader(header, m_boundary.data(), normalizedName);
 
         if (std::holds_alternative<RefPtr<File>>(item.data))
-            appendMultiPartFileValue(*std::get<RefPtr<File>>(item.data), header, encoding);
+            appendMultiPartFileValue(*std::get<RefPtr<File>>(item.data), header, encoding, formData.scriptExecutionContext() ? formData.scriptExecutionContext()->topOrigin().data() : SecurityOriginData::createOpaque());
         else
             appendMultiPartStringValue(std::get<String>(item.data), header, encoding);
 
@@ -306,14 +306,14 @@ String FormData::flattenToString() const
     return PAL::Latin1Encoding().decode(bytes.data(), bytes.size());
 }
 
-static void appendBlobResolved(BlobRegistryImpl* blobRegistry, FormData& formData, const URL& url)
+static void appendBlobResolved(BlobRegistryImpl* blobRegistry, FormData& formData, const FormDataElement::EncodedBlobData& formBlobData)
 {
     if (!blobRegistry) {
         LOG_ERROR("Tried to resolve a blob without a usable registry");
         return;
     }
 
-    auto* blobData = blobRegistry->getBlobDataFromURL(url);
+    auto* blobData = blobRegistry->getBlobDataFromURL(formBlobData.url);
     if (!blobData) {
         LOG_ERROR("Could not get blob data from a registry");
         return;
@@ -357,7 +357,7 @@ Ref<FormData> FormData::resolveBlobReferences(BlobRegistryImpl* blobRegistryImpl
             }, [&] (const FormDataElement::EncodedFileData& fileData) {
                 newFormData->appendFileRange(fileData.filename, fileData.fileStart, fileData.fileLength, fileData.expectedFileModificationTime);
             }, [&] (const FormDataElement::EncodedBlobData& blobData) {
-                appendBlobResolved(blobRegistryImpl ? blobRegistryImpl : blobRegistry().blobRegistryImpl(), newFormData.get(), blobData.url);
+                appendBlobResolved(blobRegistryImpl ? blobRegistryImpl : blobRegistry().blobRegistryImpl(), newFormData.get(), blobData);
             }
         );
     }

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "BlobData.h"
+#include "SecurityOriginData.h"
 #include <variant>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Forward.h>
@@ -52,10 +53,10 @@ struct FormDataElement {
         : data(WTFMove(array)) { }
     FormDataElement(const String& filename, int64_t fileStart, int64_t fileLength, std::optional<WallTime> expectedFileModificationTime)
         : data(EncodedFileData { filename, fileStart, fileLength, expectedFileModificationTime }) { }
-    explicit FormDataElement(const URL& blobURL)
-        : data(EncodedBlobData { blobURL }) { }
+    explicit FormDataElement(const URL& blobURL, const SecurityOriginData& topOrigin)
+        : data(EncodedBlobData { blobURL, topOrigin }) { }
 
-    uint64_t lengthInBytes(const Function<uint64_t(const URL&)>&) const;
+    uint64_t lengthInBytes(const Function<uint64_t(const URL&, const SecurityOriginData&)>&) const;
     uint64_t lengthInBytes() const;
 
     FormDataElement isolatedCopy() const;
@@ -84,6 +85,7 @@ struct FormDataElement {
 
     struct EncodedBlobData {
         URL url;
+        SecurityOriginData topOrigin;
 
         bool operator==(const EncodedBlobData& other) const
         {
@@ -155,7 +157,7 @@ public:
     WEBCORE_EXPORT void appendData(const void* data, size_t);
     void appendFile(const String& filePath);
     WEBCORE_EXPORT void appendFileRange(const String& filename, long long start, long long length, std::optional<WallTime> expectedModificationTime);
-    WEBCORE_EXPORT void appendBlob(const URL& blobURL);
+    WEBCORE_EXPORT void appendBlob(const URL& blobURL, const SecurityOriginData&);
 
     WEBCORE_EXPORT Vector<uint8_t> flatten() const; // omits files
     String flattenToString() const; // omits files
@@ -201,7 +203,7 @@ private:
     FormData() = default;
     FormData(const FormData&);
 
-    void appendMultiPartFileValue(const File&, Vector<char>& header, PAL::TextEncoding&);
+    void appendMultiPartFileValue(const File&, Vector<char>& header, PAL::TextEncoding&, const SecurityOriginData&);
     void appendMultiPartStringValue(const String&, Vector<char>& header, PAL::TextEncoding&);
     void appendMultiPartKeyValuePairItems(const DOMFormData&);
     void appendNonMultiPartKeyValuePairItems(const DOMFormData&, EncodingType);

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
@@ -366,7 +366,7 @@ RetainPtr<CFReadStreamRef> createHTTPBodyCFReadStream(FormData& formData)
     // Precompute the content length so CFNetwork doesn't use chunked mode.
     unsigned long long length = 0;
     for (auto& element : dataForUpload.data().elements()) {
-        length += element.lengthInBytes([](auto& url) {
+        length += element.lengthInBytes([](auto& url, auto&) {
             return blobRegistry().blobRegistryImpl()->blobSize(url);
         });
     }

--- a/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
@@ -116,7 +116,7 @@ void ResourceRequest::updateSoupMessageBody(SoupMessage* soupMessage, BlobRegist
     auto resolvedFormData = formData->resolveBlobReferences();
     uint64_t length = 0;
     for (auto& element : resolvedFormData->elements()) {
-        length += element.lengthInBytes([&](auto& url) {
+        length += element.lengthInBytes([&](auto& url, auto&) {
             return blobRegistry.blobSize(url);
         });
     }

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -129,7 +129,7 @@ Ref<FetchResponse> ServiceWorkerInternals::createOpaqueWithBlobBodyResponse(Scri
 {
     auto blob = Blob::create(&context);
     auto formData = FormData::create();
-    formData->appendBlob(blob->url());
+    formData->appendBlob(blob->url(), context.topOrigin().data());
 
     ResourceResponse response;
     response.setType(ResourceResponse::Type::Cors);

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -538,7 +538,7 @@ ExceptionOr<void> XMLHttpRequest::send(Blob& body)
         }
 
         m_requestEntityBody = FormData::create();
-        m_requestEntityBody->appendBlob(body.url());
+        m_requestEntityBody->appendBlob(body.url(), scriptExecutionContext()->topOrigin().data());
     }
 
     return createRequest();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1514,6 +1514,7 @@ header: <WebCore/FormData.h>
 
 [Nested] struct WebCore::FormDataElement::EncodedBlobData {
     URL url;
+    WebCore::SecurityOriginData topOrigin;
 }
 
 header: <WebCore/NetworkLoadInformation.h>


### PR DESCRIPTION
#### 54431684bf98e4c6498c39713b407538b15f9e4e
<pre>
Plumb top origin into FormData
<a href="https://bugs.webkit.org/show_bug.cgi?id=254225">https://bugs.webkit.org/show_bug.cgi?id=254225</a>
rdar://107013433

Reviewed by NOBODY (OOPS!).

Currently, FormData doesn&apos;t know its associated top SecurityOrigin. In this
patch we plumb that information when the data is a blob. This is a pre-patch
that&apos;s necessary for follow-up work on partitioning the blob registry.

* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::bodyAsFormData const):
(WebCore::FetchBody::take):
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormDataElement::lengthInBytes const):
(WebCore::FormDataElement::isolatedCopy const):
(WebCore::FormData::appendBlob):
(WebCore::FormData::appendMultiPartFileValue):
(WebCore::FormData::appendMultiPartKeyValuePairItems):
(WebCore::appendBlobResolved):
(WebCore::FormData::resolveBlobReferences):
* Source/WebCore/platform/network/FormData.h:
(WebCore::FormDataElement::FormDataElement):
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp:
(WebCore::createHTTPBodyCFReadStream):
* Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp:
(WebCore::ResourceRequest::updateSoupMessageBody const):
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
(WebCore::ServiceWorkerInternals::createOpaqueWithBlobBodyResponse):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::send):
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::toFormData):
(WebKit::applyFrameState):
(WebKit::toHistoryItem):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54431684bf98e4c6498c39713b407538b15f9e4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/27 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18 "17 flakes 117 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->