### PR TITLE
allowedLookalikeCharacterStrings should support more than one string per domain

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8699,9 +8699,14 @@ void WebPage::setLookalikeCharacterStrings(Vector<WebCore::LookalikeCharactersSa
 void WebPage::setAllowedLookalikeCharacterStrings(Vector<LookalikeCharactersSanitizationData>&& allowStrings)
 {
     m_allowedLookalikeCharacterStrings.clear();
-    m_allowedLookalikeCharacterStrings.reserveInitialCapacity(allowStrings.size());
-    for (auto& data : allowStrings)
-        m_allowedLookalikeCharacterStrings.add(data.domain, data.lookalikeCharacters);
+    for (auto& data : allowStrings) {
+        if (!m_allowedLookalikeCharacterStrings.isValidKey(data.domain))
+            continue;
+
+        m_allowedLookalikeCharacterStrings.ensure(data.domain, [&] {
+            return HashSet<String> { };
+        }).iterator->value.add(data.lookalikeCharacters);
+    }
 }
 #endif // ENABLE(NETWORK_CONNECTION_INTEGRITY)
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2589,7 +2589,7 @@ private:
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
     HashSet<String> m_lookalikeCharacterStrings;
     HashMap<WebCore::RegistrableDomain, HashSet<String>> m_domainScopedLookalikeCharacterStrings;
-    HashMap<WebCore::RegistrableDomain, String> m_allowedLookalikeCharacterStrings;
+    HashMap<WebCore::RegistrableDomain, HashSet<String>> m_allowedLookalikeCharacterStrings;
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)


### PR DESCRIPTION
#### 0dc81bf9250bbf7e4aa0f5c591d913c0fc1fa767
<pre>
allowedLookalikeCharacterStrings should support more than one string per domain
<a href="https://bugs.webkit.org/show_bug.cgi?id=254241">https://bugs.webkit.org/show_bug.cgi?id=254241</a>
rdar://107026826

Reviewed by Wenson Hsieh.

m_allowedLookalikeCharacterStrings currently maps a WebCore::RegistrableDomain to a String. We should
change this to map to a HashSet&lt;String&gt; so we can allow more than one String per domain.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setAllowedLookalikeCharacterStrings):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/261975@main">https://commits.webkit.org/261975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aa51d06f8782fefeee2a2edd2f6984cffaf13bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/33 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/31 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/30 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/25 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/25 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/28 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/25 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/28 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->