### PR TITLE
Avoid unnecessary calls to updateGlobalPosition() in AnimationTimeline::animationTimingDidChange()

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -45,17 +45,18 @@ void AnimationTimeline::forgetAnimation(WebAnimation* animation)
 
 void AnimationTimeline::animationTimingDidChange(WebAnimation& animation)
 {
+    if (!m_animations.add(animation))
+        return;
+
     updateGlobalPosition(animation);
 
-    if (m_animations.add(animation)) {
-        m_allAnimations.append(animation);
-        auto* timeline = animation.timeline();
-        if (timeline && timeline != this)
-            timeline->removeAnimation(animation);
-        else if (timeline == this && is<KeyframeEffect>(animation.effect())) {
-            if (auto styleable = downcast<KeyframeEffect>(animation.effect())->targetStyleable())
-                styleable->animationWasAdded(animation);
-        }
+    m_allAnimations.append(animation);
+    auto* timeline = animation.timeline();
+    if (timeline && timeline != this)
+        timeline->removeAnimation(animation);
+    else if (timeline == this && is<KeyframeEffect>(animation.effect())) {
+        if (auto styleable = downcast<KeyframeEffect>(animation.effect())->targetStyleable())
+            styleable->animationWasAdded(animation);
     }
 }
 


### PR DESCRIPTION
#### 74a0fece34e811e30517e5ed468d1354106cb882
<pre>
Avoid unnecessary calls to updateGlobalPosition() in AnimationTimeline::animationTimingDidChange()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254298">https://bugs.webkit.org/show_bug.cgi?id=254298</a>

Reviewed by NOBODY (OOPS!).

Update AnimationTimeline::animationTimingDidChange() to only call updateGlobalPosition()
for new animations. For pre-existing animations, it is safe to assume they already have
a global position.

* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::animationTimingDidChange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74a0fece34e811e30517e5ed468d1354106cb882

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/227 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/230 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/248 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/216 "1 flakes 10 failures") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/193 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/227 "9 flakes 10 failures") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/215 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/222 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/218 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->