### PR TITLE
[JSC] Optimize Function#bind further

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -35,6 +35,7 @@
 #include "DFGAbstractInterpreterClobberState.h"
 #include "DOMJITGetterSetter.h"
 #include "DOMJITSignature.h"
+#include "FunctionPrototype.h"
 #include "GetByStatus.h"
 #include "GetterSetter.h"
 #include "HashMapImplInlines.h"
@@ -2948,6 +2949,32 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case FunctionBind: {
+        if (m_graph.m_plan.isUnlinked()) {
+            clobberWorld();
+            setTypeForNode(node, SpecFunction);
+            break;
+        }
+
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+        Edge target = m_graph.child(node, 0);
+        AbstractValue& targetValue = forNode(target);
+        auto& structureSet = targetValue.m_structure;
+        if (!(targetValue.m_type & ~SpecFunction) && structureSet.isFinite() && structureSet.size() == 1) {
+            RegisteredStructure structure = structureSet.onlyStructure();
+            if (JSBoundFunction::canSkipNameAndLengthMaterialization(globalObject, structure.get())) {
+                m_state.setShouldTryConstantFolding(true);
+                didFoldClobberWorld();
+                setForNode(node, globalObject->boundFunctionStructure());
+                break;
+            }
+        }
+
+        clobberWorld();
+        setTypeForNode(node, SpecFunction);
+        break;
+    }
+
     case NumberToStringWithRadix: {
         JSValue radixValue = forNode(node->child2()).m_value;
         if (radixValue && radixValue.isInt32()) {
@@ -3363,6 +3390,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         setForNode(node, 
             m_codeBlock->globalObjectFor(node->origin.semantic)->asyncFunctionStructure());
         break;
+
+    case NewBoundFunction: {
+        setForNode(node, m_codeBlock->globalObjectFor(node->origin.semantic)->boundFunctionStructure());
+        break;
+    }
 
     case NewFunction: {
         JSGlobalObject* globalObject = m_codeBlock->globalObjectFor(node->origin.semantic);

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1859,6 +1859,11 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         write(HeapObjectCount);
         return;
 
+    case NewBoundFunction:
+        read(HeapObjectCount);
+        write(HeapObjectCount);
+        return;
+
     case RegExpExec:
     case RegExpTest:
     case RegExpTestInline:
@@ -1961,6 +1966,10 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
     case FunctionToString:
         def(PureValue(node));
+        return;
+
+    case FunctionBind:
+        clobberTop(); // Slow path can clobber top.
         return;
         
     case CountExecution:

--- a/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
@@ -60,6 +60,7 @@ bool clobbersExitState(Graph& graph, Node* node)
     case NewInternalFieldObject:
     case NewRegexp:
     case NewStringObject:
+    case NewBoundFunction:
     case PhantomNewObject:
     case MaterializeNewObject:
     case PhantomNewFunction:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -292,6 +292,7 @@ bool doesGC(Graph& graph, Node* node)
     case CallWasm:
     case ForceOSRExit:
     case FunctionToString:
+    case FunctionBind:
     case GetById:
     case GetByIdDirect:
     case GetByIdDirectFlush:
@@ -388,6 +389,7 @@ bool doesGC(Graph& graph, Node* node)
     case NewGeneratorFunction:
     case NewAsyncGeneratorFunction:
     case NewAsyncFunction:
+    case NewBoundFunction:
     case NewTypedArray:
     case ThrowStaticError:
     case GetPropertyEnumerator:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2007,6 +2007,11 @@ private:
             break;
         }
 
+        case FunctionBind: {
+            fixEdge<ObjectUse>(m_graph.child(node, 0));
+            break;
+        }
+
         case SetPrivateBrand: {
             fixEdge<CellUse>(node->child1());
             fixEdge<SymbolUse>(node->child2());
@@ -3016,6 +3021,7 @@ private:
         case FilterSetPrivateBrandStatus:
         case InvalidationPoint:
         case GetWebAssemblyInstanceExports:
+        case NewBoundFunction:
             break;
 #else // not ASSERT_ENABLED
         default:

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -229,6 +229,8 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
         out.print(comma, SpeculationDump(node->prediction()));
     if (node->hasNumberOfArgumentsToSkip())
         out.print(comma, "numberOfArgumentsToSkip = ", node->numberOfArgumentsToSkip());
+    if (node->hasNumberOfBoundArguments())
+        out.print(comma, "numberOfBoundArguments = ", node->numberOfBoundArguments());
     if (node->hasArrayMode())
         out.print(comma, node->arrayMode());
     if (node->hasArithUnaryType())

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -132,6 +132,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case NewGeneratorFunction:
     case NewAsyncFunction:
     case NewAsyncGeneratorFunction:
+    case NewBoundFunction:
     case NewStringObject:
     case NewInternalFieldObject:
     case NewRegexp:

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -265,6 +265,12 @@ void Node::convertToNewArrayWithSize()
     m_opInfo = indexingType;
 }
 
+void Node::convertToNewBoundFunction(FrozenValue* executable)
+{
+    m_op = NewBoundFunction;
+    m_opInfo = executable;
+}
+
 void Node::convertToDirectCall(FrozenValue* executable)
 {
     NodeType newOp = LastNodeType;

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -827,7 +827,9 @@ public:
 
     void convertToNewArrayBuffer(FrozenValue* immutableButterfly);
     void convertToNewArrayWithSize();
-    
+
+    void convertToNewBoundFunction(FrozenValue*);
+
     void convertToDirectCall(FrozenValue*);
 
     void convertToCallWasm(FrozenValue*);
@@ -1917,6 +1919,7 @@ public:
         case NewGeneratorFunction:
         case NewAsyncFunction:
         case NewAsyncGeneratorFunction:
+        case NewBoundFunction:
         case CreateActivation:
         case MaterializeCreateActivation:
         case NewRegexp:
@@ -2273,6 +2276,7 @@ public:
 
     bool isFunctionAllocation()
     {
+        // Do not include NewBoundFunction right now since it is allocating with NativeExecutable.
         switch (op()) {
         case NewFunction:
         case NewGeneratorFunction:
@@ -3207,6 +3211,17 @@ public:
     bool hasBucketOwnerType()
     {
         return op() == GetMapBucketNext || op() == LoadKeyFromMapBucket || op() == LoadValueFromMapBucket;
+    }
+
+    unsigned numberOfBoundArguments()
+    {
+        ASSERT(hasNumberOfBoundArguments());
+        return m_opInfo2.as<unsigned>();
+    }
+
+    bool hasNumberOfBoundArguments()
+    {
+        return op() == FunctionBind || op() == NewBoundFunction;
     }
 
     BucketOwnerType bucketOwnerType()

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -441,6 +441,7 @@ namespace JSC { namespace DFG {
     macro(NumberToStringWithRadix, NodeResultJS | NodeMustGenerate) \
     macro(NumberToStringWithValidRadixConstant, NodeResultJS) \
     macro(FunctionToString, NodeResultJS) \
+    macro(FunctionBind, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(MakeRope, NodeResultJS) \
     macro(InByVal, NodeResultBoolean | NodeMustGenerate) \
     macro(InById, NodeResultBoolean | NodeMustGenerate) \
@@ -474,6 +475,7 @@ namespace JSC { namespace DFG {
     macro(NewGeneratorFunction, NodeResultJS) \
     macro(NewAsyncGeneratorFunction, NodeResultJS) \
     macro(NewAsyncFunction, NodeResultJS) \
+    macro(NewBoundFunction, NodeResultJS | NodeHasVarArgs) \
     \
     /* Block terminals. */\
     macro(Jump, NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -37,10 +37,12 @@ namespace JSC {
 
 class DateInstance;
 class JSBigInt;
+class JSBoundFunction;
 class JSPropertyNameEnumerator;
 class JSRopeString;
 class JSWeakMap;
 class JSWeakSet;
+class NativeExecutable;
 class OptimizingCallLinkInfo;
 struct UnlinkedStringJumpTable;
 
@@ -271,6 +273,8 @@ JSC_DECLARE_JIT_OPERATION(operationInt32ToStringWithValidRadix, char*, (JSGlobal
 JSC_DECLARE_JIT_OPERATION(operationInt52ToStringWithValidRadix, char*, (JSGlobalObject*, int64_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationDoubleToStringWithValidRadix, char*, (JSGlobalObject*, double, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationFunctionToString, JSString*, (JSGlobalObject*, JSFunction*));
+JSC_DECLARE_JIT_OPERATION(operationFunctionBind, JSBoundFunction*, (JSGlobalObject*, JSObject*, unsigned, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationNewBoundFunction, JSBoundFunction*, (JSGlobalObject*, JSFunction*, unsigned, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue));
 
 JSC_DECLARE_JIT_OPERATION(operationNormalizeMapKeyHeapBigInt, EncodedJSValue, (VM*, JSBigInt*));
 JSC_DECLARE_JIT_OPERATION(operationMapHash, UCPUStrictInt32, (JSGlobalObject*, EncodedJSValue input));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -973,7 +973,9 @@ private:
         case NewFunction:
         case NewGeneratorFunction:
         case NewAsyncGeneratorFunction:
-        case NewAsyncFunction: {
+        case NewAsyncFunction:
+        case NewBoundFunction:
+        case FunctionBind: {
             setPrediction(SpecFunction);
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -623,6 +623,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case NewGeneratorFunction:
     case NewAsyncGeneratorFunction:
     case NewAsyncFunction:
+    case NewBoundFunction:
     case Jump:
     case Branch:
     case Switch:
@@ -706,6 +707,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ArithIMul:
     case TryGetById:
     case StringLocaleCompare:
+    case FunctionBind:
         return false;
 
     case StringReplaceString:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1257,6 +1257,7 @@ public:
     
     void compileToStringOrCallStringConstructorOrStringValueOf(Node*);
     void compileFunctionToString(Node*);
+    void compileFunctionBind(Node*);
     void compileNumberToStringWithRadix(Node*);
     void compileNumberToStringWithValidRadixConstant(Node*);
     void compileNumberToStringWithValidRadixConstant(Node*, int32_t radix);
@@ -1448,6 +1449,7 @@ public:
     template <typename ClassType> void compileNewFunctionCommon(GPRReg, RegisteredStructure, GPRReg, GPRReg, GPRReg, JumpList&, size_t, FunctionExecutable*);
     void compileNewFunction(Node*);
     void compileSetFunctionName(Node*);
+    void compileNewBoundFunction(Node*);
     void compileNewRegexp(Node*);
     void compileForwardVarargs(Node*);
     void compileVarargsLength(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3092,7 +3092,7 @@ void SpeculativeJIT::compile(Node* node)
     case FunctionToString:
         compileFunctionToString(node);
         break;
-        
+
     case NewStringObject: {
         compileNewStringObject(node);
         break;
@@ -4269,6 +4269,8 @@ void SpeculativeJIT::compile(Node* node)
     case DateGetTime:
     case StringCodePointAt:
     case CallWasm:
+    case FunctionBind:
+    case NewBoundFunction:
         DFG_CRASH(m_graph, node, "unexpected node in DFG backend");
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -389,6 +389,7 @@ private:
             case NewGeneratorFunction:
             case NewAsyncGeneratorFunction:
             case NewAsyncFunction:
+            case NewBoundFunction:
             case AllocatePropertyStorage:
             case ReallocatePropertyStorage:
                 // Nodes that allocate get to set their epoch because for those nodes we know

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -92,6 +92,15 @@ namespace JSC { namespace FTL {
     macro(JSArrayBufferView_mode, JSArrayBufferView::offsetOfMode()) \
     macro(JSArrayBufferView_vector, JSArrayBufferView::offsetOfVector()) \
     macro(JSBigInt_length, JSBigInt::offsetOfLength()) \
+    macro(JSBoundFunction_targetFunction, JSBoundFunction::offsetOfTargetFunction()) \
+    macro(JSBoundFunction_boundThis, JSBoundFunction::offsetOfBoundThis()) \
+    macro(JSBoundFunction_boundArg0, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 0) \
+    macro(JSBoundFunction_boundArg1, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 1) \
+    macro(JSBoundFunction_boundArg2, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 2) \
+    macro(JSBoundFunction_nameMayBeNull, JSBoundFunction::offsetOfNameMayBeNull()) \
+    macro(JSBoundFunction_length, JSBoundFunction::offsetOfLength()) \
+    macro(JSBoundFunction_boundArgsLength, JSBoundFunction::offsetOfBoundArgsLength()) \
+    macro(JSBoundFunction_canConstruct, JSBoundFunction::offsetOfCanConstruct()) \
     macro(JSCell_cellState, JSCell::cellStateOffset()) \
     macro(JSCell_header, 0) \
     macro(JSCell_indexingTypeAndMisc, JSCell::indexingTypeAndMiscOffset()) \

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -144,6 +144,7 @@ inline CapabilityLevel canCompile(Node* node)
     case NewGeneratorFunction:
     case NewAsyncFunction:
     case NewAsyncGeneratorFunction:
+    case NewBoundFunction:
     case GetClosureVar:
     case PutClosureVar:
     case GetInternalField:
@@ -222,6 +223,7 @@ inline CapabilityLevel canCompile(Node* node)
     case ToNumeric:
     case ToString:
     case FunctionToString:
+    case FunctionBind:
     case ToObject:
     case CallObjectConstructor:
     case CallStringConstructor:

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -336,11 +336,11 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
         unsigned index = 0;
         JSArray* array = constructEmptyArray(globalObject, nullptr);
         RETURN_IF_EXCEPTION(scope, JSValue());
-        array->putDirectIndex(globalObject, index++, constructInternalProperty(globalObject, "targetFunction"_s, boundFunction->flattenedTargetFunction()));
+        array->putDirectIndex(globalObject, index++, constructInternalProperty(globalObject, "targetFunction"_s, boundFunction->targetFunction()));
         RETURN_IF_EXCEPTION(scope, JSValue());
         array->putDirectIndex(globalObject, index++, constructInternalProperty(globalObject, "boundThis"_s, boundFunction->boundThis()));
         RETURN_IF_EXCEPTION(scope, JSValue());
-        if (boundFunction->boundArgs()) {
+        if (boundFunction->boundArgsLength()) {
             scope.release();
             array->putDirectIndex(globalObject, index++, constructInternalProperty(globalObject, "boundArgs"_s, boundFunction->boundArgsCopy(globalObject)));
             return array;

--- a/Source/JavaScriptCore/interpreter/ProtoCallFrame.h
+++ b/Source/JavaScriptCore/interpreter/ProtoCallFrame.h
@@ -43,10 +43,10 @@ public:
     Register argCountAndCodeOriginValue;
     Register thisArg;
     uint32_t paddedArgCount;
-    JSValue *args;
+    EncodedJSValue* args;
     JSGlobalObject* globalObject;
 
-    inline void init(CodeBlock*, JSGlobalObject*, JSObject*, JSValue, int, JSValue* otherArgs = nullptr);
+    inline void init(CodeBlock*, JSGlobalObject*, JSObject*, JSValue, int, EncodedJSValue* otherArgs = nullptr);
 
     inline CodeBlock* codeBlock() const;
     inline void setCodeBlock(CodeBlock*);
@@ -78,12 +78,12 @@ public:
     JSValue argument(size_t argumentIndex)
     {
         ASSERT(static_cast<int>(argumentIndex) < argumentCount());
-        return args[argumentIndex];
+        return JSValue::decode(args[argumentIndex]);
     }
     void setArgument(size_t argumentIndex, JSValue value)
     {
         ASSERT(static_cast<int>(argumentIndex) < argumentCount());
-        args[argumentIndex] = value;
+        args[argumentIndex] = JSValue::encode(value);
     }
 };
 

--- a/Source/JavaScriptCore/interpreter/ProtoCallFrameInlines.h
+++ b/Source/JavaScriptCore/interpreter/ProtoCallFrameInlines.h
@@ -30,7 +30,7 @@
 
 namespace JSC {
 
-inline void ProtoCallFrame::init(CodeBlock* codeBlock, JSGlobalObject* globalObject, JSObject* callee, JSValue thisValue, int argCountIncludingThis, JSValue* otherArgs)
+inline void ProtoCallFrame::init(CodeBlock* codeBlock, JSGlobalObject* globalObject, JSObject* callee, JSValue thisValue, int argCountIncludingThis, EncodedJSValue* otherArgs)
 {
     this->args = otherArgs;
     this->setCodeBlock(codeBlock);

--- a/Source/JavaScriptCore/runtime/InternalFunction.cpp
+++ b/Source/JavaScriptCore/runtime/InternalFunction.cpp
@@ -189,7 +189,7 @@ JSGlobalObject* getFunctionRealm(JSGlobalObject* globalObject, JSObject* object)
 
     while (true) {
         if (object->inherits<JSBoundFunction>()) {
-            object = jsCast<JSBoundFunction*>(object)->flattenedTargetFunction();
+            object = jsCast<JSBoundFunction*>(object)->targetFunction();
             continue;
         }
         if (object->inherits<JSRemoteFunction>()) {

--- a/Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp
@@ -125,7 +125,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlCollatorPrototypeGetterCompare, (JSGlobalObject* gl
         JSFunction* targetObject = JSFunction::create(vm, globalObject, 2, "compare"_s, intlCollatorFuncCompare, ImplementationVisibility::Public);
 
         // c. Let bc be BoundFunctionCreate(F, «this value»).
-        boundCompare = JSBoundFunction::create(vm, globalObject, targetObject, targetObject, collator, nullptr, 2, jsEmptyString(vm));
+        boundCompare = JSBoundFunction::create(vm, globalObject, targetObject, collator, { }, 2, jsEmptyString(vm));
         RETURN_IF_EXCEPTION(scope, { });
         boundCompare->reifyLazyPropertyIfNeeded(vm, globalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
@@ -149,7 +149,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlDateTimeFormatPrototypeGetterFormat, (JSGlobalObjec
         // b. The value of F’s length property is 1. (Note: F’s length property was 0 in ECMA-402 1.0)
         JSFunction* targetObject = JSFunction::create(vm, globalObject, 1, "format"_s, intlDateTimeFormatFuncFormatDateTime, ImplementationVisibility::Public);
         // c. Let bf be BoundFunctionCreate(F, «this value»).
-        boundFormat = JSBoundFunction::create(vm, globalObject, targetObject, targetObject, dtf, nullptr, 1, jsEmptyString(vm));
+        boundFormat = JSBoundFunction::create(vm, globalObject, targetObject, dtf, { }, 1, jsEmptyString(vm));
         RETURN_IF_EXCEPTION(scope, { });
         boundFormat->reifyLazyPropertyIfNeeded(vm, globalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp
@@ -130,7 +130,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlNumberFormatPrototypeGetterFormat, (JSGlobalObject*
         // b. The value of F’s length property is 1.
         auto* targetObject = JSFunction::create(vm, globalObject, 1, "format"_s, intlNumberFormatFuncFormat, ImplementationVisibility::Public);
         // c. Let bf be BoundFunctionCreate(F, «this value»).
-        boundFormat = JSBoundFunction::create(vm, globalObject, targetObject, targetObject, nf, nullptr, 1, jsEmptyString(vm));
+        boundFormat = JSBoundFunction::create(vm, globalObject, targetObject, nf, { }, 1, jsEmptyString(vm));
         RETURN_IF_EXCEPTION(scope, { });
         boundFormat->reifyLazyPropertyIfNeeded(vm, globalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -167,6 +167,7 @@ namespace JSC {
     macro(AtomicsXorIntrinsic) \
     macro(ParseIntIntrinsic) \
     macro(FunctionToStringIntrinsic) \
+    macro(FunctionBindIntrinsic) \
     \
     /* Getter intrinsics. */ \
     macro(TypedArrayLengthIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.h
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.h
@@ -32,18 +32,16 @@ namespace JSC {
 
 JSC_DECLARE_HOST_FUNCTION(boundThisNoArgsFunctionCall);
 JSC_DECLARE_HOST_FUNCTION(boundFunctionCall);
-JSC_DECLARE_HOST_FUNCTION(boundThisNoArgsFunctionConstruct);
 JSC_DECLARE_HOST_FUNCTION(boundFunctionConstruct);
 JSC_DECLARE_HOST_FUNCTION(isBoundFunction);
 JSC_DECLARE_HOST_FUNCTION(hasInstanceBoundFunction);
 
 class JSBoundFunction final : public JSFunction {
 public:
-    typedef JSFunction Base;
+    using Base = JSFunction;
     static constexpr unsigned StructureFlags = Base::StructureFlags & ~ImplementsDefaultHasInstance;
     static_assert(StructureFlags & ImplementsHasInstance);
-
-    static constexpr unsigned maxNumberOfCloningBoundArguments = 64;
+    static constexpr unsigned maxEmbeddedArgs = 3; // Keep sizeof(JSBoundFunction) <= 96.
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
@@ -51,21 +49,14 @@ public:
         return vm.boundFunctionSpace<mode>();
     }
 
-    JS_EXPORT_PRIVATE static JSBoundFunction* create(VM&, JSGlobalObject*, JSObject* targetFunction, JSObject* flattenedTargetFunction, JSValue boundThis, JSImmutableButterfly* boundArgs, double length, JSString* nameMayBeNull);
+    JS_EXPORT_PRIVATE static JSBoundFunction* create(VM&, JSGlobalObject*, JSObject* targetFunction, JSValue boundThis, ArgList, double length, JSString* nameMayBeNull);
+    static JSBoundFunction* createRaw(VM&, JSGlobalObject*, JSFunction* targetFunction, unsigned boundArgsLength, JSValue boundThis, JSValue arg0, JSValue arg1, JSValue arg2);
     
     static bool customHasInstance(JSObject*, JSGlobalObject*, JSValue);
 
-    // If boundArgs' length is too large, we should not clone boundArgs when wrapping the bound function again.
-    bool canCloneBoundArgs() const
-    {
-        return boundArgsLength() <= JSBoundFunction::maxNumberOfCloningBoundArguments;
-    }
-
     JSObject* targetFunction() { return m_targetFunction.get(); }
-    JSObject* flattenedTargetFunction() { return m_flattendTargetFunction.get(); }
     JSValue boundThis() { return m_boundThis.get(); }
-    JSImmutableButterfly* boundArgs() { return m_boundArgs.get(); } // DO NOT allow this array to be mutated!
-    unsigned boundArgsLength() const { return m_boundArgs ? m_boundArgs->length() : 0; }
+    unsigned boundArgsLength() const { return m_boundArgsLength; }
     JSArray* boundArgsCopy(JSGlobalObject*);
     JSString* nameMayBeNull() { return m_nameMayBeNull.get(); }
     JSString* name()
@@ -83,7 +74,12 @@ public:
         return m_nameMayBeNull->tryGetValue(allocationAllowed);
     }
 
-    double length(VM&) { return m_length; }
+    double length(VM& vm)
+    {
+        if (std::isnan(m_length))
+            return lengthSlow(vm);
+        return m_length;
+    }
 
     static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
     {
@@ -91,31 +87,65 @@ public:
         return Structure::create(vm, globalObject, prototype, TypeInfo(JSFunctionType, StructureFlags), info()); 
     }
     
-    static ptrdiff_t offsetOfFlattenedTargetFunction() { return OBJECT_OFFSETOF(JSBoundFunction, m_flattendTargetFunction); }
+    static ptrdiff_t offsetOfTargetFunction() { return OBJECT_OFFSETOF(JSBoundFunction, m_targetFunction); }
     static ptrdiff_t offsetOfBoundThis() { return OBJECT_OFFSETOF(JSBoundFunction, m_boundThis); }
     static ptrdiff_t offsetOfBoundArgs() { return OBJECT_OFFSETOF(JSBoundFunction, m_boundArgs); }
+    static ptrdiff_t offsetOfBoundArgsLength() { return OBJECT_OFFSETOF(JSBoundFunction, m_boundArgsLength); }
+    static ptrdiff_t offsetOfNameMayBeNull() { return OBJECT_OFFSETOF(JSBoundFunction, m_nameMayBeNull); }
+    static ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(JSBoundFunction, m_length); }
+    static ptrdiff_t offsetOfCanConstruct() { return OBJECT_OFFSETOF(JSBoundFunction, m_canConstruct); }
+
+    template<typename Functor>
+    void forEachBoundArg(const Functor& func)
+    {
+        unsigned length = boundArgsLength();
+        if (!length)
+            return;
+        if (length <= m_boundArgs.size()) {
+            for (unsigned index = 0; index < length; ++index) {
+                if (func(m_boundArgs[index].get()) == IterationStatus::Done)
+                    return;
+            }
+            return;
+        }
+        for (unsigned index = 0; index < length; ++index) {
+            if (func(jsCast<JSImmutableButterfly*>(m_boundArgs[0].get())->get(index)) == IterationStatus::Done)
+                return;
+        }
+    }
+
+    bool canConstruct()
+    {
+        if (m_canConstruct == TriState::Indeterminate)
+            return canConstructSlow();
+        return m_canConstruct == TriState::True;
+    }
+
+    static bool canSkipNameAndLengthMaterialization(JSGlobalObject*, Structure*);
 
     DECLARE_INFO;
 
 private:
-    JSBoundFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSObject* targetFunction, JSObject* flattenedTargetFunction, JSValue boundThis, JSImmutableButterfly* boundArgs, JSString* nameMayBeNull, double length);
+    JSBoundFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSObject* targetFunction, JSValue boundThis, unsigned boundArgsLength, JSValue arg0, JSValue arg1, JSValue arg2, JSString* nameMayBeNull, double length);
 
     JSString* nameSlow(VM&);
+    double lengthSlow(VM&);
+    bool canConstructSlow();
 
     void finishCreation(VM&);
     DECLARE_VISIT_CHILDREN;
 
     WriteBarrier<JSObject> m_targetFunction;
-    WriteBarrier<JSObject> m_flattendTargetFunction;
     WriteBarrier<Unknown> m_boundThis;
-    WriteBarrier<JSImmutableButterfly> m_boundArgs;
+    std::array<WriteBarrier<Unknown>, maxEmbeddedArgs> m_boundArgs { };
     WriteBarrier<JSString> m_nameMayBeNull;
-    double m_length;
+    double m_length { PNaN };
+    unsigned m_boundArgsLength { 0 };
+    TriState m_canConstruct { TriState::Indeterminate };
 };
 
 JSC_DECLARE_HOST_FUNCTION(boundFunctionCall);
 JSC_DECLARE_HOST_FUNCTION(boundFunctionConstruct);
 JSC_DECLARE_HOST_FUNCTION(boundThisNoArgsFunctionCall);
-JSC_DECLARE_HOST_FUNCTION(boundThisNoArgsFunctionConstruct);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -466,10 +466,15 @@ CallData JSFunction::getConstructData(JSCell* cell)
 
     JSFunction* thisObject = jsCast<JSFunction*>(cell);
     if (thisObject->isHostFunction()) {
-        if (thisObject->nativeConstructor() != callHostFunctionAsConstructor) {
+        if (thisObject->inherits<JSBoundFunction>()) {
+            if (jsCast<JSBoundFunction*>(thisObject)->canConstruct()) {
+                constructData.type = CallData::Type::Native;
+                constructData.native.function = thisObject->nativeConstructor();
+                constructData.native.isBoundFunction = true;
+            }
+        } else if (thisObject->nativeConstructor() != callHostFunctionAsConstructor) {
             constructData.type = CallData::Type::Native;
             constructData.native.function = thisObject->nativeConstructor();
-            constructData.native.isBoundFunction = thisObject->inherits<JSBoundFunction>();
         }
     } else {
         FunctionExecutable* functionExecutable = thisObject->jsExecutable();

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -762,6 +762,7 @@ void JSGlobalObject::init(VM& vm)
     };
     initFunctionStructures(m_builtinFunctions);
     initFunctionStructures(m_ordinaryFunctions);
+    m_boundFunctionStructure.set(vm, this, JSBoundFunction::createStructure(vm, this, m_functionPrototype.get()));
 
     m_customGetterFunctionStructure.initLater(
         [] (const Initializer<Structure>& init) {
@@ -770,10 +771,6 @@ void JSGlobalObject::init(VM& vm)
     m_customSetterFunctionStructure.initLater(
         [] (const Initializer<Structure>& init) {
             init.set(JSCustomSetterFunction::createStructure(init.vm, init.owner, init.owner->m_functionPrototype.get()));
-        });
-    m_boundFunctionStructure.initLater(
-        [] (const Initializer<Structure>& init) {
-            init.set(JSBoundFunction::createStructure(init.vm, init.owner, init.owner->m_functionPrototype.get()));
         });
     m_nativeStdFunctionStructure.initLater(
         [] (const Initializer<Structure>& init) {
@@ -2422,10 +2419,10 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     };
     visitFunctionStructures(thisObject->m_builtinFunctions);
     visitFunctionStructures(thisObject->m_ordinaryFunctions);
+    visitor.append(thisObject->m_boundFunctionStructure);
 
     thisObject->m_customGetterFunctionStructure.visit(visitor);
     thisObject->m_customSetterFunctionStructure.visit(visitor);
-    thisObject->m_boundFunctionStructure.visit(visitor);
     thisObject->m_nativeStdFunctionStructure.visit(visitor);
     thisObject->m_remoteFunctionStructure.visit(visitor);
     visitor.append(thisObject->m_shadowRealmObjectStructure);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -317,6 +317,7 @@ public:
     };
     FunctionStructures m_builtinFunctions;
     FunctionStructures m_ordinaryFunctions;
+    WriteBarrierStructureID m_boundFunctionStructure;
 
     WriteBarrierStructureID m_shadowRealmObjectStructure;
     WriteBarrierStructureID m_regExpStructure;
@@ -333,7 +334,6 @@ public:
     WriteBarrierStructureID m_regExpMatchesArrayWithIndicesStructure;
     WriteBarrierStructureID m_regExpMatchesIndicesArrayStructure;
 
-    LazyProperty<JSGlobalObject, Structure> m_boundFunctionStructure;
     LazyProperty<JSGlobalObject, Structure> m_customGetterFunctionStructure;
     LazyProperty<JSGlobalObject, Structure> m_customSetterFunctionStructure;
     LazyProperty<JSGlobalObject, Structure> m_nativeStdFunctionStructure;
@@ -776,7 +776,7 @@ public:
         return m_ordinaryFunctions.strictFunctionStructure.get();
     }
 
-    Structure* boundFunctionStructure() const { return m_boundFunctionStructure.get(this); }
+    Structure* boundFunctionStructure() const { return m_boundFunctionStructure.get(); }
     Structure* customGetterFunctionStructure() const { return m_customGetterFunctionStructure.get(this); }
     Structure* customSetterFunctionStructure() const { return m_customSetterFunctionStructure.get(this); }
     Structure* nativeStdFunctionStructure() const { return m_nativeStdFunctionStructure.get(this); }

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -543,10 +543,8 @@ public:
     Strong<JSCell> m_sentinelSetBucket;
     Strong<JSCell> m_sentinelMapBucket;
 
-    Weak<NativeExecutable> m_fastBoundExecutable;
-    Weak<NativeExecutable> m_fastCanConstructBoundExecutable;
-    Weak<NativeExecutable> m_slowBoundExecutable;
-    Weak<NativeExecutable> m_slowCanConstructBoundExecutable;
+    Strong<NativeExecutable> m_fastCanConstructBoundExecutable;
+    Strong<NativeExecutable> m_slowCanConstructBoundExecutable;
 
     Weak<NativeExecutable> m_fastRemoteFunctionExecutable;
     Weak<NativeExecutable> m_slowRemoteFunctionExecutable;
@@ -660,7 +658,7 @@ public:
     NativeExecutable* getHostFunction(NativeFunction, ImplementationVisibility, NativeFunction constructor, const String& name);
     NativeExecutable* getHostFunction(NativeFunction, ImplementationVisibility, Intrinsic, NativeFunction constructor, const DOMJIT::Signature*, const String& name);
 
-    NativeExecutable* getBoundFunction(bool isJSFunction, bool canConstruct);
+    NativeExecutable* getBoundFunction(bool isJSFunction);
     NativeExecutable* getRemoteFunction(bool isJSFunction);
 
     CodePtr<JSEntryPtrTag> getCTIInternalFunctionTrampolineFor(CodeSpecializationKind);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -73,7 +73,7 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyFunction, (JSGlobalObject* globalObject,
     if (Options::useTracePoints())
         traceScope.emplace(WebAssemblyExecuteStart, WebAssemblyExecuteEnd);
 
-    Vector<JSValue, MarkedArgumentBuffer::inlineCapacity> boxedArgs;
+    Vector<EncodedJSValue, MarkedArgumentBuffer::inlineCapacity> boxedArgs;
     JSWebAssemblyInstance* jsInstance = wasmFunction->instance();
     Wasm::Instance* wasmInstance = &jsInstance->instance();
 
@@ -83,10 +83,10 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyFunction, (JSGlobalObject* globalObject,
     for (unsigned argIndex = 0; argIndex < signature.argumentCount(); ++argIndex) {
         uint64_t value = fromJSValue(globalObject, signature.argumentType(argIndex), callFrame->argument(argIndex));
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
-        boxedArgs.append(JSValue::decode(value));
+        boxedArgs.append(value);
     }
 
-    JSValue* args = boxedArgs.data();
+    EncodedJSValue* args = boxedArgs.data();
     int argCount = boxedArgs.size() + 1;
 
     // Note: we specifically use the WebAssemblyFunction as the callee to begin with in the ProtoCallFrame.

--- a/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
@@ -288,7 +288,7 @@ JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnSett
 {
     JSC::VM& vm = globalObject->vm();
     auto onSettled = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseSettled, ImplementationVisibility::Public);
-    return JSC::JSBoundFunction::create(vm, globalObject, onSettled, onSettled, this, nullptr, 1, jsEmptyString(vm));
+    return JSC::JSBoundFunction::create(vm, globalObject, onSettled, this, { }, 1, jsEmptyString(vm));
 }
 
 template<typename JSWrapper, typename IteratorTraits>
@@ -320,7 +320,7 @@ JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnFulf
 {
     JSC::VM& vm = globalObject->vm();
     auto onFulFilled = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseFulFilled, ImplementationVisibility::Public);
-    return JSC::JSBoundFunction::create(vm, globalObject, onFulFilled, onFulFilled, this, nullptr, 1, jsEmptyString(vm));
+    return JSC::JSBoundFunction::create(vm, globalObject, onFulFilled, this, { }, 1, jsEmptyString(vm));
 }
 
 template<typename JSWrapper, typename IteratorTraits>
@@ -351,7 +351,7 @@ JSBoundFunction* JSDOMAsyncIteratorBase<JSWrapper, IteratorTraits>::createOnReje
 {
     JSC::VM& vm = globalObject->vm();
     auto onRejected = JSC::JSFunction::create(vm, globalObject, 0, String(), onPromiseRejected, ImplementationVisibility::Public);
-    return JSC::JSBoundFunction::create(vm, globalObject, onRejected, onRejected, this, nullptr, 1, jsEmptyString(vm));
+    return JSC::JSBoundFunction::create(vm, globalObject, onRejected, this, { }, 1, jsEmptyString(vm));
 }
 
 template<typename JSWrapper, typename IteratorTraits>


### PR DESCRIPTION
#### 109405481c53542efeb133a5960a9f5c6255bad4
<pre>
[JSC] Optimize Function#bind further
<a href="https://bugs.webkit.org/show_bug.cgi?id=254242">https://bugs.webkit.org/show_bug.cgi?id=254242</a>
rdar://107026972

Reviewed by Justin Michaud.

This patch makes Function#bind faster.

1. Now, JSBoundFunction has embedded bound arguments up to 3. So we can avoid allocating JSImmutableButterfly
   for small # of bound arguments, which is super common in practice.
2. Many JSBoundFunction properties materialization gets lazily done. &quot;name&quot;, &quot;length&quot;, and construct-ability too.
3. Simplify JSBoundFunction. We remove flattening since it is too complicated and performance gain was not much.
   Also, we remove complicated NativeExecutable for JSBoundFunction to make JSBoundFunction allocation simple.
4. Introduce FunctionBind node into DFG / FTL and handling it, which improves performance for generic case.
5. Furthermore, we lower FunctionBind into NewBoundFunction is input&apos;s structure meets invariant. This inlines
   JSBoundFunction allocation completely (and due to (2) and (3), the code becomes super simple) and offers massive
   performance boost.

                                       ToT                     Patched

    function-bind-creation        9.6877+-0.0297     ^      4.0682+-0.0563        ^ definitely 2.3814x faster
    function-bind                46.4667+-0.1078     ^     14.9119+-0.0942        ^ definitely 3.1161x faster

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp:
(JSC::DFG::clobbersExitState):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dump):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.cpp:
(JSC::DFG::Node::convertToNewBoundFunction):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasCellOperand):
(JSC::DFG::Node::isFunctionAllocation):
(JSC::DFG::Node::numberOfBoundArguments):
(JSC::DFG::Node::hasNumberOfBoundArguments):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
(JSC::DFG::SpeculativeJIT::compileFunctionBind):
(JSC::DFG::SpeculativeJIT::compileNewBoundFunction):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileNewBoundFunction):
(JSC::FTL::DFG::LowerDFGToB3::compileFunctionBind):
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::getInternalProperties):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeBoundCall):
(JSC::Interpreter::executeCall):
(JSC::Interpreter::executeModuleProgram):
* Source/JavaScriptCore/interpreter/ProtoCallFrame.h:
* Source/JavaScriptCore/interpreter/ProtoCallFrameInlines.h:
(JSC::ProtoCallFrame::init):
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::boundFunctionCallGenerator):
* Source/JavaScriptCore/runtime/ArgList.h:
(JSC::ArgList::ArgList):
(JSC::ArgList::at const):
(JSC::ArgList::data const):
* Source/JavaScriptCore/runtime/FunctionPrototype.cpp:
(JSC::FunctionPrototype::addFunctionProperties):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/InternalFunction.cpp:
(JSC::getFunctionRealm):
* Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSBoundFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSBoundFunction::create):
(JSC::JSBoundFunction::JSBoundFunction):
(JSC::JSBoundFunction::boundArgsCopy):
(JSC::JSBoundFunction::lengthSlow):
(JSC::JSBoundFunction::canConstructSlow):
(JSC::JSBoundFunction::canSkipNameAndLengthMaterialization):
(JSC::JSBoundFunction::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSBoundFunction.h:
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::getConstructData):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::boundFunctionStructureConcurrently const):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::getBoundFunction):
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/JSDOMAsyncIterator.h:
(WebCore::IteratorTraits&gt;::createOnSettledFunction):
(WebCore::IteratorTraits&gt;::createOnFulfilledFunction):
(WebCore::IteratorTraits&gt;::createOnRejectedFunction):

Canonical link: <a href="https://commits.webkit.org/261993@main">https://commits.webkit.org/261993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cd700814ff753b9589d24e0abd4ec7ea1a91d1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/158 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/174 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/170 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/153 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/179 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/178 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/166 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/175 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/28 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/171 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/186 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/28 "Passed tests") | 
<!--EWS-Status-Bubble-End-->