### PR TITLE
[UI-side compositing] Send events to the WebWheelEventCoalescer before sending them to the scrolling thread

### DIFF
--- a/LayoutTests/tiled-drawing/scrolling/fast-scroll-div-latched-mainframe-with-handler.html
+++ b/LayoutTests/tiled-drawing/scrolling/fast-scroll-div-latched-mainframe-with-handler.html
@@ -88,6 +88,7 @@
             {
                 type : "wheel",
                 deltaY : -10,
+                viewX : startPosX + 1, // defeat coalescing
                 phase : "changed"
             },
             {

--- a/Source/WebKit/Shared/WebWheelEventCoalescer.h
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.h
@@ -26,38 +26,17 @@
 #pragma once
 
 #include "NativeWebWheelEvent.h"
-#include <WebCore/ScrollingCoordinatorTypes.h>
 #include <wtf/Deque.h>
 #include <wtf/FastMalloc.h>
 
 namespace WebKit {
 
-struct NativeWebWheelEventAndSteps {
-    NativeWebWheelEvent event;
-    OptionSet<WebCore::WheelEventProcessingSteps> processingSteps;
-};
-
-struct WebWheelEventAndSteps {
-    WebWheelEvent event;
-    OptionSet<WebCore::WheelEventProcessingSteps> processingSteps;
-    
-    WebWheelEventAndSteps(const WebWheelEvent& event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps)
-        : event(event)
-        , processingSteps(processingSteps)
-    { }
-
-    explicit WebWheelEventAndSteps(const NativeWebWheelEventAndSteps& nativeEventAndSteps)
-        : event(nativeEventAndSteps.event)
-        , processingSteps(nativeEventAndSteps.processingSteps)
-    { }
-};
-
 class WebWheelEventCoalescer {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     // If this returns true, use nextEventToDispatch() to get the event to dispatch.
-    bool shouldDispatchEvent(const NativeWebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>);
-    std::optional<WebWheelEventAndSteps> nextEventToDispatch();
+    bool shouldDispatchEvent(const NativeWebWheelEvent&);
+    std::optional<WebWheelEvent> nextEventToDispatch();
 
     NativeWebWheelEvent takeOldestEventBeingProcessed();
 
@@ -66,14 +45,14 @@ public:
     void clear();
 
 private:
-    using CoalescedEventSequence = Vector<NativeWebWheelEventAndSteps>;
+    using CoalescedEventSequence = Vector<NativeWebWheelEvent>;
 
-    static bool canCoalesce(const WebWheelEventAndSteps&, const WebWheelEventAndSteps&);
-    static WebWheelEventAndSteps coalesce(const WebWheelEventAndSteps&, const WebWheelEventAndSteps&);
+    static bool canCoalesce(const WebWheelEvent&, const WebWheelEvent&);
+    static WebWheelEvent coalesce(const WebWheelEvent&, const WebWheelEvent&);
 
     bool shouldDispatchEventNow(const WebWheelEvent&) const;
 
-    Deque<NativeWebWheelEventAndSteps, 2> m_wheelEventQueue;
+    Deque<NativeWebWheelEvent, 2> m_wheelEventQueue;
     Deque<std::unique_ptr<CoalescedEventSequence>> m_eventsBeingProcessed;
 };
 

--- a/Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp
@@ -143,7 +143,7 @@ void WKPageHandleWheelEvent(WKPageRef pageRef, WKWheelEvent event)
         1, static_cast<int32_t>(event.delta.width), 0
     };
 
-    WebKit::toImpl(pageRef)->handleWheelEvent(NativeWebWheelEvent(&xEvent, deviceScaleFactor, WebWheelEvent::Phase::PhaseNone, WebWheelEvent::Phase::PhaseNone));
+    WebKit::toImpl(pageRef)->handleNativeWheelEvent(NativeWebWheelEvent(&xEvent, deviceScaleFactor, WebWheelEvent::Phase::PhaseNone, WebWheelEvent::Phase::PhaseNone));
 
     struct wpe_input_axis_event yEvent = {
         wpe_input_axis_event_type_motion,
@@ -151,7 +151,7 @@ void WKPageHandleWheelEvent(WKPageRef pageRef, WKWheelEvent event)
         0, static_cast<int32_t>(event.delta.height), 0
     };
 
-    WebKit::toImpl(pageRef)->handleWheelEvent(NativeWebWheelEvent(&yEvent, deviceScaleFactor, WebWheelEvent::Phase::PhaseNone, WebWheelEvent::Phase::PhaseNone));
+    WebKit::toImpl(pageRef)->handleNativeWheelEvent(NativeWebWheelEvent(&yEvent, deviceScaleFactor, WebWheelEvent::Phase::PhaseNone, WebWheelEvent::Phase::PhaseNone));
 }
 
 void WKPagePaint(WKPageRef pageRef, unsigned char* surfaceData, WKSize wkSurfaceSize, WKRect wkPaintRect)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1402,7 +1402,7 @@ static gboolean webkitWebViewBaseScrollEvent(GtkWidget* widget, GdkEventScroll* 
 
     FloatSize delta = wheelTicks.scaled(stepX, stepY);
 
-    priv->pageProxy->handleWheelEvent(NativeWebWheelEvent(event, position, globalPosition, delta, wheelTicks, phase, WebWheelEvent::Phase::PhaseNone, hasPreciseScrollingDeltas));
+    priv->pageProxy->handleNativeWheelEvent(NativeWebWheelEvent(event, position, globalPosition, delta, wheelTicks, phase, WebWheelEvent::Phase::PhaseNone, hasPreciseScrollingDeltas));
 
     return GDK_EVENT_STOP;
 }
