### PR TITLE
web manifest: implement background_color member parsing

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -62,6 +62,7 @@ struct ApplicationManifest {
     Display display;
     URL startURL;
     URL id;
+    Color backgroundColor;
     Color themeColor;
     Vector<Icon> icons;
 };

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -78,6 +78,7 @@ ApplicationManifest ApplicationManifestParser::parseManifest(const String& text,
     parsedManifest.description = parseDescription(*manifest);
     parsedManifest.shortName = parseShortName(*manifest);
     parsedManifest.scope = parseScope(*manifest, documentURL, parsedManifest.startURL);
+    parsedManifest.backgroundColor = parseColor(*manifest, "background_color"_s);
     parsedManifest.themeColor = parseColor(*manifest, "theme_color"_s);
     parsedManifest.icons = parseIcons(*manifest);
     parsedManifest.id = parseId(*manifest, parsedManifest.startURL);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -799,6 +799,7 @@ struct WebCore::ApplicationManifest {
     WebCore::ApplicationManifest::Display display
     URL startURL
     URL id
+    WebCore::Color backgroundColor
     WebCore::Color themeColor
     Vector<WebCore::ApplicationManifest::Icon> icons
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
@@ -61,6 +61,12 @@ WK_CLASS_AVAILABLE(macos(10.13.4), ios(11.3))
 @property (nonatomic, readonly, copy) NSArray<_WKApplicationManifestIcon *> *icons WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 #if TARGET_OS_IPHONE
+@property (nonatomic, readonly, nullable, copy) UIColor *backgroundColor WK_API_AVAILABLE(ios(WK_IOS_TBA));
+#else
+@property (nonatomic, readonly, nullable, copy) NSColor *backgroundColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
+#endif
+
+#if TARGET_OS_IPHONE
 @property (nonatomic, readonly, nullable, copy) UIColor *themeColor WK_API_AVAILABLE(ios(15.0));
 #else
 @property (nonatomic, readonly, nullable, copy) NSColor *themeColor WK_API_AVAILABLE(macos(12.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -156,6 +156,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
     NSInteger display = [aDecoder decodeIntegerForKey:@"display"];
     URL startURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"start_url"];
     URL manifestId = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"manifestId"];
+    WebCore::CocoaColor *backgroundColor = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"background_color"];
     WebCore::CocoaColor *themeColor = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"theme_color"];
     NSArray<_WKApplicationManifestIcon *> *icons = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [_WKApplicationManifestIcon class]]] forKey:@"icons"];
 
@@ -167,6 +168,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
         static_cast<WebCore::ApplicationManifest::Display>(display),
         WTFMove(startURL),
         WTFMove(manifestId),
+        WebCore::roundAndClampToSRGBALossy(backgroundColor.CGColor),
         WebCore::roundAndClampToSRGBALossy(themeColor.CGColor),
         makeVector<WebCore::ApplicationManifest::Icon>(icons),
     };
@@ -195,6 +197,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
     [aCoder encodeInteger:static_cast<NSInteger>(_applicationManifest->applicationManifest().display) forKey:@"display"];
     [aCoder encodeObject:self.startURL forKey:@"start_url"];
     [aCoder encodeObject:self.manifestId forKey:@"manifestId"];
+    [aCoder encodeObject:self.backgroundColor forKey:@"background_color"];
     [aCoder encodeObject:self.themeColor forKey:@"theme_color"];
     [aCoder encodeObject:self.icons forKey:@"icons"];
 }
@@ -238,6 +241,11 @@ static NSString *nullableNSString(const WTF::String& string)
 - (NSURL *)startURL
 {
     return _applicationManifest->applicationManifest().startURL;
+}
+
+- (WebCore::CocoaColor *)backgroundColor
+{
+    return cocoaColor(_applicationManifest->applicationManifest().backgroundColor).autorelease();
 }
 
 - (WebCore::CocoaColor *)themeColor
@@ -316,6 +324,11 @@ static NSString *nullableNSString(const WTF::String& string)
 }
 
 - (NSURL *)startURL
+{
+    return nil;
+}
+
+- (WebCore::CocoaColor *)backgroundColor
 {
     return nil;
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
@@ -140,6 +140,13 @@ public:
         testScope(rawJSON, String(), expectedValue);
     }
 
+    void testBackgroundColor(const String& rawJSON, const Color& expectedValue)
+    {
+        auto manifest = parseTopLevelProperty("background_color"_s, rawJSON);
+        auto value = manifest.backgroundColor;
+        EXPECT_EQ(expectedValue, value);
+    }
+
     void testThemeColor(const String& rawJSON, const Color& expectedValue)
     {
         auto manifest = parseTopLevelProperty("theme_color"_s, rawJSON);
@@ -384,6 +391,26 @@ TEST_F(ApplicationManifestParserTest, Scope)
 
     // It's fine if the document URL or manifest URL aren't within the application scope - only the start URL needs to be.
     testScope("\"https://example.com/other\""_s, "https://example.com/other/start-url"_s, "https://example.com/other"_s);
+}
+
+TEST_F(ApplicationManifestParserTest, BackgroundColor)
+{
+    testBackgroundColor("123"_s, Color());
+    testBackgroundColor("null"_s, Color());
+    testBackgroundColor("true"_s, Color());
+    testBackgroundColor("{ }"_s, Color());
+    testBackgroundColor("[ ]"_s, Color());
+    testBackgroundColor("\"\""_s, Color());
+    testBackgroundColor("\"garbage string\""_s, Color());
+
+    testBackgroundColor("\"red\""_s, Color::red);
+    testBackgroundColor("\"#f00\""_s, Color::red);
+    testBackgroundColor("\"#ff0000\""_s, Color::red);
+    testBackgroundColor("\"#ff0000ff\""_s, Color::red);
+    testBackgroundColor("\"rgb(255, 0, 0)\""_s, Color::red);
+    testBackgroundColor("\"rgba(255, 0, 0, 1)\""_s, Color::red);
+    testBackgroundColor("\"hsl(0, 100%, 50%)\""_s, Color::red);
+    testBackgroundColor("\"hsla(0, 100%, 50%, 1)\""_s, Color::red);
 }
 
 TEST_F(ApplicationManifestParserTest, ThemeColor)


### PR DESCRIPTION
#### c86b7e17dd8d3a2365a22dd5be9c39072fa280f4
<pre>
web manifest: implement background_color member parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=254253">https://bugs.webkit.org/show_bug.cgi?id=254253</a>
rdar://107035193

Reviewed by Chris Dumez.

Implements the background_color member in compliance with the manifest spec.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseManifest):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithCoder:]):
(-[_WKApplicationManifest encodeWithCoder:]):
(-[_WKApplicationManifest backgroundColor]):
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(ApplicationManifestParserTest::testBackgroundColor):
(TEST_F):

Canonical link: <a href="https://commits.webkit.org/262195@main">https://commits.webkit.org/262195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86a26a2afef0e58277268e3b8eac5fe7d9a39e9a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/390 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/359 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/596 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/418 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/364 "7 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/423 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/341 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/380 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/357 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/375 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/202 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/372 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->