### PR TITLE
[web-animations] Make WPT test at animation-model/keyframe-effects/effect-value-transformed-distance.html pass reliably

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/cubic-bezier-timing-functions-output-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/cubic-bezier-timing-functions-output-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL cubic-bezier easing with input progress greater than 1 assert_approx_equals: The left of the animation should be approximately 98.8706654939602 at 230ms expected 98.8706654939602 +/- 0.01 but got 98.89859
-FAIL cubic-bezier easing with input progress greater than 1 and where the tangent on the upper boundary is infinity assert_approx_equals: The left of the animation should be approximately 106.31755608768113 at 230ms expected 106.31755608768113 +/- 0.01 but got 106.359596
-FAIL cubic-bezier easing with input progress less than 0 assert_approx_equals: The left of the animation should be approximately -16.589193103032184 at 10ms expected -16.589193103032184 +/- 0.01 but got -17.508368
-FAIL cubic-bezier easing with input progress less than 0 and where the tangent on the lower boundary is infinity assert_approx_equals: The left of the animation should be approximately 0 at 300ms expected 0 +/- 0.01 but got 512.077454
+PASS cubic-bezier easing with input progress greater than 1
+PASS cubic-bezier easing with input progress greater than 1 and where the tangent on the upper boundary is infinity
+PASS cubic-bezier easing with input progress less than 0
+PASS cubic-bezier easing with input progress less than 0 and where the tangent on the lower boundary is infinity
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-transformed-distance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-transformed-distance-expected.txt
@@ -10,7 +10,7 @@ PASS A linear function on a keyframe affects the resulting style
 PASS A ease function on a keyframe affects the resulting style
 PASS A ease-in function on a keyframe affects the resulting style
 PASS A ease-in-out function on a keyframe affects the resulting style
-FAIL A ease-out function on a keyframe affects the resulting style assert_approx_equals: The width should be approximately 116.05721544376388 at 1100ms expected 116.05721544376388 +/- 0.02 but got 116.078125
+PASS A ease-out function on a keyframe affects the resulting style
 PASS A easing function which produces values greater than 1 on a keyframe affects the resulting style
 PASS A easing function which produces values less than 1 on a keyframe affects the resulting style
 PASS Linear-equivalent cubic-bezier keyframe easing applied to an effect with a step-start function does not alter the result

--- a/LayoutTests/transitions/frames-timing-function-expected.txt
+++ b/LayoutTests/transitions/frames-timing-function-expected.txt
@@ -1,6 +1,6 @@
 The box should move horizontally 200px over 1s, in 4 equal increments.
 
-FAIL - "-webkit-transform.4" property for "box" element at 0.25s expected: 50 but saw: matrix(1, 0, 0, 1, 81.713303, 0)
-FAIL - "-webkit-transform.4" property for "box" element at 0.5s expected: 100 but saw: matrix(1, 0, 0, 1, 160.482788, 0)
-FAIL - "-webkit-transform.4" property for "box" element at 0.75s expected: 150 but saw: matrix(1, 0, 0, 1, 192.137558, 0)
+FAIL - "-webkit-transform.4" property for "box" element at 0.25s expected: 50 but saw: matrix(1, 0, 0, 1, 81.702118, 0)
+FAIL - "-webkit-transform.4" property for "box" element at 0.5s expected: 100 but saw: matrix(1, 0, 0, 1, 160.480682, 0)
+FAIL - "-webkit-transform.4" property for "box" element at 0.75s expected: 150 but saw: matrix(1, 0, 0, 1, 192.091797, 0)
 

