### PR TITLE
sfgate.com is unreadable when dark mode is forced using `-[WKWebpagePreferences _setColorSchemePreference:]`

### DIFF
--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -696,16 +696,8 @@ const FeatureSchema& prefersColorScheme()
         "prefers-color-scheme"_s,
         Vector { CSSValueLight, CSSValueDark },
         [](auto& context) {
-            bool useDarkAppearance = [&] {
-                auto& frame = *context.document.frame();
-                if (frame.document()->loader()) {
-                    auto colorSchemePreference = frame.document()->loader()->colorSchemePreference();
-                    if (colorSchemePreference != ColorSchemePreference::NoPreference)
-                        return colorSchemePreference == ColorSchemePreference::Dark;
-                }
-
-                return frame.page()->useDarkAppearance();
-            }();
+            auto& frame = *context.document.frame();
+            bool useDarkAppearance = frame.page()->useDarkAppearance();
 
             return MatchingIdentifiers { useDarkAppearance ? CSSValueDark : CSSValueLight };
         }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7890,12 +7890,6 @@ bool Document::useDarkAppearance(const RenderStyle* style) const
     UNUSED_PARAM(style);
 #endif
 
-    if (DocumentLoader* documentLoader = loader()) {
-        auto colorSchemePreference = documentLoader->colorSchemePreference();
-        if (colorSchemePreference != ColorSchemePreference::NoPreference)
-            return colorSchemePreference == ColorSchemePreference::Dark;
-    }
-
     bool pageUsesDarkAppearance = false;
     if (Page* documentPage = page())
         pageUsesDarkAppearance = documentPage->useDarkAppearance();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3606,6 +3606,13 @@ bool Page::useDarkAppearance() const
         return false;
     if (m_useDarkAppearanceOverride)
         return m_useDarkAppearanceOverride.value();
+
+    if (auto* documentLoader = localMainFrame->loader().documentLoader()) {
+        auto colorSchemePreference = documentLoader->colorSchemePreference();
+        if (colorSchemePreference != ColorSchemePreference::NoPreference)
+            return colorSchemePreference == ColorSchemePreference::Dark;
+    }
+
     return m_useDarkAppearance;
 #else
     return false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/color-scheme.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/color-scheme.html
@@ -1,5 +1,10 @@
 <html>
 <head>
+<style>
+body {
+    background-color: Canvas;
+}
+</style>
 <script>
 function testColorScheme() {
     if (window.matchMedia("(prefers-color-scheme: light)").matches) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -1722,6 +1722,35 @@ TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeLight)
     [webView waitForMessage:@"light-detected"];
 }
 
+TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeDark)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    configuration.get().defaultWebpagePreferences._colorSchemePreference = _WKWebsiteColorSchemePreferenceDark;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    [webView loadTestPageNamed:@"color-scheme"];
+    [webView waitForMessage:@"dark-detected"];
+}
+
+TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeDarkForContentThatDoesNotSupportDarkMode)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"color-scheme"];
+
+    NSString *backgroundColorWithoutPreference = [webView stringByEvaluatingJavaScript:@"getComputedStyle(document.body).backgroundColor"];
+
+    configuration.get().defaultWebpagePreferences._colorSchemePreference = _WKWebsiteColorSchemePreferenceDark;
+    webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"color-scheme"];
+
+    NSString *backgroundColorWithPreference = [webView stringByEvaluatingJavaScript:@"getComputedStyle(document.body).backgroundColor"];
+
+    EXPECT_WK_STREQ(backgroundColorWithoutPreference, backgroundColorWithPreference);
+}
+
 TEST(WebpagePreferences, ContentRuleListEnablement)
 {
     [TestProtocol registerWithScheme:@"https"];
@@ -1791,18 +1820,6 @@ TEST(WebpagePreferences, ContentRuleListEnablement)
     EXPECT_TRUE(canLoadImage(@"./400x400-green.png"));
     EXPECT_FALSE(canLoadImage(@"./sunset-in-cupertino-200px.png"));
     EXPECT_TRUE(canLoadImage(@"./sunset-in-cupertino-100px.tiff"));
-}
-
-TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeDark)
-{
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-
-    configuration.get().defaultWebpagePreferences._colorSchemePreference = _WKWebsiteColorSchemePreferenceDark;
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-
-    [webView loadTestPageNamed:@"color-scheme"];
-    [webView waitForMessage:@"dark-detected"];
 }
 
 TEST(WebpagePreferences, ToggleNetworkConnectionIntegrity)


### PR DESCRIPTION
#### 3caad3cea6986d04c33e2bf76c52a1ebff9964c4
<pre>
sfgate.com is unreadable when dark mode is forced using `-[WKWebpagePreferences _setColorSchemePreference:]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=254239">https://bugs.webkit.org/show_bug.cgi?id=254239</a>
rdar://106873224

Reviewed by Wenson Hsieh.

245233@main added `WKWebpagePreferences` SPI to support a user-specified
color-scheme preference. The intent of the preference is to override the
system color-scheme preference.

However, the current implementation is flawed, as it not only overrides the
system preference, but also forces sites to opt-in to the user-specified
color scheme.

`Document::useDarkAppearance` is used to determine whether or not
a site supports a dark color-scheme. The value is derived from the `color-scheme`
CSS property or `&lt;meta&gt;` tag. If a dark-color scheme is declared as supported,
all semantic colors will be resolved with a dark color-scheme. By default,
the root background and text colors are semantic.

sfgate.com does not support a dark color-scheme. They do not modify the root
background color, but use custom text colors. Consequently, forcing dark mode
makes the text unreadable, as the background adapts to dark mode, but the text
does not. This is one of many possible sources of compatibility issues when
forcing a used color-scheme value on a page.

To fix, do not modify the site&apos;s used color-scheme when the SPI is used.
Instead, simply report the user&apos;s preferred color-scheme as the overridden
value, exposed only via media queries. This change carries no compatibility
risk, as users are free to change their preferred color-scheme at a global level.

* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::prefersColorScheme):

`Page::useDarkAppearance` will report the overridden value if there is one, and
will otherwise fall back to the system value, so the removed code is redundant.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::useDarkAppearance const):

Remove problematic logic that was forcing sites to opt-in to dark mode.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::useDarkAppearance const):

Report the user&apos;s preferred color-scheme with an override if one is specified.

* Tools/TestWebKitAPI/Tests/WebKit/color-scheme.html:

Update test page to use a semantic color that can be read.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:

Added a new test to ensure that content is not forced into dark mode when the
user preference is overridden.

Moved an existing test to be closer to another similar test.

Canonical link: <a href="https://commits.webkit.org/261967@main">https://commits.webkit.org/261967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5084781e23aa014e16f5a2a055df7c3326531eb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/40 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/38 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/37 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/32 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/38 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/28 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/31 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/35 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/32 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/29 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/35 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->