### PR TITLE
[hooks/pre-push] Make our pre-push hook case insensitive

### DIFF
--- a/Tools/Scripts/hooks/pre-push
+++ b/Tools/Scripts/hooks/pre-push
@@ -99,7 +99,7 @@ def security_level_for_remote(remote):
     match = REMOTE_RE.match(remote)
     if not match:
         return None
-    return SECURITY_LEVELS.get('{}:{}'.format(match.group('host'), match.group('path')), None)
+    return SECURITY_LEVELS.get('{}:{}'.format(match.group('host'), match.group('path')).lower(), None)
 
 
 def security_level_for_remotes(remotes, name_to_remote=None):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
@@ -108,7 +108,7 @@ class InstallHooks(Command):
         for name, rmt in remotes_by_name.items():
             match = cls.REMOTE_RE.match(rmt)
             if match:
-                result['{}:{}'.format(match.group('host'), match.group('path'))] = levels_by_name.get(name, None)
+                result['{}:{}'.format(match.group('host'), match.group('path')).lower()] = levels_by_name.get(name, None)
 
         proc = run(
             [local.Git.executable(), 'config', '--get-regexp', 'remote.+url'],
@@ -122,7 +122,7 @@ class InstallHooks(Command):
             match = cls.REMOTE_RE.match(value)
             if not match:
                 continue
-            key = '{}:{}'.format(match.group('host'), match.group('path'))
+            key = '{}:{}'.format(match.group('host'), match.group('path')).lower()
             if key in result:
                 continue
             repo = 'https://{}/{}'.format(match.group('host'), match.group('path'))
@@ -131,7 +131,7 @@ class InstallHooks(Command):
             parent = ((remote.GitHub(repo).request() or {}).get('parent') or {}).get('full_name')
             if not parent:
                 continue
-            parent_key = '{}:{}'.format(match.group('host'), parent)
+            parent_key = '{}:{}'.format(match.group('host'), parent).lower()
             if parent_key in result:
                 result[key] = result[parent_key]
         return result
@@ -168,15 +168,15 @@ class InstallHooks(Command):
                 sys.stderr.write("'{}' is not a valid security level\n".format(value))
                 continue
             value = int(value)
-            if key in security_levels:
-                exisiting_level = security_levels.get(key, None)
+            if key.lower() in security_levels:
+                exisiting_level = security_levels.get(key.lower(), None)
                 if exisiting_level is None:
                     sys.stderr.write("'{}' is already specified, but with an unknown security level\n".format(key))
                 if exisiting_level != value:
                     sys.stderr.write("'{}' already has a security level of '{}'\n".format(key, exisiting_level))
                     early_exit = True
                     continue
-            security_levels[key] = value
+            security_levels[key.lower()] = value
         if early_exit:
             return 1
 


### PR DESCRIPTION
#### 305fc1b1cf5931248c265a39dfc2aa272b8cd1d6
<pre>
[hooks/pre-push] Make our pre-push hook case insensitive
<a href="https://bugs.webkit.org/show_bug.cgi?id=254303">https://bugs.webkit.org/show_bug.cgi?id=254303</a>
<a href="https://rdar.apple.com/107109166">rdar://107109166</a>

Reviewed by Aakash Jain.

Make all our remote logic in our pre-push hook case insensitive.

* Tools/Scripts/hooks/pre-push:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py:
(InstallHooks._security_levels):
(InstallHooks.main):

Canonical link: <a href="https://commits.webkit.org/276030@main">https://commits.webkit.org/276030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04f517349fae4ac809c53f891a455f0f0a7ef9b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20036 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19644 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16991 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/43451 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38590 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1636 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39730 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47767 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15213 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/43624 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20037 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41473 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5935 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->