### PR TITLE
Adjust interaction regions to match updated spec.

### DIFF
--- a/LayoutTests/interaction-region/aria-roles-expected.txt
+++ b/LayoutTests/interaction-region/aria-roles-expected.txt
@@ -19,23 +19,23 @@ Menu option 3
         (interaction
             (rect (0,0) width=800 height=20)
 )
-        (borderRadius 0.00),
+        (borderRadius 8.00),
         (interaction
             (rect (0,20) width=800 height=20)
 )
-        (borderRadius 0.00),
+        (borderRadius 8.00),
         (interaction
             (rect (40,56) width=760 height=20)
 )
-        (borderRadius 0.00),
+        (borderRadius 8.00),
         (interaction
             (rect (40,76) width=760 height=20)
 )
-        (borderRadius 0.00),
+        (borderRadius 8.00),
         (interaction
             (rect (40,96) width=760 height=20)
 )
-        (borderRadius 0.00)])
+        (borderRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
+++ b/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
@@ -31,7 +31,7 @@ Nested  Nested  Nested Secondary
         (interaction
             (rect (293,20) width=69 height=20)
 )
-        (borderRadius 5.00)])
+        (borderRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
@@ -13,9 +13,9 @@ This is a link.
 
       (interaction regions [
         (interaction
-            (rect (-3,-3) width=35 height=25)
+            (rect (-4,-4) width=37 height=27)
 )
-        (borderRadius 0.00)])
+        (borderRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-expected.txt
@@ -13,9 +13,9 @@ This is a link.
 
       (interaction regions [
         (interaction
-            (rect (-3,-3) width=35 height=25)
+            (rect (-4,-4) width=37 height=27)
 )
-        (borderRadius 0.00)])
+        (borderRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
@@ -14,9 +14,9 @@ This is a link, outside the frame.
 
       (interaction regions [
         (interaction
-            (rect (-3,-3) width=35 height=25)
+            (rect (-4,-4) width=37 height=27)
 )
-        (borderRadius 0.00)])
+        (borderRadius 8.00)])
       )
       (children 1
         (GraphicsLayer
@@ -28,9 +28,9 @@ This is a link, outside the frame.
 
           (interaction regions [
             (interaction
-                (rect (7,7) width=35 height=25)
+                (rect (6,6) width=37 height=27)
 )
-            (borderRadius 0.00)])
+            (borderRadius 8.00)])
           )
         )
       )

--- a/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
@@ -14,9 +14,9 @@ This is a link, inside the layer.
 
       (interaction regions [
         (interaction
-            (rect (-3,-3) width=35 height=25)
+            (rect (-4,-4) width=37 height=27)
 )
-        (borderRadius 0.00)])
+        (borderRadius 8.00)])
       )
       (children 1
         (GraphicsLayer
@@ -28,9 +28,9 @@ This is a link, inside the layer.
 
           (interaction regions [
             (interaction
-                (rect (-3,-3) width=35 height=25)
+                (rect (-4,-4) width=37 height=27)
 )
-            (borderRadius 0.00)])
+            (borderRadius 8.00)])
           )
         )
       )

