### PR TITLE
[Draft] Speculatively sweep to freelist during down time

### DIFF
--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -94,7 +94,7 @@ MarkedBlock::Handle* BlockDirectory::findEmptyBlockToSteal()
     return m_blocks[m_emptyCursor];
 }
 
-MarkedBlock::Handle* BlockDirectory::findBlockForAllocation(LocalAllocator& allocator)
+MarkedBlock::Handle* BlockDirectory::findBlockForAllocation(LocalAllocator& allocator, bool speculative)
 {
     for (;;) {
         allocator.m_allocationCursor = (m_bits.canAllocateButNotEmpty() | m_bits.empty()).findBit(allocator.m_allocationCursor, true);
@@ -103,7 +103,8 @@ MarkedBlock::Handle* BlockDirectory::findBlockForAllocation(LocalAllocator& allo
         
         unsigned blockIndex = allocator.m_allocationCursor++;
         MarkedBlock::Handle* result = m_blocks[blockIndex];
-        setIsCanAllocateButNotEmpty(NoLockingNecessary, blockIndex, false);
+        if (LIKELY(!speculative))
+            setIsCanAllocateButNotEmpty(NoLockingNecessary, blockIndex, false);
         return result;
     }
 }

--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -145,7 +145,9 @@ private:
     friend class LocalSideAllocator;
     friend class MarkedBlock;
     
-    MarkedBlock::Handle* findBlockForAllocation(LocalAllocator&);
+public:
+    MarkedBlock::Handle* findBlockForAllocation(LocalAllocator&, bool isSpecilative = false);
+private:
     
     MarkedBlock::Handle* tryAllocateBlock(Heap&);
     
@@ -173,7 +175,7 @@ private:
     BlockDirectory* m_nextDirectory { nullptr };
     BlockDirectory* m_nextDirectoryInSubspace { nullptr };
     BlockDirectory* m_nextDirectoryInAlignedMemoryAllocator { nullptr };
-    
+public:
     SentinelLinkedList<LocalAllocator, BasicRawSentinelNode<LocalAllocator>> m_localAllocators;
 };
 

--- a/Source/JavaScriptCore/heap/IncrementalSweeper.h
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BlockDirectory.h"
 #include "JSRunLoopTimer.h"
 
 namespace JSC {
@@ -45,11 +46,14 @@ public:
 
 private:
     bool sweepNextBlock(VM&);
+    bool constructNextSpeculativeFreeList(VM&);
     void doSweep(VM&, MonotonicTime startTime);
     void scheduleTimer();
     
     BlockDirectory* m_currentDirectory;
+    std::optional<decltype(m_currentDirectory->m_localAllocators.end())> m_currentAllocator;
     bool m_shouldFreeFastMallocMemoryAfterSweeping { false };
+    bool doneSweeping { false };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -441,6 +441,7 @@ void MarkedBlock::Handle::sweepSpeculativelyToFreeList()
     FreeCell* head = nullptr;
     uintptr_t secret = static_cast<uintptr_t>(vm().heapRandom().getUint64());
     bool isEmpty = true;
+    (void) isEmpty;
     size_t count = 0;
     auto handleDeadCell = [&] (size_t i) {
         HeapCell* cell = reinterpret_cast_ptr<HeapCell*>(&block().atoms()[i]);

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -36,7 +36,8 @@
 
 namespace JSC {
 
-class AlignedMemoryAllocator;    
+class AlignedMemoryAllocator;
+struct FreeCell;
 class FreeList;
 class Heap;
 class JSCell;
@@ -142,6 +143,8 @@ public:
         // the block. If it's not set and the block has nothing marked, then we'll make the
         // mistake of making a pop freelist rather than a bump freelist.
         void sweep(FreeList*);
+
+        void sweepSpeculativelyToFreeList();
         
         // This is to be called by Subspace.
         template<typename DestroyFunc>
@@ -296,10 +299,15 @@ public:
 
         HeapVersion m_markingVersion;
         HeapVersion m_newlyAllocatedVersion;
+        HeapVersion m_sweepListMarkingVersion { static_cast<HeapVersion>(-1) };
+        HeapVersion m_sweepListAllocVersion { static_cast<HeapVersion>(-1) };
+        uint16_t m_sweepListCount { 0 };
 
         Bitmap<atomsPerBlock> m_marks;
         Bitmap<atomsPerBlock> m_newlyAllocated;
         void* m_verifierMemo { nullptr };
+        FreeCell* m_sweepListHead { nullptr };
+        uintptr_t m_sweepListSecret { 0 };
     };
     
 private:


### PR DESCRIPTION
#### 38120acff9839e35673b986287091ee893b778c1
<pre>
[Draft] Speculatively sweep to freelist during down time
<a href="https://bugs.webkit.org/show_bug.cgi?id=254305">https://bugs.webkit.org/show_bug.cgi?id=254305</a>
rdar://107111250

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::findBlockForAllocation):
* Source/JavaScriptCore/heap/BlockDirectory.h:
* Source/JavaScriptCore/heap/IncrementalSweeper.cpp:
(JSC::IncrementalSweeper::IncrementalSweeper):
(JSC::IncrementalSweeper::doSweep):
(JSC::IncrementalSweeper::constructNextSpeculativeFreeList):
(JSC::IncrementalSweeper::startSweeping):
(JSC::IncrementalSweeper::stopSweeping):
* Source/JavaScriptCore/heap/IncrementalSweeper.h:
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::sweepSpeculativelyToFreeList):
* Source/JavaScriptCore/heap/MarkedBlock.h:
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::Handle::specializedSweep):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d66092af6e19f9ea0832b1a910ea7245115dfbcc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/245 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/224 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/487 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/268 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/314 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/223 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/210 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/246 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/253 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/388 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/260 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/241 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/31 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/237 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/259 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/31 "Passed tests") | 
<!--EWS-Status-Bubble-End-->