### PR TITLE
Drop AnimationTimeline::m_allAnimations

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -38,17 +38,11 @@ namespace WebCore {
 AnimationTimeline::AnimationTimeline() = default;
 AnimationTimeline::~AnimationTimeline() = default;
 
-void AnimationTimeline::forgetAnimation(WebAnimation* animation)
-{
-    m_allAnimations.removeFirst(animation);
-}
-
 void AnimationTimeline::animationTimingDidChange(WebAnimation& animation)
 {
     updateGlobalPosition(animation);
 
     if (m_animations.add(animation)) {
-        m_allAnimations.append(animation);
         auto* timeline = animation.timeline();
         if (timeline && timeline != this)
             timeline->removeAnimation(animation);

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -45,7 +45,6 @@ public:
 
     const AnimationCollection& relevantAnimations() const { return m_animations; }
 
-    void forgetAnimation(WebAnimation*);
     virtual void animationTimingDidChange(WebAnimation&);
     virtual void removeAnimation(WebAnimation&);
 
@@ -55,7 +54,6 @@ public:
 protected:
     AnimationTimeline();
 
-    Vector<WeakPtr<WebAnimation, WeakPtrImplWithEventTargetData>> m_allAnimations;
     AnimationCollection m_animations;
 
 private:

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -113,9 +113,6 @@ WebAnimation::~WebAnimation()
 {
     InspectorInstrumentation::willDestroyWebAnimation(*this);
 
-    if (m_timeline)
-        m_timeline->forgetAnimation(this);
-
     ASSERT(instances().contains(this));
     instances().remove(this);
 }


### PR DESCRIPTION
#### ab90dbdd61bfba28539fa87268524c5426060f54
<pre>
Drop AnimationTimeline::m_allAnimations
<a href="https://bugs.webkit.org/show_bug.cgi?id=254294">https://bugs.webkit.org/show_bug.cgi?id=254294</a>

Reviewed by Antoine Quint.

Drop AnimationTimeline::m_allAnimations as it seems using AnimationTimeline::m_animations
is equivalent.

* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::animationTimingDidChange):
(WebCore::AnimationTimeline::forgetAnimation): Deleted.
* Source/WebCore/animation/AnimationTimeline.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::removeReplacedAnimations):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::~WebAnimation):

Canonical link: <a href="https://commits.webkit.org/262012@main">https://commits.webkit.org/262012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bd9d3dd2fbcb971b56d216e4e04459a2ce4045d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/287 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/447 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/238 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/207 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/185 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/217 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/207 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/178 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/213 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/210 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/31 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->