@@ -1478,7 +1478,7 @@ static gboolean handleScroll(WebKitWebViewBase* webViewBase, double deltaX, doub
     delta = wheelTicks.scaled(stepX, stepY);
 #endif
 
-    priv->pageProxy->handleWheelEvent(NativeWebWheelEvent(event, position, position, delta, wheelTicks, phase, WebWheelEvent::Phase::PhaseNone, hasPreciseScrollingDeltas));
+    priv->pageProxy->handleNativeWheelEvent(NativeWebWheelEvent(event, position, position, delta, wheelTicks, phase, WebWheelEvent::Phase::PhaseNone, hasPreciseScrollingDeltas));
 
     return GDK_EVENT_STOP;
 }
@@ -3279,7 +3279,7 @@ void webkitWebViewBaseSynthesizeWheelEvent(WebKitWebViewBase* webViewBase, const
     if (!hasPreciseDeltas)
         delta.scale(static_cast<float>(Scrollbar::pixelsPerLineStep()));
 
-    priv->pageProxy->handleWheelEvent(NativeWebWheelEvent(const_cast<GdkEvent*>(event), { x, y }, widgetRootCoords(GTK_WIDGET(webViewBase), x, y),
+    priv->pageProxy->handleNativeWheelEvent(NativeWebWheelEvent(const_cast<GdkEvent*>(event), { x, y }, widgetRootCoords(GTK_WIDGET(webViewBase), x, y),
         delta, wheelTicks, toWebKitWheelEventPhase(phase), toWebKitWheelEventPhase(momentumPhase), true));
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -241,7 +241,7 @@ void PageClientImpl::doneWithTouchEvent(const NativeWebTouchEvent& touchEvent, b
             auto* event = &axisEvent.event;
 #endif
             if (event->type != wpe_input_axis_event_type_null) {
-                page.handleWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(),
+                page.handleNativeWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(),
                     axisEvent.phase, WebWheelEvent::Phase::PhaseNone));
             }
         });

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -204,7 +204,7 @@ View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseC
                     phase = WebWheelEvent::Phase::PhaseEnded;
 
                 auto& page = view.page();
-                page.handleWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(), phase, momentumPhase));
+                page.handleNativeWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(), phase, momentumPhase));
                 return;
             }
 #endif
@@ -226,7 +226,7 @@ View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseC
 
             if (shouldDispatch) {
                 auto& page = view.page();
-                page.handleWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(), phase, momentumPhase));
+                page.handleNativeWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(), phase, momentumPhase));
             }
         },
         // handle_touch_event