--- a/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
@@ -14,13 +14,13 @@ This is a link, outside the frame.
 
       (interaction regions [
         (interaction
-            (rect (-3,-3) width=35 height=25)
+            (rect (-4,-4) width=37 height=27)
 )
-        (borderRadius 0.00),
+        (borderRadius 8.00),
         (interaction
-            (rect (7,27) width=35 height=25)
+            (rect (6,26) width=37 height=27)
 )
-        (borderRadius 0.00)])
+        (borderRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt
@@ -13,9 +13,9 @@ Link Child Disabled Link
 
       (interaction regions [
         (interaction
-            (rect (-3,-3) width=76 height=25)
+            (rect (-4,-4) width=78 height=27)
 )
-        (borderRadius 0.00)])
+        (borderRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -69,6 +69,7 @@
                                       (type interaction)
                                       (layer bounds [x: 0 y: 0 width: 284 height: 192])
                                       (layer position [x: 152 y: 152])
+                                      (layer cornerRadius 8)
                                       (sublayers
                                         (
                                           (layer bounds [x: 0 y: 0 width: 284 height: 192])
@@ -78,6 +79,7 @@
                                       (type interaction)
                                       (layer bounds [x: 0 y: 0 width: 59 height: 20])
                                       (layer position [x: 29.5 y: 29.5])
+                                      (layer cornerRadius 9)
                                       (sublayers
                                         (
                                           (layer bounds [x: 0 y: 0 width: 59 height: 20])
@@ -100,12 +102,13 @@
                                           (sublayers
                                             (
                                               (type interaction)
-                                              (layer bounds [x: 0 y: 0 width: 74 height: 25])
+                                              (layer bounds [x: 0 y: 0 width: 76 height: 27])
                                               (layer position [x: 34 y: 34])
+                                              (layer cornerRadius 8)
                                               (sublayers
                                                 (
-                                                  (layer bounds [x: 0 y: 0 width: 74 height: 25])
-                                                  (layer position [x: 37 y: 37])
+                                                  (layer bounds [x: 0 y: 0 width: 76 height: 27])
+                                                  (layer position [x: 38 y: 38])
                                                   (layer opacity 0))))))
                                         (
                                           (layer bounds [x: 0 y: 0 width: 800 height: 600])
@@ -118,12 +121,13 @@
                                               (layer position [x: 400 y: 400]))
                                             (
                                               (type interaction)
-                                              (layer bounds [x: 0 y: 0 width: 31 height: 25])
+                                              (layer bounds [x: 0 y: 0 width: 33 height: 27])
                                               (layer position [x: 12.5 y: 12.5])
+                                              (layer cornerRadius 8)
                                               (sublayers
                                                 (
-                                                  (layer bounds [x: 0 y: 0 width: 31 height: 25])
-                                                  (layer position [x: 15.5 y: 15.5])
+                                                  (layer bounds [x: 0 y: 0 width: 33 height: 27])
+                                                  (layer position [x: 16.5 y: 16.5])
                                                   (layer opacity 0))))
                                             (
                                               (layer bounds [x: 0 y: 0 width: 800 height: 20])
@@ -145,7 +149,8 @@
               (sublayers
                 (
                   (layer bounds [x: 0 y: 0 width: 794 height: 6])
-                  (layer position [x: 397 y: 397]))))
+                  (layer position [x: 397 y: 397])
+                  (layer cornerRadius 3.5))))
             (
               (layer bounds [x: 0 y: 0 width: 794 height: 6])
               (layer position [x: 397 y: 397])
@@ -162,7 +167,8 @@
               (sublayers
                 (
                   (layer bounds [x: 0 y: 0 width: 6 height: 594])
-                  (layer position [x: 3 y: 3]))))
+                  (layer position [x: 3 y: 3])
+                  (layer cornerRadius 3.5))))
             (
               (layer bounds [x: 0 y: 0 width: 6 height: 594])
               (layer position [x: 3 y: 3])

--- a/LayoutTests/interaction-region/overlap-expected.txt
+++ b/LayoutTests/interaction-region/overlap-expected.txt
@@ -18,7 +18,7 @@
         (interaction
             (rect (0,0) width=200 height=100)
 )
-        (borderRadius 0.00)])
+        (borderRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/split-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/split-inline-link-expected.txt
@@ -14,13 +14,13 @@ short second line.
 
       (interaction regions [
         (interaction
-            (rect (198,-3) width=31 height=25)
+            (rect (197,-4) width=33 height=27)
 )
-        (borderRadius 0.00),
+        (borderRadius 8.00),
         (interaction
-            (rect (-3,17) width=115 height=25)
+            (rect (-4,16) width=117 height=27)
 )
-        (borderRadius 0.00)])
+        (borderRadius 8.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
@@ -16,21 +16,21 @@ Line
 
       (interaction regions [
         (interaction
-            (rect (-3,-3) width=36 height=25)
+            (rect (-4,-4) width=38 height=27)
 )
-        (borderRadius 0.00),
+        (borderRadius 8.00),
         (interaction
-            (rect (-3,17) width=36 height=25)
+            (rect (-4,16) width=38 height=27)
 )
-        (borderRadius 0.00),
+        (borderRadius 8.00),
         (interaction
-            (rect (-3,37) width=36 height=25)
+            (rect (-4,36) width=38 height=27)
 )
-        (borderRadius 0.00),
+        (borderRadius 8.00),
         (interaction
-            (rect (-3,57) width=36 height=25)
+            (rect (-4,56) width=38 height=27)
 )
-        (borderRadius 0.00)])
+        (borderRadius 8.00)])
       )
     )
   )

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3175,22 +3175,22 @@ InteractionRegionInlinePadding:
   status: embedder
   defaultValue:
     WebKitLegacy:
