### PR TITLE
Avoid virtual function calls for AnimationTimeline::isDocumentTimeline()

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -40,7 +40,8 @@ class AnimationTimeline : public RefCounted<AnimationTimeline>, public CanMakeWe
 public:
     virtual ~AnimationTimeline();
 
-    virtual bool isDocumentTimeline() const { return false; }
+    // DocumentTimeline is currently the only subclass of AnimationTimeline.
+    constexpr static bool isDocumentTimeline() { return true; }
 
     const AnimationCollection& relevantAnimations() const { return m_animations; }
 

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -48,8 +48,6 @@ public:
     static Ref<DocumentTimeline> create(Document&);
     static Ref<DocumentTimeline> create(Document&, DocumentTimelineOptions&&);
 
-    bool isDocumentTimeline() const final { return true; }
-
     Document* document() const { return m_document.get(); }
 
     std::optional<Seconds> currentTime() override;


### PR DESCRIPTION
#### 53474172a408e3800b18ec3b4d559afd79586016
<pre>
Avoid virtual function calls for AnimationTimeline::isDocumentTimeline()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254295">https://bugs.webkit.org/show_bug.cgi?id=254295</a>

Reviewed by Ryosuke Niwa.

Avoid virtual function calls for AnimationTimeline::isDocumentTimeline().
DocumentTimeline is currently the only subclass of AnimationTimeline.

* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::isDocumentTimeline):
(WebCore::AnimationTimeline::isDocumentTimeline const): Deleted.
* Source/WebCore/animation/DocumentTimeline.h:

Canonical link: <a href="https://commits.webkit.org/262003@main">https://commits.webkit.org/262003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88839b513168d252173ece2355c72c3496393933

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/220 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/222 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/241 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/211 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/188 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/221 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/210 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/217 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/54 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/213 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->