### PR TITLE
Replace ResourceResponse with ResourceResponse::CrossThreadData in CacheStorage messages

### DIFF
--- a/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
@@ -153,6 +153,38 @@ Record Record::copy() const
     return Record { identifier, updateResponseCounter, requestHeadersGuard, request, options, referrer, responseHeadersGuard, response, copyResponseBody(responseBody), responseBodySize };
 }
 
+CrossThreadRecord toCrossThreadRecord(Record&& record)
+{
+    return CrossThreadRecord {
+        record.identifier,
+        record.updateResponseCounter,
+        record.requestHeadersGuard,
+        WTFMove(record.request).isolatedCopy(),
+        WTFMove(record.options).isolatedCopy(),
+        WTFMove(record.referrer).isolatedCopy(),
+        record.responseHeadersGuard,
+        record.response.crossThreadData(),
+        isolatedResponseBody(record.responseBody),
+        record.responseBodySize
+    };
+}
+
+Record fromCrossThreadRecord(CrossThreadRecord&& record)
+{
+    return Record {
+        record.identifier,
+        record.updateResponseCounter,
+        record.requestHeadersGuard,
+        WTFMove(record.request),
+        WTFMove(record.options),
+        WTFMove(record.referrer),
+        record.responseHeadersGuard,
+        ResourceResponse::fromCrossThreadData(WTFMove(record.response)),
+        WTFMove(record.responseBody),
+        record.responseBodySize
+    };
+}
+
 } // namespace DOMCacheEngine
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cache/DOMCacheEngine.h
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.h
@@ -80,6 +80,42 @@ struct Record {
     uint64_t responseBodySize;
 };
 
+struct CrossThreadRecord {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    CrossThreadRecord(const CrossThreadRecord&) = delete;
+    CrossThreadRecord& operator=(const CrossThreadRecord&) = delete;
+    CrossThreadRecord() = default;
+    CrossThreadRecord(CrossThreadRecord&&) = default;
+    CrossThreadRecord& operator=(CrossThreadRecord&&) = default;
+    CrossThreadRecord(uint64_t identifier, uint64_t updateResponseCounter, FetchHeaders::Guard requestHeadersGuard, ResourceRequest&& request, FetchOptions options, String&& referrer, FetchHeaders::Guard responseHeadersGuard, ResourceResponse::CrossThreadData&& response, ResponseBody&& responseBody, uint64_t responseBodySize)
+        : identifier(identifier)
+        , updateResponseCounter(updateResponseCounter)
+        , requestHeadersGuard(requestHeadersGuard)
+        , request(WTFMove(request))
+        , options(options)
+        , referrer(WTFMove(referrer))
+        , responseHeadersGuard(responseHeadersGuard)
+        , response(WTFMove(response))
+        , responseBody(WTFMove(responseBody))
+        , responseBodySize(responseBodySize)
+    {
+    }
+
+    uint64_t identifier;
+    uint64_t updateResponseCounter;
+    FetchHeaders::Guard requestHeadersGuard;
+    ResourceRequest request;
+    FetchOptions options;
+    String referrer;
+    FetchHeaders::Guard responseHeadersGuard;
+    ResourceResponse::CrossThreadData response;
+    ResponseBody responseBody;
+    uint64_t responseBodySize;
+};
+
+WEBCORE_EXPORT CrossThreadRecord toCrossThreadRecord(Record&&);
+WEBCORE_EXPORT Record fromCrossThreadRecord(CrossThreadRecord&&);
+
 struct CacheInfo {
     DOMCacheIdentifier identifier;
     String name;
@@ -117,6 +153,9 @@ using CacheInfosCallback = CompletionHandler<void(CacheInfosOrError&&)>;
 
 using RecordsOrError = Expected<Vector<Record>, Error>;
 using RecordsCallback = CompletionHandler<void(RecordsOrError&&)>;
+
+using CrossThreadRecordsOrError = Expected<Vector<CrossThreadRecord>, Error>;
+using CrossThreadRecordsCallback = CompletionHandler<void(CrossThreadRecordsOrError&&)>;
 
 using CompletionCallback = CompletionHandler<void(std::optional<Error>&&)>;
 

--- a/Source/WebCore/loader/CrossOriginAccessControl.h
+++ b/Source/WebCore/loader/CrossOriginAccessControl.h
@@ -28,6 +28,7 @@
 
 #include "HTTPHeaderNames.h"
 #include "ReferrerPolicy.h"
+#include "ResourceResponse.h"
 #include "StoredCredentialsPolicy.h"
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
@@ -89,6 +90,7 @@ WEBCORE_EXPORT Expected<void, String> validatePreflightResponse(PAL::SessionID, 
 
 enum class ForNavigation : bool { No, Yes };
 WEBCORE_EXPORT std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedderPolicyValue, const SecurityOrigin&, const URL&, const ResourceResponse&, ForNavigation);
+WEBCORE_EXPORT std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedderPolicyValue, const SecurityOrigin&, const URL&, bool isResponseNull, const URL& responseURL, const String& crossOriginResourcePolicyHeaderValue, ForNavigation);
 std::optional<ResourceError> validateRangeRequestedFlag(const ResourceRequest&, const ResourceResponse&);
 String validateCrossOriginRedirectionURL(const URL&);
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -38,6 +38,7 @@
 #include <wtf/Span.h>
 #include <wtf/URL.h>
 #include <wtf/WallTime.h>
