### PR TITLE
StyleRuleGroup should use composition instead of inheritance

### DIFF
--- a/Source/WebCore/css/CSSConditionRule.cpp
+++ b/Source/WebCore/css/CSSConditionRule.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-CSSConditionRule::CSSConditionRule(StyleRuleGroup& group, CSSStyleSheet* parent)
+CSSConditionRule::CSSConditionRule(StyleRuleBase& group, CSSStyleSheet* parent)
     : CSSGroupingRule(group, parent)
 {
 }

--- a/Source/WebCore/css/CSSConditionRule.h
+++ b/Source/WebCore/css/CSSConditionRule.h
@@ -38,7 +38,7 @@ public:
     virtual String conditionText() const = 0;
 
 protected:
-    CSSConditionRule(StyleRuleGroup&, CSSStyleSheet* parent);
+    CSSConditionRule(StyleRuleBase&, CSSStyleSheet* parent);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSContainerRule.cpp
+++ b/Source/WebCore/css/CSSContainerRule.cpp
@@ -46,7 +46,7 @@ Ref<CSSContainerRule> CSSContainerRule::create(StyleRuleContainer& rule, CSSStyl
 
 const StyleRuleContainer& CSSContainerRule::styleRuleContainer() const
 {
-    return downcast<StyleRuleContainer>(groupRule());
+    return downcast<StyleRuleContainer>(rule());
 }
 
 String CSSContainerRule::cssText() const

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -42,9 +42,10 @@ public:
     CSSRule* item(unsigned index) const;
 
 protected:
-    CSSGroupingRule(StyleRuleGroup&, CSSStyleSheet* parent);
-    const StyleRuleGroup& groupRule() const { return m_groupRule; }
-    StyleRuleGroup& groupRule() { return m_groupRule; }
+    CSSGroupingRule(StyleRuleBase&, CSSStyleSheet* parent);
+    const StyleRuleGroup& groupRule() const;
+    StyleRuleGroup& groupRule();
+    StyleRuleBase& rule() const { return m_groupRule; }
     void reattach(StyleRuleBase&) override;
     void appendCSSTextForItems(StringBuilder&) const;
 
@@ -52,7 +53,7 @@ protected:
     void cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& rules) const;
 
 private:
-    Ref<StyleRuleGroup> m_groupRule;
+    Ref<StyleRuleBase> m_groupRule;
     mutable Vector<RefPtr<CSSRule>> m_childRuleCSSOMWrappers;
     mutable std::unique_ptr<CSSRuleList> m_ruleListCSSOMWrapper;
 };

--- a/Source/WebCore/css/CSSLayerBlockRule.cpp
+++ b/Source/WebCore/css/CSSLayerBlockRule.cpp
@@ -61,7 +61,7 @@ String CSSLayerBlockRule::cssText() const
 
 String CSSLayerBlockRule::name() const
 {
-    auto& layer = downcast<StyleRuleLayer>(groupRule());
+    auto& layer = downcast<StyleRuleLayer>(rule());
 
     if (layer.name().isEmpty())
         return emptyString();

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -44,12 +44,12 @@ CSSMediaRule::~CSSMediaRule()
 
 const MQ::MediaQueryList& CSSMediaRule::mediaQueries() const
 {
-    return downcast<StyleRuleMedia>(groupRule()).mediaQueries();
+    return downcast<StyleRuleMedia>(rule()).mediaQueries();
 }
 
 void CSSMediaRule::setMediaQueries(MQ::MediaQueryList&& queries)
 {
-    downcast<StyleRuleMedia>(groupRule()).setMediaQueries(WTFMove(queries));
+    downcast<StyleRuleMedia>(rule()).setMediaQueries(WTFMove(queries));
 }
 
 String CSSMediaRule::cssText() const

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -58,7 +58,7 @@ String CSSSupportsRule::cssText() const
 
 String CSSSupportsRule::conditionText() const
 {
-    return downcast<StyleRuleSupports>(groupRule()).conditionText();
+    return downcast<StyleRuleSupports>(rule()).conditionText();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -474,7 +474,7 @@ static bool traverseRulesInVector(const Vector<RefPtr<StyleRuleBase>>& rules, co
             return true;
         if (!rule->isGroupRule())
             continue;
-        if (traverseRulesInVector(downcast<StyleRuleGroup>(*rule).childRules(), handler))
+        if (traverseRulesInVector(StyleRuleGroup::fromStyleRuleBase(*rule)->childRules(), handler))
             return true;
     }
     return false;

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -124,7 +124,7 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
     case StyleRuleType::Media: {
         auto& mediaRule = downcast<StyleRuleMedia>(*rule);
         if (m_mediaQueryCollector.pushAndEvaluate(mediaRule.mediaQueries()))
-            addChildRules(mediaRule.childRules());
+            addChildRules(mediaRule.ruleGroup().childRules());
         m_mediaQueryCollector.pop(mediaRule.mediaQueries());
         return;
     }
@@ -136,7 +136,7 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
             m_ruleSet->m_containerQueries.append({ containerRule, previousContainerQueryIdentifier });
             m_currentContainerQueryIdentifier = m_ruleSet->m_containerQueries.size();
         }
-        addChildRules(containerRule.childRules());
+        addChildRules(containerRule.ruleGroup().childRules());
         if (m_ruleSet)
             m_currentContainerQueryIdentifier = previousContainerQueryIdentifier;
         return;
@@ -154,7 +154,7 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
         }
         // Block syntax.
         pushCascadeLayer(layerRule.name());
