### PR TITLE
REGRESSION(260575@main): Subtitles do not work when playing Apple Event video in full screen

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm
@@ -151,8 +151,8 @@ void VideoFullscreenModelVideoElement::setVideoFullscreenLayer(PlatformLayer* vi
 #else
     [m_videoFullscreenLayer setAnchorPoint:CGPointMake(0.5, 0.5)];
 #endif
-    [m_videoFullscreenLayer setBounds:m_videoFrame];
-    
+    [m_videoFullscreenLayer setFrame:m_videoFrame];
+
     if (!m_videoElement) {
         completionHandler();
         return;
@@ -187,7 +187,7 @@ void VideoFullscreenModelVideoElement::requestFullscreenMode(HTMLMediaElementEnu
 void VideoFullscreenModelVideoElement::setVideoLayerFrame(FloatRect rect)
 {
     m_videoFrame = rect;
-    [m_videoFullscreenLayer setBounds:CGRect(rect)];
+    [m_videoFullscreenLayer setFrame:CGRect(rect)];
     if (m_videoElement)
         m_videoElement->setVideoFullscreenFrame(rect);
 }

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -191,8 +191,10 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, __AVPlayerLayerView)
     [CATransaction setAnimationDuration:0];
     [CATransaction setDisableActions:YES];
 
-    if (auto* model = _fullscreenInterface ? _fullscreenInterface->videoFullscreenModel() : nullptr)
-        model->setVideoLayerFrame(_targetVideoFrame);
+    if (auto* model = _fullscreenInterface ? _fullscreenInterface->videoFullscreenModel() : nullptr) {
+        FloatRect targetVideoBounds { { }, _targetVideoFrame.size() };
+        model->setVideoLayerFrame(targetVideoBounds);
+    }
 
     _previousVideoGravity = _videoGravity;
 


### PR DESCRIPTION
#### 213d9746a1a2cca3981c1fe8a27102bb6d8bad62
<pre>
REGRESSION(260575@main): Subtitles do not work when playing Apple Event video in full screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=254229">https://bugs.webkit.org/show_bug.cgi?id=254229</a>
rdar://106342886

Reviewed by Per Arne Vollan.

Add a further (partial) roll-out of 260575@main by falling back to the previous
behavior in VideoFullscreenManager when the blockMediaLayerRehostingInWebContentProcess()
setting is disabled.

Drive-by fix: even after the partial roll-out, pinch zooming video content in fullscreen
is laid out incorrectly. Pass the correct frame down to the WebContent process in
-[WebAVPlayerLayer resolveBounds], and set the frame (rather than the bounds) of the
videoFullscreenLayer in VideoFullscreenModelVideoElement.

* Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm:
(WebCore::VideoFullscreenModelVideoElement::setVideoFullscreenLayer):
(WebCore::VideoFullscreenModelVideoElement::setVideoLayerFrame):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer resolveBounds]):
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::didExitFullscreen):
(WebKit::VideoFullscreenManager::didCleanupFullscreen):
(WebKit::VideoFullscreenManager::setVideoLayerFrameFenced):

Canonical link: <a href="https://commits.webkit.org/262024@main">https://commits.webkit.org/262024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec9e300520d341881e3f774c311fe633594c9b31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/258 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/513 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/304 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/265 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/339 "38 flakes 110 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/281 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/265 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/274 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/73 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/269 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->