### PR TITLE
Speed up JSNodeList indexing

### DIFF
--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -419,6 +419,10 @@
                 "url": "https://webidl.spec.whatwg.org/#PutForwards"
             }
         },
+        "RaisesException": {
+            "contextsAllowed": ["operation"],
+            "notes": "Should only be used on indexed getters that have to throw an exception in some cases"
+        },
         "Reflect": {
             "contextsAllowed": ["attribute"],
             "values": ["*"]

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
@@ -163,8 +163,8 @@ bool JSTestEventTarget::getOwnPropertySlot(JSObject* object, JSGlobalObject* lex
     auto* thisObject = jsCast<JSTestEventTarget*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLInterface<Node>>(*lexicalGlobalObject, *thisObject->globalObject(), throwScope, thisObject->wrapped().item(index.value()));
+        if (auto item = thisObject->wrapped().item(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLInterface<Node>>(*lexicalGlobalObject, *thisObject->globalObject(), throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;
@@ -191,8 +191,8 @@ bool JSTestEventTarget::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObje
     auto* thisObject = jsCast<JSTestEventTarget*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLInterface<Node>>(*lexicalGlobalObject, *thisObject->globalObject(), throwScope, thisObject->wrapped().item(index));
+        if (auto item = thisObject->wrapped().item(index); LIKELY(!!item)) {
+            auto value = toJS<IDLInterface<Node>>(*lexicalGlobalObject, *thisObject->globalObject(), throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
@@ -161,8 +161,8 @@ bool JSTestIndexedSetterNoIdentifier::getOwnPropertySlot(JSObject* object, JSGlo
     auto* thisObject = jsCast<JSTestIndexedSetterNoIdentifier*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index.value()));
+        if (auto item = thisObject->wrapped().item(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -178,8 +178,8 @@ bool JSTestIndexedSetterNoIdentifier::getOwnPropertySlotByIndex(JSObject* object
     auto* thisObject = jsCast<JSTestIndexedSetterNoIdentifier*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index));
+        if (auto item = thisObject->wrapped().item(index); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
@@ -161,8 +161,8 @@ bool JSTestIndexedSetterThrowingException::getOwnPropertySlot(JSObject* object, 
     auto* thisObject = jsCast<JSTestIndexedSetterThrowingException*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index.value()));
+        if (auto item = thisObject->wrapped().item(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -178,8 +178,8 @@ bool JSTestIndexedSetterThrowingException::getOwnPropertySlotByIndex(JSObject* o
     auto* thisObject = jsCast<JSTestIndexedSetterThrowingException*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index));
+        if (auto item = thisObject->wrapped().item(index); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
@@ -170,8 +170,8 @@ bool JSTestIndexedSetterWithIdentifier::getOwnPropertySlot(JSObject* object, JSG
     auto* thisObject = jsCast<JSTestIndexedSetterWithIdentifier*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index.value()));
+        if (auto item = thisObject->wrapped().item(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -187,8 +187,8 @@ bool JSTestIndexedSetterWithIdentifier::getOwnPropertySlotByIndex(JSObject* obje
     auto* thisObject = jsCast<JSTestIndexedSetterWithIdentifier*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index));
+        if (auto item = thisObject->wrapped().item(index); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
@@ -162,8 +162,8 @@ bool JSTestNamedAndIndexedSetterNoIdentifier::getOwnPropertySlot(JSObject* objec
     auto* thisObject = jsCast<JSTestNamedAndIndexedSetterNoIdentifier*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index.value()));
+        if (auto item = thisObject->wrapped().item(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -190,8 +190,8 @@ bool JSTestNamedAndIndexedSetterNoIdentifier::getOwnPropertySlotByIndex(JSObject
     auto* thisObject = jsCast<JSTestNamedAndIndexedSetterNoIdentifier*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index));
+        if (auto item = thisObject->wrapped().item(index); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
@@ -162,8 +162,8 @@ bool JSTestNamedAndIndexedSetterThrowingException::getOwnPropertySlot(JSObject* 
     auto* thisObject = jsCast<JSTestNamedAndIndexedSetterThrowingException*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index.value()));
+        if (auto item = thisObject->wrapped().item(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -190,8 +190,8 @@ bool JSTestNamedAndIndexedSetterThrowingException::getOwnPropertySlotByIndex(JSO
     auto* thisObject = jsCast<JSTestNamedAndIndexedSetterThrowingException*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index));
+        if (auto item = thisObject->wrapped().item(index); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
@@ -173,8 +173,8 @@ bool JSTestNamedAndIndexedSetterWithIdentifier::getOwnPropertySlot(JSObject* obj
     auto* thisObject = jsCast<JSTestNamedAndIndexedSetterWithIdentifier*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index.value()));
+        if (auto item = thisObject->wrapped().item(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -201,8 +201,8 @@ bool JSTestNamedAndIndexedSetterWithIdentifier::getOwnPropertySlotByIndex(JSObje
     auto* thisObject = jsCast<JSTestNamedAndIndexedSetterWithIdentifier*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index));
+        if (auto item = thisObject->wrapped().item(index); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
@@ -162,8 +162,8 @@ bool JSTestNamedDeleterWithIndexedGetter::getOwnPropertySlot(JSObject* object, J
     auto* thisObject = jsCast<JSTestNamedDeleterWithIndexedGetter*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index.value()));
+        if (auto item = thisObject->wrapped().item(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;
@@ -190,8 +190,8 @@ bool JSTestNamedDeleterWithIndexedGetter::getOwnPropertySlotByIndex(JSObject* ob
     auto* thisObject = jsCast<JSTestNamedDeleterWithIndexedGetter*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().item(index));
+        if (auto item = thisObject->wrapped().item(index); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
@@ -173,8 +173,8 @@ bool JSTestNamedSetterWithIndexedGetter::getOwnPropertySlot(JSObject* object, JS
     auto* thisObject = jsCast<JSTestNamedSetterWithIndexedGetter*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().indexedSetter(index.value()));
+        if (auto item = thisObject->wrapped().indexedSetter(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;
@@ -201,8 +201,8 @@ bool JSTestNamedSetterWithIndexedGetter::getOwnPropertySlotByIndex(JSObject* obj
     auto* thisObject = jsCast<JSTestNamedSetterWithIndexedGetter*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().indexedSetter(index));
+        if (auto item = thisObject->wrapped().indexedSetter(index); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
@@ -173,8 +173,8 @@ bool JSTestNamedSetterWithIndexedGetterAndSetter::getOwnPropertySlot(JSObject* o
     auto* thisObject = jsCast<JSTestNamedSetterWithIndexedGetterAndSetter*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().indexedSetter(index.value()));
+        if (auto item = thisObject->wrapped().indexedSetter(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -201,8 +201,8 @@ bool JSTestNamedSetterWithIndexedGetterAndSetter::getOwnPropertySlotByIndex(JSOb
     auto* thisObject = jsCast<JSTestNamedSetterWithIndexedGetterAndSetter*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, thisObject->wrapped().indexedSetter(index));
+        if (auto item = thisObject->wrapped().indexedSetter(index); LIKELY(!!item)) {
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -2689,8 +2689,8 @@ bool JSTestObj::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexicalGlob
     auto* thisObject = jsCast<JSTestObj*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
-        if (index.value() < thisObject->wrapped().length()) {
-            auto value = toJS<IDLNullable<IDLDOMString>>(*lexicalGlobalObject, throwScope, thisObject->wrapped().nullableStringSpecialMethod(index.value()));
+        if (auto item = thisObject->wrapped().nullableStringSpecialMethod(index.value()); LIKELY(!!item)) {
+            auto value = toJS<IDLNullable<IDLDOMString>>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;
@@ -2706,8 +2706,8 @@ bool JSTestObj::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* lexi
     auto* thisObject = jsCast<JSTestObj*>(object);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (LIKELY(index <= MAX_ARRAY_INDEX)) {
-        if (index < thisObject->wrapped().length()) {
-            auto value = toJS<IDLNullable<IDLDOMString>>(*lexicalGlobalObject, throwScope, thisObject->wrapped().nullableStringSpecialMethod(index));
+        if (auto item = thisObject->wrapped().nullableStringSpecialMethod(index); LIKELY(!!item)) {
+            auto value = toJS<IDLNullable<IDLDOMString>>(*lexicalGlobalObject, throwScope, WTFMove(item));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -130,10 +130,10 @@ void CSSUnparsedValue::serialize(StringBuilder& builder, OptionSet<Serialization
     }
 }
 
-ExceptionOr<CSSUnparsedSegment> CSSUnparsedValue::item(size_t index)
+std::optional<CSSUnparsedSegment> CSSUnparsedValue::item(size_t index)
 {
     if (index >= m_segments.size())
-        return Exception { RangeError, makeString("Index ", index, " exceeds index range for unparsed segments.") };
+        return std::nullopt;
     return CSSUnparsedSegment { m_segments[index] };
 }
 

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.h
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.h
@@ -45,7 +45,7 @@ public:
     void serialize(StringBuilder&, OptionSet<SerializationArguments>) const final;
     size_t length() const { return m_segments.size(); }
     
-    ExceptionOr<CSSUnparsedSegment> item(size_t);
+    std::optional<CSSUnparsedSegment> item(size_t);
     ExceptionOr<CSSUnparsedSegment> setItem(size_t, CSSUnparsedSegment&&);
 
     CSSStyleValueType getType() const final { return CSSStyleValueType::CSSUnparsedValue; }

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.idl
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.idl
@@ -36,6 +36,6 @@ typedef (USVString or CSSOMVariableReferenceValue) CSSUnparsedSegment;
 
     iterable<CSSUnparsedSegment>;
     readonly attribute unsigned long length;
-    getter CSSUnparsedSegment (unsigned long index);
+    getter CSSUnparsedSegment? (unsigned long index);
     setter CSSUnparsedSegment (unsigned long index, CSSUnparsedSegment val);
 };

--- a/Source/WebCore/css/typedom/numeric/CSSNumericArray.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSNumericArray.cpp
@@ -56,10 +56,10 @@ CSSNumericArray::CSSNumericArray(FixedVector<Ref<CSSNumericValue>>&& values)
 {
 }
 
-ExceptionOr<Ref<CSSNumericValue>> CSSNumericArray::item(size_t index)
+RefPtr<CSSNumericValue> CSSNumericArray::item(size_t index)
 {
     if (index >= m_array.size())
-        return Exception { RangeError, makeString("Index ", index, " exceeds index range for CSSNumericArray.") };
+        return nullptr;
     return m_array[index].copyRef();
 }
 

--- a/Source/WebCore/css/typedom/numeric/CSSNumericArray.h
+++ b/Source/WebCore/css/typedom/numeric/CSSNumericArray.h
@@ -41,7 +41,7 @@ public:
     static Ref<CSSNumericArray> create(FixedVector<CSSNumberish>&&);
     static Ref<CSSNumericArray> create(Vector<Ref<CSSNumericValue>>&&);
     size_t length() const { return m_array.size(); };
-    ExceptionOr<Ref<CSSNumericValue>> item(size_t index);
+    RefPtr<CSSNumericValue> item(size_t index);
     const Vector<Ref<CSSNumericValue>>& array() const { return m_array; }
     void forEach(Function<void(const CSSNumericValue&, bool first)>);
 

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -117,12 +117,9 @@ ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(Vector<RefPtr<CSST
     return adoptRef(*new CSSTransformValue(WTFMove(transforms)));
 }
 
-ExceptionOr<RefPtr<CSSTransformComponent>> CSSTransformValue::item(size_t index)
+RefPtr<CSSTransformComponent> CSSTransformValue::item(size_t index)
 {
-    if (index >= m_components.size())
-        return Exception { RangeError, makeString("Index ", index, " exceeds the range of CSSTransformValue.") };
-
-    return RefPtr<CSSTransformComponent> { m_components[index] };
+    return index < m_components.size() ? m_components[index] : nullptr;
 }
 
 ExceptionOr<RefPtr<CSSTransformComponent>> CSSTransformValue::setItem(size_t index, Ref<CSSTransformComponent>&& value)

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.h
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.h
@@ -43,7 +43,7 @@ public:
     static ExceptionOr<Ref<CSSTransformValue>> create(Vector<RefPtr<CSSTransformComponent>>&&);
 
     size_t length() const { return m_components.size(); }
-    ExceptionOr<RefPtr<CSSTransformComponent>> item(size_t);
+    RefPtr<CSSTransformComponent> item(size_t);
     ExceptionOr<RefPtr<CSSTransformComponent>> setItem(size_t, Ref<CSSTransformComponent>&&);
     
     bool is2D() const;

--- a/Source/WebCore/svg/SVGLengthList.idl
+++ b/Source/WebCore/svg/SVGLengthList.idl
@@ -33,7 +33,7 @@
 
     undefined clear();
     SVGLength initialize(SVGLength newItem);
-    getter SVGLength getItem(unsigned long index);
+    [RaisesException] getter SVGLength getItem(unsigned long index);
     SVGLength insertItemBefore(SVGLength newItem, unsigned long index);
     SVGLength replaceItem(SVGLength newItem, unsigned long index);
     SVGLength removeItem(unsigned long index);

--- a/Source/WebCore/svg/SVGNumberList.idl
+++ b/Source/WebCore/svg/SVGNumberList.idl
@@ -32,7 +32,7 @@
 
     undefined clear();
     SVGNumber initialize(SVGNumber newItem);
-    getter SVGNumber getItem(unsigned long index);
+    [RaisesException] getter SVGNumber getItem(unsigned long index);
     SVGNumber insertItemBefore(SVGNumber newItem, unsigned long index);
     SVGNumber replaceItem(SVGNumber newItem, unsigned long index);
     SVGNumber removeItem(unsigned long index);

--- a/Source/WebCore/svg/SVGPathSegList.idl
+++ b/Source/WebCore/svg/SVGPathSegList.idl
@@ -32,7 +32,7 @@
 
     undefined clear();
     SVGPathSeg initialize(SVGPathSeg newItem);
-    getter SVGPathSeg getItem(unsigned long index);
+    [RaisesException] getter SVGPathSeg getItem(unsigned long index);
     SVGPathSeg insertItemBefore(SVGPathSeg newItem, unsigned long index);
     SVGPathSeg replaceItem(SVGPathSeg newItem, unsigned long index);
     SVGPathSeg removeItem(unsigned long index);

--- a/Source/WebCore/svg/SVGPointList.idl
+++ b/Source/WebCore/svg/SVGPointList.idl
@@ -31,7 +31,7 @@
 
     undefined clear();
     SVGPoint initialize(SVGPoint newItem);
-    getter SVGPoint getItem(unsigned long index);
+    [RaisesException] getter SVGPoint getItem(unsigned long index);
     SVGPoint insertItemBefore(SVGPoint newItem, unsigned long index);
     SVGPoint replaceItem(SVGPoint newItem, unsigned long index);
     SVGPoint removeItem(unsigned long index);

--- a/Source/WebCore/svg/SVGStringList.idl
+++ b/Source/WebCore/svg/SVGStringList.idl
@@ -31,7 +31,7 @@
 
     undefined clear();
     DOMString initialize(DOMString newItem);
-    getter DOMString getItem(unsigned long index);
+    [RaisesException] getter DOMString getItem(unsigned long index);
     DOMString insertItemBefore(DOMString newItem, unsigned long index);
     DOMString replaceItem(DOMString newItem, unsigned long index);
     DOMString removeItem(unsigned long index);

--- a/Source/WebCore/svg/SVGTransformList.idl
+++ b/Source/WebCore/svg/SVGTransformList.idl
@@ -32,7 +32,7 @@
 
     undefined clear();
     SVGTransform initialize(SVGTransform newItem);
-    getter SVGTransform getItem(unsigned long index);
+    [RaisesException] getter SVGTransform getItem(unsigned long index);
     SVGTransform insertItemBefore(SVGTransform newItem, unsigned long index);
     SVGTransform replaceItem(SVGTransform newItem, unsigned long index);
     SVGTransform removeItem(unsigned long index);


### PR DESCRIPTION
#### 4cf7b61be1fa78f8578e5f4262145fd22656fcd8
<pre>
Speed up JSNodeList indexing
<a href="https://bugs.webkit.org/show_bug.cgi?id=254190">https://bugs.webkit.org/show_bug.cgi?id=254190</a>

Reviewed by Ryosuke Niwa.

Speed up JSNodeList indexing by generating more efficient JS bindings code.

The generated bindings code looked like:
```
if (index &lt; list-&gt;length())
    return toJS(list-&gt;item(index));
```

This was a bit inefficient in the common case since `item()` would repeat the
bounds check and return null when out of bounds. It was even more unfortunate
for NodeList since both `length()` and `item()` are virtual.

As a result, I updated the bindings generator to generate:
```
if (auto item = list-&gt;item(index); LIKELY(!!item))
    return toJS(WTFMove(item));
```

This avoids the duplicates out-of-bounds checks and results in a single virtual
function call for JSNodeList instead of 2.

Only a few SVG list types still use the old logic since they may throw in some
cases, as per the specification. This is very unusual but supported via a new
[RaisesException] in the IDL.

Some other types had logic that would throw an exception when out of bounds but
this logic could never be triggered because the JS bindings were already doing
a bounds check before calling `item()`. I updated those types to return null
instead.

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateIndexedGetter):
(GenerateGetOwnPropertySlot):
(GenerateGetOwnPropertySlotByIndex):
* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
(WebCore::CSSUnparsedValue::item):
* Source/WebCore/css/typedom/CSSUnparsedValue.h:
* Source/WebCore/css/typedom/CSSUnparsedValue.idl:
* Source/WebCore/css/typedom/numeric/CSSNumericArray.cpp:
(WebCore::CSSNumericArray::item):
* Source/WebCore/css/typedom/numeric/CSSNumericArray.h:
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
(WebCore::CSSTransformValue::item):
* Source/WebCore/css/typedom/transform/CSSTransformValue.h:
* Source/WebCore/svg/SVGLengthList.idl:
* Source/WebCore/svg/SVGNumberList.idl:
* Source/WebCore/svg/SVGPathSegList.idl:
* Source/WebCore/svg/SVGPointList.idl:
* Source/WebCore/svg/SVGStringList.idl:
* Source/WebCore/svg/SVGTransformList.idl:

Canonical link: <a href="https://commits.webkit.org/261988@main">https://commits.webkit.org/261988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8b0ec1914c262f1ec0d2e0d4bac1febcf7be281

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/238 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/143 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/160 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/129 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/46 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/161 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->