### PR TITLE
Add test function to expose if in UI-side compositing mode

### DIFF
--- a/LayoutTests/fast/scrolling/ios/ui-side-compositing-check-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/ui-side-compositing-check-expected.txt
@@ -1,0 +1,5 @@
+PASS window.internals.isUsingUISideCompositing() is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/ui-side-compositing-check.html
+++ b/LayoutTests/fast/scrolling/ios/ui-side-compositing-check.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script>
+        if (window.testRunner)
+          testRunner.dumpAsText();
+        shouldBe("window.internals.isUsingUISideCompositing()", "true");
+    </script>
+    <script src="../../../resources/js-test-post.js"></script>
+</head>
+</html>

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -631,6 +631,8 @@ public:
 
     virtual void decidePolicyForModalContainer(OptionSet<ModalContainerControlType>, CompletionHandler<void(ModalContainerDecision)>&&) = 0;
 
+    virtual bool isUsingUISideCompositing() const { return false; }
+    
     WEBCORE_EXPORT virtual ~ChromeClient();
 
 protected:

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7128,4 +7128,15 @@ bool Internals::isVisuallyNonEmpty() const
     return frameView && frameView->isVisuallyNonEmpty();
 }
 
+bool Internals::isUsingUISideCompositing() const
+{
+    auto* document = contextDocument();
+    if (!document)
+        return false;
+    auto* page = document->page();
+    if (!page)
+        return false;
+    return page->chrome().client().isUsingUISideCompositing();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1377,6 +1377,8 @@ public:
     SelectorFilterHashCounts selectorFilterHashCounts(const String& selector);
 
     bool isVisuallyNonEmpty() const;
+        
+    bool isUsingUISideCompositing() const;
 
 private:
     explicit Internals(Document&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1203,4 +1203,6 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     SelectorFilterHashCounts selectorFilterHashCounts(DOMString selector);
 
     readonly attribute boolean isVisuallyNonEmpty;
+    
+    boolean isUsingUISideCompositing();
 };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1624,4 +1624,14 @@ const AtomString& WebChromeClient::searchStringForModalContainerObserver() const
 }
 #endif
 
+bool WebChromeClient::isUsingUISideCompositing() const
+{
+#if PLATFORM(COCOA)
+    return m_page.drawingArea()->type() == DrawingAreaType::RemoteLayerTree;
+#else
+    return false;
+#endif
+}
+
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -478,6 +478,8 @@ private:
     void decidePolicyForModalContainer(OptionSet<WebCore::ModalContainerControlType>, CompletionHandler<void(WebCore::ModalContainerDecision)>&&) final;
 
     const AtomString& searchStringForModalContainerObserver() const final;
+    
+    bool isUsingUISideCompositing() const;
 
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };


### PR DESCRIPTION
#### e0dffb1d363adaafa15acaadff7272d3af1d62a4
<pre>
Add test function to expose if in UI-side compositing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=254288">https://bugs.webkit.org/show_bug.cgi?id=254288</a>
rdar://107078044

Reviewed by Simon Fraser.

Add test function to expose if in UI-side compositing mode.

* LayoutTests/fast/scrolling/ios/ui-side-compositing-check-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/ui-side-compositing-check.html: Added.
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::isUsingUISideCompositing const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isUsingUISideCompositing const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::isUsingUISideCompositing const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:

Canonical link: <a href="https://commits.webkit.org/262130@main">https://commits.webkit.org/262130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e4157f156a441c0942b0aace5737fe25ebe32f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/584 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/822 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/818 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/653 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/597 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/644 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/620 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/633 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/639 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/70 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->