+#include <wtf/persistence/PersistentCoders.h>
 
 namespace WebCore {
 
@@ -76,6 +77,26 @@ public:
         CrossThreadData() = default;
         CrossThreadData(CrossThreadData&&) = default;
         CrossThreadData& operator=(CrossThreadData&&) = default;
+        CrossThreadData(URL&& url, String&& mimeType, long long expectedContentLength, String&& textEncodingName, int httpStatusCode, String&& httpStatusText, String&& httpVersion, HTTPHeaderMap&& httpHeaderFields, std::optional<NetworkLoadMetrics>&& networkLoadMetrics, Source source, Type type, Tainting tainting, bool isRedirected, UsedLegacyTLS usedLegacyTLS, WasPrivateRelayed wasPrivateRelayed, bool isRangeRequested, std::optional<CertificateInfo> certificateInfo)
+            : url(WTFMove(url))
+            , mimeType(WTFMove(mimeType))
+            , expectedContentLength(expectedContentLength)
+            , textEncodingName(WTFMove(textEncodingName))
+            , httpStatusCode(httpStatusCode)
+            , httpStatusText(WTFMove(httpStatusText))
+            , httpVersion(WTFMove(httpVersion))
+            , httpHeaderFields(WTFMove(httpHeaderFields))
+            , networkLoadMetrics(WTFMove(networkLoadMetrics))
+            , source(source)
+            , type(type)
+            , tainting(tainting)
+            , isRedirected(isRedirected)
+            , usedLegacyTLS(usedLegacyTLS)
+            , wasPrivateRelayed(wasPrivateRelayed)
+            , isRangeRequested(isRangeRequested)
+            , certificateInfo(certificateInfo)
+        {
+        }
 
         WEBCORE_EXPORT CrossThreadData isolatedCopy() const;
 
@@ -83,15 +104,19 @@ public:
         String mimeType;
         long long expectedContentLength;
         String textEncodingName;
-        int httpStatusCode;
+        short httpStatusCode;
         String httpStatusText;
         String httpVersion;
         HTTPHeaderMap httpHeaderFields;
         std::optional<NetworkLoadMetrics> networkLoadMetrics;
+        Source source;
         Type type;
         Tainting tainting;
         bool isRedirected;
+        UsedLegacyTLS usedLegacyTLS;
+        WasPrivateRelayed wasPrivateRelayed;
         bool isRangeRequested;
+        std::optional<CertificateInfo> certificateInfo;
     };
     
     struct ResponseData {
@@ -510,5 +535,17 @@ template<> struct EnumTraitsForPersistence<WebCore::ResourceResponseBase::Source
         WebCore::ResourceResponseBase::Source::InspectorOverride
     >;
 };
+
+namespace Persistence {
+
+class Decoder;
+class Encoder;
+
+template<> struct Coder<WebCore::ResourceResponseBase::CrossThreadData> {
+    WEBCORE_EXPORT static void encode(Encoder&, const WebCore::ResourceResponseBase::CrossThreadData&);
+    WEBCORE_EXPORT static std::optional<WebCore::ResourceResponseBase::CrossThreadData> decode(Decoder&);
+};
+
+} // namespace Persistence
 
 } // namespace WTF

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -31,6 +31,7 @@
 #include "CacheStorageMemoryStore.h"
 #include <WebCore/CacheQueryOptions.h>
 #include <WebCore/CrossOriginAccessControl.h>