--- a/Source/WebCore/platform/graphics/UnitBezier.h
+++ b/Source/WebCore/platform/graphics/UnitBezier.h
@@ -31,18 +31,64 @@
 namespace WebCore {
 
     struct UnitBezier {
+
+#define CUBIC_BEZIER_SPLINE_SAMPLES 11
+
+        static constexpr double kBezierEpsilon = 1e-7;
+        static constexpr int kMaxNewtonIterations = 4;
+
         UnitBezier(double p1x, double p1y, double p2x, double p2y)
         {
             // Calculate the polynomial coefficients, implicit first and last control points are (0,0) and (1,1).
             cx = 3.0 * p1x;
             bx = 3.0 * (p2x - p1x) - cx;
             ax = 1.0 - cx -bx;
-             
+
             cy = 3.0 * p1y;
             by = 3.0 * (p2y - p1y) - cy;
             ay = 1.0 - cy - by;
+
+            // End-point gradients are used to calculate timing function results
+            // outside the range [0, 1].
+            //
+            // There are four possibilities for the gradient at each end:
+            // (1) the closest control point is not horizontally coincident with regard to
+            //     (0, 0) or (1, 1). In this case the line between the end point and
+            //     the control point is tangent to the bezier at the end point.
+            // (2) the closest control point is coincident with the end point. In
+            //     this case the line between the end point and the far control
+            //     point is tangent to the bezier at the end point.
+            // (3) both internal control points are coincident with an endpoint. There
+            //     are two special case that fall into this category:
+            //     CubicBezier(0, 0, 0, 0) and CubicBezier(1, 1, 1, 1). Both are
+            //     equivalent to linear.
+            // (4) the closest control point is horizontally coincident with the end
+            //     point, but vertically distinct. In this case the gradient at the
+            //     end point is Infinite. However, this causes issues when
+            //     interpolating. As a result, we break down to a simple case of
+            //     0 gradient under these conditions.
+            if (p1x > 0)
+                startGradient = p1y / p1x;
+            else if (!p1y && p2x > 0)
+                startGradient = p2y / p2x;
+            else if (!p1y && !p2y)
+                startGradient = 1;
+            else
+                startGradient = 0;
+            if (p2x < 1)
+                endGradient = (p2y - 1) / (p2x - 1);
+            else if (p2y == 1 && p1x < 1)
+                endGradient = (p1y - 1) / (p1x - 1);
+            else if (p2y == 1 && p1y == 1)
+                endGradient = 1;
+            else
+                endGradient = 0;
+
+            double deltaT = 1.0 / (CUBIC_BEZIER_SPLINE_SAMPLES - 1);
+            for (int i = 0; i < CUBIC_BEZIER_SPLINE_SAMPLES; i++)
+                splineSamples[i] = sampleCurveX(i * deltaT);
         }
-        
+
         double sampleCurveX(double t)
         {
             // `ax t^3 + bx t^2 + cx t' expanded using Horner's rule.
@@ -58,38 +104,44 @@ namespace WebCore {
         {
             return (3.0 * ax * t + 2.0 * bx) * t + cx;
         }
-        
+
         // Given an x value, find a parametric value it came from.
         double solveCurveX(double x, double epsilon)
         {
-            double t0;
-            double t1;
-            double t2;
-            double x2;
-            double d2;
-            int i;
+            double t0 = 0.0;
+            double t1 = 0.0;
+            double t2 = x;
+            double x2 = 0.0;
+            double d2 = 0.0;
+            int i = 0;
 
-            // First try a few iterations of Newton's method -- normally very fast.
-            for (t2 = x, i = 0; i < 8; i++) {
+            // Linear interpolation of spline curve for initial guess.
+            double deltaT = 1.0 / (CUBIC_BEZIER_SPLINE_SAMPLES - 1);
+            for (i = 1; i < CUBIC_BEZIER_SPLINE_SAMPLES; i++) {
+                if (x <= splineSamples[i]) {
+                    t1 = deltaT * i;
+                    t0 = t1 - deltaT;
+                    t2 = t0 + (t1 - t0) * (x - splineSamples[i - 1]) / (splineSamples[i] - splineSamples[i - 1]);
+                    break;
+                }
+            }
+
+            // Perform a few iterations of Newton's method -- normally very fast.
+            // See https://en.wikipedia.org/wiki/Newton%27s_method.
+            double newtonEpsilon = std::min(kBezierEpsilon, epsilon);
+            for (i = 0; i < kMaxNewtonIterations; i++) {
                 x2 = sampleCurveX(t2) - x;
-                if (fabs (x2) < epsilon)
+                if (std::abs(x2) < newtonEpsilon)
                     return t2;
                 d2 = sampleCurveDerivativeX(t2);
-                if (std::abs(d2) < 1e-6)
+                if (std::abs(d2) < kBezierEpsilon)
                     break;
                 t2 = t2 - x2 / d2;
             }
+            if (std::abs(x2) < epsilon)
+                return t2;
 
             // Fall back to the bisection method for reliability.
-            t0 = 0.0;
-            t1 = 1.0;
-            t2 = x;
-
-            if (t2 < t0)
-                return t0;
-            if (t2 > t1)
-                return t1;
-
             while (t0 < t1) {
                 x2 = sampleCurveX(t2);
                 if (std::abs(x2 - x) < epsilon)
@@ -98,7 +150,7 @@ namespace WebCore {
                     t0 = t2;
                 else
                     t1 = t2;
-                t2 = (t1 - t0) * .5 + t0;
+                t2 = (t1 + t0) * .5;
             }
 
             // Failure.
@@ -107,6 +159,10 @@ namespace WebCore {
 
         double solve(double x, double epsilon)
         {
+            if (x < 0.0)
+                return 0.0 + startGradient * x;
+            if (x > 1.0)
+                return 1.0 + endGradient * (x - 1.0);
             return sampleCurveY(solveCurveX(x, epsilon));
         }
         
@@ -118,6 +174,11 @@ namespace WebCore {
         double ay;
         double by;
         double cy;
+
+        double startGradient;
+        double endGradient;
+
+        double splineSamples[CUBIC_BEZIER_SPLINE_SAMPLES];
     };
 }
 #endif


### PR DESCRIPTION
#### 3e3695777894f55445055f997000fb74fc9e92ae
<pre>
[web-animations] Make WPT test at animation-model/keyframe-effects/effect-value-transformed-distance.html pass reliably
<a href="https://bugs.webkit.org/show_bug.cgi?id=186493">https://bugs.webkit.org/show_bug.cgi?id=186493</a>
&lt;rdar://problem/41000157&gt;

Reviewed by Dean Jackson.

Unsure as to why we were the only browser to fail this test related to cubic-bezier accuracy,
I adjusted our UnitBezier code to match Chromium&apos;s ui/gfx/geometry/cubic_bezier.cc and this
solved this browser-specific failure.

This also addressed the issue where css/css-easing/cubic-bezier-timing-functions-output.html
was a unique failure in WebKit.

* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/cubic-bezier-timing-functions-output-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-transformed-distance-expected.txt:
* LayoutTests/transitions/frames-timing-function-expected.txt:
* Source/WebCore/platform/graphics/UnitBezier.h:
(WebCore::UnitBezier::UnitBezier):
(WebCore::UnitBezier::solveCurveX):
(WebCore::UnitBezier::solve):

Canonical link: <a href="https://commits.webkit.org/262008@main">https://commits.webkit.org/262008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b3911eb9220eb03974bb36ad20da56f2045551e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/200 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/264 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/270 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/197 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/170 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/206 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/188 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/202 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/193 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/30 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->