### PR TITLE
MTLDebugDevice does not respond to _purgeDevice

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/ScopedRenderingResourcesRequestCocoa.mm
+++ b/Source/WebKit/GPUProcess/graphics/ScopedRenderingResourcesRequestCocoa.mm
@@ -60,11 +60,14 @@ void ScopedRenderingResourcesRequest::freeRenderingResources()
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 #if PLATFORM(MAC)
     auto devices = adoptNS(MTLCopyAllDevices());
-    for (id <MTLDevice> device : devices.get())
-        [(_MTLDevice *)device _purgeDevice];
+    for (id<MTLDevice> device : devices.get()) {
+        if ([device respondsToSelector:@selector(_purgeDevice)])
+            [(_MTLDevice *)device _purgeDevice];
+    }
 #else
     RetainPtr<MTLDevice> devicePtr = adoptNS(MTLCreateSystemDefaultDevice());
-    [(_MTLDevice *)devicePtr.get() _purgeDevice];
+    if ([devicePtr.get() respondsToSelector:@selector(_purgeDevice)])
+        [(_MTLDevice *)devicePtr.get() _purgeDevice];
 #endif
     END_BLOCK_OBJC_EXCEPTIONS
 }


### PR DESCRIPTION
#### 547b0c241c711fe5f9ef02be817cf4bf7cc3cecf
<pre>
MTLDebugDevice does not respond to _purgeDevice
<a href="https://bugs.webkit.org/show_bug.cgi?id=254301">https://bugs.webkit.org/show_bug.cgi?id=254301</a>
&lt;radar://107108867&gt;

Reviewed by Myles C. Maxfield.

When running with API validation enabled, calling _purgeDevice is an
unrecognized selector.

* Source/WebKit/GPUProcess/graphics/ScopedRenderingResourcesRequestCocoa.mm:
(WebKit::ScopedRenderingResourcesRequest::freeRenderingResources):

Canonical link: <a href="https://commits.webkit.org/262000@main">https://commits.webkit.org/262000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45c07afedbffefafb0b3aad39c3c86ffb8b3af67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/212 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/235 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/237 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/256 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/220 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/200 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/231 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/222 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/226 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/51 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/225 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->