### PR TITLE
[popover] Handle showPopover changing popover attribute during beforetoggle

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -25,7 +25,7 @@ PASS Removing a visible popover=auto element from the document should close the 
 PASS A showing popover=auto does not match :modal
 PASS Removing a visible popover=manual element from the document should close the popover
 PASS A showing popover=manual does not match :modal
-FAIL Changing the popover type in a "beforetoggle" event handler should throw an exception (during showPopover()) assert_throws_dom: function "() => popover.showPopover()" did not throw
+PASS Changing the popover type in a "beforetoggle" event handler should throw an exception (during showPopover())
 PASS Changing the popover type in a "beforetoggle" event handler should throw an exception (during hidePopover())
 PASS Changing a popover from auto to auto (via attr), and then auto during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via attr), and then manual during 'beforetoggle' works

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -25,7 +25,7 @@ PASS Removing a visible popover=auto element from the document should close the 
 PASS A showing popover=auto does not match :modal
 PASS Removing a visible popover=manual element from the document should close the popover
 PASS A showing popover=manual does not match :modal
-FAIL Changing the popover type in a "beforetoggle" event handler should throw an exception (during showPopover()) assert_throws_dom: function "() => popover.showPopover()" did not throw
+PASS Changing the popover type in a "beforetoggle" event handler should throw an exception (during showPopover())
 PASS Changing the popover type in a "beforetoggle" event handler should throw an exception (during hidePopover())
 PASS Changing a popover from auto to auto (via attr), and then auto during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via attr), and then manual during 'beforetoggle' works

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1344,7 +1344,7 @@ ExceptionOr<void> HTMLElement::showPopover()
         document().hideAllPopoversUntil(ancestor.get(), FocusPreviousElement::No, FireEvents::Yes);
 
         if (popoverState() != originalState)
-            return { };
+            return Exception { InvalidStateError, "The value of the popover attribute was changed while hiding the popover."_s };
 
         if (auto check = checkPopoverValidity(*this, PopoverVisibilityState::Hidden); check.hasException())
             return check.releaseException();


### PR DESCRIPTION
#### 8cbe612512c81c0353fc4a0b9d9d9d28db7096c2
<pre>
[popover] Handle showPopover changing popover attribute during beforetoggle
<a href="https://bugs.webkit.org/show_bug.cgi?id=254268">https://bugs.webkit.org/show_bug.cgi?id=254268</a>

Reviewed by Tim Nguyen.

Handle showPopover changing popover attribute during beforetoggle by throwing an exception:
<a href="https://github.com/whatwg/html/pull/9058">https://github.com/whatwg/html/pull/9058</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::showPopover):

Canonical link: <a href="https://commits.webkit.org/262026@main">https://commits.webkit.org/262026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b74a9822e5b6a854d13b95d387342daf28ffbdce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/510 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/299 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/336 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/236 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/277 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/260 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/229 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/270 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/75 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/264 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->