+#include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/ResourceError.h>
 #include <wtf/Scope.h>
 
@@ -130,16 +131,16 @@ void CacheStorageCache::open(WebCore::DOMCacheEngine::CacheIdentifierCallback&& 
     });
 }
 
-static CacheStorageRecord toCacheStorageRecord(WebCore::DOMCacheEngine::Record&& record, FileSystem::Salt salt, const String& uniqueName)
+static CacheStorageRecord toCacheStorageRecord(WebCore::DOMCacheEngine::CrossThreadRecord&& record, FileSystem::Salt salt, const String& uniqueName)
 {
     NetworkCache::Key key { "record"_s, uniqueName, { }, createVersion4UUIDString(), salt };
     CacheStorageRecordInformation recordInfo { WTFMove(key), MonotonicTime::now().secondsSinceEpoch().milliseconds(), record.identifier, 0 , record.responseBodySize, record.request.url(), false, { } };
-    recordInfo.updateVaryHeaders(record.request, record.response.httpHeaderField(WebCore::HTTPHeaderName::Vary));
+    recordInfo.updateVaryHeaders(record.request, record.response.httpHeaderFields.get(WebCore::HTTPHeaderName::Vary));
 
-    return CacheStorageRecord { WTFMove(recordInfo), record.requestHeadersGuard, WTFMove(record.request), record.options, WTFMove(record.referrer), record.responseHeadersGuard, record.response.crossThreadData(), record.responseBodySize, WTFMove(record.responseBody) };
+    return CacheStorageRecord { WTFMove(recordInfo), record.requestHeadersGuard, WTFMove(record.request), record.options, WTFMove(record.referrer), record.responseHeadersGuard, WTFMove(record.response), record.responseBodySize, WTFMove(record.responseBody) };
 }
 
