### PR TITLE
Plumb an optional top SecurityOriginData into ThreadableBlobRegistry

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSourceRegistry.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceRegistry.cpp
@@ -62,7 +62,7 @@ void MediaSourceRegistry::registerURL(const ScriptExecutionContext& context, con
     m_mediaSources.add(urlString, std::pair { RefPtr { &source }, context.identifier() });
 }
 
-void MediaSourceRegistry::unregisterURL(const URL& url)
+void MediaSourceRegistry::unregisterURL(const URL& url, const SecurityOriginData&)
 {
     // MediaSource objects are not exposed to workers.
     if (!isMainThread())

--- a/Source/WebCore/Modules/mediasource/MediaSourceRegistry.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceRegistry.h
@@ -49,7 +49,7 @@ public:
 
     // Registers a blob URL referring to the specified media source.
     void registerURL(const ScriptExecutionContext&, const URL&, URLRegistrable&) final;
-    void unregisterURL(const URL&) final;
+    void unregisterURL(const URL&, const SecurityOriginData& topOrigin) final;
     void unregisterURLsForContext(const ScriptExecutionContext&) final;
     URLRegistrable* lookup(const String&) const final;
 

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.h
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.h
@@ -42,15 +42,17 @@ struct PolicyContainer;
 
 class ThreadableBlobRegistry {
 public:
-    static void registerBlobURL(SecurityOrigin*, PolicyContainer&&, const URL&, const URL& srcURL);
+    static void registerBlobURL(SecurityOrigin*, PolicyContainer&&, const URL&, const URL& srcURL, const std::optional<SecurityOriginData>& topOrigin);
+    static void registerBlobURL(SecurityOrigin*, PolicyContainer&&, const URL&, const URLKeepingBlobAlive& srcURL);
     static void registerInternalFileBlobURL(const URL&, const String& path, const String& replacementPath, const String& contentType);
     static void registerInternalBlobURL(const URL&, Vector<BlobPart>&& blobParts, const String& contentType);
     static void registerInternalBlobURLOptionallyFileBacked(const URL&, const URL& srcURL, const String& fileBackedPath, const String& contentType);
     static void registerInternalBlobURLForSlice(const URL& newURL, const URL& srcURL, long long start, long long end, const String& contentType);
-    static void unregisterBlobURL(const URL&);
+    static void unregisterBlobURL(const URL&, const std::optional<SecurityOriginData>& topOrigin);
+    static void unregisterBlobURL(const URLKeepingBlobAlive&);
 
-    static void registerBlobURLHandle(const URL&);
-    static void unregisterBlobURLHandle(const URL&);
+    static void registerBlobURLHandle(const URL&, const std::optional<SecurityOriginData>& topOrigin);
+    static void unregisterBlobURLHandle(const URL&, const std::optional<SecurityOriginData>& topOrigin);
 
     WEBCORE_EXPORT static unsigned long long blobSize(const URL&);
 

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
@@ -64,13 +64,13 @@ URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(URLKeepingBlobAlive&& other)
 void URLKeepingBlobAlive::registerBlobURLHandleIfNecessary()
 {
     if (m_url.protocolIsBlob())
-        ThreadableBlobRegistry::registerBlobURLHandle(m_url);
+        ThreadableBlobRegistry::registerBlobURLHandle(m_url, m_topOrigin);
 }
 
 void URLKeepingBlobAlive::unregisterBlobURLHandleIfNecessary()
 {
     if (m_url.protocolIsBlob())
-        ThreadableBlobRegistry::unregisterBlobURLHandle(m_url);
+        ThreadableBlobRegistry::unregisterBlobURLHandle(m_url, m_topOrigin);
 }
 
 URLKeepingBlobAlive URLKeepingBlobAlive::isolatedCopy() const

--- a/Source/WebCore/html/PublicURLManager.cpp
+++ b/Source/WebCore/html/PublicURLManager.cpp
@@ -69,7 +69,7 @@ void PublicURLManager::revoke(const URL& url)
         return;
 
     URLRegistry::forEach([&](auto& registry) {
-        registry.unregisterURL(url);
+        registry.unregisterURL(url, scriptExecutionContext()->topOrigin().data());
     });
 }
 

--- a/Source/WebCore/html/URLRegistry.h
+++ b/Source/WebCore/html/URLRegistry.h
@@ -36,6 +36,7 @@
 namespace WebCore {
 
 class ScriptExecutionContext;
+class SecurityOriginData;
 class URLRegistry;
 
 class URLRegistrable {
@@ -53,7 +54,7 @@ public:
 
     virtual ~URLRegistry();
     virtual void registerURL(const ScriptExecutionContext&, const URL&, URLRegistrable&) = 0;
-    virtual void unregisterURL(const URL&) = 0;
+    virtual void unregisterURL(const URL&, const SecurityOriginData& topOrigin) = 0;
     virtual void unregisterURLsForContext(const ScriptExecutionContext&) = 0;
 
     // This is an optional API


### PR DESCRIPTION
#### 6f972bb0d49772d10b770dc3f4be2d2118a21615
<pre>
Plumb an optional top SecurityOriginData into ThreadableBlobRegistry
<a href="https://bugs.webkit.org/show_bug.cgi?id=254235">https://bugs.webkit.org/show_bug.cgi?id=254235</a>
rdar://problem/107024226

Reviewed by Chris Dumez.

Plumb into ThreadableBlobRegistry the top SecurityOriginData associated with
the Blob URL.

For public Blob URLs, this origin is obtained from the top document. For
internal Blob URLs, the value is std::nullopt because a blob is not inherently
bound to a top origin.

This is a pre-patch for partitioning the blob registry by top origin. This
change should have any behavioral change.

* Source/WebCore/Modules/mediasource/MediaSourceRegistry.cpp:
(WebCore::MediaSourceRegistry::unregisterURL):
* Source/WebCore/Modules/mediasource/MediaSourceRegistry.h:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::BlobURLRegistry::registerURL):
(WebCore::BlobURLRegistry::unregisterURL):
(WebCore::BlobURLRegistry::unregisterURLsForContext):
(WebCore::Blob::Blob):
(WebCore::Blob::~Blob):
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
(WebCore::ThreadableBlobRegistry::registerBlobURL):
(WebCore::ThreadableBlobRegistry::unregisterBlobURL):
(WebCore::ThreadableBlobRegistry::registerBlobURLHandle):
(WebCore::ThreadableBlobRegistry::unregisterBlobURLHandle):
* Source/WebCore/fileapi/ThreadableBlobRegistry.h:
* Source/WebCore/fileapi/URLKeepingBlobAlive.cpp:
(WebCore::URLKeepingBlobAlive::registerBlobURLHandleIfNecessary):
(WebCore::URLKeepingBlobAlive::unregisterBlobURLHandleIfNecessary):
* Source/WebCore/html/PublicURLManager.cpp:
(WebCore::PublicURLManager::revoke):
* Source/WebCore/html/URLRegistry.h:

Canonical link: <a href="https://commits.webkit.org/266021@main">https://commits.webkit.org/266021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/922e9f44374feac3c9b11b86377f51d00c6c3210

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14311 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14748 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14740 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18468 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11545 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14734 "3 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9944 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11268 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3089 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15601 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11883 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->