### PR TITLE
[WGSL] Add support for textures

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTTypeName.h
+++ b/Source/WebGPU/WGSL/AST/ASTTypeName.h
@@ -103,9 +103,22 @@ public:
         Mat3x4,
         Mat4x2,
         Mat4x3,
-        Mat4x4
+        Mat4x4,
+        Texture1d,
+        Texture2d,
+        Texture2dArray,
+        Texture3d,
+        TextureCube,
+        TextureCubeArray,
+        TextureMultisampled2d,
+        TextureStorage1d,
+        TextureStorage2d,
+        TextureStorage2dArray,
+        TextureStorage3d,
+
+        LastEntry = TextureStorage3d,
     };
-    static constexpr unsigned NumberOfBaseTypes = 12;
+    static constexpr unsigned NumberOfBaseTypes = static_cast<unsigned>(Base::LastEntry) + 1;
 
     ParameterizedTypeName(SourceSpan span, Base base, TypeName::Ref&& elementType)
         : TypeName(span)
@@ -139,6 +152,28 @@ public:
             return Base::Mat4x3;
         if (view == "mat4x4"_s)
             return Base::Mat4x4;
+        if (view == "texture_1d"_s)
+            return Base::Texture1d;
+        if (view == "texture_2d"_s)
+            return Base::Texture2d;
+        if (view == "texture_2d_array"_s)
+            return Base::Texture2dArray;
+        if (view == "texture_3d"_s)
+            return Base::Texture3d;
+        if (view == "texture_cube"_s)
+            return Base::TextureCube;
+        if (view == "texture_cube_array"_s)
+            return Base::TextureCubeArray;
+        if (view == "texture_multisampled_2d"_s)
+            return Base::TextureMultisampled2d;
+        if (view == "texture_storage_1d"_s)
+            return Base::TextureStorage1d;
+        if (view == "texture_storage_2d"_s)
+            return Base::TextureStorage2d;
+        if (view == "texture_storage_2d_array"_s)
+            return Base::TextureStorage2dArray;
+        if (view == "texture_storage_3d"_s)
+            return Base::TextureStorage3d;
         return std::nullopt;
     }
 

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -319,6 +319,12 @@ void FunctionDefinitionWriter::visit(AST::ParameterizedTypeName& type)
         m_stringBuilder.append(", ", columns, ", ", rows, ">");
     };
 
+    const auto& texture = [&](const char* name, const char* mode = "sample") {
+        m_stringBuilder.append(name, "<");
+        visit(type.elementType());
+        m_stringBuilder.append(", access::", mode, ">");
+    };
+
     switch (type.base()) {
     case AST::ParameterizedTypeName::Base::Vec2:
         vec(2);
@@ -357,6 +363,41 @@ void FunctionDefinitionWriter::visit(AST::ParameterizedTypeName& type)
         break;
     case AST::ParameterizedTypeName::Base::Mat4x4:
         matrix(4, 4);
+        break;
+
+    case AST::ParameterizedTypeName::Base::Texture1d:
+        texture("texture1d");
+        break;
+    case AST::ParameterizedTypeName::Base::Texture2d:
+        texture("texture2d");
+        break;
+    case AST::ParameterizedTypeName::Base::Texture2dArray:
+        texture("texture2d_array");
+        break;
+    case AST::ParameterizedTypeName::Base::Texture3d:
+        texture("texture3d");
+        break;
+    case AST::ParameterizedTypeName::Base::TextureCube:
+        texture("texturecube");
+        break;
+    case AST::ParameterizedTypeName::Base::TextureCubeArray:
+        texture("texturecube_array");
+        break;
+    case AST::ParameterizedTypeName::Base::TextureMultisampled2d:
+        texture("texture2d_ms");
+        break;
+
+    case AST::ParameterizedTypeName::Base::TextureStorage1d:
+        texture("texture1d", "write");
+        break;
+    case AST::ParameterizedTypeName::Base::TextureStorage2d:
+        texture("texture2d", "write");
+        break;
+    case AST::ParameterizedTypeName::Base::TextureStorage2dArray:
+        texture("texture2d_aray", "write");
+        break;
+    case AST::ParameterizedTypeName::Base::TextureStorage3d:
+        texture("texture3d", "write");
         break;
     }
 }

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -48,6 +48,7 @@ using namespace Types;
 // Vector: size in the least significant byte.
 // Matrix: rows in byte 1 and columns in byte 2
 // Array: 0 for dynamic array or 32-bit size in the upper 32-bits
+// Texture: kind << 16
 struct VectorKey {
     Type* elementType;
     uint8_t size;
@@ -68,6 +69,13 @@ struct ArrayKey {
     std::optional<unsigned> size;
 
     uint64_t extra() const { return size.has_value() ? static_cast<uint64_t>(*size) << 32 : 0; }
+};
+
+struct TextureKey {
+    Type* elementType;
+    Texture::Kind kind;
+
+    uint64_t extra() const { return static_cast<uint64_t>(kind) << 16; }
 };
 
 template<typename Key>
@@ -111,6 +119,18 @@ TypeStore::TypeStore()
     allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat4x2, 4, 2);
     allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat4x3, 4, 3);
     allocateConstructor(&TypeStore::matrixType, AST::ParameterizedTypeName::Base::Mat4x4, 4, 4);
