### PR TITLE
Minor tweaks to DocumentTimelinesController

### DIFF
--- a/Source/WebCore/animation/DocumentTimelinesController.cpp
+++ b/Source/WebCore/animation/DocumentTimelinesController.cpp
@@ -44,7 +44,6 @@ namespace WebCore {
 
 DocumentTimelinesController::DocumentTimelinesController(Document& document)
     : m_document(document)
-    , m_frameRateAligner()
 {
     if (auto* page = document.page()) {
         if (page->settings().hiddenPageCSSAnimationSuspensionEnabled() && !page->isVisible())
@@ -250,11 +249,6 @@ void DocumentTimelinesController::resumeAnimations()
 
     for (auto& timeline : m_timelines)
         timeline.resumeAnimations();
-}
-
-bool DocumentTimelinesController::animationsAreSuspended() const
-{
-    return m_isSuspended;
 }
 
 ReducedResolutionSeconds DocumentTimelinesController::liveCurrentTime() const

--- a/Source/WebCore/animation/DocumentTimelinesController.h
+++ b/Source/WebCore/animation/DocumentTimelinesController.h
@@ -57,14 +57,9 @@ public:
 
     WEBCORE_EXPORT void suspendAnimations();
     WEBCORE_EXPORT void resumeAnimations();
-    WEBCORE_EXPORT bool animationsAreSuspended() const;
+    bool animationsAreSuspended() const { return m_isSuspended; }
 
 private:
-    struct AnimationsToProcess {
-        Vector<RefPtr<WebAnimation>> animationsToRemove;
-        Vector<RefPtr<CSSTransition>> completedTransitions;
-    };
-
     ReducedResolutionSeconds liveCurrentTime() const;
     void cacheCurrentTime(ReducedResolutionSeconds);
     void maybeClearCachedCurrentTime();

--- a/Source/WebCore/animation/FrameRateAligner.h
+++ b/Source/WebCore/animation/FrameRateAligner.h
@@ -35,7 +35,7 @@ namespace WebCore {
 class FrameRateAligner {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit FrameRateAligner();
+    FrameRateAligner();
     ~FrameRateAligner();
 
     void beginUpdate(ReducedResolutionSeconds, std::optional<FramesPerSecond>);


### PR DESCRIPTION
#### 9d395faae3e72ba053a2253551190aabf707f9a0
<pre>
Minor tweaks to DocumentTimelinesController
<a href="https://bugs.webkit.org/show_bug.cgi?id=254310">https://bugs.webkit.org/show_bug.cgi?id=254310</a>

Reviewed by Yusuke Suzuki.

Drop unnecessary / dead code and inline animationsAreSuspended().

* Source/WebCore/animation/DocumentTimelinesController.cpp:
(WebCore::DocumentTimelinesController::DocumentTimelinesController):
(WebCore::DocumentTimelinesController::animationsAreSuspended const): Deleted.
* Source/WebCore/animation/DocumentTimelinesController.h:
(WebCore::DocumentTimelinesController::animationsAreSuspended const):
* Source/WebCore/animation/FrameRateAligner.h:

Canonical link: <a href="https://commits.webkit.org/262005@main">https://commits.webkit.org/262005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/336c4eff1a17e51152a1c1a41e40985843ba0315

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/256 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/235 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/259 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/260 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/281 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/244 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/219 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/243 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/253 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/53 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/247 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->