### PR TITLE
TextManipulationController can remove whitespace between a list of white-space: nowrap items

### DIFF
--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -340,6 +340,10 @@ static bool isEnclosingItemBoundaryElement(const Element& element)
             if (parent->hasTagName(HTMLNames::navTag) || role(*parent) == AccessibilityRole::LandmarkNavigation)
                 return true;
         }
+
+        // Treat a or li with white-space: nowrap as its own paragraph so that wrapping whitespace between them will be preserved.
+        if (renderer->style().whiteSpace() == WhiteSpace::NoWrap)
+            return true;
     }
 
     if (displayType == DisplayType::TableCell)


### PR DESCRIPTION
#### da777142e59de9309b1c4b670730663e1295180a
<pre>
TextManipulationController can remove whitespace between a list of white-space: nowrap items
<a href="https://bugs.webkit.org/show_bug.cgi?id=254319">https://bugs.webkit.org/show_bug.cgi?id=254319</a>
&lt;rdar://103521673&gt;

Reviewed by Sihui Liu.

There are some websites which use an anchor element with `white-space: nowrap` as a list item
and with a fixed width constraint such that each anchor element is displayed on its own line.

Prior to this patch, such a content is extracted by TextManipulationController as a one long
paragraph because there is no br or block element to explicitly wrap the text.

This is problematic since we can strip away those whitespaces between the anchor elements
when we&apos;re placing the translated results, making the whole content to be in a single contiguous
text with `white-space: nowrap` (i.e. all anchor elements appear in a single non-wrapping line).

Because whitespaces between these anchor elements are indistinguishable from those that appear
within each anchor element, preserving those whitespaces between anchor elements is not enough.
Instead, we treat each anchor element with `white-space: nowrap` as its own paragraph so that
whitespaces between them are left undisturbed.

* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::isEnclosingItemBoundaryElement): Treat an anchor element with `white-space: nowrap`
as a boundary element.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm:
(TextManipulation.CompleteTextManipulationPreservesWhitespacesBetweenItems):

Canonical link: <a href="https://commits.webkit.org/262036@main">https://commits.webkit.org/262036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db61b917144ce2100646914fb70175e2335a4c82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/278 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/508 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/275 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/297 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/334 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/275 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/258 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/228 "Exiting early after 60 failures. 55004 tests run. 60 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/268 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/262 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/40 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->