### PR TITLE
Non-unified build fixes, late March 2023 edition

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaDeviceInfo.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDeviceInfo.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include <wtf/IsoMallocInlines.h>
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(MediaDeviceInfo);

--- a/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SpeechRecognitionErrorEvent.h"
 
+#include "ScriptExecutionContext.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(SPEECH_SYNTHESIS)
 
+#include "ScriptExecutionContext.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEvent.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(SPEECH_SYNTHESIS)
 
+#include "ScriptExecutionContext.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.h
@@ -26,8 +26,11 @@
 #pragma once
 
 #include "StylePropertyMap.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
+
+class WeakPtrImplWithEventTargetData;
 
 class InlineStylePropertyMap final : public StylePropertyMap {
 public:

--- a/Source/WebCore/dom/DecodedDataDocumentParser.cpp
+++ b/Source/WebCore/dom/DecodedDataDocumentParser.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DecodedDataDocumentParser.h"
 
+#include "Document.h"
 #include "DocumentWriter.h"
 #include "SegmentedString.h"
 #include "TextResourceDecoder.h"

--- a/Source/WebCore/dom/DocumentSharedObjectPool.h
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <memory>
-#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/StringHash.h>
 

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.cpp
@@ -30,6 +30,7 @@
 
 #include "InbandTextTrackPrivate.h"
 #include "Logging.h"
+#include "ScriptExecutionContext.h"
 #include "VTTCue.h"
 #include "VTTRegionList.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -32,6 +32,7 @@
 #include "LayoutBox.h"
 #include "LayoutBoxGeometry.h"
 #include "LayoutState.h"
+#include "Shape.h"
 #include "TextUtil.h"
 #include <wtf/unicode/CharacterNames.h>
 

--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -36,6 +36,7 @@
 #include "LocalFrameView.h"
 #include "Page.h"
 #include "PaintInfo.h"
+#include "RenderLayer.h"
 #include "RenderView.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -44,6 +44,7 @@
 #include "WKString.h"
 #include "WKWebsiteDataStoreRef.h"
 #include "WebContextInjectedBundleClient.h"
+#include "WebFrameProxy.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
 #include <WebCore/GamepadProvider.h>

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -38,6 +38,7 @@
 #include "WebPageMessages.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcessMessages.h"
+#include "WebProcessProxy.h"
 
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/ShouldTreatAsContinuingLoad.h>

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -29,6 +29,7 @@
 #include "DrawingAreaProxy.h"
 #include "Logging.h"
 #include "WebBackForwardCache.h"
+#include "WebFrameProxy.h"
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
 #include "WebPageProxyMessages.h"

--- a/Source/WebKit/UIProcess/WebFormClient.cpp
+++ b/Source/WebKit/UIProcess/WebFormClient.cpp
@@ -30,6 +30,7 @@
 #include "APIString.h"
 #include "WKAPICast.h"
 #include "WebFormSubmissionListenerProxy.h"
+#include "WebFrameProxy.h"
 #include "WebPageProxy.h"
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -44,6 +44,7 @@
 #include "SpeechRecognitionRemoteRealtimeMediaSourceManager.h"
 #include "SpeechRecognitionRemoteRealtimeMediaSourceManagerMessages.h"
 #include "SpeechRecognitionServerMessages.h"
+#include "SuspendedPageProxy.h"
 #include "TextChecker.h"
 #include "TextCheckerState.h"
 #include "UserData.h"

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -29,6 +29,7 @@
 #include "APIUIClient.h"
 #include "WebFullScreenManagerProxy.h"
 #include "WebPageProxy.h"
+#include "WebProcessProxy.h"
 #include "WebScreenOrientationManagerMessages.h"
 #include "WebScreenOrientationManagerProxyMessages.h"
 #include <WebCore/Exception.h>


### PR DESCRIPTION
#### a4430db566242c984fab96196f4d5cbabff71c2d
<pre>
Non-unified build fixes, late March 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=254260">https://bugs.webkit.org/show_bug.cgi?id=254260</a>

Unreviewed non-unified build fixes.

* Source/WebCore/Modules/mediastream/MediaDeviceInfo.cpp: Add missing
  wtf/IsoMallocInlines.h header inclusion.
* Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.cpp: Add
  missing ScriptExecutionContext.h header inclusion.
* Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.cpp: Ditto.
* Source/WebCore/Modules/speech/SpeechSynthesisEvent.cpp: Ditto.
* Source/WebCore/css/typedom/InlineStylePropertyMap.h: Add missing
  wtf/WeakPtr.h header inclusion, and missing WeakPtrImplWithEventTargetData
  forward declaration.
* Source/WebCore/dom/DecodedDataDocumentParser.cpp: Add missing
  Document.h header inclusion.
* Source/WebCore/dom/DocumentSharedObjectPool.h: Replace unused
  wtf/HashMap.h header inclusion with the correct wtf/HashSet.h one.
* Source/WebCore/html/track/InbandWebVTTTextTrack.cpp: Add missing
  ScriptExecutionContext.h header inclusion.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
  Add missing Shape.h header inclusion.
* Source/WebCore/rendering/RenderHTMLCanvas.cpp: Add missing
  RenderLayer.h header inclusion.
* Source/WebKit/UIProcess/API/C/WKContext.cpp: Add missing
  WebFrameProxy.h header inclusion.
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp: Add missing
  WebProcessProxy.h header inclusion.
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp: Add missing
  WebFrameProxy.h header inclusion.
* Source/WebKit/UIProcess/WebFormClient.cpp: Ditto.
* Source/WebKit/UIProcess/WebProcessProxy.cpp: Add missing
  SuspendedPageProxy.h header inclusion.
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp: Add
  missing WebProcessProxy.h header inclusion.

Canonical link: <a href="https://commits.webkit.org/261953@main">https://commits.webkit.org/261953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7a5eb2e783f988e426f97fe414ff7f57b4c289e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/82 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/95 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/94 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/76 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/96 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/85 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/78 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/92 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/87 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/76 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/73 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/91 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->