-      default: 3
+      default: 4
     WebKit:
-      default: 3
+      default: 4
     WebCore:
-      default: 3
+      default: 4
 
 InteractionRegionMinimumCornerRadius:
   type: double
   status: embedder
   defaultValue:
     WebKitLegacy:
-      default: 4
+      default: 8
     WebKit:
-      default: 4
+      default: 8
     WebCore:
-      default: 4
+      default: 8
 
 InteractionRegionsEnabled:
   type: bool

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -220,6 +220,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
             bounds.expand(IntSize(borderBoxRect.size() - contentBoxRect.size()));
         }
     }
+    borderRadius = std::max<float>(borderRadius, regionRenderer.document().settings().interactionRegionMinimumCornerRadius());
 
     Region boundsRegion;
     boundsRegion.unite(bounds);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -117,6 +117,9 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     if (layer.opacity != 1.0)
         ts.dumpProperty("layer opacity", makeString(layer.opacity));
 
+    if (layer.cornerRadius != 0.0)
+        ts.dumpProperty("layer cornerRadius", makeString(layer.cornerRadius));
+    
     if (traverse && layer.sublayers.count > 0) {
         TextStream::GroupScope scope(ts);
         ts << "sublayers";

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -120,7 +120,6 @@ void updateLayersForInteractionRegions(CALayer *layer, RemoteLayerTreeHost& host
     }
 
     bool applyBackgroundColorForDebugging = [[NSUserDefaults standardUserDefaults] boolForKey:@"WKInteractionRegionDebugFill"];
-    float minimumBorderRadius = host.drawingArea().page().preferences().interactionRegionMinimumCornerRadius();
 
     NSUInteger insertionPoint = 0;
     for (const WebCore::InteractionRegion& region : properties.eventRegion.interactionRegions()) {
@@ -171,7 +170,7 @@ void updateLayersForInteractionRegions(CALayer *layer, RemoteLayerTreeHost& host
             }
 
             configureLayerForInteractionRegion(interactionLayer.get(), makeString("WKInteractionRegion-"_s, region.elementIdentifier.toUInt64()));
-            [interactionLayer setCornerRadius:std::max(region.borderRadius, minimumBorderRadius)];
+            [interactionLayer setCornerRadius:region.borderRadius];
             [layer insertSublayer:interactionLayer.get() atIndex: insertionPoint];
             insertionPoint++;
         }


### PR DESCRIPTION
#### e260c5317c072812673aa479f00fca3b76004a0a
<pre>
Adjust interaction regions to match updated spec.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254254">https://bugs.webkit.org/show_bug.cgi?id=254254</a>
rdar://106317786

Reviewed by Tim Horton.

* LayoutTests/interaction-region/aria-roles-expected.txt:
* LayoutTests/interaction-region/consolidated-nested-regions-expected.txt:
* LayoutTests/interaction-region/inline-link-dark-background-expected.txt:
* LayoutTests/interaction-region/inline-link-expected.txt:
* LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt:
* LayoutTests/interaction-region/inline-link-in-layer-expected.txt:
* LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt:
* LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt:
* LayoutTests/interaction-region/layer-tree-expected.txt:
* LayoutTests/interaction-region/overlap-expected.txt:
* LayoutTests/interaction-region/split-inline-link-expected.txt:
* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(dumpCALayer):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):

Canonical link: <a href="https://commits.webkit.org/262030@main">https://commits.webkit.org/262030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46185d939f172b0a8585022da6402a295d15c97b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/341 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/322 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/383 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/344 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/369 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/312 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/300 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/341 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/350 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/323 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/357 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/336 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/76 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/327 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/355 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/44 "Passed tests") | 
<!--EWS-Status-Bubble-End-->