@@ -256,7 +256,7 @@ View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseC
                         auto* event = &axisEvent.event;
 #endif
                         if (event->type != wpe_input_axis_event_type_null) {
-                            page.handleWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(),
+                            page.handleNativeWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(),
                                 axisEvent.phase, WebWheelEvent::Phase::PhaseNone));
                             handledThroughGestureController = true;
                         }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -100,7 +100,7 @@ std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScroll
     return std::exchange(m_requestedScroll, { });
 }
 
-void RemoteScrollingCoordinatorProxy::handleWheelEvent(const NativeWebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+void RemoteScrollingCoordinatorProxy::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
 {
 #if !(PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING))
     if (!m_scrollingTree)
@@ -132,7 +132,7 @@ void RemoteScrollingCoordinatorProxy::handleWheelEvent(const NativeWebWheelEvent
 #endif
 }
 
-void RemoteScrollingCoordinatorProxy::continueWheelEventHandling(const NativeWebWheelEvent& wheelEvent, WheelEventHandlingResult result)
+void RemoteScrollingCoordinatorProxy::continueWheelEventHandling(const WebWheelEvent& wheelEvent, WheelEventHandlingResult result)
 {
     webPageProxy().continueWheelEventHandling(wheelEvent, result);
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -52,6 +52,7 @@ class RemoteLayerTreeHost;
 class RemoteScrollingCoordinatorTransaction;
 class RemoteScrollingTree;
 class WebPageProxy;
+class WebWheelEvent;
 
 class RemoteScrollingCoordinatorProxy : public CanMakeWeakPtr<RemoteScrollingCoordinatorProxy> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -93,8 +94,9 @@ public:
 
     void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
 
-    virtual void handleWheelEvent(const NativeWebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
-    void continueWheelEventHandling(const NativeWebWheelEvent&, WebCore::WheelEventHandlingResult);
+    virtual void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&) { }
+    virtual void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    void continueWheelEventHandling(const WebWheelEvent&, WebCore::WheelEventHandlingResult);
 
     void handleMouseEvent(const WebCore::PlatformMouseEvent&);
     

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -63,8 +63,10 @@ public:
     ~RemoteLayerTreeEventDispatcher();
     
     void invalidate();
+    
+    void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&);
 
-    void handleWheelEvent(const NativeWebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
 
     void setScrollingTree(RefPtr<RemoteScrollingTree>&&);
 
@@ -85,7 +87,7 @@ private:
 
     void wheelEventHysteresisUpdated(PAL::HysteresisState);
 
-    void willHandleWheelEvent(const NativeWebWheelEvent&);
+    void willHandleWheelEvent(const WebWheelEvent&);
     void wheelEventWasHandledByScrollingThread(WheelEventHandlingResult);
 
     DisplayLink* displayLink() const;
@@ -110,7 +112,7 @@ private:
     Lock m_scrollingTreeLock;
     RefPtr<RemoteScrollingTree> m_scrollingTree WTF_GUARDED_BY_LOCK(m_scrollingTreeLock);
 
-    Deque<NativeWebWheelEvent, 2> m_wheelEventsBeingProcessed;
+    Deque<WebWheelEvent, 2> m_wheelEventsBeingProcessed; // FIXME: Remove
 
     WeakPtr<RemoteScrollingCoordinatorProxyMac> m_scrollingCoordinator;
     WebCore::PageIdentifier m_pageIdentifier;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -41,7 +41,8 @@ public:
     ~RemoteScrollingCoordinatorProxyMac();
 
 private:
-    void handleWheelEvent(const NativeWebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) override;
+    void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&) override;
+    void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) override;
 
     bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
     bool scrollingTreeNodeRequestsKeyboardScroll(WebCore::ScrollingNodeID, const WebCore::RequestedKeyboardScrollData&) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -61,12 +61,21 @@ RemoteScrollingCoordinatorProxyMac::~RemoteScrollingCoordinatorProxyMac()
 #endif
 }
 
