### PR TITLE
REGRESSION(261820@main): ASSERTION FAILED: [source isKindOfClass:[DestinationClass class]]

### DIFF
--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -533,7 +533,7 @@ RetainPtr<NSObject<NSSecureCoding>> Object::toNSObject()
     case Object::Type::Int64:
         return adoptNS([[NSNumber alloc] initWithLongLong:static_cast<API::Int64&>(*this).value()]);
     case Object::Type::Data:
-        return API::wrapper(static_cast<API::String&>(*this));
+        return API::wrapper(static_cast<API::Data&>(*this));
     case Object::Type::String:
         return (NSString *)static_cast<API::String&>(*this).string();
     default:


### PR DESCRIPTION
#### 9758573dc911f717409885d92a7e689f79b5d813
<pre>
REGRESSION(261820@main): ASSERTION FAILED: [source isKindOfClass:[DestinationClass class]]
<a href="https://bugs.webkit.org/show_bug.cgi?id=254306">https://bugs.webkit.org/show_bug.cgi?id=254306</a>
rdar://107112432

Unreviewed.

* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::toNSObject):
Typo - I had the wrong type of API object.

Canonical link: <a href="https://commits.webkit.org/262034@main">https://commits.webkit.org/262034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c6ce4f497bbb24983a429c853c9d373cd645dbb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/261 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/239 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/500 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/264 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/285 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/327 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/223 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/262 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/247 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/256 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/57 "layout-tests (failure)") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/251 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/38 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->