-void CacheStorageCache::retrieveRecords(WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::RecordsCallback&& callback)
+void CacheStorageCache::retrieveRecords(WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&& callback)
 {
     ASSERT(m_isInitialized);
     assertIsOnCorrectQueue();
@@ -173,21 +174,21 @@ void CacheStorageCache::retrieveRecords(WebCore::RetrieveRecordsOptions&& option
         return callback({ });
     
     m_store->readRecords(targetRecordInfos, [options = WTFMove(options), callback = WTFMove(callback)](auto&& cacheStorageRecords) mutable {
-        Vector<WebCore::DOMCacheEngine::Record> result;
+        Vector<WebCore::DOMCacheEngine::CrossThreadRecord> result;
         result.reserveInitialCapacity(cacheStorageRecords.size());
-        for (auto& cacheStorageRecord : cacheStorageRecords) {
+        for (auto&& cacheStorageRecord : cacheStorageRecords) {
             if (!cacheStorageRecord)
                 continue;
     
-            WebCore::DOMCacheEngine::Record record { cacheStorageRecord->info.identifier, 0, cacheStorageRecord->requestHeadersGuard, cacheStorageRecord->request, cacheStorageRecord->options, cacheStorageRecord->referrer, cacheStorageRecord->responseHeadersGuard, { }, nullptr, 0 };
+            WebCore::DOMCacheEngine::CrossThreadRecord record { cacheStorageRecord->info.identifier, 0, cacheStorageRecord->requestHeadersGuard, WTFMove(cacheStorageRecord->request), cacheStorageRecord->options, WTFMove(cacheStorageRecord->referrer), cacheStorageRecord->responseHeadersGuard, { }, nullptr, 0 };
             if (options.shouldProvideResponse) {
-                record.response = WebCore::ResourceResponse::fromCrossThreadData(WTFMove(cacheStorageRecord->responseData));
+                record.response = WTFMove(cacheStorageRecord->responseData);
                 record.responseBody = WTFMove(cacheStorageRecord->responseBody);
                 record.responseBodySize = cacheStorageRecord->responseBodySize;
             }
 
-            if (record.response.type() == WebCore::ResourceResponse::Type::Opaque) {
-                if (WebCore::validateCrossOriginResourcePolicy(options.crossOriginEmbedderPolicy.value, options.sourceOrigin, record.request.url(), record.response, WebCore::ForNavigation::No))
+            if (record.response.type == WebCore::ResourceResponse::Type::Opaque) {
+                if (WebCore::validateCrossOriginResourcePolicy(options.crossOriginEmbedderPolicy.value, options.sourceOrigin, record.request.url(), false, record.response.url, record.response.httpHeaderFields.get(WebCore::HTTPHeaderName::CrossOriginResourcePolicy), WebCore::ForNavigation::No))
                     return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::CORP));
             }
 
@@ -258,7 +259,7 @@ CacheStorageRecordInformation* CacheStorageCache::findExistingRecord(const WebCo
     return &iterator->value[index];
 }
 
-void CacheStorageCache::putRecords(Vector<WebCore::DOMCacheEngine::Record>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void CacheStorageCache::putRecords(Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     ASSERT(m_isInitialized);
     assertIsOnCorrectQueue();

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -46,9 +46,9 @@ public:
 
     void getSize(CompletionHandler<void(uint64_t)>&&);
     void open(WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
-    void retrieveRecords(WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::RecordsCallback&&);
+    void retrieveRecords(WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&);
     void removeRecords(WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
-    void putRecords(Vector<WebCore::DOMCacheEngine::Record>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void putRecords(Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void removeAllRecords();
     void close();
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1284,7 +1284,7 @@ void NetworkStorageManager::cacheStorageDereference(IPC::Connection& connection,
     cacheStorageManager->dereference(connection.uniqueID(), cacheIdentifier);
 }
 
-void NetworkStorageManager::cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::RecordsCallback&& callback)
+void NetworkStorageManager::cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&& callback)
 {
     auto* cache = m_cacheStorageRegistry->cache(cacheIdentifier);
     if (!cache)
@@ -1302,7 +1302,7 @@ void NetworkStorageManager::cacheStorageRemoveRecords(WebCore::DOMCacheIdentifie
     cache->removeRecords(WTFMove(request), WTFMove(options), WTFMove(callback));
 }
 
-void NetworkStorageManager::cacheStoragePutRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::Record>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void NetworkStorageManager::cacheStoragePutRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     auto* cache = m_cacheStorageRegistry->cache(cacheIdentifier);
     if (!cache)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -199,9 +199,9 @@ private:
     void cacheStorageAllCaches(const WebCore::ClientOrigin&, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&);
     void cacheStorageReference(IPC::Connection&, WebCore::DOMCacheIdentifier);
     void cacheStorageDereference(IPC::Connection&, WebCore::DOMCacheIdentifier);
-    void cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::RecordsCallback&&);
+    void cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&);
     void cacheStorageRemoveRecords(WebCore::DOMCacheIdentifier, WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
-    void cacheStoragePutRecords(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::Record>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void cacheStoragePutRecords(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void cacheStorageClearMemoryRepresentation(const WebCore::ClientOrigin&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::Error>&&)>&&);
     void cacheStorageRepresentation(CompletionHandler<void(String&&)>&&);
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -83,9 +83,9 @@
     CacheStorageAllCaches(struct WebCore::ClientOrigin origin, uint64_t updateCounter) -> (WebCore::DOMCacheEngine::CacheInfosOrError result)
     CacheStorageReference(WebCore::DOMCacheIdentifier cacheIdentifier)
     CacheStorageDereference(WebCore::DOMCacheIdentifier cacheIdentifier)
-    CacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, struct WebCore::RetrieveRecordsOptions options) -> (WebCore::DOMCacheEngine::RecordsOrError result)
+    CacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, struct WebCore::RetrieveRecordsOptions options) -> (WebCore::DOMCacheEngine::CrossThreadRecordsOrError result)
     CacheStorageRemoveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest request, struct WebCore::CacheQueryOptions options) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
-    CacheStoragePutRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::Record> record) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
+    CacheStoragePutRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord> records) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
     CacheStorageClearMemoryRepresentation(struct WebCore::ClientOrigin origin) -> (std::optional<WebCore::DOMCacheEngine::Error> error)
     CacheStorageRepresentation() -> (String representation)
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -36,6 +36,19 @@ header: <WebCore/DOMCacheEngine.h>
     bool hadStorageError;
 };
 
+[CustomHeader] struct WebCore::DOMCacheEngine::CrossThreadRecord {
+    uint64_t identifier;
+    uint64_t updateResponseCounter;
+    WebCore::FetchHeadersGuard requestHeadersGuard;
+    WebCore::ResourceRequest request;
+    WebCore::FetchOptions options;
+    String referrer;
+    WebCore::FetchHeadersGuard responseHeadersGuard;
+    WebCore::ResourceResponse::CrossThreadData response;
+    std::variant<std::nullptr_t, Ref<WebCore::FormData>, Ref<WebCore::SharedBuffer>> responseBody;
+    uint64_t responseBodySize;
+};
+
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::TransformationMatrix {
     double m11()
     double m12()
@@ -2361,6 +2374,27 @@ class WebCore::ResourceResponseBase {
 
 class WebCore::ResourceResponse : WebCore::ResourceResponseBase {
 }
+
+header: <WebCore/ResourceResponseBase.h>
+[CustomHeader, NoForwardDeclaration=<WebCore/ResourceResponseBase.h>] struct WebCore::ResourceResponseBase::CrossThreadData {
+    URL url;
+    String mimeType;
+    long long expectedContentLength;
+    String textEncodingName;
+    short httpStatusCode;
+    String httpStatusText;
+    String httpVersion;
+    WebCore::HTTPHeaderMap httpHeaderFields;
+    std::optional<WebCore::NetworkLoadMetrics> networkLoadMetrics;
+    WebCore::ResourceResponseBase::Source source;
+    WebCore::ResourceResponseBase::Type type;
+    WebCore::ResourceResponseBase::Tainting tainting;
+    bool isRedirected;
+    WebCore::UsedLegacyTLS usedLegacyTLS;
+    WebCore::WasPrivateRelayed wasPrivateRelayed;
+    bool isRangeRequested;
+    std::optional<WebCore::CertificateInfo> certificateInfo;
+};
 
 enum class WebCore::ReferrerPolicy : uint8_t {
     EmptyString,


### PR DESCRIPTION
#### 2f169036ec502e5451e1a00f5d9d268cf4ffe6bd
<pre>
Replace ResourceResponse with ResourceResponse::CrossThreadData in CacheStorage messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=254231">https://bugs.webkit.org/show_bug.cgi?id=254231</a>
rdar://107020237

Reviewed by Youenn Fablet.

NetworkStorageManager receives and handles CacheStorage messages on a WorkQueue, which is not tied to one thread.
ResourceResponse contains AtomSring members, which can only be accessed from the thread where they are created. To avoid
threading issues, we replace ResourceResponse with ResourceResponse::CrossThreadData in CacheStorage messages that are
sent to and sent from NetworkStorageManager.

To make this change, this patch introduces DOMCacheEngine::CrossThreadRecord and adds encode/decode functions for
ResourceResponse::CrossThreadData. It also adds members to ResourceResponse::CrossThreadData so that it contains all
information needed for persistence encoding/decoding.

* Source/WebCore/Modules/cache/DOMCacheEngine.cpp:
(WebCore::DOMCacheEngine::toCrossThreadRecord):
(WebCore::DOMCacheEngine::fromCrossThreadRecord):
* Source/WebCore/Modules/cache/DOMCacheEngine.h:
(WebCore::DOMCacheEngine::CrossThreadRecord::CrossThreadRecord):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::shouldCrossOriginResourcePolicyCancelLoad):
(WebCore::validateCrossOriginResourcePolicy):
* Source/WebCore/loader/CrossOriginAccessControl.h:
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::CrossThreadData::isolatedCopy const):
(WebCore::ResourceResponseBase::crossThreadData const):
(WebCore::ResourceResponseBase::fromCrossThreadData):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseBase::CrossThreadData&gt;::encode):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseBase::CrossThreadData&gt;::decode):
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseBase::CrossThreadData::CrossThreadData):
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::toCacheStorageRecord):
(WebKit::CacheStorageCache::retrieveRecords):
(WebKit::CacheStorageCache::putRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::decodeRecordHeader):
(WebKit::readRecordInfoFromFileData):
(WebKit::CacheStorageDiskStore::readRecordFromFileData):
(WebKit::encodeRecordHeader):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::cacheStorageRetrieveRecords):
(WebKit::NetworkStorageManager::cacheStoragePutRecords):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(generate_headers_for_header):
(generate_header):
(parse_serialized_types):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::retrieveRecords):
(WebKit::WebCacheStorageConnection::batchPutOperation):

Canonical link: <a href="https://commits.webkit.org/262102@main">https://commits.webkit.org/262102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99a4baab41944107cd89a9bf0da4d69e0fa90fd7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/471 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/532 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/718 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/624 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/558 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/506 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/544 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/476 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/527 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/507 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/522 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/132 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/516 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->