-void RemoteScrollingCoordinatorProxyMac::handleWheelEvent(const NativeWebWheelEvent& nativeWheelEvent, RectEdges<bool> rubberBandableEdges)
+void RemoteScrollingCoordinatorProxyMac::cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent& nativeWheelEvent)
 {
 #if ENABLE(SCROLLING_THREAD)
-    m_wheelEventDispatcher->handleWheelEvent(nativeWheelEvent, rubberBandableEdges);
+    m_wheelEventDispatcher->cacheWheelEventScrollingAccelerationCurve(nativeWheelEvent);
 #else
     UNUSED_PARAM(nativeWheelEvent);
+#endif
+}
+
+void RemoteScrollingCoordinatorProxyMac::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+{
+#if ENABLE(SCROLLING_THREAD)
+    m_wheelEventDispatcher->handleWheelEvent(wheelEvent, rubberBandableEdges);
+#else
+    UNUSED_PARAM(wheelEvent);
     UNUSED_PARAM(rubberBandableEdges);
 #endif
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3030,45 +3030,52 @@ void WebPageProxy::dispatchWheelEventWithoutScrolling(const WebWheelEvent& event
 }
 #endif
 
-void WebPageProxy::handleWheelEvent(const NativeWebWheelEvent& event)
+void WebPageProxy::handleNativeWheelEvent(const NativeWebWheelEvent& nativeWheelEvent)
 {
     if (!hasRunningProcess())
         return;
 
     closeOverlayedViews();
 
+    cacheWheelEventScrollingAccelerationCurve(nativeWheelEvent);
+
+    if (!wheelEventCoalescer().shouldDispatchEvent(nativeWheelEvent))
+        return;
+
+    auto eventToDispatch = *wheelEventCoalescer().nextEventToDispatch();
+    handleWheelEvent(eventToDispatch);
+}
+
+void WebPageProxy::handleWheelEvent(const WebWheelEvent& wheelEvent)
+{
+    if (!hasRunningProcess())
+        return;
+
     if (drawingArea()->shouldSendWheelEventsToEventDispatcher()) {
-#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-        // FIXME: We should not have to look this up repeatedly, but it can also change occasionally.
-        if (event.momentumPhase() == WebWheelEvent::PhaseBegan && preferences().momentumScrollingAnimatorEnabled())
-            m_scrollingAccelerationCurve = ScrollingAccelerationCurve::fromNativeWheelEvent(event);
-#endif
-        continueWheelEventHandling(event, { WheelEventProcessingSteps::SynchronousScrolling, false });
+        continueWheelEventHandling(wheelEvent, { WheelEventProcessingSteps::SynchronousScrolling, false });
         return;
     }
 
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
     if (m_scrollingCoordinatorProxy) {
         auto rubberBandableEdges = rubberBandableEdgesRespectingHistorySwipe();
-        m_scrollingCoordinatorProxy->handleWheelEvent(event, rubberBandableEdges);
+        m_scrollingCoordinatorProxy->handleWheelEvent(wheelEvent, rubberBandableEdges);
         // continueWheelEventHandling() will get called after the event has been handled by the scrolling thread.
     }
 #endif
 }
 
-void WebPageProxy::continueWheelEventHandling(const NativeWebWheelEvent& wheelEvent, const WheelEventHandlingResult& result)
+void WebPageProxy::continueWheelEventHandling(const WebWheelEvent& wheelEvent, const WheelEventHandlingResult& result)
 {
+    LOG_WITH_STREAM(WheelEvents, stream << "WebPageProxy::continueWheelEventHandling - " << result);
+
     if (!result.needsMainThreadProcessing()) {
-        if (!result.wasHandled)
-            wheelEventWasNotHandled(wheelEvent);
+        wheelEventHandlingCompleted(result.wasHandled);
         return;
     }
 
-    if (wheelEventCoalescer().shouldDispatchEvent(wheelEvent, result.steps)) {
-        auto eventAndSteps = wheelEventCoalescer().nextEventToDispatch();
-        auto rubberBandableEdges = rubberBandableEdgesRespectingHistorySwipe();
-        sendWheelEvent(eventAndSteps->event, eventAndSteps->processingSteps, rubberBandableEdges);
-    }
+    auto rubberBandableEdges = rubberBandableEdgesRespectingHistorySwipe();
+    sendWheelEvent(wheelEvent, result.steps, rubberBandableEdges);
 }
 
 void WebPageProxy::sendWheelEvent(const WebWheelEvent& event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps, RectEdges<bool> rubberBandableEdges)
@@ -3082,12 +3089,7 @@ void WebPageProxy::sendWheelEvent(const WebWheelEvent& event, OptionSet<WebCore:
         return;
 
     if (drawingArea()->shouldSendWheelEventsToEventDispatcher()) {
-#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-        if (event.momentumPhase() == WebWheelEvent::PhaseBegan && m_scrollingAccelerationCurve != m_lastSentScrollingAccelerationCurve) {
-            connection->send(Messages::EventDispatcher::SetScrollingAccelerationCurve(m_webPageID, m_scrollingAccelerationCurve), 0, { }, Thread::QOS::UserInteractive);
-            m_lastSentScrollingAccelerationCurve = m_scrollingAccelerationCurve;
-        }
-#endif
+        sendWheelEventScrollingAccelerationCurveIfNecessary(event);
         connection->send(Messages::EventDispatcher::WheelEvent(m_webPageID, event, rubberBandableEdges), 0, { }, Thread::QOS::UserInteractive);
     } else
         send(Messages::WebPage::HandleWheelEvent(event, processingSteps));
@@ -3095,6 +3097,66 @@ void WebPageProxy::sendWheelEvent(const WebWheelEvent& event, OptionSet<WebCore:
     // Manually ping the web process to check for responsiveness since our wheel
     // event will dispatch to a non-main thread, which always responds.
     m_process->isResponsiveWithLazyStop();
+}
+
+void WebPageProxy::wheelEventHandlingCompleted(bool wasHandled)
+{
+    auto oldestProcessedEvent = wheelEventCoalescer().takeOldestEventBeingProcessed();
+
+    LOG_WITH_STREAM(WheelEvents, stream << "WebPageProxy::wheelEventHandlingCompleted - taking " << platform(oldestProcessedEvent) << " handled " << wasHandled);
+
+    if (!wasHandled) {
+        m_uiClient->didNotHandleWheelEvent(this, oldestProcessedEvent);
+        pageClient().wheelEventWasNotHandledByWebCore(oldestProcessedEvent);
+    }
+
+    if (auto eventToSend = wheelEventCoalescer().nextEventToDispatch()) {
+        handleWheelEvent(*eventToSend);
+        return;
+    }
+    
+    if (auto* automationSession = process().processPool().automationSession())
+        automationSession->wheelEventsFlushedForPage(*this);
+}
+
+void WebPageProxy::cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent& nativeWheelEvent)
+{
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    if (m_scrollingCoordinatorProxy) {
+        m_scrollingCoordinatorProxy->cacheWheelEventScrollingAccelerationCurve(nativeWheelEvent);
+        return;
+    }
+
+    ASSERT(drawingArea()->shouldSendWheelEventsToEventDispatcher());
+
+    if (nativeWheelEvent.momentumPhase() != WebWheelEvent::PhaseBegan)
+        return;
+
+    if (!preferences().momentumScrollingAnimatorEnabled())
+        return;
+
+    // FIXME: We should not have to fetch the curve repeatedly, but it can also change occasionally.
+    m_scrollingAccelerationCurve = ScrollingAccelerationCurve::fromNativeWheelEvent(nativeWheelEvent);
+#endif
+}
+
+void WebPageProxy::sendWheelEventScrollingAccelerationCurveIfNecessary(const WebWheelEvent& event)
+{
+    ASSERT(drawingArea()->shouldSendWheelEventsToEventDispatcher());
+#if ENABLE(MOMENTUM_EVENT_DISPATCHER)
+    if (event.momentumPhase() != WebWheelEvent::PhaseBegan)
+        return;
+        
+    if (m_scrollingAccelerationCurve == m_lastSentScrollingAccelerationCurve)
+        return;
+
+    auto* connection = messageSenderConnection();
+    if (!connection)
+        return;
+
+    connection->send(Messages::EventDispatcher::SetScrollingAccelerationCurve(m_webPageID, m_scrollingAccelerationCurve), 0, { }, Thread::QOS::UserInteractive);
+    m_lastSentScrollingAccelerationCurve = m_scrollingAccelerationCurve;
+#endif
 }
 
 #if HAVE(CVDISPLAYLINK)
