### PR TITLE
Fix @counter-style behavior for empty-string symbol.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/empty-string-symbol-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/empty-string-symbol-expected-mismatch.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Test: counter-style empty string symbol</title>
+<ol style="list-style-type: a"><li>Decimal marker. Should have "1." as marker.</ol>
+<ol style="list-style-type: a"><li>Empty string marker, should have "" as marker.</ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/empty-string-symbol-notref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/empty-string-symbol-notref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Test: counter-style empty string symbol</title>
+<ol style="list-style-type: a"><li>Decimal marker. Should have "1." as marker.</ol>
+<ol style="list-style-type: a"><li>Empty string marker, should have "" as marker.</ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/empty-string-symbol.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/empty-string-symbol.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Test: counter-style empty string symbol</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles-3/#typedef-symbol">
+<link rel="mismatch" href="empty-string-symbol-notref.html">
+<style type="text/css">
+  @counter-style a {
+    system: cyclic;
+    symbols: "";
+    prefix: "";
+    suffix: "";
+  }
+</style>
+<ol><li>Decimal marker. Should have "1." as marker.</ol>
+<ol style="list-style-type: a"><li>Empty string marker, should have "" as marker.</ol>

--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -63,7 +63,6 @@ String CSSCounterStyle::counterForSystemCyclic(int value) const
 // https://www.w3.org/TR/css-counter-styles-3/#fixed-system
 String CSSCounterStyle::counterForSystemFixed(int value) const
 {
-    // Empty string will force value to be handled by fallback.
     if (value < firstSymbolValueForFixedSystem())
         return { };
     unsigned valueOffset = value - firstSymbolValueForFixedSystem();
@@ -209,7 +208,7 @@ String CSSCounterStyle::text(int value)
         return fallbackText(value);
 
     auto result = initialRepresentation(value);
-    if (result.isEmpty())
+    if (result.isNull())
         return fallbackText(value);
     applyPadSymbols(result, value);
     if (shouldApplyNegativeSymbols(value))


### PR DESCRIPTION
#### 140b74df15a9f630502fe68121c15ae3a658075c
<pre>
Fix @counter-style behavior for empty-string symbol.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254269">https://bugs.webkit.org/show_bug.cgi?id=254269</a>
rdar://107053810

For a system that accepts a single symbol, like cyclic,
if we input a symbol that is an empty string, the text
representation is being considered invalid and it is
falling back to &apos;decimal&apos;.
This is is wrong, since empty string is a valid string.

This happens because we were checking against isEmpty()
instead of isNull().

Reviewed by Chris Dumez.

* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/empty-string-symbol-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/empty-string-symbol-notref.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/empty-string-symbol-notref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/empty-string-symbol.html: Added.
* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::CSSCounterStyle::counterForSystemFixed const):
(WebCore::CSSCounterStyle::text):

Canonical link: <a href="https://commits.webkit.org/261971@main">https://commits.webkit.org/261971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6eaf25601631be8a6b754a604825e9fd2b37257

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/136 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/151 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/227 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/142 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/132 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/144 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/32 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/148 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->