### PR TITLE
New test: TestWebKitAPI.TextManipulation.StartTextManipulationFindsContentInIframeInsertedLater is a flaky failure on iOS and Ventura

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm
@@ -1423,7 +1423,7 @@ TEST(TextManipulation, StartTextManipulationFindsContentInIframeInsertedLater)
     };
 
     [webView objectByEvaluatingJavaScript:@"frame = document.createElement('iframe');"
-        "document.body.appendChild(frame); frame.contentDocument.body.innerHTML = '<p>WebKit</p>';"];
+        "frame.srcdoc = '<!DOCTYPE html><div>WebKit</div>'; document.body.appendChild(frame); true"];
 
     TestWebKitAPI::Util::run(&done);
 


### PR DESCRIPTION
#### 192e26a16ad54baf1da70e6da769e4b38bbb0671
<pre>
New test: TestWebKitAPI.TextManipulation.StartTextManipulationFindsContentInIframeInsertedLater is a flaky failure on iOS and Ventura
<a href="https://bugs.webkit.org/show_bug.cgi?id=254192">https://bugs.webkit.org/show_bug.cgi?id=254192</a>

Reviewed by Wenson Hsieh.

The flakiness was caused by the race condition between when the 4th item is created after DOM mutation and when done is set to true.
Use srcdoc instead of setting innerHTML so that there is no DOM mutation, and therefore there will always be at most 3 items.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/261986@main">https://commits.webkit.org/261986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78fd03189b0e0adb0f6691c37379db54d7986900

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/51 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/44 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/46 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/45 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/39 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/36 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/38 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/43 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/37 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/36 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/45 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->