@@ -3121,12 +3183,6 @@ void WebPageProxy::updateWheelEventActivityAfterProcessSwap()
 #if HAVE(CVDISPLAYLINK)
     updateDisplayLinkFrequency();
 #endif
-}
-
-void WebPageProxy::wheelEventWasNotHandled(const NativeWebWheelEvent& event)
-{
-    m_uiClient->didNotHandleWheelEvent(this, event);
-    pageClient().wheelEventWasNotHandledByWebCore(event);
 }
 
 WebWheelEventCoalescer& WebPageProxy::wheelEventCoalescer()
@@ -7906,16 +7962,7 @@ void WebPageProxy::didReceiveEvent(WebEventType eventType, bool handled)
 
     case WebEventType::Wheel: {
         MESSAGE_CHECK(m_process, wheelEventCoalescer().hasEventsBeingProcessed());
-        auto oldestProcessedEvent = wheelEventCoalescer().takeOldestEventBeingProcessed();
-
-        // FIXME: Dispatch additional events to the didNotHandleWheelEvent client function.
-        if (!handled)
-            wheelEventWasNotHandled(oldestProcessedEvent);
-
-        if (auto eventToSend = wheelEventCoalescer().nextEventToDispatch())
-            sendWheelEvent(eventToSend->event, eventToSend->processingSteps, rubberBandableEdgesRespectingHistorySwipe());
-        else if (auto* automationSession = process().processPool().automationSession())
-            automationSession->wheelEventsFlushedForPage(*this);
+        wheelEventHandlingCompleted(handled);
         break;
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1090,8 +1090,8 @@ public:
     void flushPendingMouseEventCallbacks();
 
     bool isProcessingWheelEvents() const;
-    void handleWheelEvent(const NativeWebWheelEvent&);
-    void continueWheelEventHandling(const NativeWebWheelEvent&, const WebCore::WheelEventHandlingResult&);
+    void handleNativeWheelEvent(const NativeWebWheelEvent&);
+    void continueWheelEventHandling(const WebWheelEvent&, const WebCore::WheelEventHandlingResult&);
 
     bool isProcessingKeyboardEvents() const;
     bool handleKeyboardEvent(const NativeWebKeyboardEvent&);
@@ -2628,8 +2628,13 @@ private:
 
     void setRenderTreeSize(uint64_t treeSize) { m_renderTreeSize = treeSize; }
 
+    void handleWheelEvent(const WebWheelEvent&);
     void sendWheelEvent(const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, WebCore::RectEdges<bool> rubberBandableEdges);
-    void wheelEventWasNotHandled(const NativeWebWheelEvent&);
+
+    void wheelEventHandlingCompleted(bool wasHandled);
+
+    void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&);
+    void sendWheelEventScrollingAccelerationCurveIfNecessary(const WebWheelEvent&);
 
     WebWheelEventCoalescer& wheelEventCoalescer();
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4561,7 +4561,7 @@ void WebViewImpl::scrollWheel(NSEvent *event)
         return;
 
     NativeWebWheelEvent webEvent = NativeWebWheelEvent(event, m_view.getAutoreleased());
