### PR TITLE
REGRESSION (260842@main): Rendered document markers are always opaque

### DIFF
--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -832,7 +832,7 @@ void TextBoxPainter<TextBoxPath>::paintPlatformDocumentMarker(const MarkedText& 
 
     auto lineStyleColor = RenderTheme::singleton().documentMarkerLineColor(lineStyleMode, m_renderer.styleColorOptions());
     if (auto* marker = markedText.marker)
-        lineStyleColor = lineStyleColor.colorWithAlpha(marker->opacity());
+        lineStyleColor = lineStyleColor.colorWithAlphaMultipliedBy(marker->opacity());
 
     bounds.moveBy(m_paintRect.location());
     m_paintInfo.context().drawDotsForDocumentMarker(bounds, { lineStyleMode, lineStyleColor });


### PR DESCRIPTION
#### 35e844fd941fb841c8342d7e19f70bcd17d81869
<pre>
REGRESSION (260842@main): Rendered document markers are always opaque
<a href="https://bugs.webkit.org/show_bug.cgi?id=254314">https://bugs.webkit.org/show_bug.cgi?id=254314</a>
rdar://106372237

Reviewed by Wenson Hsieh.

In order to support fading out document markers, 260842@main added logic to
adjust the opacity of the used marker color at paint time. However, the method
used to adjust opacity overrides the alpha value of the color rather than
multiplying it. This results in opaque colors as the alpha value is forced to 1.

* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarker):

Canonical link: <a href="https://commits.webkit.org/262022@main">https://commits.webkit.org/262022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4836b02a80bc3bdedd2294569dae91b9512b41c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/263 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/241 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/268 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/502 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/287 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/329 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/225 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/263 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/249 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/217 "Exiting early after 60 failures. 55006 tests run. 60 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/257 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/253 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/33 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->