### PR TITLE
[JSC] Align RegExp V Flags Syntax errors with V8

### DIFF
--- a/JSTests/stress/regexp-vflag-property-of-strings.js
+++ b/JSTests/stress/regexp-vflag-property-of-strings.js
@@ -203,8 +203,8 @@ testRegExpSyntaxError("[1-3&&a--\\q{XYZ}]", "v", "SyntaxError: Invalid regular e
 // Test 31
 testRegExpSyntaxError("[a-z&&1--\\q{XYZ}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 testRegExpSyntaxError("[a-z&&1--\\p{White_Space}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
-testRegExpSyntaxError("[a&&&\\p{White_Space}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
-testRegExpSyntaxError("[a&&&]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&&\\p{White_Space}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a&&&]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
 testRegExpSyntaxError("[a&&-]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
 
 // Test 36
@@ -218,33 +218,33 @@ testRegExpSyntaxError("[a&&{]", "v", "SyntaxError: Invalid regular expression: i
 testRegExpSyntaxError("[a&&}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
 testRegExpSyntaxError("[a&&/]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
 testRegExpSyntaxError("[a&&|]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&&&]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
-testRegExpSyntaxError("[a&&!!]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a&&&&]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a&&!!]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 46
-testRegExpSyntaxError("[a&&##]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&$$]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&%%]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&**]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&++]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a&&##]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&$$]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&%%]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&**]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&++]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 51
-testRegExpSyntaxError("[a&&,,]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&..]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&::]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&;;]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&<<]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a&&,,]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&..]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&::]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&;;]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&<<]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 56
-testRegExpSyntaxError("[a&&==]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&>>]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&??]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&@@]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&^^]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a&&==]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&>>]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&??]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&@@]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&^^]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 61
-testRegExpSyntaxError("[a&&``]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a&&~~]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a&&``]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a&&~~]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 testRegExpSyntaxError("[a--(]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
 testRegExpSyntaxError("[a--)]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
 testRegExpSyntaxError("[a--[]", "v", "SyntaxError: Invalid regular expression: missing terminating ] for character class");
@@ -258,30 +258,30 @@ testRegExpSyntaxError("[a--|]", "v", "SyntaxError: Invalid regular expression: i
 
 // Test 71
 testRegExpSyntaxError("[a--&&]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
-testRegExpSyntaxError("[a--!!]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--##]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--$$]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--%%]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a--!!]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--##]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--$$]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--%%]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 76
-testRegExpSyntaxError("[a--**]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--++]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--,,]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--..]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--::]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a--**]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--++]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--,,]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--..]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--::]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 81
-testRegExpSyntaxError("[a--;;]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--<<]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--==]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a-->>]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--??]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a--;;]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--<<]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--==]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a-->>]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--??]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 86
-testRegExpSyntaxError("[a--@@]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--^^]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--``]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a--~~]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a--@@]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--^^]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--``]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a--~~]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 testRegExpSyntaxError("[a&&b-c]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 91
@@ -293,31 +293,31 @@ testRegExpSyntaxError("[a-z&&k]", "v", "SyntaxError: Invalid regular expression:
 
 // Test 96
 testRegExpSyntaxError("[a---]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a&&b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a!!b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a##b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a$$b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a\\q{a&&b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a!!b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a##b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a$$b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 101
-testRegExpSyntaxError("[a\\q{a%%b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a**b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a++b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a,,b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a..b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a\\q{a%%b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a**b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a++b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a,,b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a..b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 106
-testRegExpSyntaxError("[a\\q{a::b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a;;b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a<<b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a==b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a>>b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a\\q{a::b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a;;b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a<<b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a==b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a>>b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 111
-testRegExpSyntaxError("[a\\q{a??b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a@@b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a^^b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a``b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExpSyntaxError("[a\\q{a~~b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[a\\q{a??b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a@@b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a^^b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a``b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[a\\q{a~~b}]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 116
 testRegExpSyntaxError("[a\\q{a(b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
@@ -329,14 +329,14 @@ testRegExpSyntaxError("[a\\q{a{b}]", "v", "SyntaxError: Invalid regular expressi
 // Test 121
 testRegExpSyntaxError("[a\\q{a/b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
 testRegExpSyntaxError("[a\\q{a-b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[\p{ASCII}---]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
 testRegExp(/[\p{ASCII}&&\&]/v, "a&b", ["&"]);
 testRegExp(/[\p{ASCII}&&\-]/v, "a-b", ["-"]);
-testRegExp(/[\p{ASCII}--\&]/v, "&b", ["b"]);
 
 // Test 126
+testRegExp(/[\p{ASCII}--\&]/v, "&b", ["b"]);
 testRegExp(/[\p{ASCII}--&]/v, "&b", ["b"]);
 testRegExp(/[\p{ASCII}--\-]/v, "-b", ["b"]);
-testRegExp(/[\p{ASCII}---]/v, "-b", ["b"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "a", ["a"]);
 
@@ -394,4 +394,3 @@ testRegExp(/[a\(\)]+/v, "a()", ["a()"]);
 testRegExp(/[a\q{\(\)}]{2}/v, "()a()", ["()a"]);
 testRegExp(/[a\q{\(\)}]+/v, "()a()", ["()a()"]);
 testRegExp(/[a\q{\=\=}]+/v, "==a==", ["==a=="]);
-

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -1124,7 +1124,7 @@ private:
             if (!atEndOfPattern()) {
                 UChar32 nextCh = peek();
                 if (ch == nextCh && strchr("&!#$%*+,.:;<=>?@^`~", ch)) {
-                    m_errorCode = ErrorCode::InvalidClassSetCharacter;
+                    m_errorCode = ErrorCode::InvalidClassSetOperation;
                     return -1;
                 }
             }
@@ -1252,6 +1252,10 @@ private:
                 consume();
                 if (peek() == '-') {
                     consume();
+                    if (peek() == '-') {
+                        m_errorCode = ErrorCode::InvalidClassSetCharacter;
+                        return;
+                    }
                     classSetConstructor.setSubtractOp();
                     break;
                 }
@@ -1266,7 +1270,7 @@ private:
                 if (peek() == '&') {
                     consume();
                     if (peek() == '&') {
-                        m_errorCode = ErrorCode::InvalidClassSetOperation;
+                        m_errorCode = ErrorCode::InvalidClassSetCharacter;
                         return;
                     }
                     classSetConstructor.setIntersectionOp();


### PR DESCRIPTION
#### 825b9eb20878e31d5064ef2961973ab432af3055
<pre>
[JSC] Align RegExp V Flags Syntax errors with V8
<a href="https://bugs.webkit.org/show_bug.cgi?id=254313">https://bugs.webkit.org/show_bug.cgi?id=254313</a>
rdar://107116409

Reviewed by Yusuke Suzuki.

Updated syntax error tests after comparing to the types of errors that V8 throws.
The changes in errors are either from &quot;invalid class set character&quot; to &quot;invalid operation in class set&quot;
or the opposite, from &quot;invalid operation in class set&quot; to &quot;invalid class set character&quot;.

Found and fixed one case where we weren&apos;t throwing an &quot;invalid class set character&quot; syntax error when
three dashes appear in a row, e.g. /a---x/v.

* JSTests/stress/regexp-vflag-property-of-strings.js:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::consumeAndCheckIfValidClassSetCharacter):
(JSC::Yarr::Parser::parseClassSet):

Canonical link: <a href="https://commits.webkit.org/262017@main">https://commits.webkit.org/262017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e411fbba821875d6fd8b7319aa1cef43ef5c77e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/309 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/287 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/339 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/309 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/334 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/288 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/269 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/316 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/292 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/322 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/297 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/67 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/295 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/320 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/39 "Passed tests") | 
<!--EWS-Status-Bubble-End-->