+
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::Texture1d, Texture::Kind::Texture1d);
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::Texture2d, Texture::Kind::Texture2d);
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::Texture2dArray, Texture::Kind::Texture2dArray);
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::Texture3d, Texture::Kind::Texture3d);
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::TextureCube, Texture::Kind::TextureCube);
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::TextureCubeArray, Texture::Kind::TextureCubeArray);
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::TextureMultisampled2d, Texture::Kind::TextureMultisampled2d);
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::TextureStorage1d, Texture::Kind::TextureStorage1d);
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::TextureStorage2d, Texture::Kind::TextureStorage2d);
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::TextureStorage2dArray, Texture::Kind::TextureStorage2dArray);
+    allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::TextureStorage3d, Texture::Kind::TextureStorage3d);
 }
 
 Type* TypeStore::structType(AST::Structure& structure)
@@ -153,6 +173,17 @@ Type* TypeStore::matrixType(Type* elementType, uint8_t columns, uint8_t rows)
     if (type)
         return type;
     type = allocateType<Matrix>(elementType, columns, rows);
+    m_cache.insert(key, type);
+    return type;
+}
+
+Type* TypeStore::textureType(Type* elementType, Texture::Kind kind)
+{
+    TextureKey key { elementType, kind };
+    Type* type = m_cache.find(key);
+    if (type)
+        return type;
+    type = allocateType<Texture>(elementType, kind);
     m_cache.insert(key, type);
     return type;
 }

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -59,6 +59,7 @@ public:
     Type* arrayType(Type*, std::optional<unsigned>);
     Type* vectorType(Type*, uint8_t);
     Type* matrixType(Type*, uint8_t columns, uint8_t rows);
+    Type* textureType(Type*, Types::Texture::Kind);
 
     Type* constructType(AST::ParameterizedTypeName::Base, Type*);
 

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -69,6 +69,44 @@ void Type::dump(PrintStream& out) const
             // Bottom is an implementation detail and should never leak, but we
             // keep the ability to print it in debug to help when dumping types
             out.print("⊥");
+        },
+        [&](const Texture& texture) {
+            switch (texture.kind) {
+            case Texture::Kind::Texture1d:
+                out.print("texture_1d");
+                break;
+            case Texture::Kind::Texture2d:
+                out.print("texture_2d");
+                break;
+            case Texture::Kind::Texture2dArray:
+                out.print("texture_2d_array");
+                break;
+            case Texture::Kind::Texture3d:
+                out.print("texture_3d");
+                break;
+            case Texture::Kind::TextureCube:
+                out.print("texture_cube");
+                break;
+            case Texture::Kind::TextureCubeArray:
+                out.print("texture_cube_array");
+                break;
+            case Texture::Kind::TextureMultisampled2d:
+                out.print("texture_multisampled_2d");
+                break;
+            case Texture::Kind::TextureStorage1d:
+                out.print("texture_storage_1d");
+                break;
+            case Texture::Kind::TextureStorage2d:
+                out.print("texture_storage_2d");
+                break;
+            case Texture::Kind::TextureStorage2dArray:
+                out.print("texture_storage_2d_array");
+                break;
+            case Texture::Kind::TextureStorage3d:
+                out.print("texture_storage_3d");
+                break;
+            }
+            out.print("<", *texture.element, ">");
         });
 }
 

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -56,6 +56,25 @@ struct Primitive {
     Kind kind;
 };
 
+struct Texture {
+    enum class Kind : uint8_t {
+        Texture1d = 1,
+        Texture2d,
+        Texture2dArray,
+        Texture3d,
+        TextureCube,
+        TextureCubeArray,
+        TextureMultisampled2d,
+        TextureStorage1d,
+        TextureStorage2d,
+        TextureStorage2dArray,
+        TextureStorage3d,
+    };
+
+    Type* element;
+    Kind kind;
+};
+
 struct Vector {
     Type* element;
     uint8_t size;
@@ -93,7 +112,8 @@ struct Type : public std::variant<
     Types::Array,
     Types::Struct,
     Types::Function,
-    Types::Bottom
+    Types::Bottom,
+    Types::Texture
 > {
     using std::variant<
         Types::Primitive,
@@ -102,7 +122,8 @@ struct Type : public std::variant<
         Types::Array,
         Types::Struct,
         Types::Function,
-        Types::Bottom
+        Types::Bottom,
+        Types::Texture
         >::variant;
     void dump(PrintStream&) const;
     String toString() const;


### PR DESCRIPTION
#### ac45a24e64e7049b9fc1e19b7221d074f30f2d49
<pre>
[WGSL] Add support for textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=254278">https://bugs.webkit.org/show_bug.cgi?id=254278</a>
&lt;rdar://problem/107067119&gt;

Reviewed by Mike Wyrzykowski.

Still needs the functions that use textures to make it useful, but this patch
adds support for textures in the parser, type checker and code generator.

* Source/WebGPU/WGSL/AST/ASTTypeName.h:
(WGSL::AST::ParameterizedTypeName::stringViewToKind):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TextureKey::extra const):
(WGSL::TypeStore::TypeStore):
(WGSL::TypeStore::textureType):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/262063@main">https://commits.webkit.org/262063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/222370d2d50d3353a414e735f73eb3093f1e0d0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/367 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/343 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/584 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/396 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/412 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/323 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/360 "9 failures") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/347 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/354 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/105 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/352 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->