### PR TITLE
Fix inline-block abspos bug

### DIFF
--- a/LayoutTests/fast/block/bug369123-expected.html
+++ b/LayoutTests/fast/block/bug369123-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<p>The blue block should be on the right of the green block, not below it.</p>
+<div>
+    <div style='display: inline-block; width: 50px; height: 50px; background: green;'></div>
+    <div style='display: inline-block; position: fixed; width: 50px; height: 50px; background: blue;'></div>
+</div>

--- a/LayoutTests/fast/block/bug369123.html
+++ b/LayoutTests/fast/block/bug369123.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<p>The blue block should be on the right of the green block, not below it.</p>
+<div>
+    <div style='display: inline-block; width: 50px; height: 50px; background: green;'></div>
+    <div id=blue style='position: fixed; width: 50px; height: 50px; background: blue;'></div>
+</div>
+<script>
+document.body.offsetTop;
+blue.style.display = 'inline-block';
+</script>

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -3,8 +3,8 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2005 Allan Sandfeld Jensen (kde@carewolf.com)
  *           (C) 2005, 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2005, 2006, 2007, 2008, 2009 Apple Inc. All rights reserved.
- * Copyright (C) 2010, 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -133,6 +133,21 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
 {
     RenderElement::styleDidChange(diff, oldStyle);
     updateFromStyle();
+
+    // When an out-of-flow-positioned element changes its display between block and inline-block,
+    // then an incremental layout on the element's containing block lays out the element through
+    // LayoutPositionedObjects, which skips laying out the element's parent.
+    // The element's parent needs to relayout so that it calls
+    // RenderBlockFlow::setStaticInlinePositionForChild with the out-of-flow-positioned child, so
+    // that when it's laid out, its RenderBox::computePositionedLogicalWidth/Height takes into
+    // account its new inline/block position rather than its old block/inline position.
+    // Position changes and other types of display changes are handled elsewhere.
+    if ((oldStyle && isOutOfFlowPositioned() && parent() && (parent() != containingBlock()))
+        && (style().position() == oldStyle->position())
+        && (style().isOriginalDisplayInlineType() != oldStyle->isOriginalDisplayInlineType())
+        && ((style().isOriginalDisplayBlockType()) || (style().isOriginalDisplayInlineType()))
+        && ((oldStyle->isOriginalDisplayBlockType()) || (oldStyle->isOriginalDisplayInlineType())))
+            parent()->setChildNeedsLayout();
 
     bool gainedOrLostLayer = false;
     if (requiresLayer()) {


### PR DESCRIPTION
#### 47b7f1121f2edcadb0294aa318e0b8ef082b312c
<pre>
Fix inline-block abspos bug

<a href="https://bugs.webkit.org/show_bug.cgi?id=249391">https://bugs.webkit.org/show_bug.cgi?id=249391</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/b1dbd0d86f09b9dccd410d1d106c76f029fa5b48">https://chromium.googlesource.com/chromium/blink/+/b1dbd0d86f09b9dccd410d1d106c76f029fa5b48</a>

When an out-of-flow-positioned element changes its display between block and
inline-block, then an incremental layout on the element&apos;s containing block lays
out the element through LayoutPositionedObjects, which skips laying out the
element&apos;s parent. The element&apos;s parent needs to relayout so that it calls
RenderBlockFlow::setStaticInlinePositionForChild with the out-of-flow-positioned
child, so that when it&apos;s laid out, its
RenderBox::computePositionedLogicalWidth/Height takes into account its new
inline/block position rather than its old block/inline position.

* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(RenderLayerModelObject::styleDidChange):
* LayoutTests/fast/block/bug369123.html: Add Test Case
* LayoutTests/fast/block/bug369123-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/262042@main">https://commits.webkit.org/262042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/463a082d089677f94e3304c6c5dcbfe0321f313a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/39 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/37 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/36 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/29 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34 "3 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/30 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85 "12 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/34 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/28 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/28 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/89 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/34 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->