-    m_page->handleWheelEvent(webEvent);
+    m_page->handleNativeWheelEvent(webEvent);
 }
 
 void WebViewImpl::swipeWithEvent(NSEvent *event)

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -379,7 +379,7 @@ LRESULT WebView::onWheelEvent(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
         return 0;
     }
 
-    m_page->handleWheelEvent(wheelEvent);
+    m_page->handleNativeWheelEvent(wheelEvent);
 
     handled = true;
     return 0;


### PR DESCRIPTION
#### 43c540f60166ca42ad00b9d538c232a02b3ec3ce
<pre>
[UI-side compositing] Send events to the WebWheelEventCoalescer before sending them to the scrolling thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=254247">https://bugs.webkit.org/show_bug.cgi?id=254247</a>
rdar://107032016

Reviewed by Tim Horton.

With UI-side compositing, we first try to handle a wheel event in the scrolling thread in the UI
process, and may then send it to the web process. A future patch will add some post-web-process
handling, so we have to avoid starting to handle the next wheel event in the meantime.

WebWheelEventCoalescer already takes case of this, so call `wheelEventCoalescer().shouldDispatchEvent()`
before we dispatch any wheel event to the scrolling coordinator in the UI process.

This has a few ramifications. If WebWheelEventCoalescer coalesces events, it can only spit out
WebWheelEvents (no corresponding NSEvent), rather than NativeWebWheelEvents. So we have to call
cacheWheelEventScrollingAccelerationCurve() for the UI-side MomentumEventDispatcher before doing
anything else, but the rest of the event handling chain can deal in WebWheelEvents.

