### PR TITLE
Re-enable new Set methods following confirmation of intersection algorithm

### DIFF
--- a/JSTests/stress/set-prototype-intersection.js
+++ b/JSTests/stress/set-prototype-intersection.js
@@ -26,6 +26,8 @@ assertArrayContent(Array.from(set1.intersection(set3)), [1]);
 assertArrayContent(Array.from(set2.intersection(set3)), [1]);
 assertArrayContent(Array.from(set2.intersection(set4)), [2, 1]);
 assertArrayContent(Array.from(set3.intersection(set4)), [3, 1]);
+assertArrayContent(Array.from(set4.intersection(set2)), [2, 1]);
+assertArrayContent(Array.from(set4.intersection(set3)), [3, 1]);
 assertArrayContent(Array.from(set5.intersection(set3)), [3, 1]);
 assertArrayContent(Array.from(set5.intersection(map1)), [obj1]);
 

--- a/LayoutTests/js/Object-getOwnPropertyNames-expected.txt
+++ b/LayoutTests/js/Object-getOwnPropertyNames-expected.txt
@@ -67,7 +67,7 @@ PASS getSortedOwnPropertyNames(Symbol.prototype) is ['constructor', 'description
 PASS getSortedOwnPropertyNames(Map) is ['length', 'name', 'prototype']
 PASS getSortedOwnPropertyNames(Map.prototype) is ['clear', 'constructor', 'delete', 'entries', 'forEach', 'get', 'has', 'keys', 'set', 'size', 'values']
 PASS getSortedOwnPropertyNames(Set) is ['length', 'name', 'prototype']
-PASS getSortedOwnPropertyNames(Set.prototype) is ['add', 'clear', 'constructor', 'delete', 'entries', 'forEach', 'has', 'keys', 'size', 'values']
+PASS getSortedOwnPropertyNames(Set.prototype) is ['add', 'clear', 'constructor', 'delete', 'difference', 'entries', 'forEach', 'has', 'intersection', 'isDisjointFrom', 'isSubsetOf', 'isSupersetOf', 'keys', 'size', 'symmetricDifference', 'union', 'values']
 PASS getSortedOwnPropertyNames(WeakMap) is ['length', 'name', 'prototype']
 PASS getSortedOwnPropertyNames(WeakMap.prototype) is ['constructor', 'delete', 'get', 'has', 'set']
 PASS getSortedOwnPropertyNames(WeakSet) is ['length', 'name', 'prototype']

--- a/LayoutTests/js/script-tests/Object-getOwnPropertyNames.js
+++ b/LayoutTests/js/script-tests/Object-getOwnPropertyNames.js
@@ -76,7 +76,7 @@ var expectedPropertyNamesSet = {
     "Map": "['length', 'name', 'prototype']",
     "Map.prototype": "['clear', 'constructor', 'delete', 'entries', 'forEach', 'get', 'has', 'keys', 'set', 'size', 'values']",
     "Set": "['length', 'name', 'prototype']",
-    "Set.prototype": "['add', 'clear', 'constructor', 'delete', 'entries', 'forEach', 'has', 'keys', 'size', 'values']",
+    "Set.prototype": "['add', 'clear', 'constructor', 'delete', 'difference', 'entries', 'forEach', 'has', 'intersection', 'isDisjointFrom', 'isSubsetOf', 'isSupersetOf', 'keys', 'size', 'symmetricDifference', 'union', 'values']",
     "WeakMap": "['length', 'name', 'prototype']",
     "WeakMap.prototype": "['constructor', 'delete', 'get', 'has', 'set']",
     "WeakSet": "['length', 'name', 'prototype']",

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -116,8 +116,6 @@ function intersection(other)
                 result.@add(key);
         } while (true);
     } else {
-        // FIXME: This path needs to have the iteration order of the receiver but we don't have a good way to compare in constant time the relative ordering of two keys.
-        // https://bugs.webkit.org/show_bug.cgi?id=251869
         var iterator = keys.@call(other, keys);
         var wrapper = {
             @@iterator: function () { return iterator; }

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -560,9 +560,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useArrayFromAsync, true, Normal, "Expose the Array.fromAsync.") \
     v(Bool, useArrayGroupMethod, true, Normal, "Expose the group() and groupToMap() methods on Array.") \
     v(Bool, useAtomicsWaitAsync, true, Normal, "Expose the waitAsync() methods on Atomics.") \
-    /* FIXME: Set.prototype.intersection's iterate the other object path needs to have the iteration order of the receiver but we don't have a good way to compare in constant time the relative ordering of two keys. */ \
-    /* https://bugs.webkit.org/show_bug.cgi?id=251869 */ \
-    v(Bool, useSetMethods, false, Normal, "Expose the various Set.prototype methods for handling combinations of sets") \
+    v(Bool, useSetMethods, true, Normal, "Expose the various Set.prototype methods for handling combinations of sets") \
     v(Bool, useImportAssertion, false, Normal, "Enable import assertion.") \
     v(Bool, useIntlDurationFormat, true, Normal, "Expose the Intl DurationFormat.") \
     v(Bool, useResizableArrayBuffer, true, Normal, "Expose ResizableArrayBuffer feature.") \


### PR DESCRIPTION
#### 29a10740cf9d9d7653a729b9767480a3146cabcf
<pre>
Re-enable new Set methods following confirmation of intersection algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=254249">https://bugs.webkit.org/show_bug.cgi?id=254249</a>

Reviewed by Yusuke Suzuki.

The TC39 Set Methods proposal had been blocked pending a final decision on the algorithm for Set.prototype.intersection,
but it was decided in today&apos;s plenary to simply not sort the output in the case where we iterate over the parameter set.

This is our existing behavior, so <a href="https://webkit.org/b/251869">https://webkit.org/b/251869</a> becomes unnecessary and we can just go with what we have.

* JSTests/stress/set-prototype-intersection.js:
Add a couple of tests to demonstrate commutativity.

* LayoutTests/js/Object-getOwnPropertyNames-expected.txt:
* LayoutTests/js/script-tests/Object-getOwnPropertyNames.js:
Update expectations.

* Source/JavaScriptCore/builtins/SetPrototype.js:
* Source/JavaScriptCore/runtime/OptionsList.h:
Remove FIXMEs and flip runtime option.

Canonical link: <a href="https://commits.webkit.org/261946@main">https://commits.webkit.org/261946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5eefbaae020d8c9b79959919ffb31641cc48bbfa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/70 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/71 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/55 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/64 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/63 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/55 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/52 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/66 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/57 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/58 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/52 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/63 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/67 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/58 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/52 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/72 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/49 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/62 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/71 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/12 "Passed tests") | 
<!--EWS-Status-Bubble-End-->