### PR TITLE
[PlayStation] Remove Warnings

### DIFF
--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1016,9 +1016,9 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
     auto& page = *frame.page();
 
     if (m_documentLoader) {
-        const auto& resourceRequest = request.resourceRequest();
         bool madeHTTPS { false };
 #if ENABLE(CONTENT_EXTENSIONS)
+        const auto& resourceRequest = request.resourceRequest();
         auto results = page.userContentProvider().processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester()), *m_documentLoader);
         bool blockedLoad = results.summary.blockedLoad;
         madeHTTPS = results.summary.madeHTTPS;

--- a/Source/WebCore/platform/network/curl/SynchronousLoaderClientCurl.cpp
+++ b/Source/WebCore/platform/network/curl/SynchronousLoaderClientCurl.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-void SynchronousLoaderClient::didReceiveAuthenticationChallenge(ResourceHandle* handle, const AuthenticationChallenge& challenge)
+void SynchronousLoaderClient::didReceiveAuthenticationChallenge(ResourceHandle*, const AuthenticationChallenge&)
 {
     ASSERT_NOT_REACHED();
 }


### PR DESCRIPTION
#### 22729d7ebb8b747e5dda9abe92d5a6d11676b2d9
<pre>
[PlayStation] Remove Warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=254243">https://bugs.webkit.org/show_bug.cgi?id=254243</a>

Reviewed by Fujii Hironori.

For CachedResourceLoader, it appears the users of the resourceRequest variable
are inside the CONTENT_EXTENSIONS enable. For the SynchronousLoaderClientCurl,
the body of the method was removed as part of a cleanup but the parameters are
still named and no longer used (and the names don&apos;t provide a lot of
information)

* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/platform/network/curl/SynchronousLoaderClientCurl.cpp:
(WebCore::SynchronousLoaderClient::didReceiveAuthenticationChallenge):

Canonical link: <a href="https://commits.webkit.org/261952@main">https://commits.webkit.org/261952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/657b63734c3c12a824e3c5bfe535a932a6594285

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/36 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/33 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/34 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/33 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/28 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/27 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/31 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/27 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/25 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/31 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->