This also means that WebWheelEventCoalescer coalesces before we know about processing steps, so
it no longer have to deal with {event, processing steps} pairs, and we can revert to the simpler
implementation that only tracks events.

Finally, when the UI-side scrolling thread finishes its event handling (and no further processing
is needed), we need to take an event from WebWheelEventCoalescer&apos;s queue via takeOldestEventBeingProcessed(),
and see if there is another event in the queue to start processing; this code is now shared
with the code that runs when the web processes finishes its wheel event handling, via WebPageProxy::wheelEventHandlingCompleted().

Make one test slightly more robust by defeating coalescing.

* LayoutTests/tiled-drawing/scrolling/fast-scroll-div-latched-mainframe-with-handler.html:
* Source/WebKit/Shared/WebWheelEventCoalescer.cpp:
(WebKit::operator&lt;&lt;):
(WebKit::WebWheelEventCoalescer::canCoalesce):
(WebKit::WebWheelEventCoalescer::coalesce):
(WebKit::WebWheelEventCoalescer::nextEventToDispatch):
(WebKit::WebWheelEventCoalescer::shouldDispatchEvent):
(WebKit::WebWheelEventCoalescer::takeOldestEventBeingProcessed):
* Source/WebKit/Shared/WebWheelEventCoalescer.h:
(WebKit::WebWheelEventAndSteps::WebWheelEventAndSteps): Deleted.
* Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp:
(WKPageHandleWheelEvent):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseScrollEvent):
(handleScroll):
(webkitWebViewBaseSynthesizeWheelEvent):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::doneWithTouchEvent):
* Source/WebKit/UIProcess/API/wpe/WPEView.cpp:
(WKWPE::m_backend):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::handleWheelEvent):
(WebKit::RemoteScrollingCoordinatorProxy::continueWheelEventHandling):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::cacheWheelEventScrollingAccelerationCurve):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::cacheWheelEventScrollingAccelerationCurve):
(WebKit::RemoteLayerTreeEventDispatcher::willHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::handleWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::cacheWheelEventScrollingAccelerationCurve):
(WebKit::RemoteScrollingCoordinatorProxyMac::handleWheelEvent):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleNativeWheelEvent): New function which is the entry point to wheel event handling,
taking a NativeWebWheelEvent.
(WebKit::WebPageProxy::handleWheelEvent): Takes a WebWheelEvent; called by both handleNativeWheelEvent, and via wheelEventHandlingCompleted().
(WebKit::WebPageProxy::continueWheelEventHandling):
(WebKit::WebPageProxy::sendWheelEvent):
(WebKit::WebPageProxy::wheelEventHandlingCompleted):
(WebKit::WebPageProxy::cacheWheelEventScrollingAccelerationCurve):
(WebKit::WebPageProxy::sendWheelEventScrollingAccelerationCurveIfNecessary):
(WebKit::WebPageProxy::didReceiveEvent):
(WebKit::WebPageProxy::wheelEventWasNotHandled): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::scrollWheel):
* Source/WebKit/UIProcess/win/WebView.cpp:
(WebKit::WebView::onWheelEvent):

Canonical link: <a href="https://commits.webkit.org/262015@main">https://commits.webkit.org/262015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7db79c3bf0d91807e2fc3a9ed78a7779c6199dc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/257 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/258 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/236 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/263 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/496 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/282 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/325 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/220 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/258 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/244 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/207 "Exiting early after 60 failures. 55012 tests run. 1 flakes 60 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/252 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/68 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/248 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->