### PR TITLE
[JSC] Track @@toStringTag in Structure

### DIFF
--- a/JSTests/microbenchmarks/to-string-object.js
+++ b/JSTests/microbenchmarks/to-string-object.js
@@ -1,0 +1,9 @@
+function test(object) {
+    return String(object);
+}
+noInline(test);
+
+var object = { __proto__: { __proto__: { } } };
+for (var i = 0; i < 1e6; ++i) {
+    test(object);
+}

--- a/Source/JavaScriptCore/builtins/BuiltinNames.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.cpp
@@ -37,7 +37,7 @@
 namespace JSC {
 namespace Symbols {
 
-#define INITIALIZE_BUILTIN_STATIC_SYMBOLS(name) SymbolImpl::StaticSymbolImpl name##Symbol { "Symbol." #name };
+#define INITIALIZE_BUILTIN_STATIC_SYMBOLS(name, flags) SymbolImpl::StaticSymbolImpl name##Symbol { "Symbol." #name, flags };
 JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_WELL_KNOWN_SYMBOL(INITIALIZE_BUILTIN_STATIC_SYMBOLS)
 #undef INITIALIZE_BUILTIN_STATIC_SYMBOLS
 
@@ -54,7 +54,7 @@ SymbolImpl::StaticSymbolImpl polyProtoPrivateName { "PolyProto", SymbolImpl::s_f
 } // namespace Symbols
 
 #define INITIALIZE_BUILTIN_NAMES_IN_JSC(name) , m_##name(JSC::Identifier::fromString(vm, #name ""_s))
-#define INITIALIZE_BUILTIN_SYMBOLS_IN_JSC(name) \
+#define INITIALIZE_BUILTIN_SYMBOLS_IN_JSC(name, flag) \
     , m_##name##Symbol(JSC::Identifier::fromUid(vm, &static_cast<SymbolImpl&>(JSC::Symbols::name##Symbol))) \
     , m_##name##SymbolPrivateIdentifier(JSC::Identifier::fromString(vm, #name ""_s))
 
@@ -65,7 +65,7 @@ SymbolImpl::StaticSymbolImpl polyProtoPrivateName { "PolyProto", SymbolImpl::s_f
         m_privateNameSet.add(symbol); \
     } while (0);
 
-#define INITIALIZE_WELL_KNOWN_SYMBOL_PUBLIC_TO_PRIVATE_ENTRY(name) \
+#define INITIALIZE_WELL_KNOWN_SYMBOL_PUBLIC_TO_PRIVATE_ENTRY(name, flag) \
     do { \
         SymbolImpl* symbol = static_cast<SymbolImpl*>(m_##name##Symbol.impl()); \
         m_wellKnownSymbolsMap.add(m_##name##SymbolPrivateIdentifier.impl(), symbol); \

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -35,8 +35,8 @@
 namespace JSC {
 
 #define DECLARE_BUILTIN_NAMES_IN_JSC(name) const JSC::Identifier m_##name;
-#define DECLARE_BUILTIN_SYMBOLS_IN_JSC(name) const JSC::Identifier m_##name##Symbol; const JSC::Identifier m_##name##SymbolPrivateIdentifier;
-#define DECLARE_BUILTIN_SYMBOL_ACCESSOR(name) \
+#define DECLARE_BUILTIN_SYMBOLS_IN_JSC(name, flags) const JSC::Identifier m_##name##Symbol; const JSC::Identifier m_##name##SymbolPrivateIdentifier;
+#define DECLARE_BUILTIN_SYMBOL_ACCESSOR(name, flags) \
     const JSC::Identifier& name##Symbol() const { return m_##name##Symbol; }
 #define DECLARE_BUILTIN_IDENTIFIER_ACCESSOR_IN_JSC(name) \
     const JSC::Identifier& name##PublicName() const { return m_##name; } \
@@ -216,7 +216,7 @@ namespace JSC {
 
 
 namespace Symbols {
-#define DECLARE_BUILTIN_STATIC_SYMBOLS(name) extern JS_EXPORT_PRIVATE SymbolImpl::StaticSymbolImpl name##Symbol;
+#define DECLARE_BUILTIN_STATIC_SYMBOLS(name, flags) extern JS_EXPORT_PRIVATE SymbolImpl::StaticSymbolImpl name##Symbol;
 JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_WELL_KNOWN_SYMBOL(DECLARE_BUILTIN_STATIC_SYMBOLS)
 #undef DECLARE_BUILTIN_STATIC_SYMBOLS
 

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2069,10 +2069,6 @@ private:
         }
 
         case ObjectToString: {
-#if USE(JSVALUE64)
-            if (node->child1()->shouldSpeculateObject())
-                fixEdge<ObjectUse>(node->child1());
-#endif
             break;
         }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -7613,56 +7613,7 @@ IGNORE_CLANG_WARNINGS_END
     void compileObjectToString()
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-        switch (m_node->child1().useKind()) {
-        case ObjectUse: {
-            LBasicBlock notNullCase = m_out.newBlock();
-            LBasicBlock rareDataCase = m_out.newBlock();
-            LBasicBlock useCacheCase = m_out.newBlock();
-            LBasicBlock slowCase = m_out.newBlock();
-            LBasicBlock continuation = m_out.newBlock();
-
-            LValue object = lowObject(m_node->child1());
-            LValue structure = loadStructure(object);
-            LValue previousOrRareData = m_out.loadPtr(structure, m_heaps.Structure_previousOrRareData);
-            m_out.branch(m_out.notNull(previousOrRareData), unsure(notNullCase), unsure(slowCase));
-
-            LBasicBlock lastNext = m_out.appendTo(notNullCase, rareDataCase);
-            m_out.branch(
-                isCellWithType(previousOrRareData, StructureType, std::nullopt),
-                unsure(slowCase), unsure(rareDataCase));
-
-            m_out.appendTo(rareDataCase, useCacheCase);
-            LValue cache = m_out.loadPtr(previousOrRareData, m_heaps.StructureRareData_specialPropertyCache);
-            m_out.branch(m_out.isNull(cache), unsure(slowCase), unsure(useCacheCase));
-
-            m_out.appendTo(useCacheCase, slowCase);
-            LValue string = m_out.loadPtr(cache, m_heaps.SpecialPropertyCache_cachedToStringTagValue);
-            ValueFromBlock fastResult = m_out.anchor(string);
-            ASSERT(bitwise_cast<uintptr_t>(JSCell::seenMultipleCalleeObjects()) == 1);
-            m_out.branch(m_out.belowOrEqual(string, m_out.constIntPtr(bitwise_cast<void*>(JSCell::seenMultipleCalleeObjects()))), unsure(slowCase), unsure(continuation));
-
-            m_out.appendTo(slowCase, continuation);
-            VM& vm = this->vm();
-            LValue slowResultValue = lazySlowPath(
-                [=, &vm] (const Vector<Location>& locations) -> RefPtr<LazySlowPath::Generator> {
-                    return createLazyCallGenerator(vm,
-                        operationObjectToStringObjectSlow, locations[0].directGPR(), CCallHelpers::TrustedImmPtr(globalObject), locations[1].directGPR());
-                },
-                object);
-            ValueFromBlock slowResult = m_out.anchor(slowResultValue);
-            m_out.jump(continuation);
-
-            m_out.appendTo(continuation, lastNext);
-            setJSValue(m_out.phi(pointerType(), fastResult, slowResult));
-            break;
-        }
-        case UntypedUse:
-            setJSValue(vmCall(pointerType(), operationObjectToStringUntyped, weakPointer(globalObject), lowJSValue(m_node->child1())));
-            break;
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-            break;
-        }
+        setJSValue(vmCall(pointerType(), operationObjectToStringUntyped, weakPointer(globalObject), lowJSValue(m_node->child1())));
     }
 
     void compileObjectAssign()

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.cpp
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.cpp
@@ -29,7 +29,7 @@ namespace JSC {
 #define INITIALIZE_PROPERTY_NAME(name) , name(Identifier::fromString(vm, #name ""_s))
 #define INITIALIZE_KEYWORD(name) , name##Keyword(Identifier::fromString(vm, #name ""_s))
 #define INITIALIZE_PRIVATE_NAME(name) , name##PrivateName(m_builtinNames->name##PrivateName())
-#define INITIALIZE_SYMBOL(name) , name##Symbol(m_builtinNames->name##Symbol())
+#define INITIALIZE_SYMBOL(name, flags) , name##Symbol(m_builtinNames->name##Symbol())
 #define INITIALIZE_PRIVATE_FIELD_NAME(name) , name##PrivateField(Identifier::fromString(vm, "#" #name ""_s))
 
 CommonIdentifiers::CommonIdentifiers(VM& vm)

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -345,19 +345,19 @@
     macro(yield)
 
 #define JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_WELL_KNOWN_SYMBOL(macro) \
-    macro(hasInstance) \
-    macro(isConcatSpreadable) \
-    macro(asyncIterator) \
-    macro(iterator) \
-    macro(match) \
-    macro(matchAll) \
-    macro(replace) \
-    macro(search) \
-    macro(species) \
-    macro(split) \
-    macro(toPrimitive) \
-    macro(toStringTag) \
-    macro(unscopables)
+    macro(hasInstance, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol) \
+    macro(isConcatSpreadable, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol) \
+    macro(asyncIterator, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol) \
+    macro(iterator, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol) \
+    macro(match, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol) \
+    macro(matchAll, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol) \
+    macro(replace, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol) \
+    macro(search, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol) \
+    macro(species, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol) \
+    macro(split, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol) \
+    macro(toPrimitive, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol | SymbolImpl::s_flagIsInterestingSymbol) \
+    macro(toStringTag, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol | SymbolImpl::s_flagIsInterestingSymbol) \
+    macro(unscopables, SymbolImpl::s_flagDefault | SymbolImpl::s_flagIsWellKnownSymbol)
 
 #define JSC_PARSER_PRIVATE_NAMES(macro) \
     macro(generator) \
@@ -405,7 +405,7 @@ namespace JSC {
         JSC_COMMON_IDENTIFIERS_EACH_PROPERTY_NAME(JSC_IDENTIFIER_DECLARE_PROPERTY_NAME_GLOBAL)
 #undef JSC_IDENTIFIER_DECLARE_PROPERTY_NAME_GLOBAL
 
-#define JSC_IDENTIFIER_DECLARE_PRIVATE_WELL_KNOWN_SYMBOL_GLOBAL(name) const Identifier name##Symbol;
+#define JSC_IDENTIFIER_DECLARE_PRIVATE_WELL_KNOWN_SYMBOL_GLOBAL(name, flags) const Identifier name##Symbol;
         JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_WELL_KNOWN_SYMBOL(JSC_IDENTIFIER_DECLARE_PRIVATE_WELL_KNOWN_SYMBOL_GLOBAL)
 #undef JSC_IDENTIFIER_DECLARE_PRIVATE_WELL_KNOWN_SYMBOL_GLOBAL
         const Identifier intlLegacyConstructedSymbol;

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -988,6 +988,7 @@ public:
 
     bool mayBePrototype() const;
     void didBecomePrototype();
+    bool mayHaveInterestingSymbols() const;
 
     std::optional<Structure::PropertyHashEntry> findPropertyHashEntry(PropertyName) const;
 

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -824,4 +824,18 @@ bool JSObject::fastForEachPropertyWithSideEffectFreeFunctor(VM& vm, const Functo
     return true;
 }
 
+inline bool JSObject::mayHaveInterestingSymbols() const
+{
+    const JSObject* cursor = this;
+    while (true) {
+        Structure* structure = cursor->structure();
+        if (UNLIKELY(structure->hasInterestingSymbols()))
+            return true;
+        JSValue prototype = cursor->getPrototypeDirect();
+        if (!prototype.isObject())
+            return false;
+        cursor = asObject(prototype);
+    }
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ObjectPrototype.h
+++ b/Source/JavaScriptCore/runtime/ObjectPrototype.h
@@ -53,5 +53,6 @@ private:
 JS_EXPORT_PRIVATE JSC_DECLARE_HOST_FUNCTION(objectProtoFuncToString);
 JSString* objectPrototypeToString(JSGlobalObject*, JSValue thisValue);
 bool objectPrototypeHasOwnProperty(JSGlobalObject*, JSObject* base, const Identifier& property);
+JSString* objectPrototypeToStringSlow(JSGlobalObject*, JSObject*);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/SmallStrings.cpp
+++ b/Source/JavaScriptCore/runtime/SmallStrings.cpp
@@ -56,8 +56,18 @@ void SmallStrings::initializeCommonStrings(VM& vm)
     JSC_COMMON_STRINGS_EACH_NAME(JSC_COMMON_STRINGS_ATTRIBUTE_INITIALIZE)
 #undef JSC_COMMON_STRINGS_ATTRIBUTE_INITIALIZE
     initialize(&vm, m_objectStringStart, "[object "_s);
-    initialize(&vm, m_nullObjectString, "[object Null]"_s);
-    initialize(&vm, m_undefinedObjectString, "[object Undefined]"_s);
+    initialize(&vm, m_objectNullString, "[object Null]"_s);
+    initialize(&vm, m_objectUndefinedString, "[object Undefined]"_s);
+    initialize(&vm, m_objectObjectString, "[object Object]"_s);
+    initialize(&vm, m_objectArrayString, "[object Array]"_s);
+    initialize(&vm, m_objectFunctionString, "[object Function]"_s);
+    initialize(&vm, m_objectArgumentsString, "[object Arguments]"_s);
+    initialize(&vm, m_objectDateString, "[object Date]"_s);
+    initialize(&vm, m_objectRegExpString, "[object RegExp]"_s);
+    initialize(&vm, m_objectErrorString, "[object Error]"_s);
+    initialize(&vm, m_objectBooleanString, "[object Boolean]"_s);
+    initialize(&vm, m_objectNumberString, "[object Number]"_s);
+    initialize(&vm, m_objectStringString, "[object String]"_s);
     initialize(&vm, m_boundPrefixString, "bound "_s);
     initialize(&vm, m_notEqualString, "not-equal"_s);
     initialize(&vm, m_timedOutString, "timed-out"_s);
@@ -78,8 +88,18 @@ void SmallStrings::visitStrongReferences(Visitor& visitor)
     JSC_COMMON_STRINGS_EACH_NAME(JSC_COMMON_STRINGS_ATTRIBUTE_VISIT)
 #undef JSC_COMMON_STRINGS_ATTRIBUTE_VISIT
     visitor.appendUnbarriered(m_objectStringStart);
-    visitor.appendUnbarriered(m_nullObjectString);
-    visitor.appendUnbarriered(m_undefinedObjectString);
+    visitor.appendUnbarriered(m_objectNullString);
+    visitor.appendUnbarriered(m_objectUndefinedString);
+    visitor.appendUnbarriered(m_objectObjectString);
+    visitor.appendUnbarriered(m_objectArrayString);
+    visitor.appendUnbarriered(m_objectFunctionString);
+    visitor.appendUnbarriered(m_objectArgumentsString);
+    visitor.appendUnbarriered(m_objectDateString);
+    visitor.appendUnbarriered(m_objectRegExpString);
+    visitor.appendUnbarriered(m_objectErrorString);
+    visitor.appendUnbarriered(m_objectBooleanString);
+    visitor.appendUnbarriered(m_objectNumberString);
+    visitor.appendUnbarriered(m_objectStringString);
     visitor.appendUnbarriered(m_boundPrefixString);
     visitor.appendUnbarriered(m_notEqualString);
     visitor.appendUnbarriered(m_timedOutString);

--- a/Source/JavaScriptCore/runtime/SmallStrings.h
+++ b/Source/JavaScriptCore/runtime/SmallStrings.h
@@ -113,8 +113,20 @@ public:
     }
 
     JSString* objectStringStart() const { return m_objectStringStart; }
-    JSString* nullObjectString() const { return m_nullObjectString; }
-    JSString* undefinedObjectString() const { return m_undefinedObjectString; }
+
+    JSString* objectNullString() const { return m_objectNullString; }
+    JSString* objectUndefinedString() const { return m_objectUndefinedString; }
+    JSString* objectObjectString() const { return m_objectObjectString; }
+    JSString* objectArrayString() const { return m_objectArrayString; }
+    JSString* objectFunctionString() const { return m_objectFunctionString; }
+    JSString* objectArgumentsString() const { return m_objectArgumentsString; }
+    JSString* objectDateString() const { return m_objectDateString; }
+    JSString* objectRegExpString() const { return m_objectRegExpString; }
+    JSString* objectErrorString() const { return m_objectErrorString; }
+    JSString* objectBooleanString() const { return m_objectBooleanString; }
+    JSString* objectNumberString() const { return m_objectNumberString; }
+    JSString* objectStringString() const { return m_objectStringString; }
+
     JSString* boundPrefixString() const { return m_boundPrefixString; }
     JSString* notEqualString() const { return m_notEqualString; }
     JSString* timedOutString() const { return m_timedOutString; }
@@ -138,8 +150,19 @@ private:
     JSC_COMMON_STRINGS_EACH_NAME(JSC_COMMON_STRINGS_ATTRIBUTE_DECLARATION)
 #undef JSC_COMMON_STRINGS_ATTRIBUTE_DECLARATION
     JSString* m_objectStringStart { nullptr };
-    JSString* m_nullObjectString { nullptr };
-    JSString* m_undefinedObjectString { nullptr };
+    JSString* m_objectNullString { nullptr };
+    JSString* m_objectUndefinedString { nullptr };
+    JSString* m_objectObjectString { nullptr };
+    JSString* m_objectArrayString { nullptr };
+    JSString* m_objectFunctionString { nullptr };
+    JSString* m_objectArgumentsString { nullptr };
+    JSString* m_objectDateString { nullptr };
+    JSString* m_objectRegExpString { nullptr };
+    JSString* m_objectErrorString { nullptr };
+    JSString* m_objectBooleanString { nullptr };
+    JSString* m_objectNumberString { nullptr };
+    JSString* m_objectStringString { nullptr };
+
     JSString* m_boundPrefixString { nullptr };
     JSString* m_notEqualString { nullptr };
     JSString* m_timedOutString { nullptr };

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -212,6 +212,7 @@ Structure::Structure(VM& vm, JSGlobalObject* globalObject, JSValue prototype, co
     setHasAnyKindOfGetterSetterProperties(classInfo->hasStaticPropertyWithAnyOfAttributes(static_cast<uint8_t>(PropertyAttribute::AccessorOrCustomAccessorOrValue)));
     setHasReadOnlyOrGetterSetterPropertiesExcludingProto(hasAnyKindOfGetterSetterProperties() || classInfo->hasStaticPropertyWithAnyOfAttributes(static_cast<uint8_t>(PropertyAttribute::ReadOnly)));
     setHasUnderscoreProtoPropertyExcludingOriginalProto(false);
+    setHasInterestingSymbols(typeInfo.overridesGetPrototype() || typeInfo.prohibitsPropertyCaching() || typeInfo.getOwnPropertySlotIsImpureForPropertyAbsence() || typeInfo.getOwnPropertySlotIsImpure());
     setIsQuickPropertyAccessAllowedForEnumeration(true);
     setTransitionPropertyAttributes(0);
     setTransitionKind(TransitionKind::Unknown);
@@ -248,11 +249,14 @@ Structure::Structure(VM& vm, CreatingEarlyCellTag)
     , m_classInfo(info())
     , m_transitionWatchpointSet(IsWatched)
 {
+    TypeInfo typeInfo = TypeInfo(StructureType, StructureFlags);
+
     setDictionaryKind(NoneDictionaryKind);
     setIsPinnedPropertyTable(false);
     setHasAnyKindOfGetterSetterProperties(m_classInfo->hasStaticPropertyWithAnyOfAttributes(static_cast<uint8_t>(PropertyAttribute::AccessorOrCustomAccessorOrValue)));
     setHasReadOnlyOrGetterSetterPropertiesExcludingProto(hasAnyKindOfGetterSetterProperties() || m_classInfo->hasStaticPropertyWithAnyOfAttributes(static_cast<uint8_t>(PropertyAttribute::ReadOnly)));
     setHasUnderscoreProtoPropertyExcludingOriginalProto(false);
+    setHasInterestingSymbols(typeInfo.overridesGetPrototype() || typeInfo.prohibitsPropertyCaching() || typeInfo.getOwnPropertySlotIsImpureForPropertyAbsence() || typeInfo.getOwnPropertySlotIsImpure());
     setIsQuickPropertyAccessAllowedForEnumeration(true);
     setTransitionPropertyAttributes(0);
     setTransitionKind(TransitionKind::Unknown);
@@ -265,7 +269,6 @@ Structure::Structure(VM& vm, CreatingEarlyCellTag)
     setTransitionOffset(vm, invalidOffset);
     setMaxOffset(vm, invalidOffset);
  
-    TypeInfo typeInfo = TypeInfo(StructureType, StructureFlags);
     m_blob = TypeInfoBlob(0, typeInfo);
     m_outOfLineTypeFlags = typeInfo.outOfLineTypeFlags();
 
@@ -294,6 +297,7 @@ Structure::Structure(VM& vm, Structure* previous)
     setHasAnyKindOfGetterSetterProperties(previous->hasAnyKindOfGetterSetterProperties());
     setHasReadOnlyOrGetterSetterPropertiesExcludingProto(previous->hasReadOnlyOrGetterSetterPropertiesExcludingProto());
     setHasUnderscoreProtoPropertyExcludingOriginalProto(previous->hasUnderscoreProtoPropertyExcludingOriginalProto());
+    setHasInterestingSymbols(previous->hasInterestingSymbols());
     setIsQuickPropertyAccessAllowedForEnumeration(previous->isQuickPropertyAccessAllowedForEnumeration());
     setTransitionPropertyAttributes(0);
     setTransitionKind(TransitionKind::Unknown);

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -807,7 +807,8 @@ public:
     DEFINE_BITFIELD(bool, hasReadOnlyOrGetterSetterPropertiesExcludingProto, HasReadOnlyOrGetterSetterPropertiesExcludingProto, 1, 4);
     DEFINE_BITFIELD(bool, isQuickPropertyAccessAllowedForEnumeration, IsQuickPropertyAccessAllowedForEnumeration, 1, 5);
     DEFINE_BITFIELD(TransitionPropertyAttributes, transitionPropertyAttributes, TransitionPropertyAttributes, 8, 6);
-    DEFINE_BITFIELD(TransitionKind, transitionKind, TransitionKind, 6, 14);
+    DEFINE_BITFIELD(TransitionKind, transitionKind, TransitionKind, 5, 14);
+    DEFINE_BITFIELD(bool, hasInterestingSymbols, HasInterestingSymbols, 1, 19);
     DEFINE_BITFIELD(bool, didPreventExtensions, DidPreventExtensions, 1, 20);
     DEFINE_BITFIELD(bool, didTransition, DidTransition, 1, 21);
     DEFINE_BITFIELD(bool, staticPropertiesReified, StaticPropertiesReified, 1, 22);

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -485,9 +485,13 @@ inline PropertyOffset Structure::add(VM& vm, PropertyName propertyName, unsigned
     ASSERT(!JSC::isValidOffset(get(vm, propertyName)));
 
     checkConsistency();
-    if (attributes & PropertyAttribute::DontEnum || propertyName.isSymbol())
+    if (attributes & PropertyAttribute::DontEnum)
         setIsQuickPropertyAccessAllowedForEnumeration(false);
-    if (propertyName == vm.propertyNames->underscoreProto)
+    if (propertyName.isSymbol()) {
+        setIsQuickPropertyAccessAllowedForEnumeration(false);
+        if (static_cast<SymbolImpl&>(*propertyName.uid()).isInterestingSymbol())
+            setHasInterestingSymbols(true);
+    } else if (propertyName == vm.propertyNames->underscoreProto)
         setHasUnderscoreProtoPropertyExcludingOriginalProto(true);
 
     auto rep = propertyName.uid();

--- a/Source/JavaScriptCore/runtime/SymbolConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolConstructor.cpp
@@ -61,8 +61,8 @@ SymbolConstructor::SymbolConstructor(VM& vm, Structure* structure)
 {
 }
 
-#define INITIALIZE_WELL_KNOWN_SYMBOLS(name) \
-putDirectWithoutTransition(vm, Identifier::fromString(vm, #name ""_s), Symbol::create(vm, static_cast<SymbolImpl&>(*vm.propertyNames->name##Symbol.impl())), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+#define INITIALIZE_WELL_KNOWN_SYMBOLS(name, flags) \
+    putDirectWithoutTransition(vm, Identifier::fromString(vm, #name ""_s), Symbol::create(vm, static_cast<SymbolImpl&>(*vm.propertyNames->name##Symbol.impl())), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 
 void SymbolConstructor::finishCreation(VM& vm, SymbolPrototype* prototype)
 {

--- a/Source/WTF/wtf/text/SymbolImpl.h
+++ b/Source/WTF/wtf/text/SymbolImpl.h
@@ -36,15 +36,19 @@ class RegisteredSymbolImpl;
 class SymbolImpl : public UniquedStringImpl {
 public:
     using Flags = unsigned;
-    static constexpr Flags s_flagDefault = 0u;
-    static constexpr Flags s_flagIsNullSymbol = 0b001u;
-    static constexpr Flags s_flagIsRegistered = 0b010u;
-    static constexpr Flags s_flagIsPrivate = 0b100u;
+    static constexpr Flags s_flagDefault             = 0b00000u;
+    static constexpr Flags s_flagIsNullSymbol        = 0b00001u;
+    static constexpr Flags s_flagIsRegistered        = 0b00010u;
+    static constexpr Flags s_flagIsPrivate           = 0b00100u;
+    static constexpr Flags s_flagIsWellKnownSymbol   = 0b01000u;
+    static constexpr Flags s_flagIsInterestingSymbol = 0b10000u;
 
     unsigned hashForSymbol() const { return m_hashForSymbolShiftedWithFlagCount >> s_flagCount; }
     bool isNullSymbol() const { return m_flags & s_flagIsNullSymbol; }
     bool isRegistered() const { return m_flags & s_flagIsRegistered; }
     bool isPrivate() const { return m_flags & s_flagIsPrivate; }
+    bool isWellKnownSymbol() const { return m_flags & s_flagIsWellKnownSymbol; }
+    bool isInterestingSymbol() const { return m_flags & s_flagIsInterestingSymbol; }
 
     SymbolRegistry* symbolRegistry() const;
 


### PR DESCRIPTION
#### c2cd01a127f96797e318f662ea3be0769835eb04
<pre>
[JSC] Track @@toStringTag in Structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=254257">https://bugs.webkit.org/show_bug.cgi?id=254257</a>
rdar://107111713

Reviewed by NOBODY (OOPS!).

This patch introduces interesting-symbols concept borrowing from V8 and SpiderMonkey. This is basically @@toStringTag and @@toPrimitive.
And each Structure tracks whether it has these properties. This is important since these symbols are used in a critical path of `ToString`
operation and `Object.prototype.toString`.

This patch marks these symbols as interesting-symbols. And we add a bit in Structure saying &quot;this structure may hold interesting-symbols&quot;.
By using this information, we optimize `Object.prototype.toString`, `ToPrimitive`, and `ToString` calls further.

We also simplify our DFG / FTL ObjectToString code since now C++ side has enough simple fast path for them.

This patch improves a microbenchmark by 2.8x.

                                 ToT                     Patched

    to-string-object       67.4338+-0.7510     ^     24.0256+-0.2124        ^ definitely 2.8067x faster

* Source/JavaScriptCore/builtins/BuiltinNames.cpp:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/runtime/CommonIdentifiers.cpp:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::add):
* Source/JavaScriptCore/runtime/SymbolConstructor.cpp:
* Source/WTF/wtf/text/SymbolImpl.h:
(WTF::SymbolImpl::isInterestingSymbol const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2cd01a127f96797e318f662ea3be0769835eb04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/360 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/602 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/422 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/420 "3 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/428 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/348 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/343 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/383 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/396 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/361 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/408 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/378 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/62 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/375 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/408 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/61 "Passed tests") | 
<!--EWS-Status-Bubble-End-->