### PR TITLE
[GLib] webkit_user_content_manager_register_script_message_handler() world_name parameter should be nullable

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in
@@ -123,7 +123,7 @@ webkit_user_content_manager_unregister_script_message_handler          (WebKitUs
  * webkit_user_content_manager_register_script_message_handler:
  * @manager: A #WebKitUserContentManager
  * @name: Name of the script message channel
- * @world_name (nullable): the name of a #WebKitScriptWorld
+ * @world_name: (nullable): the name of a #WebKitScriptWorld
  *
  * Registers a new user script message handler in script world.
  *


### PR DESCRIPTION
#### 48a7c504b3975421404178d4b69c6bd56c3118f0
<pre>
[GLib] webkit_user_content_manager_register_script_message_handler() world_name parameter should be nullable
<a href="https://bugs.webkit.org/show_bug.cgi?id=254264">https://bugs.webkit.org/show_bug.cgi?id=254264</a>

Reviewed by Carlos Garcia Campos.

* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in:

Canonical link: <a href="https://commits.webkit.org/261956@main">https://commits.webkit.org/261956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d22f276cfbd4a98d9c1968c2e8b27b8f659365b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/97 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/108 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/87 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/97 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/91 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/93 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/104 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/101 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/88 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/88 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/21 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/105 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->