-        addChildRules(layerRule.childRules());
+        addChildRules(layerRule.ruleGroup().childRules());
         popCascadeLayer(layerRule.name());
         return;
     }
@@ -171,7 +171,7 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
 
     case StyleRuleType::Supports:
         if (downcast<StyleRuleSupports>(*rule).conditionIsSupported())
-            addChildRules(downcast<StyleRuleSupports>(*rule).childRules());
+            addChildRules(downcast<StyleRuleSupports>(*rule).ruleGroup().childRules());
         return;
 
     case StyleRuleType::Import:

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -50,7 +50,7 @@ static bool shouldDirtyAllStyle(const Vector<RefPtr<StyleRuleBase>>& rules)
 {
     for (auto& rule : rules) {
         if (is<StyleRuleMedia>(*rule)) {
-            if (shouldDirtyAllStyle(downcast<StyleRuleMedia>(*rule).childRules()))
+            if (shouldDirtyAllStyle(downcast<StyleRuleMedia>(*rule).ruleGroup().childRules()))
                 return true;
             continue;
         }


### PR DESCRIPTION
#### f3dde5a057f6faa79f5bcc7ae72a3faa8ee334bb
<pre>
StyleRuleGroup should use composition instead of inheritance
<a href="https://bugs.webkit.org/show_bug.cgi?id=254297">https://bugs.webkit.org/show_bug.cgi?id=254297</a>
rdar://107103847

Reviewed by NOBODY (OOPS!).

The inheritance comes from the CSSGroupingRule spec,
but we have no reason to follow the same pattern/hierarchy in our
internal representation.

* Source/WebCore/css/CSSConditionRule.cpp:
(WebCore::CSSConditionRule::CSSConditionRule):
* Source/WebCore/css/CSSConditionRule.h:
* Source/WebCore/css/CSSContainerRule.cpp:
(WebCore::CSSContainerRule::styleRuleContainer const):
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::CSSGroupingRule):
(WebCore::CSSGroupingRule::~CSSGroupingRule):
(WebCore::CSSGroupingRule::insertRule):
(WebCore::CSSGroupingRule::deleteRule):
(WebCore::CSSGroupingRule::cssTextForDeclsAndRules const):
(WebCore::CSSGroupingRule::length const):
(WebCore::CSSGroupingRule::item const):
(WebCore::CSSGroupingRule::reattach):
(WebCore::CSSGroupingRule::groupRule const):
(WebCore::CSSGroupingRule::groupRule):
* Source/WebCore/css/CSSGroupingRule.h:
(WebCore::CSSGroupingRule::rule const):
(WebCore::CSSGroupingRule::groupRule const): Deleted.
(WebCore::CSSGroupingRule::groupRule): Deleted.
* Source/WebCore/css/CSSLayerBlockRule.cpp:
(WebCore::CSSLayerBlockRule::name const):
* Source/WebCore/css/CSSMediaRule.cpp:
(WebCore::CSSMediaRule::mediaQueries const):
(WebCore::CSSMediaRule::setMediaQueries):
* Source/WebCore/css/CSSSupportsRule.cpp:
(WebCore::CSSSupportsRule::conditionText const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleGroup::StyleRuleGroup):
(WebCore::StyleRuleGroup::childRules):
(WebCore::StyleRuleGroup::fromStyleRuleBase):
(WebCore::StyleRuleMedia::StyleRuleMedia):
(WebCore::StyleRuleSupports::StyleRuleSupports):
(WebCore::StyleRuleLayer::StyleRuleLayer):
(WebCore::StyleRuleContainer::StyleRuleContainer):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isStyleRuleWithNesting const):
(WebCore::StyleRuleBase::isGroupRule const):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::traverseRulesInVector):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::shouldDirtyAllStyle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3dde5a057f6faa79f5bcc7ae72a3faa8ee334bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/291 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/269 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/522 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/316 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/348 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/252 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/291 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/382 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/284 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/279 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->