### PR TITLE
REGRESSION(261912@main): [ macOS ] media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-top-right-controls-bar-hidden-when-mute-button-disabled.html is a constant text failure

### DIFF
--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-top-right-controls-bar-hidden-when-mute-button-disabled-expected.txt
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-top-right-controls-bar-hidden-when-mute-button-disabled-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Mute button is enabled
-PASS mediaControls.muteButton.parent.parent is mediaControls.topRightControlsBar
+PASS mediaControls.muteButton.parent.parent became mediaControls.topRightControlsBar
 PASS mediaControls.topRightControlsBar.parent is mediaControls
 
 Mute button is disabled

--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-top-right-controls-bar-hidden-when-mute-button-disabled.html
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-top-right-controls-bar-hidden-when-mute-button-disabled.html
@@ -4,21 +4,28 @@
 <body>
 <script type="text/javascript">
 
+window.jsTestIsAsync = true;
+
 description("Testing the top right controls bar isn't visible when the mute button is disabled.");
 
-const mediaControls = new MacOSInlineMediaControls({ width: 250, height: 250 });
+const mediaControls = new MacOSInlineMediaControls({ width: 300, height: 250 });
 
-debug("Mute button is enabled");
-shouldBe("mediaControls.muteButton.parent.parent", "mediaControls.topRightControlsBar");
-shouldBe("mediaControls.topRightControlsBar.parent", "mediaControls");
+(async function () {
+    debug("Mute button is enabled");
 
-debug("")
-debug("Mute button is disabled");
-mediaControls.muteButton.enabled = false;
-shouldBe("mediaControls.muteButton.parent.parent", "mediaControls.bottomControlsBar");
-shouldBeNull("mediaControls.topRightControlsBar.parent");
+    await new Promise(resolve => shouldBecomeEqual("mediaControls.muteButton.parent.parent", "mediaControls.topRightControlsBar", resolve));
+    shouldBe("mediaControls.topRightControlsBar.parent", "mediaControls");
 
-debug("");
+    debug("")
+    debug("Mute button is disabled");
+    mediaControls.muteButton.enabled = false;
+    shouldBe("mediaControls.muteButton.parent.parent", "mediaControls.bottomControlsBar");
+    shouldBeNull("mediaControls.topRightControlsBar.parent");
+
+    debug("");
+
+    finishJSTest();
+})();
 
 </script>
 <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2803,5 +2803,3 @@ webkit.org/b/254044 webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/webxr [ Skip ]
 webkit.org/b/254044 http/wpt/webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/feature-policy/reporting/xr-reporting.https.html [ Skip ]
-
-webkit.org/b/254254 media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-top-right-controls-bar-hidden-when-mute-button-disabled.html [ Failure ]


### PR DESCRIPTION
#### 934f8ed073f26981d56de40e1848240732b7500c
<pre>
REGRESSION(261912@main): [ macOS ] media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-top-right-controls-bar-hidden-when-mute-button-disabled.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=254245">https://bugs.webkit.org/show_bug.cgi?id=254245</a>
rdar://107028528

Reviewed by Dean Jackson.

This test regressed because it assumed the mute button would be located in the bottoms bar
with controls sized with a width of 250px. However, in 261912@main, we enforced correctly
removing the container to the right of the time control if there isn&apos;t enough room to show
the ellipsis button at all.

We fix this test by making the controls wider and also make it more robust by not making
assumption on timing of the first test condition being true and using shouldBecomeEqual()
instead, wrapper in a promise for code clarity.

* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-top-right-controls-bar-hidden-when-mute-button-disabled-expected.txt:
* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-top-right-controls-bar-hidden-when-mute-button-disabled.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/261991@main">https://commits.webkit.org/261991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47496c75bf0c0e4f2280aa643fe7d3bfd92be1b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/118 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/199 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/145 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/122 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112 "38 flakes 119 failures 1 missing results") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/128 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126 "12 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/101 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/126 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->