### PR TITLE
make all { No, Yes } and { Yes, No } enums use bool as underlying type

### DIFF
--- a/Source/JavaScriptCore/bytecode/ExecutableInfo.h
+++ b/Source/JavaScriptCore/bytecode/ExecutableInfo.h
@@ -31,7 +31,7 @@ namespace JSC {
     
 enum class DerivedContextType : uint8_t { None, DerivedConstructorContext, DerivedMethodContext };
 enum class EvalContextType    : uint8_t { None, FunctionEvalContext, InstanceFieldEvalContext };
-enum class NeedsClassFieldInitializer : uint8_t { No, Yes };
+enum class NeedsClassFieldInitializer : bool { No, Yes };
 
 // FIXME: These flags, ParserModes and propagation to XXXCodeBlocks should be reorganized.
 // https://bugs.webkit.org/show_bug.cgi?id=151547

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -69,9 +69,9 @@ namespace JSC {
         ExpectArrayConstructor
     };
 
-    enum class EmitAwait { Yes, No };
+    enum class EmitAwait : bool { No, Yes };
 
-    enum class DebuggableCall { Yes, No };
+    enum class DebuggableCall : bool { No, Yes };
     enum class ThisResolutionType { Local, Scoped };
     enum class InvalidPrototypeMode : uint8_t { Throw, Ignore };
     enum class LinkTimeConstant : int32_t;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1322,7 +1322,7 @@ public:
     void compilePutByVal(Node*);
 
     // We use a scopedLambda to placate register allocation validation.
-    enum class CanUseFlush { Yes, No };
+    enum class CanUseFlush : bool { No, Yes };
     void compileGetByVal(Node*, const ScopedLambda<std::tuple<JSValueRegs, DataFormat, CanUseFlush>(DataFormat preferredFormat)>& prefix);
 
     void compileGetCharCodeAt(Node*);

--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -87,7 +87,7 @@ public:
     RefPtr<SharedTask<MarkedBlock::Handle*()>> parallelNotEmptyBlockSource();
     
     void addBlock(MarkedBlock::Handle*);
-    enum class WillDeleteBlock { No, Yes };
+    enum class WillDeleteBlock : bool { No, Yes };
     // If WillDeleteBlock::Yes is passed then the block will be left in an invalid state. We do this, however, to avoid potentially paging in / decompressing old blocks to update their handle just before freeing them.
     void removeBlock(MarkedBlock::Handle*, WillDeleteBlock = WillDeleteBlock::No);
 

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -373,7 +373,7 @@ MacroAssemblerCodeRef<JITStubRoutinePtrTag> virtualThunkFor(VM& vm, CallMode cal
 
 enum ThunkEntryType { EnterViaCall, EnterViaJumpWithSavedTags, EnterViaJumpWithoutSavedTags };
 enum class ThunkFunctionType { JSFunction, InternalFunction };
-enum class IncludeDebuggerHook { No, Yes };
+enum class IncludeDebuggerHook : bool { No, Yes };
 
 static MacroAssemblerCodeRef<JITThunkPtrTag> nativeForGenerator(VM& vm, ThunkFunctionType thunkFunctionType, CodeSpecializationKind kind, ThunkEntryType entryType = EnterViaCall, IncludeDebuggerHook includeDebuggerHook = IncludeDebuggerHook::No)
 {

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1779,7 +1779,7 @@ private:
     enum class BlockType : uint8_t { Normal, CatchBlock, StaticBlock };
     template <class TreeBuilder> TreeStatement parseBlockStatement(TreeBuilder&, BlockType = BlockType::Normal);
 
-    enum class IsOnlyChildOfStatement { Yes, No };
+    enum class IsOnlyChildOfStatement : bool { No, Yes };
     template <class TreeBuilder> TreeExpression parseExpression(TreeBuilder&, IsOnlyChildOfStatement = IsOnlyChildOfStatement::No);
 
     template <class TreeBuilder> TreeExpression parseAssignmentExpression(TreeBuilder&, ExpressionErrorClassifier&);

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -302,7 +302,7 @@ struct CalendarRecord {
 std::optional<TimeZoneID> parseTimeZoneName(StringView);
 std::optional<Duration> parseDuration(StringView);
 std::optional<int64_t> parseTimeZoneNumericUTCOffset(StringView);
-enum class ValidateTimeZoneID { Yes, No };
+enum class ValidateTimeZoneID : bool { No, Yes };
 std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>>> parseTime(StringView);
 std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>, std::optional<CalendarRecord>>> parseCalendarTime(StringView);
 std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>>> parseDateTime(StringView);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1044,7 +1044,7 @@ public:
     JS_EXPORT_PRIVATE void clearPendingImportMaps();
 
 protected:
-    enum class HasSpeciesProperty : bool { Yes, No };
+    enum class HasSpeciesProperty : bool { No, Yes };
     template<typename SpeciesWatchpoint>
     void tryInstallSpeciesWatchpoint(JSObject* prototype, JSObject* constructor, std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>& constructorWatchpoint, std::unique_ptr<SpeciesWatchpoint>&, InlineWatchpointSet&, HasSpeciesProperty);
 

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -187,8 +187,8 @@ ALWAYS_INLINE JSString* jsSpliceSubstringsWithSeparators(JSGlobalObject* globalO
     RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
 }
 
-enum class StringReplaceSubstitutions : bool { Yes, No };
-enum class StringReplaceUseTable : bool { Yes, No };
+enum class StringReplaceSubstitutions : bool { No, Yes };
+enum class StringReplaceUseTable : bool { No, Yes };
 template<StringReplaceSubstitutions substitutions, StringReplaceUseTable useTable, typename TableType>
 ALWAYS_INLINE JSString* stringReplaceStringString(JSGlobalObject* globalObject, JSString* stringCell, String string, String search, String replacement, const TableType* table)
 {

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -850,7 +850,7 @@ private:
     
     static Structure* toDictionaryTransition(VM&, Structure*, DictionaryKind, DeferredStructureTransitionWatchpointFire* = nullptr);
 
-    enum class ShouldPin { No, Yes };
+    enum class ShouldPin : bool { No, Yes };
     template<ShouldPin, typename Func>
     PropertyOffset add(VM&, PropertyName, unsigned attributes, const Func&);
     PropertyOffset add(VM&, PropertyName, unsigned attributes);

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.h
@@ -74,7 +74,7 @@ public:
         FatalError,
     };
 
-    enum class IsEndOfStream { Yes, No };
+    enum class IsEndOfStream : bool { No, Yes };
 
     StreamingParser(ModuleInformation&, StreamingParserClient&);
 

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -796,7 +796,7 @@ bool isHiddenFile(const String& path)
 #endif
 }
 
-enum class ShouldFollowSymbolicLinks { No, Yes };
+enum class ShouldFollowSymbolicLinks : bool { No, Yes };
 static std::optional<FileType> fileTypePotentiallyFollowingSymLinks(const String& path, ShouldFollowSymbolicLinks shouldFollowSymbolicLinks)
 {
     std::error_code ec;

--- a/Source/WTF/wtf/Language.h
+++ b/Source/WTF/wtf/Language.h
@@ -35,7 +35,7 @@
 
 namespace WTF {
 
-enum class ShouldMinimizeLanguages { No, Yes };
+enum class ShouldMinimizeLanguages : bool { No, Yes };
 
 WTF_EXPORT_PRIVATE String defaultLanguage(ShouldMinimizeLanguages = ShouldMinimizeLanguages::Yes); // Thread-safe.
 WTF_EXPORT_PRIVATE Vector<String> userPreferredLanguages(ShouldMinimizeLanguages = ShouldMinimizeLanguages::Yes); // Thread-safe, returns BCP 47 language tags.

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -95,7 +95,7 @@ private:
     template<typename CharacterType> bool parsePort(CodePointIterator<CharacterType>&);
 
     void failure();
-    enum class ReportSyntaxViolation { No, Yes };
+    enum class ReportSyntaxViolation : bool { No, Yes };
     template<typename CharacterType, ReportSyntaxViolation reportSyntaxViolation = ReportSyntaxViolation::Yes>
     void advance(CodePointIterator<CharacterType>& iterator) { advance<CharacterType, reportSyntaxViolation>(iterator, iterator); }
     template<typename CharacterType, ReportSyntaxViolation = ReportSyntaxViolation::Yes>

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.h
@@ -76,7 +76,7 @@ private:
 
     Pasteboard& activePasteboard();
 
-    enum class SessionIsValid { No, Yes };
+    enum class SessionIsValid : bool { No, Yes };
     SessionIsValid updateSessionValidity();
 
     class ItemWriter : public RefCounted<ItemWriter> {

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h
@@ -76,7 +76,7 @@ public:
 
     void objectStoreRecordsChanged();
 
-    enum class ShouldIncludePrefetchedRecords { No, Yes };
+    enum class ShouldIncludePrefetchedRecords : bool { No, Yes };
     void currentData(IDBGetResult&, const std::optional<IDBKeyPath>&, ShouldIncludePrefetchedRecords = ShouldIncludePrefetchedRecords::No);
 
 private:

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -80,7 +80,7 @@ public:
     bool userGestureRequired() const;
     bool shouldForceControlsDisplay() const;
 
-    enum class ForceUpdate { Yes, No };
+    enum class ForceUpdate : bool { No, Yes };
     void updateCaptionDisplaySizes(ForceUpdate = ForceUpdate::No);
     void updateTextTrackRepresentationImageIfNeeded();
     void enteredFullscreen();

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -102,7 +102,7 @@ private:
     void stopRecordingInternal(CompletionHandler<void()>&& = [] { });
     void dispatchError(Exception&&);
 
-    enum class TakePrivateRecorder { No, Yes };
+    enum class TakePrivateRecorder : bool { No, Yes };
     using FetchDataCallback = Function<void(RefPtr<FragmentedSharedBuffer>&&, const String& mimeType, double)>;
     void fetchData(FetchDataCallback&&, TakePrivateRecorder);
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h
@@ -74,7 +74,7 @@ private:
     TransformResult decryptFrame(Span<const uint8_t>);
     TransformResult encryptFrame(Span<const uint8_t>);
 
-    enum class ShouldUpdateKeys { No, Yes };
+    enum class ShouldUpdateKeys : bool { No, Yes };
     ExceptionOr<void> updateEncryptionKey(const Vector<uint8_t>& rawKey, std::optional<uint64_t>, ShouldUpdateKeys = ShouldUpdateKeys::Yes) WTF_REQUIRES_LOCK(m_keyLock);
 
     ExceptionOr<Vector<uint8_t>> computeSaltKey(const Vector<uint8_t>&);

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -542,7 +542,7 @@ static RTCSignalingState toRTCSignalingState(webrtc::PeerConnectionInterface::Si
     return RTCSignalingState::Stable;
 }
 
-enum class GatherSignalingState { No, Yes };
+enum class GatherSignalingState : bool { No, Yes };
 static std::optional<PeerConnectionBackend::DescriptionStates> descriptionsFromPeerConnection(webrtc::PeerConnectionInterface* connection, GatherSignalingState gatherSignalingState = GatherSignalingState::No)
 {
     if (!connection)

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -99,7 +99,7 @@ static ExceptionOr<void> checkAndCanonicalizeAmount(PaymentCurrencyAmount& amoun
     return { };
 }
 
-enum class NegativeAmountAllowed { Yes, No };
+enum class NegativeAmountAllowed : bool { No, Yes };
 static ExceptionOr<void> checkAndCanonicalizePaymentItem(PaymentItem& item, NegativeAmountAllowed negativeAmountAllowed)
 {
     auto exception = checkAndCanonicalizeAmount(item.amount);

--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -176,7 +176,7 @@ PushTopics PushTopics::isolatedCopy() &&
     return { crossThreadCopy(WTFMove(enabledTopics)), crossThreadCopy(WTFMove(ignoredTopics)) };
 }
 
-enum class ShouldDeleteAndRetry { No, Yes };
+enum class ShouldDeleteAndRetry : bool { No, Yes };
 
 static Expected<UniqueRef<SQLiteDatabase>, ShouldDeleteAndRetry> openAndMigrateDatabaseImpl(const String& path)
 {

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -474,7 +474,7 @@ protected:
     UChar32 characterBefore(const CharacterOffset&);
     CharacterOffset characterOffsetForNodeAndOffset(Node&, int, TraverseOption = TraverseOptionDefault);
 
-    enum class NeedsContextAtParagraphStart { Yes, No };
+    enum class NeedsContextAtParagraphStart : bool { No, Yes };
     CharacterOffset previousBoundary(const CharacterOffset&, BoundarySearchFunction, NeedsContextAtParagraphStart = NeedsContextAtParagraphStart::No);
     CharacterOffset nextBoundary(const CharacterOffset&, BoundarySearchFunction);
     CharacterOffset startCharacterOffsetOfWord(const CharacterOffset&, EWordSide = RightWordIfOnBoundary);

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -504,7 +504,7 @@ public:
     bool childrenInitialized() const { return m_childrenInitialized; }
     const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) override;
     virtual void addChildren() { }
-    enum class DescendIfIgnored : uint8_t { No, Yes };
+    enum class DescendIfIgnored : bool { No, Yes };
     virtual void addChild(AXCoreObject*, DescendIfIgnored = DescendIfIgnored::Yes);
     virtual void insertChild(AXCoreObject*, unsigned, DescendIfIgnored = DescendIfIgnored::Yes);
     virtual bool canHaveChildren() const { return true; }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -72,7 +72,7 @@ private:
     bool isAXIsolatedObjectInstance() const override { return true; }
     AccessibilityObject* associatedAXObject() const;
 
-    enum class IsRoot : bool { Yes, No };
+    enum class IsRoot : bool { No, Yes };
     void initializeProperties(const Ref<AccessibilityObject>&, IsRoot);
     void initializePlatformProperties(const Ref<const AccessibilityObject>&);
 

--- a/Source/WebCore/animation/FrameRateAligner.h
+++ b/Source/WebCore/animation/FrameRateAligner.h
@@ -41,7 +41,7 @@ public:
     void beginUpdate(ReducedResolutionSeconds, std::optional<FramesPerSecond>);
     void finishUpdate();
 
-    enum class ShouldUpdate { Yes, No };
+    enum class ShouldUpdate : bool { No, Yes };
     ShouldUpdate updateFrameRate(FramesPerSecond);
 
     std::optional<Seconds> timeUntilNextUpdateForFrameRate(FramesPerSecond, ReducedResolutionSeconds) const;

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -155,7 +155,7 @@ public:
     bool computeTransformedExtentViaMatrix(const FloatRect&, const RenderStyle&, LayoutRect&) const;
     bool forceLayoutIfNeeded();
 
-    enum class Accelerated : uint8_t { Yes, No };
+    enum class Accelerated : bool { No, Yes };
     bool isCurrentlyAffectingProperty(CSSPropertyID, Accelerated = Accelerated::No) const;
     bool isRunningAcceleratedAnimationForProperty(CSSPropertyID) const;
     bool isRunningAcceleratedTransformRelatedAnimation() const;

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -58,7 +58,7 @@ enum class AnimationImpact : uint8_t {
     ForcesStackingContext   = 1 << 1
 };
 
-enum class UseAcceleratedAction : uint8_t { Yes, No };
+enum class UseAcceleratedAction : bool { No, Yes };
 
 enum class WebAnimationType : uint8_t { CSSAnimation, CSSTransition, WebAnimation };
 

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.h
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.h
@@ -51,7 +51,7 @@ class Element;
 class HTMLElement;
 class JSDOMGlobalObject;
 
-enum class ParserConstructElementWithEmptyStack { No, Yes };
+enum class ParserConstructElementWithEmptyStack : bool { No, Yes };
 
 class JSCustomElementInterface : public RefCounted<JSCustomElementInterface>, public ActiveDOMCallback {
 public:

--- a/Source/WebCore/bindings/js/JSDOMAbstractOperations.h
+++ b/Source/WebCore/bindings/js/JSDOMAbstractOperations.h
@@ -33,7 +33,7 @@ namespace WebCore {
 // Implementations of the abstract operations defined at
 // https://webidl.spec.whatwg.org/#legacy-platform-object-abstract-ops
 
-enum class LegacyOverrideBuiltIns { No, Yes };
+enum class LegacyOverrideBuiltIns : bool { No, Yes };
 
 // An implementation of the 'named property visibility algorithm'
 // https://webidl.spec.whatwg.org/#dfn-named-property-visibility

--- a/Source/WebCore/bindings/js/JSDOMPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMPromise.h
@@ -44,7 +44,7 @@ public:
         return guarded();
     }
 
-    enum class IsCallbackRegistered { No, Yes };
+    enum class IsCallbackRegistered : bool { No, Yes };
     IsCallbackRegistered whenSettled(std::function<void()>&&);
     JSC::JSValue result() const;
 

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -35,7 +35,7 @@
 namespace WebCore {
 
 class JSLocalDOMWindow;
-enum class RejectAsHandled : uint8_t { No, Yes };
+enum class RejectAsHandled : bool { No, Yes };
 
 class DeferredPromise : public DOMGuarded<JSC::JSPromise> {
 public:

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -173,7 +173,7 @@ private:
 };
 
 
-enum class UseCustomHeapCellType { Yes, No };
+enum class UseCustomHeapCellType : bool { No, Yes };
 
 template<typename T, UseCustomHeapCellType useCustomHeapCellType, typename GetClient, typename SetClient, typename GetServer, typename SetServer>
 ALWAYS_INLINE JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm, GetClient getClient, SetClient setClient, GetServer getServer, SetServer setServer, JSC::HeapCellType& (*getCustomHeapCellType)(JSHeapData&) = nullptr)

--- a/Source/WebCore/css/DOMMatrixReadOnly.h
+++ b/Source/WebCore/css/DOMMatrixReadOnly.h
@@ -47,7 +47,7 @@ class DOMMatrixReadOnly : public ScriptWrappable, public RefCounted<DOMMatrixRea
 public:
     static ExceptionOr<Ref<DOMMatrixReadOnly>> create(ScriptExecutionContext&, std::optional<std::variant<String, Vector<double>>>&&);
 
-    enum class Is2D { No, Yes };
+    enum class Is2D : bool { No, Yes };
     static Ref<DOMMatrixReadOnly> create(const TransformationMatrix& matrix, Is2D is2D)
     {
         return adoptRef(*new DOMMatrixReadOnly(matrix, is2D));

--- a/Source/WebCore/css/SelectorFilter.h
+++ b/Source/WebCore/css/SelectorFilter.h
@@ -65,7 +65,7 @@ public:
 
 private:
     void initializeParentStack(Element& parent);
-    enum class IncludeRightmost : bool { Yes, No };
+    enum class IncludeRightmost : bool { No, Yes };
     static void collectSelectorHashes(CollectedSelectorHashes&, const CSSSelector& rightmostSelector, IncludeRightmost);
     static Hashes chooseSelectorHashesForFilter(const CollectedSelectorHashes&);
 

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -474,7 +474,7 @@ RefPtr<StyleRuleCharset> CSSParserImpl::consumeCharsetRule(CSSParserTokenRange p
     return StyleRuleCharset::create();
 }
 
-enum class AllowAnonymous { Yes, No };
+enum class AllowAnonymous : bool { No, Yes };
 static std::optional<CascadeLayerName> consumeCascadeLayerName(CSSParserTokenRange& range, AllowAnonymous allowAnonymous)
 {
     CascadeLayerName name;

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -3714,7 +3714,7 @@ static RefPtr<CSSValue> consumeDeprecatedGradient(CSSParserTokenRange& range, co
     }
 }
 
-enum class SupportsColorHints : bool { Yes, No };
+enum class SupportsColorHints : bool { No, Yes };
 
 template<typename Consumer>
 static std::optional<CSSGradientColorStopList> consumeColorStopList(CSSParserTokenRange& range, const CSSParserContext& context, SupportsColorHints supportsColorHints, Consumer&& consumeStopPosition)

--- a/Source/WebCore/display/DisplayTreeBuilder.h
+++ b/Source/WebCore/display/DisplayTreeBuilder.h
@@ -69,7 +69,7 @@ private:
     void recursiveBuildDisplayTree(const Layout::LayoutState&, const Layout::Box&, InsertionPosition&);
     void buildInlineDisplayTree(const Layout::LayoutState&, const Layout::ElementBox&, InsertionPosition&);
 
-    enum class WillTraverseDescendants { Yes, No };
+    enum class WillTraverseDescendants : bool { No, Yes };
     StackingItem* insertIntoTree(std::unique_ptr<Box>&&, InsertionPosition&, WillTraverseDescendants);
     void insert(std::unique_ptr<Box>&&, InsertionPosition&) const;
 

--- a/Source/WebCore/display/css/DisplayCSSPainter.h
+++ b/Source/WebCore/display/css/DisplayCSSPainter.h
@@ -58,7 +58,7 @@ private:
     static void recursivePaintDescendants(const ContainerBox&, PaintingContext&);
     static void recursivePaintDescendantsForPhase(const ContainerBox&, PaintingContext&, PaintPhase);
 
-    enum class IncludeStackingContextDescendants { Yes, No };
+    enum class IncludeStackingContextDescendants : bool { No, Yes };
     static void paintAtomicallyPaintedBox(const StackingItem&, PaintingContext&, const IntRect& dirtyRect, IncludeStackingContextDescendants = IncludeStackingContextDescendants::No);
 
     static void paintStackingContext(const StackingItem&, PaintingContext&, const IntRect& dirtyRect);

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -406,7 +406,7 @@ static bool containsIncludingHostElements(const Node& possibleAncestor, const No
     return false;
 }
 
-enum class ShouldValidateChildParent { No, Yes };
+enum class ShouldValidateChildParent : bool { No, Yes };
 static inline ExceptionOr<void> checkAcceptChild(ContainerNode& newParent, Node& newChild, const Node* refChild, Document::AcceptChildOperation operation, ShouldValidateChildParent shouldValidateChildParent)
 {
     if (containsIncludingHostElements(newChild, newParent))

--- a/Source/WebCore/dom/DataTransfer.h
+++ b/Source/WebCore/dom/DataTransfer.h
@@ -135,7 +135,7 @@ private:
     String readStringFromPasteboard(Document&, const String& lowercaseType, WebContentReadingPolicy) const;
     bool shouldSuppressGetAndSetDataToAvoidExposingFilePaths() const;
 
-    enum class AddFilesType { No, Yes };
+    enum class AddFilesType : bool { No, Yes };
     Vector<String> types(AddFilesType) const;
     Vector<Ref<File>> filesFromPasteboardAndItemList(ScriptExecutionContext*) const;
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -866,7 +866,7 @@ public:
     void hoveredElementDidDetach(Element&);
     void elementInActiveChainDidDetach(Element&);
 
-    enum class CaptureChange : uint8_t { Yes, No };
+    enum class CaptureChange : bool { No, Yes };
     void updateHoverActiveState(const HitTestRequest&, Element*, CaptureChange = CaptureChange::No);
 
     // Updates for :target (CSS3 selector).

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -790,7 +790,7 @@ private:
     void updateNameForTreeScope(TreeScope&, const AtomString& oldName, const AtomString& newName);
     void updateNameForDocument(HTMLDocument&, const AtomString& oldName, const AtomString& newName);
 
-    enum class NotifyObservers { No, Yes };
+    enum class NotifyObservers : bool { No, Yes };
     void updateId(const AtomString& oldId, const AtomString& newId, NotifyObservers = NotifyObservers::Yes);
     void updateIdForTreeScope(TreeScope&, const AtomString& oldId, const AtomString& newId, NotifyObservers = NotifyObservers::Yes);
 

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -51,7 +51,7 @@
 namespace WebCore {
 namespace FragmentDirectiveRangeFinder {
 
-enum class BoundaryPointIsAtEnd { No, Yes };
+enum class BoundaryPointIsAtEnd : bool { No, Yes };
 enum class WordBounded : bool { No, Yes };
 
 // https://wicg.github.io/scroll-to-text-fragment/#search-invisible

--- a/Source/WebCore/dom/MouseRelatedEvent.h
+++ b/Source/WebCore/dom/MouseRelatedEvent.h
@@ -41,7 +41,7 @@ struct MouseRelatedEventInit : public EventModifierInit {
 class MouseRelatedEvent : public UIEventWithKeyState {
     WTF_MAKE_ISO_ALLOCATED(MouseRelatedEvent);
 public:
-    enum class IsSimulated : uint8_t { Yes, No };
+    enum class IsSimulated : bool { No, Yes };
 
     // Note that these values are adjusted to counter the effects of zoom, so that values
     // exposed via DOM APIs are invariant under zooming.

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -55,7 +55,7 @@ public:
         bool isPrimary { false };
     };
 
-    enum class IsPrimary : uint8_t { No, Yes };
+    enum class IsPrimary : bool { No, Yes };
 
     static Ref<PointerEvent> create(const AtomString& type, Init&& initializer)
     {

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -111,7 +111,7 @@ public:
     virtual EventLoopTaskGroup& eventLoop() = 0;
 
     virtual const URL& url() const = 0;
-    enum class ForceUTF8 { No, Yes };
+    enum class ForceUTF8 : bool { No, Yes };
     virtual URL completeURL(const String& url, ForceUTF8 = ForceUTF8::No) const = 0;
 
     virtual String userAgent(const URL&) const = 0;
@@ -368,7 +368,7 @@ private:
 
     void dispatchMessagePortEvents();
 
-    enum class ShouldContinue { No, Yes };
+    enum class ShouldContinue : bool { No, Yes };
     void forEachActiveDOMObject(const Function<ShouldContinue(ActiveDOMObject&)>&) const;
 
     RejectedPromiseTracker* ensureRejectedPromiseTrackerSlow();

--- a/Source/WebCore/dom/UserGestureIndicator.h
+++ b/Source/WebCore/dom/UserGestureIndicator.h
@@ -92,7 +92,7 @@ public:
     void resetScope() { m_scope = GestureScope::All; }
 
     // Expand the following methods if more propagation sources are added later.
-    enum class IsPropagatedFromFetch { Yes, No };
+    enum class IsPropagatedFromFetch : bool { No, Yes };
     void setIsPropagatedFromFetch(IsPropagatedFromFetch is) { m_isPropagatedFromFetch = is; }
     void resetIsPropagatedFromFetch() { m_isPropagatedFromFetch = IsPropagatedFromFetch::No; }
     bool isPropagatedFromFetch() const { return m_isPropagatedFromFetch == IsPropagatedFromFetch::Yes; }

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -141,7 +141,7 @@ public:
     WEBCORE_EXPORT void invalidate();
 
 private:
-    enum class IsTemporarySelection { No, Yes };
+    enum class IsTemporarySelection : bool { No, Yes };
 
     void setSelection(const VisibleSelection&, IsTemporarySelection);
 
@@ -418,7 +418,7 @@ public:
     // is a frame-specific concept, because executing an editing command can run JavaScript that can do
     // anything, including changing the focused frame. That is, it is not enough to set this setting on
     // one Editor to disallow selection changes in all frames.
-    enum class RevealSelection { No, Yes };
+    enum class RevealSelection : bool { No, Yes };
     WEBCORE_EXPORT void setIgnoreSelectionChanges(bool, RevealSelection shouldRevealExistingSelection = RevealSelection::Yes);
     bool ignoreSelectionChanges() const { return m_ignoreSelectionChanges; }
 

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -246,7 +246,7 @@ public:
     void setTypingStyle(RefPtr<EditingStyle>&& style) { m_typingStyle = WTFMove(style); }
     void clearTypingStyle();
 
-    enum class ClipToVisibleContent : uint8_t { No, Yes };
+    enum class ClipToVisibleContent : bool { No, Yes };
     WEBCORE_EXPORT FloatRect selectionBounds(ClipToVisibleContent = ClipToVisibleContent::Yes);
 
     enum class TextRectangleHeight { TextHeight, SelectionHeight };

--- a/Source/WebCore/editing/HTMLInterchange.h
+++ b/Source/WebCore/editing/HTMLInterchange.h
@@ -43,7 +43,7 @@ constexpr auto AppleTabSpanClass = "Apple-tab-span"_s;
 // Controls whether a special BR which is removed upon paste in ReplaceSelectionCommand needs to be inserted
 // and making sequence of spaces not collapsible by inserting non-breaking spaces.
 // See https://trac.webkit.org/r8087 and https://trac.webkit.org/r8096.
-enum class AnnotateForInterchange : uint8_t { No, Yes };
+enum class AnnotateForInterchange : bool { No, Yes };
 
 String convertHTMLTextToInterchangeFormat(const String&, const Text*);
 

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -537,7 +537,7 @@ unsigned forwardSearchForBoundaryWithTextIterator(TextIterator& it, Vector<UChar
     return next;
 }
 
-enum class NeedsContextAtParagraphStart { Yes, No };
+enum class NeedsContextAtParagraphStart : bool { No, Yes };
 static VisiblePosition previousBoundary(const VisiblePosition& position, BoundarySearchFunction searchFunction,
     NeedsContextAtParagraphStart needsContextAtParagraphStart = NeedsContextAtParagraphStart::No)
 {

--- a/Source/WebCore/editing/cocoa/HTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.h
@@ -35,7 +35,7 @@ WEBCORE_EXPORT AttributedString attributedString(const SimpleRange&);
 // such as tables, and doesn't produce document attributes, but it does use TextIterator so
 // text offsets will exactly match plain text and other editing machinery.
 // FIXME: This function and the one above should be merged.
-enum class IncludeImages { Yes, No };
+enum class IncludeImages : bool { No, Yes };
 WEBCORE_EXPORT AttributedString editingAttributedString(const SimpleRange&, IncludeImages = IncludeImages::Yes);
 #endif
 

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -89,9 +89,9 @@ bool isPlainTextMarkup(Node*);
 // These methods are used by HTMLElement & ShadowRoot to replace the children with respected fragment/text.
 ExceptionOr<void> replaceChildrenWithFragment(ContainerNode&, Ref<DocumentFragment>&&);
 
-enum class ConvertBlocksToInlines : uint8_t { No, Yes };
-enum class SerializeComposedTree : uint8_t { No, Yes };
-enum class IgnoreUserSelectNone: uint8_t { No, Yes };
+enum class ConvertBlocksToInlines : bool { No, Yes };
+enum class SerializeComposedTree : bool { No, Yes };
+enum class IgnoreUserSelectNone : bool { No, Yes };
 WEBCORE_EXPORT String serializePreservingVisualAppearance(const SimpleRange&, Vector<Node*>* = nullptr, AnnotateForInterchange = AnnotateForInterchange::No, ConvertBlocksToInlines = ConvertBlocksToInlines::No, ResolveURLs = ResolveURLs::No);
 String serializePreservingVisualAppearance(const VisibleSelection&, ResolveURLs = ResolveURLs::No, SerializeComposedTree = SerializeComposedTree::No,
     IgnoreUserSelectNone = IgnoreUserSelectNone::Yes, Vector<Node*>* = nullptr);

--- a/Source/WebCore/fileapi/NetworkSendQueue.h
+++ b/Source/WebCore/fileapi/NetworkSendQueue.h
@@ -49,7 +49,7 @@ class WEBCORE_EXPORT NetworkSendQueue : public ContextDestructionObserver {
 public:
     using WriteString = Function<void(const CString& utf8)>;
     using WriteRawData = Function<void(const Span<const uint8_t>&)>;
-    enum class Continue { No, Yes };
+    enum class Continue : bool { No, Yes };
     using ProcessError = Function<Continue(ExceptionCode)>;
     NetworkSendQueue(ScriptExecutionContext&, WriteString&&, WriteRawData&&, ProcessError&&);
     ~NetworkSendQueue();

--- a/Source/WebCore/html/FeaturePolicy.h
+++ b/Source/WebCore/html/FeaturePolicy.h
@@ -94,7 +94,7 @@ private:
 #endif
 };
 
-enum class LogFeaturePolicyFailure { No, Yes };
+enum class LogFeaturePolicyFailure : bool { No, Yes };
 extern bool isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type, const Document&, LogFeaturePolicyFailure = LogFeaturePolicyFailure::Yes);
 
 } // namespace WebCore

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -66,7 +66,7 @@ private:
     String valueMissingText() const final;
     void handleDOMActivateEvent(Event&) final;
     RenderPtr<RenderElement> createInputRenderer(RenderStyle&&) final;
-    enum class RequestIcon { Yes, No };
+    enum class RequestIcon : bool { No, Yes };
     void setFiles(RefPtr<FileList>&&, RequestIcon, WasSetByJavaScript);
     String displayString() const final;
     void setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection) final;

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -50,7 +50,7 @@ public:
     WEBCORE_EXPORT URL blobURL() const;
     WEBCORE_EXPORT File* file() const;
 
-    enum class UpdateDisplayAttributes { No, Yes };
+    enum class UpdateDisplayAttributes : bool { No, Yes };
     void setFile(RefPtr<File>&&, UpdateDisplayAttributes = UpdateDisplayAttributes::No);
 
     const String& uniqueIdentifier() const { return m_uniqueIdentifier; }

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -108,7 +108,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     bool willRespondToMouseClickEventsWithEditability(Editability) const override;
 
-    enum class IgnoreTouchCallout { No, Yes };
+    enum class IgnoreTouchCallout : bool { No, Yes };
     bool willRespondToMouseClickEventsWithEditability(Editability, IgnoreTouchCallout) const;
 #endif
 

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -30,7 +30,7 @@ namespace WebCore {
 
 class HTMLSelectElement;
 
-enum class AllowStyleInvalidation { Yes, No };
+enum class AllowStyleInvalidation : bool { No, Yes };
 
 class HTMLOptionElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLOptionElement);

--- a/Source/WebCore/html/HTMLPlugInImageElement.h
+++ b/Source/WebCore/html/HTMLPlugInImageElement.h
@@ -26,7 +26,7 @@ namespace WebCore {
 
 class HTMLImageLoader;
 
-enum class CreatePlugins { No, Yes };
+enum class CreatePlugins : bool { No, Yes };
 
 // Base class for HTMLEmbedElement and HTMLObjectElement.
 // FIXME: This is the only class that derives from HTMLPlugInElement, so we could merge the two classes.

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -53,7 +53,7 @@ class MediaControlTextTrackContainerElement final
 public:
     static Ref<MediaControlTextTrackContainerElement> create(Document&, HTMLMediaElement&);
 
-    enum class ForceUpdate { Yes, No };
+    enum class ForceUpdate : bool { No, Yes };
     void updateSizes(ForceUpdate force = ForceUpdate::No);
     void updateDisplay();
 

--- a/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h
+++ b/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h
@@ -52,7 +52,7 @@ public:
     using EvaluationResult = Expected<ValueOrException, EvaluationError>;
     using EvaluationResultHandler = CompletionHandler<void(EvaluationResult)>;
 
-    enum class UnsuspendSoon { Yes, No };
+    enum class UnsuspendSoon : bool { No, Yes };
     
     WEBCORE_EXPORT ~InspectorFrontendAPIDispatcher();
 

--- a/Source/WebCore/layout/floats/FloatingContext.h
+++ b/Source/WebCore/layout/floats/FloatingContext.h
@@ -68,7 +68,7 @@ public:
         std::optional<PointInContextRoot> left;
         std::optional<PointInContextRoot> right;
     };
-    enum class MayBeAboveLastFloat : uint8_t { Yes, No };
+    enum class MayBeAboveLastFloat : bool { No, Yes };
     Constraints constraints(LayoutUnit candidateTop, LayoutUnit candidateBottom, MayBeAboveLastFloat) const;
 
     FloatingState::FloatItem toFloatItem(const Box& floatBox) const;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h
@@ -45,7 +45,7 @@ public:
         InlineLayoutUnit logicalWidth { 0 };
         std::optional<InlineLayoutUnit> hyphenWidth { };
     };
-    enum class IsEndOfLine { No, Yes };
+    enum class IsEndOfLine : bool { No, Yes };
     struct Result {
         enum class Action {
             Keep, // Keep content on the current line.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.h
@@ -45,7 +45,7 @@ public:
     ContentHeightAndMargin inlineBlockContentHeightAndMargin(const Box&, const HorizontalConstraints&, const OverriddenVerticalValues&) const;
     ContentWidthAndMargin inlineBlockContentWidthAndMargin(const Box&, const HorizontalConstraints&, const OverriddenHorizontalValues&) const;
 
-    enum class IsIntrinsicWidthMode : uint8_t { Yes, No };
+    enum class IsIntrinsicWidthMode : bool { No, Yes };
     InlineLayoutUnit computedTextIndent(IsIntrinsicWidthMode, std::optional<bool> previousLineEndsWithLineBreak, InlineLayoutUnit availableWidth) const;
 
     bool inlineLevelBoxAffectsLineBox(const InlineLevelBox&) const;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -40,7 +40,7 @@ class LineBoxVerticalAligner;
 
 class InlineLevelBox {
 public:
-    enum class LineSpanningInlineBox { Yes, No };
+    enum class LineSpanningInlineBox : bool { No, Yes };
     static InlineLevelBox createInlineBox(const Box&, const RenderStyle&, InlineLayoutUnit logicalLeft, InlineLayoutUnit logicalWidth, LineSpanningInlineBox = LineSpanningInlineBox::No);
     static InlineLevelBox createRootInlineBox(const Box&, const RenderStyle&, InlineLayoutUnit logicalLeft, InlineLayoutUnit logicalWidth);
     static InlineLevelBox createAtomicInlineLevelBox(const Box&, const RenderStyle&, InlineLayoutUnit logicalLeft, InlineLayoutUnit logicalWidth);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
@@ -112,7 +112,7 @@ private:
         std::optional<InlineLayoutUnit> overflowLogicalWidth { };
     };
     LayoutUnit adjustGeometryForInitialLetterIfNeeded(const Box& floatBox);
-    enum MayOverConstrainLine : uint8_t { Yes, No };
+    enum MayOverConstrainLine : bool { No, Yes };
     bool tryPlacingFloatBox(const InlineItem&, MayOverConstrainLine);
     Result handleInlineContent(InlineContentBreaker&, const InlineItemRange& needsLayoutRange, const LineCandidate&);
     std::tuple<InlineRect, bool> lineBoxForCandidateInlineContent(const LineCandidate&) const;

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h
@@ -58,7 +58,7 @@ public:
     void horizontalConstraintChanged();
 
 private:
-    enum class ShouldApplyRangeLayout : uint8_t { Yes, No };
+    enum class ShouldApplyRangeLayout : bool { No, Yes };
     void updateInlineDamage(InlineDamage::Type, std::optional<DamagedLine>, ShouldApplyRangeLayout = ShouldApplyRangeLayout::No);
     bool applyFullDamageIfNeeded(const Box&);
     const InlineDisplay::Boxes& displayBoxes() const { return m_displayContent.boxes; }

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
@@ -46,13 +46,13 @@ public:
     static InlineLayoutUnit width(const InlineTextItem&, const FontCascade&, InlineLayoutUnit contentLogicalLeft);
     static InlineLayoutUnit width(const InlineTextItem&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft);
 
-    enum class UseTrailingWhitespaceMeasuringOptimization : uint8_t { Yes, No };
+    enum class UseTrailingWhitespaceMeasuringOptimization : bool { No, Yes };
     static InlineLayoutUnit width(const InlineTextBox&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization = UseTrailingWhitespaceMeasuringOptimization::Yes);
 
     static InlineLayoutUnit trailingWhitespaceWidth(const InlineTextBox&, const FontCascade&, size_t startPosition, size_t endPosition);
 
     using FallbackFontList = HashSet<const Font*>;
-    enum class IncludeHyphen : uint8_t { No, Yes };
+    enum class IncludeHyphen : bool { No, Yes };
     static FallbackFontList fallbackFontsForText(StringView, const RenderStyle&, IncludeHyphen);
 
     struct EnclosingAscentDescent {

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -75,7 +75,7 @@ public:
     const RenderStyle& style() const { return isFirst() ? formattingContextRoot().firstLineStyle() : formattingContextRoot().style(); }
 
     bool hasEllipsis() const;
-    enum AdjustedForSelection : uint8_t { No, Yes };
+    enum AdjustedForSelection : bool { No, Yes };
     FloatRect ellipsisVisualRect(AdjustedForSelection = AdjustedForSelection::No) const;
     TextRun ellipsisText() const;
     RenderObject::HighlightState ellipsisSelectionState() const;

--- a/Source/WebCore/loader/CrossOriginAccessControl.h
+++ b/Source/WebCore/loader/CrossOriginAccessControl.h
@@ -59,7 +59,7 @@ void updateRequestReferrer(ResourceRequest&, ReferrerPolicy, const String&);
 WEBCORE_EXPORT void updateRequestForAccessControl(ResourceRequest&, SecurityOrigin&, StoredCredentialsPolicy);
 
 WEBCORE_EXPORT ResourceRequest createAccessControlPreflightRequest(const ResourceRequest&, SecurityOrigin&, const String&, bool includeFetchMetadata);
-enum class SameOriginFlag { No, Yes };
+enum class SameOriginFlag : bool { No, Yes };
 CachedResourceRequest createPotentialAccessControlRequest(ResourceRequest&&, ResourceLoaderOptions&&, Document&, const String& crossOriginAttribute, SameOriginFlag = SameOriginFlag::No);
 
 enum class HTTPHeadersToKeepFromCleaning : uint8_t {

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -51,7 +51,7 @@ namespace WebCore {
         static void loadResourceSynchronously(Document&, ResourceRequest&&, ThreadableLoaderClient&, const ThreadableLoaderOptions&, RefPtr<SecurityOrigin>&&, std::unique_ptr<ContentSecurityPolicy>&&, std::optional<CrossOriginEmbedderPolicy>&&);
         static void loadResourceSynchronously(Document&, ResourceRequest&&, ThreadableLoaderClient&, const ThreadableLoaderOptions&);
 
-        enum class ShouldLogError { No, Yes };
+        enum class ShouldLogError : bool { No, Yes };
         static RefPtr<DocumentThreadableLoader> create(Document&, ThreadableLoaderClient&, ResourceRequest&&, const ThreadableLoaderOptions&, RefPtr<SecurityOrigin>&&, std::unique_ptr<ContentSecurityPolicy>&&, std::optional<CrossOriginEmbedderPolicy>&&, String&& referrer, ShouldLogError);
         static RefPtr<DocumentThreadableLoader> create(Document&, ThreadableLoaderClient&, ResourceRequest&&, const ThreadableLoaderOptions&, String&& referrer = String());
 

--- a/Source/WebCore/loader/LinkLoader.h
+++ b/Source/WebCore/loader/LinkLoader.h
@@ -63,7 +63,7 @@ public:
     virtual ~LinkLoader();
 
     void loadLink(const LinkLoadParameters&, Document&);
-    enum class ShouldLog { No, Yes };
+    enum class ShouldLog : bool { No, Yes };
     static std::optional<CachedResource::Type> resourceTypeFromAsAttribute(const String&, Document&, ShouldLog = ShouldLog::No);
 
     enum class MediaAttributeCheck { MediaAttributeEmpty, MediaAttributeNotEmpty, SkipMediaAttributeCheck };

--- a/Source/WebCore/loader/PingLoader.h
+++ b/Source/WebCore/loader/PingLoader.h
@@ -56,7 +56,7 @@ public:
     static String sanitizeURLForReport(const URL&);
 
 private:
-    enum class ShouldFollowRedirects { No, Yes };
+    enum class ShouldFollowRedirects : bool { No, Yes };
     static void startPingLoad(LocalFrame&, ResourceRequest&, HTTPHeaderMap&& originalRequestHeaders, ShouldFollowRedirects, ContentSecurityPolicyImposition, ReferrerPolicy, std::optional<ViolationReportType> = std::nullopt);
 };
 

--- a/Source/WebCore/loader/ResourceLoadObserver.h
+++ b/Source/WebCore/loader/ResourceLoadObserver.h
@@ -43,7 +43,7 @@ public:
     using SubResourceDomain = WebCore::RegistrableDomain;
 
     // https://fetch.spec.whatwg.org/#request-destination-script-like
-    enum class FetchDestinationIsScriptLike : bool { Yes, No };
+    enum class FetchDestinationIsScriptLike : bool { No, Yes };
 
     WEBCORE_EXPORT static ResourceLoadObserver& shared();
     WEBCORE_EXPORT static ResourceLoadObserver* sharedIfExists();

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -175,7 +175,7 @@ public:
 private:
     explicit CachedResourceLoader(DocumentLoader*);
 
-    enum class ForPreload { Yes, No };
+    enum class ForPreload : bool { No, Yes };
 
     ResourceErrorOr<CachedResourceHandle<CachedResource>> requestResource(CachedResource::Type, CachedResourceRequest&&, ForPreload = ForPreload::No, ImageLoading = ImageLoading::Immediate);
     CachedResourceHandle<CachedResource> revalidateResource(CachedResourceRequest&&, CachedResource&);

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -432,7 +432,7 @@ private:
     bool dispatchSyntheticTouchEventIfEnabled(const PlatformMouseEvent&);
 #endif
     
-    enum class FireMouseOverOut { No, Yes };
+    enum class FireMouseOverOut : bool { No, Yes };
     void updateMouseEventTargetNode(const AtomString& eventType, Node*, const PlatformMouseEvent&, FireMouseOverOut);
 
     ScrollableArea* enclosingScrollableArea(Node*);
@@ -440,7 +440,7 @@ private:
 
     MouseEventWithHitTestResults prepareMouseEvent(const HitTestRequest&, const PlatformMouseEvent&);
 
-    enum class Cancelable { No, Yes };
+    enum class Cancelable : bool { No, Yes };
     bool dispatchMouseEvent(const AtomString& eventType, Node* target, int clickCount, const PlatformMouseEvent&, FireMouseOverOut);
 
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -99,7 +99,7 @@ struct ImageBitmapOptions;
 struct WindowFeatures;
 
 enum SetLocationLocking { LockHistoryBasedOnGestureState, LockHistoryAndBackForwardList };
-enum class IncludeTargetOrigin { No, Yes };
+enum class IncludeTargetOrigin : bool { No, Yes };
 
 struct WindowPostMessageOptions : public StructuredSerializeOptions {
     WindowPostMessageOptions() = default;

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -103,7 +103,7 @@ public:
         InheritedForPluginDocument,
     };
     WEBCORE_EXPORT ContentSecurityPolicyResponseHeaders responseHeaders() const;
-    enum ReportParsingErrors { No, Yes };
+    enum ReportParsingErrors : bool { No, Yes };
     WEBCORE_EXPORT void didReceiveHeaders(const ContentSecurityPolicyResponseHeaders&, String&& referrer, ReportParsingErrors = ReportParsingErrors::Yes);
     void didReceiveHeaders(const ContentSecurityPolicy&, ReportParsingErrors = ReportParsingErrors::Yes);
     void didReceiveHeader(const String&, ContentSecurityPolicyHeaderType, ContentSecurityPolicy::PolicyFrom, String&& referrer, int httpStatusCode = 0);
@@ -125,7 +125,7 @@ public:
     WEBCORE_EXPORT bool allowFrameAncestors(const Vector<RefPtr<SecurityOrigin>>& ancestorOrigins, const URL&, bool overrideContentSecurityPolicy = false) const;
     WEBCORE_EXPORT bool overridesXFrameOptions() const;
 
-    enum class RedirectResponseReceived { No, Yes };
+    enum class RedirectResponseReceived : bool { No, Yes };
     WEBCORE_EXPORT bool allowScriptFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL(), const String& = nullString(), const String& nonce = nullString()) const;
     WEBCORE_EXPORT bool allowWorkerFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL()) const;
     bool allowImageFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL()) const;

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h
@@ -37,7 +37,7 @@ class ContentSecurityPolicySourceListDirective : public ContentSecurityPolicyDir
 public:
     ContentSecurityPolicySourceListDirective(const ContentSecurityPolicyDirectiveList&, const String& name, const String& value);
 
-    enum class ShouldAllowEmptyURLIfSourceListIsNotNone { No, Yes };
+    enum class ShouldAllowEmptyURLIfSourceListIsNotNone : bool { No, Yes };
     bool allows(const URL&, bool didReceiveRedirectResponse, ShouldAllowEmptyURLIfSourceListIsNotNone);
     bool allows(const Vector<ContentSecurityPolicyHash>&) const;
     bool containsAllHashes(const Vector<ContentSecurityPolicyHash>&) const;

--- a/Source/WebCore/page/ios/ContentChangeObserver.h
+++ b/Source/WebCore/page/ios/ContentChangeObserver.h
@@ -182,7 +182,7 @@ private:
     bool visibleRendererWasDestroyed(const Element& element) const { return m_elementsWithDestroyedVisibleRenderer.contains(element); }
     bool shouldObserveVisibilityChangeForElement(const Element&);
 
-    enum class ElementHadRenderer { No, Yes };
+    enum class ElementHadRenderer : bool { No, Yes };
     bool isConsideredActionableContent(const Element&, ElementHadRenderer) const;
     
     bool isContentChangeObserverEnabled();

--- a/Source/WebCore/platform/ReferrerPolicy.cpp
+++ b/Source/WebCore/platform/ReferrerPolicy.cpp
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum class ShouldParseLegacyKeywords { No, Yes };
+enum class ShouldParseLegacyKeywords : bool { No, Yes };
 
 static std::optional<ReferrerPolicy> parseReferrerPolicyToken(StringView policy, ShouldParseLegacyKeywords shouldParseLegacyKeywords)
 {

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -44,7 +44,7 @@ class Document;
 class MediaPlaybackTarget;
 class PlatformMediaSessionClient;
 class PlatformMediaSessionManager;
-enum class DelayCallingUpdateNowPlaying { No, Yes };
+enum class DelayCallingUpdateNowPlaying : bool { No, Yes };
 struct NowPlayingInfo;
 
 class PlatformMediaSession

--- a/Source/WebCore/platform/graphics/ImageTypes.h
+++ b/Source/WebCore/platform/graphics/ImageTypes.h
@@ -68,7 +68,7 @@ enum class GammaAndColorProfileOption {
     Ignored
 };
 
-enum class ImageAnimatingState { Yes, No };
+enum class ImageAnimatingState : bool { No, Yes };
 
 enum class EncodedDataStatus {
     Error,

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -63,7 +63,7 @@ public:
 
     PlatformLayer* displayLayer();
 
-    enum class ShouldUpdateRootLayer { No, Yes };
+    enum class ShouldUpdateRootLayer : bool { No, Yes };
     void updateRootLayerBoundsAndPosition(CGRect, VideoFrameRotation, ShouldUpdateRootLayer);
     void updateRootLayerAffineTransform(CGAffineTransform);
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3089,7 +3089,7 @@ void GraphicsLayerCA::updateAnimations()
         m_animationGroups.append(WTFMove(animationGroup));
     };
 
-    enum class Additive { Yes, No };
+    enum class Additive : bool { No, Yes };
     auto prepareAnimationForAddition = [&](LayerPropertyAnimation& animation, Additive additive = Additive::Yes) {
         auto caAnim = animation.m_animation;
         caAnim->setAdditive(additive == Additive::Yes);

--- a/Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.h
+++ b/Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.h
@@ -47,8 +47,8 @@ public:
         bool isIdentity() const { return !flipX && !flipY && !angle; }
     };
 
-    enum class IsCGImageCompatible { No, Yes };
-    enum class ShouldUseIOSurface { No, Yes };
+    enum class IsCGImageCompatible : bool { No, Yes };
+    enum class ShouldUseIOSurface : bool { No, Yes };
 
     ImageRotationSessionVT(AffineTransform&&, FloatSize, IsCGImageCompatible, ShouldUseIOSurface = ShouldUseIOSurface::Yes);
     ImageRotationSessionVT(const RotationProperties&, FloatSize, IsCGImageCompatible, ShouldUseIOSurface = ShouldUseIOSurface::Yes);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListIterator.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListIterator.h
@@ -32,7 +32,7 @@ namespace DisplayList {
 
 class DisplayList::Iterator {
 public:
-    enum class ImmediatelyMoveToEnd { No, Yes };
+    enum class ImmediatelyMoveToEnd : bool { No, Yes };
     Iterator(const DisplayList& displayList, ImmediatelyMoveToEnd immediatelyMoveToEnd = ImmediatelyMoveToEnd::No)
         : m_displayList(displayList)
     {

--- a/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
@@ -448,7 +448,7 @@ static NSPasteboardType modernPasteboardTypeForWebSafeMIMEType(const String& web
     return nil;
 }
 
-enum class ContainsFileURL { No, Yes };
+enum class ContainsFileURL : bool { No, Yes };
 static String webSafeMIMETypeForModernPasteboardType(NSPasteboardType platformType, ContainsFileURL containsFileURL)
 {
     if ([platformType isEqual:NSPasteboardTypeString] && containsFileURL == ContainsFileURL::No)

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -81,7 +81,7 @@ enum class HTTPCookieAcceptPolicy : uint8_t;
 enum class IncludeSecureCookies : bool;
 enum class IncludeHttpOnlyCookies : bool;
 enum class ThirdPartyCookieBlockingMode : uint8_t { All, AllExceptBetweenAppBoundDomains, AllExceptManagedDomains, AllOnSitesWithoutUserInteraction, OnlyAccordingToPerDomainPolicy };
-enum class SameSiteStrictEnforcementEnabled : bool { Yes, No };
+enum class SameSiteStrictEnforcementEnabled : bool { No, Yes };
 enum class FirstPartyWebsiteDataRemovalMode : uint8_t { AllButCookies, None, AllButCookiesLiveOnTestingTimeout, AllButCookiesReproTestingTimeout };
 enum class ApplyTrackingPrevention : bool { No, Yes };
 enum class ScriptWrittenCookiesOnly : bool { No, Yes };

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -240,7 +240,7 @@ public:
     void setTainting(Tainting tainting) { m_tainting = tainting; }
     Tainting tainting() const { return m_tainting; }
 
-    enum class PerformExposeAllHeadersCheck : uint8_t { Yes, No };
+    enum class PerformExposeAllHeadersCheck : bool { No, Yes };
     static ResourceResponse filter(const ResourceResponse&, PerformExposeAllHeadersCheck);
 
     WEBCORE_EXPORT static ResourceResponse syntheticRedirectResponse(const URL& fromURL, const URL& toURL);

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -86,7 +86,7 @@ public:
     LayoutUnit logicalWidth() const { return style().isHorizontalWritingMode() ? width() : height(); }
     LayoutUnit logicalHeight() const { return style().isHorizontalWritingMode() ? height() : width(); }
 
-    enum class AllowIntrinsic { Yes, No };
+    enum class AllowIntrinsic : bool { No, Yes };
     LayoutUnit constrainLogicalWidthInFragmentByMinMax(LayoutUnit, LayoutUnit, RenderBlock&, RenderFragmentContainer*, AllowIntrinsic = AllowIntrinsic::Yes) const;
     LayoutUnit constrainLogicalHeightByMinMax(LayoutUnit logicalHeight, std::optional<LayoutUnit> intrinsicContentHeight) const;
     LayoutUnit constrainContentBoxLogicalHeightByMinMax(LayoutUnit logicalHeight, std::optional<LayoutUnit> intrinsicContentHeight) const;
@@ -757,7 +757,7 @@ protected:
     std::pair<LayoutUnit, LayoutUnit> computeMinMaxLogicalWidthFromAspectRatio() const;
     std::pair<LayoutUnit, LayoutUnit> computeMinMaxLogicalHeightFromAspectRatio() const;
     enum class ConstrainDimension { Width, Height };
-    enum class MinimumSizeIsAutomaticContentBased { Yes, No };
+    enum class MinimumSizeIsAutomaticContentBased : bool { No, Yes };
     void constrainLogicalMinMaxSizesByAspectRatio(LayoutUnit& minSize, LayoutUnit& maxSize, LayoutUnit computedSize, MinimumSizeIsAutomaticContentBased, ConstrainDimension) const;
 
     static LayoutUnit blockSizeFromAspectRatio(LayoutUnit borderPaddingInlineSum, LayoutUnit borderPaddingBlockSum, double aspectRatio, BoxSizing boxSizing, LayoutUnit inlineSize, AspectRatioType aspectRatioType, bool isRenderReplaced)

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -88,7 +88,7 @@ class TransformationMatrix;
 
 enum BorderRadiusClippingRule { IncludeSelfForBorderRadius, DoNotIncludeSelfForBorderRadius };
 enum IncludeSelfOrNot { IncludeSelf, ExcludeSelf };
-enum CrossFrameBoundaries { No, Yes };
+enum CrossFrameBoundaries : bool { No, Yes };
 
 enum RepaintStatus {
     NeedsNormalRepaint,
@@ -135,7 +135,7 @@ enum class IndirectCompositingReason {
     Preserve3D
 };
 
-enum class ShouldAllowCrossOriginScrolling { No, Yes };
+enum class ShouldAllowCrossOriginScrolling : bool { No, Yes };
 
 struct ScrollRectToVisibleOptions {
     SelectionRevealMode revealMode { SelectionRevealMode::Reveal };

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -59,7 +59,7 @@ public:
     {
     }
     RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, std::optional<size_t> maximumLineCountForLineClamp, std::optional<size_t> visibleLineCountForLineClamp, std::optional<LeadingTrim>);
-    enum class IsPaginated { No, Yes };
+    enum class IsPaginated : bool { No, Yes };
     explicit RenderLayoutState(RenderElement&, IsPaginated = IsPaginated::No);
 
     bool isPaginated() const { return m_isPaginated; }

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -172,7 +172,7 @@ private:
 
     LayoutUnit itemHeight() const;
 
-    enum class ConsiderPadding { Yes, No };
+    enum class ConsiderPadding : bool { No, Yes };
     int numVisibleItems(ConsiderPadding = ConsiderPadding::No) const;
     int numItems() const;
     LayoutUnit listHeight() const;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1719,7 +1719,7 @@ void RenderObject::willBeDestroyed()
     removeRareData();
 }
 
-enum class IsRemoval : uint8_t { Yes, No };
+enum class IsRemoval : bool { No, Yes };
 static void invalidateLineLayoutAfterTreeMutationIfNeeded(RenderObject& renderer, IsRemoval isRemoval)
 {
     auto* container = LayoutIntegration::LineLayout::blockContainer(renderer);

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -783,7 +783,7 @@ public:
     LayoutRect absoluteOutlineBounds() const { return outlineBoundsForRepaint(nullptr); }
 
     // FIXME: Renderers should not need to be notified about internal reparenting (webkit.org/b/224143).
-    enum class IsInternalMove { No, Yes };
+    enum class IsInternalMove : bool { No, Yes };
     virtual void insertedIntoTree(IsInternalMove = IsInternalMove::No);
     virtual void willBeRemovedFromTree(IsInternalMove = IsInternalMove::No);
 
@@ -826,8 +826,8 @@ protected:
 
     bool isSetNeedsLayoutForbidden() const;
 
-    enum class ClipRepaintToLayer : uint8_t { No, Yes };
-    enum class ForceRepaint : uint8_t { No, Yes };
+    enum class ClipRepaintToLayer : bool { No, Yes };
+    enum class ForceRepaint : bool { No, Yes };
     void issueRepaint(std::optional<LayoutRect> partialRepaintRect = std::nullopt, ClipRepaintToLayer = ClipRepaintToLayer::No, ForceRepaint = ForceRepaint::No) const;
 
 private:

--- a/Source/WebCore/rendering/RenderObjectEnums.h
+++ b/Source/WebCore/rendering/RenderObjectEnums.h
@@ -52,7 +52,7 @@ enum MarkingBehavior {
     MarkContainingBlockChain,
 };
 
-enum class ScheduleRelayout { No, Yes };
+enum class ScheduleRelayout : bool { No, Yes };
 
 enum MapCoordinatesMode {
     IsFixed             = 1 << 0,

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -324,7 +324,7 @@ private:
 
     void recalcCollapsedBorders();
     void recalcSections() const;
-    enum class BottomCaptionLayoutPhase { Yes, No };
+    enum class BottomCaptionLayoutPhase : bool { No, Yes };
     void layoutCaptions(BottomCaptionLayoutPhase = BottomCaptionLayoutPhase::No);
     void layoutCaption(RenderTableCaption&);
 

--- a/Source/WebCore/rendering/SelectionRangeData.h
+++ b/Source/WebCore/rendering/SelectionRangeData.h
@@ -56,7 +56,7 @@ private:
     SelectionGeometryGatherer m_selectionGeometryGatherer;
 #endif
     bool m_selectionWasCaret { false };
-    enum class ClipToVisibleContent { Yes, No };
+    enum class ClipToVisibleContent : bool { No, Yes };
     IntRect collectBounds(ClipToVisibleContent) const;
     void apply(const RenderRange&, RepaintMode);
 };

--- a/Source/WebCore/rendering/TextAutoSizing.h
+++ b/Source/WebCore/rendering/TextAutoSizing.h
@@ -99,7 +99,7 @@ public:
 
     void addTextNode(Text&, float size);
 
-    enum class StillHasNodes { No, Yes };
+    enum class StillHasNodes : bool { No, Yes };
     StillHasNodes adjustTextNodeSizes();
 
 private:

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -546,7 +546,7 @@ void TextBoxPainter<TextBoxPath>::collectDecoratingBoxesForTextBox(DecoratingBox
         return;
     }
 
-    enum UseOverriderDecorationStyle : bool { Yes, No };
+    enum UseOverriderDecorationStyle : bool { No, Yes };
     auto appendIfIsDecoratingBoxForBackground = [&] (auto& inlineBox, auto useOverriderDecorationStyle) {
         auto& style = m_isFirstLine ? inlineBox->renderer().firstLineStyle() : inlineBox->renderer().style();
 

--- a/Source/WebCore/rendering/line/TrailingObjects.h
+++ b/Source/WebCore/rendering/line/TrailingObjects.h
@@ -56,7 +56,7 @@ public:
             m_boxes.append(box);
     }
 
-    enum class CollapseFirstSpace { No, Yes };
+    enum class CollapseFirstSpace : bool { No, Yes };
     void updateWhitespaceCollapsingTransitionsForTrailingBoxes(LineWhitespaceCollapsingState&, const LegacyInlineIterator& lBreak, CollapseFirstSpace);
 
 private:

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -44,13 +44,13 @@ public:
 
     void attach(RenderElement& parent, RenderPtr<RenderObject>, RenderObject* beforeChild = nullptr);
 
-    enum class CanCollapseAnonymousBlock { No, Yes };
+    enum class CanCollapseAnonymousBlock : bool { No, Yes };
     RenderPtr<RenderObject> detach(RenderElement&, RenderObject&, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes) WARN_UNUSED_RETURN;
 
     void destroy(RenderObject& renderer, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes);
 
     // NormalizeAfterInsertion::Yes ensures that the destination subtree is consistent after the insertion (anonymous wrappers etc).
-    enum class NormalizeAfterInsertion { No, Yes };
+    enum class NormalizeAfterInsertion : bool { No, Yes };
     void move(RenderBoxModelObject& from, RenderBoxModelObject& to, RenderObject& child, NormalizeAfterInsertion);
 
     void updateAfterDescendants(RenderElement&);
@@ -71,7 +71,7 @@ private:
     void attachToRenderElement(RenderElement& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild = nullptr);
     void attachToRenderElementInternal(RenderElement& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild = nullptr, RenderObject::IsInternalMove = RenderObject::IsInternalMove::No);
 
-    enum class WillBeDestroyed { No, Yes };
+    enum class WillBeDestroyed : bool { No, Yes };
     RenderPtr<RenderObject> detachFromRenderElement(RenderElement& parent, RenderObject& child, WillBeDestroyed = WillBeDestroyed::Yes) WARN_UNUSED_RETURN;
     RenderPtr<RenderObject> detachFromRenderGrid(RenderGrid& parent, RenderObject& child) WARN_UNUSED_RETURN;
 

--- a/Source/WebCore/style/StyleInvalidator.h
+++ b/Source/WebCore/style/StyleInvalidator.h
@@ -70,7 +70,7 @@ public:
     static void invalidateHostAndSlottedStyleIfNeeded(ShadowRoot&);
 
 private:
-    enum class CheckDescendants { Yes, No };
+    enum class CheckDescendants : bool { No, Yes };
     CheckDescendants invalidateIfNeeded(Element&, SelectorMatchingState*);
     void invalidateStyleForTree(Element&, SelectorMatchingState*);
     void invalidateStyleForDescendants(Element&, SelectorMatchingState*);

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -154,7 +154,7 @@ bool postResolutionCallbacksAreSuspended();
 
 class PostResolutionCallbackDisabler {
 public:
-    enum class DrainCallbacks { Yes, No };
+    enum class DrainCallbacks : bool { No, Yes };
     explicit PostResolutionCallbackDisabler(Document&, DrainCallbacks = DrainCallbacks::Yes);
     ~PostResolutionCallbackDisabler();
 private:

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -117,7 +117,7 @@ static String debuggerMode()
 class RunLoopSetup {
     WTF_MAKE_NONCOPYABLE(RunLoopSetup);
 public:
-    enum class IsForDebugging { No, Yes };
+    enum class IsForDebugging : bool { No, Yes };
     RunLoopSetup(WorkerDedicatedRunLoop& runLoop, IsForDebugging isForDebugging)
         : m_runLoop(runLoop)
         , m_isForDebugging(isForDebugging)

--- a/Source/WebCore/workers/service/SWClientConnection.h
+++ b/Source/WebCore/workers/service/SWClientConnection.h
@@ -163,7 +163,7 @@ protected:
 private:
     virtual void scheduleJobInServer(const ServiceWorkerJobData&) = 0;
 
-    enum class IsJobComplete { No, Yes };
+    enum class IsJobComplete : bool { No, Yes };
     bool postTaskForJob(ServiceWorkerJobIdentifier, IsJobComplete, Function<void(ServiceWorkerJob&)>&&);
 
     bool m_isClosed { false };

--- a/Source/WebCore/workers/service/server/RegistrationDatabase.h
+++ b/Source/WebCore/workers/service/server/RegistrationDatabase.h
@@ -64,7 +64,7 @@ private:
     
     String databaseDirectoryIsolatedCopy() const { return m_databaseDirectory.isolatedCopy(); }
 
-    enum class ShouldRetry { No, Yes };
+    enum class ShouldRetry : bool { No, Yes };
     void schedulePushChanges(Vector<ServiceWorkerContextData>&&, Vector<ServiceWorkerRegistrationKey>&&, ShouldRetry, CompletionHandler<void()>&&);
     void postTaskToWorkQueue(Function<void()>&&);
 

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -92,7 +92,7 @@ public:
     String getResponseHeader(const String& name) const;
     ExceptionOr<OwnedString> responseText();
     String responseTextIgnoringResponseType() const { return m_responseBuilder.toStringPreserveCapacity(); }
-    enum class FinalMIMEType { Yes, No };
+    enum class FinalMIMEType : bool { No, Yes };
     String responseMIMEType(FinalMIMEType = FinalMIMEType::No) const;
 
     Document* optionalResponseXML() const { return m_responseDocument.get(); }

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
@@ -204,7 +204,7 @@ private:
     Vector<RegistrableDomain> ensurePrevalentResourcesForDebugMode() override;
     void removeDataRecords(CompletionHandler<void()>&&);
     void pruneStatisticsIfNeeded() override;
-    enum class AddedRecord { No, Yes };
+    enum class AddedRecord : bool { No, Yes };
     std::pair<AddedRecord, std::optional<unsigned>> ensureResourceStatisticsForRegistrableDomain(const RegistrableDomain&) WARN_UNUSED_RETURN;
     bool shouldRemoveAllWebsiteDataFor(const DomainData&, bool shouldCheckForGrandfathering);
     bool shouldRemoveAllButCookiesFor(const DomainData&, bool shouldCheckForGrandfathering);

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -215,7 +215,7 @@ private:
     bool shouldInterruptNavigationForCrossOriginEmbedderPolicy(const WebCore::ResourceResponse&);
     bool shouldInterruptWorkerLoadForCrossOriginEmbedderPolicy(const WebCore::ResourceResponse&);
 
-    enum class FirstLoad { No, Yes };
+    enum class FirstLoad : bool { No, Yes };
     void startNetworkLoad(WebCore::ResourceRequest&&, FirstLoad);
     void restartNetworkLoad(WebCore::ResourceRequest&&);
     void continueDidReceiveResponse();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
@@ -50,7 +50,7 @@ class ScrollingTreeScrollingNodeDelegateIOS final : public WebCore::ScrollingTre
     WTF_MAKE_FAST_ALLOCATED;
 public:
     
-    enum class AllowOverscrollToPreventScrollPropagation : bool { Yes, No };
+    enum class AllowOverscrollToPreventScrollPropagation : bool { No, Yes };
     
     explicit ScrollingTreeScrollingNodeDelegateIOS(WebCore::ScrollingTreeScrollingNode&);
     ~ScrollingTreeScrollingNodeDelegateIOS() final;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1651,7 +1651,7 @@ public:
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags);
     void updateReportedMediaCaptureState();
 
-    enum class CanDelayNotification { No, Yes };
+    enum class CanDelayNotification : bool { No, Yes };
     void updatePlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags, CanDelayNotification = CanDelayNotification::No);
     bool isCapturingAudio() const { return m_mediaState.containsAny(WebCore::MediaProducer::IsCapturingAudioMask); }
     bool isCapturingVideo() const { return m_mediaState.containsAny(WebCore::MediaProducer::IsCapturingVideoMask); }

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -56,7 +56,7 @@ public:
 
     void clearAllProcessesForSession(PAL::SessionID);
 
-    enum class ShouldShutDownProcess { No, Yes };
+    enum class ShouldShutDownProcess : bool { No, Yes };
     void removeProcess(WebProcessProxy&, ShouldShutDownProcess);
     static void setCachedProcessSuspensionDelayForTesting(Seconds);
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -609,7 +609,7 @@ private:
     bool shouldTakeSuspendedAssertion() const;
     bool shouldDropSuspendedAssertionAfterDelay() const;
 
-    enum class IsWeak { No, Yes };
+    enum class IsWeak : bool { No, Yes };
     template<typename T> class WeakOrStrongPtr {
     public:
         WeakOrStrongPtr(T& object, IsWeak isWeak)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -470,7 +470,7 @@ private:
 
     // FIXME: Only Cocoa ports respect ShouldCreateDirectory, so you cannot rely on it to create
     // directories. This is confusing.
-    enum class ShouldCreateDirectory { No, Yes };
+    enum class ShouldCreateDirectory : bool { No, Yes };
     static String tempDirectoryFileSystemRepresentation(const String& directoryName, ShouldCreateDirectory = ShouldCreateDirectory::Yes);
     static String cacheDirectoryFileSystemRepresentation(const String& directoryName, const String& baseCacheDirectory = nullString(), ShouldCreateDirectory = ShouldCreateDirectory::Yes);
     static String websiteDataDirectoryFileSystemRepresentation(const String& directoryName, const String& baseDataDirectory = nullString(), ShouldCreateDirectory = ShouldCreateDirectory::Yes);

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
@@ -80,7 +80,7 @@ public:
     void stageDragItem(const WebCore::DragItem&, UIImage *);
     bool hasStagedDragSource() const;
     const DragSourceState& stagedDragSource() const { return m_stagedDragSource.value(); }
-    enum class DidBecomeActive { No, Yes };
+    enum class DidBecomeActive : bool { No, Yes };
     void clearStagedDragSource(DidBecomeActive = DidBecomeActive::No);
     UITargetedDragPreview *previewForDragItem(UIDragItem *, UIView *contentView, UIView *previewContainer) const;
     void dragSessionWillDelaySetDownAnimation(dispatch_block_t completion);

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -53,7 +53,7 @@ public:
 
     AudioMediaStreamTrackRendererInternalUnitIdentifier identifier() const { return m_identifier; }
 
-    enum class IsClosed { No, Yes };
+    enum class IsClosed : bool { No, Yes };
     void reset(IsClosed);
 
 private:

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -105,7 +105,7 @@ class SharedVideoFrameReader {
 public:
     ~SharedVideoFrameReader();
 
-    enum class UseIOSurfaceBufferPool { No, Yes };
+    enum class UseIOSurfaceBufferPool : bool { No, Yes };
     explicit SharedVideoFrameReader(RefPtr<RemoteVideoFrameObjectHeap>&&, const WebCore::ProcessIdentity& = { }, UseIOSurfaceBufferPool = UseIOSurfaceBufferPool::Yes);
     SharedVideoFrameReader();
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -98,7 +98,7 @@ public:
 
     WebCore::FrameIdentifier frameID() const;
 
-    enum class ForNavigationAction { No, Yes };
+    enum class ForNavigationAction : bool { No, Yes };
     uint64_t setUpPolicyListener(WebCore::PolicyCheckIdentifier, WebCore::FramePolicyFunction&&, ForNavigationAction);
     void invalidatePolicyListeners();
     void didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1691,7 +1691,7 @@ private:
 
 #if ENABLE(META_VIEWPORT)
     void resetViewportDefaultConfiguration(WebFrame* mainFrame, bool hasMobileDocType = false);
-    enum class ZoomToInitialScale { No, Yes };
+    enum class ZoomToInitialScale : bool { No, Yes };
     void viewportConfigurationChanged(ZoomToInitialScale = ZoomToInitialScale::No);
     bool shouldIgnoreMetaViewport() const;
 #endif
@@ -1800,7 +1800,7 @@ private:
     void loadURLInFrame(URL&&, const String& referrer, WebCore::FrameIdentifier);
     void loadDataInFrame(IPC::DataReference&&, String&& MIMEType, String&& encodingName, URL&& baseURL, WebCore::FrameIdentifier);
 
-    enum class WasRestoredByAPIRequest { No, Yes };
+    enum class WasRestoredByAPIRequest : bool { No, Yes };
     void restoreSessionInternal(const Vector<BackForwardListItemState>&, WasRestoredByAPIRequest, WebBackForwardListProxy::OverwriteExistingItem);
     void restoreSession(const Vector<BackForwardListItemState>&);
     void didRemoveBackForwardItem(const WebCore::BackForwardItemIdentifier&);

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -267,7 +267,7 @@ protected:
     void finish() final { m_service.didCompleteSubscribeRequest(*this); }
 
 private:
-    enum class IsRetry { No, Yes };
+    enum class IsRetry : bool { No, Yes };
     void startImpl(IsRetry);
     void attemptToRecoverFromTopicAlreadyInFilterError(String&&);
     Vector<uint8_t> m_vapidPublicKey;

--- a/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
@@ -82,7 +82,7 @@ static ExpectedParts invalidParts(StringView urlStringWithTab)
     return { ""_s, ""_s, ""_s, ""_s, 0, ""_s , ""_s, ""_s, urlStringWithTab };
 }
 
-enum class TestTabs { No, Yes };
+enum class TestTabs : bool { No, Yes };
 
 // Inserting tabs between surrogate pairs changes the encoded value instead of being skipped by the URLParser.
 const TestTabs testTabsValueForSurrogatePairs = TestTabs::No;

--- a/Tools/TestWebKitAPI/Tests/WebCore/URLParserTextEncoding.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/URLParserTextEncoding.cpp
@@ -84,7 +84,7 @@ static ExpectedParts invalidParts(const String& urlStringWithTab)
     return {emptyString(), emptyString(), emptyString(), emptyString(), 0, emptyString(), emptyString(), emptyString(), urlStringWithTab};
 }
 
-enum class TestTabs { No, Yes };
+enum class TestTabs : bool { No, Yes };
 
 // Inserting tabs between surrogate pairs changes the encoded value instead of being skipped by the URLParser.
 const TestTabs testTabsValueForSurrogatePairs = TestTabs::No;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
@@ -482,7 +482,7 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedFormSubmission)
     action = nullptr;
 }
 
-enum class ShouldEnableProcessSwap { No, Yes };
+enum class ShouldEnableProcessSwap : bool { No, Yes };
 static void runDecidePolicyForNavigationActionForHyperlinkThatRedirects(ShouldEnableProcessSwap shouldEnableProcessSwap)
 {
     auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -898,7 +898,7 @@ RetainPtr<WKWebView> webViewWithDownloadMonitorSpeedMultiplier(size_t multiplier
     return webView;
 }
 
-enum class AppReturnsToForeground { No, Yes };
+enum class AppReturnsToForeground : bool { No, Yes };
     
 void downloadAtRate(double desiredKbps, unsigned speedMultiplier, AppReturnsToForeground returnToForeground = AppReturnsToForeground::No)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessPreWarming.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessPreWarming.mm
@@ -49,7 +49,7 @@ TEST(WKProcessPool, WarmInitialProcess)
     EXPECT_TRUE([pool _hasPrewarmedWebProcess]);
 }
 
-enum class ShouldUseEphemeralStore { No, Yes };
+enum class ShouldUseEphemeralStore : bool { No, Yes };
 static void runInitialWarmedProcessUsedTest(ShouldUseEphemeralStore shouldUseEphemeralStore)
 {
     auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -1418,7 +1418,7 @@ TEST(ProcessSwap, CrossSiteWindowOpenWithOpener)
     EXPECT_NE(pid1, pid2);
 }
 
-enum class ExpectSwap { No, Yes };
+enum class ExpectSwap : bool { No, Yes };
 enum class WindowHasName : bool { No, Yes };
 static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName, ExpectSwap expectSwap)
 {
@@ -1798,7 +1798,7 @@ TEST(ProcessSwap, ServerRedirect2)
     EXPECT_WK_STREQ(@"pson://www.webkit.org/main1.html", [[webView URL] absoluteString]);
 }
 
-enum class ShouldCacheProcessFirst { No, Yes };
+enum class ShouldCacheProcessFirst : bool { No, Yes };
 static void runSameOriginServerRedirectTest(ShouldCacheProcessFirst shouldCacheProcessFirst)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
@@ -2107,7 +2107,7 @@ TEST(ProcessSwap, CrossOriginSystemPreview)
 
 #endif
 
-enum class ShouldEnablePSON { No, Yes };
+enum class ShouldEnablePSON : bool { No, Yes };
 static void runClientSideRedirectTest(ShouldEnablePSON shouldEnablePSON)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
@@ -2973,7 +2973,7 @@ setInterval(() => {
 </body>
 )PSONRESOURCE";
 
-enum class RetainPageInBundle { No, Yes };
+enum class RetainPageInBundle : bool { No, Yes };
 
 void testReuseSuspendedProcessForRegularNavigation(RetainPageInBundle retainPageInBundle)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -514,7 +514,7 @@ static bool finished;
 }
 @end
 
-enum class ShouldEnableProcessPrewarming { No, Yes };
+enum class ShouldEnableProcessPrewarming : bool { No, Yes };
 void runWKHTTPCookieStoreWithoutProcessPool(ShouldEnableProcessPrewarming shouldEnableProcessPrewarming)
 {
     RetainPtr<NSHTTPCookie> sessionCookie = [NSHTTPCookie cookieWithProperties:@{

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -416,7 +416,7 @@ enum class Command {
 }
 @end
 
-enum class ShouldRaiseException { No, Yes };
+enum class ShouldRaiseException : bool { No, Yes };
 
 static void checkCallSequence(Vector<Command>&& commands, ShouldRaiseException shouldRaiseException)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -69,7 +69,7 @@
 
 @end
 
-enum class ShouldEnableProcessPrewarming { No, Yes };
+enum class ShouldEnableProcessPrewarming : bool { No, Yes };
 
 static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldEnableProcessPrewarming)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSStylusSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSStylusSupport.mm
@@ -48,7 +48,7 @@ static WKStylusDeviceObserver *getStylusDeviceObserver()
     return [NSClassFromString(@"WKStylusDeviceObserver") sharedInstance];
 }
 
-enum class HasStylusDevice { Yes, No };
+enum class HasStylusDevice : bool { No, Yes };
 static RetainPtr<TestWKWebView> createWebView(HasStylusDevice hasStylusDevice)
 {
     WKStylusDeviceObserver *stylusDeviceObserver = getStylusDeviceObserver();

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -169,7 +169,7 @@ private:
 };
 
 struct HTTPResponse {
-    enum class TerminateConnection { No, Yes };
+    enum class TerminateConnection : bool { No, Yes };
 
     HTTPResponse(Vector<uint8_t>&& body)
         : body(WTFMove(body)) { }


### PR DESCRIPTION
#### 44c9738463cc8eb35d7bc0879cbceaffbbdf1267
<pre>
make all { No, Yes } and { Yes, No } enums use bool as underlying type
<a href="https://bugs.webkit.org/show_bug.cgi?id=254322">https://bugs.webkit.org/show_bug.cgi?id=254322</a>

Reviewed by Chris Dumez.

Make No/Yes and Yes/No enums use bool as underlying type and ensure the values are sorted so that No==0 and Yes==1.

* Source/JavaScriptCore/bytecode/ExecutableInfo.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/heap/BlockDirectory.h:
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
* Source/JavaScriptCore/parser/Parser.h:
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/wasm/WasmStreamingParser.h:
* Source/WTF/wtf/FileSystem.cpp:
* Source/WTF/wtf/Language.h:
* Source/WTF/wtf/URLParser.h:
* Source/WebCore/Modules/async-clipboard/Clipboard.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
* Source/WebCore/Modules/push-api/PushDatabase.cpp:
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/animation/FrameRateAligner.h:
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/bindings/js/JSCustomElementInterface.h:
* Source/WebCore/bindings/js/JSDOMAbstractOperations.h:
* Source/WebCore/bindings/js/JSDOMPromise.h:
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
* Source/WebCore/bindings/js/WebCoreJSClientData.h:
* Source/WebCore/css/DOMMatrixReadOnly.h:
* Source/WebCore/css/SelectorFilter.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
* Source/WebCore/display/DisplayTreeBuilder.h:
* Source/WebCore/display/css/DisplayCSSPainter.h:
* Source/WebCore/dom/ContainerNode.cpp:
* Source/WebCore/dom/DataTransfer.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
* Source/WebCore/dom/MouseRelatedEvent.h:
* Source/WebCore/dom/PointerEvent.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/UserGestureIndicator.h:
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/editing/HTMLInterchange.h:
* Source/WebCore/editing/VisibleUnits.cpp:
* Source/WebCore/editing/cocoa/HTMLConverter.h:
* Source/WebCore/editing/markup.h:
(): Deleted.
* Source/WebCore/fileapi/NetworkSendQueue.h:
* Source/WebCore/html/FeaturePolicy.h:
* Source/WebCore/html/FileInputType.h:
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLPlugInImageElement.h:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h:
* Source/WebCore/inspector/InspectorFrontendAPIDispatcher.h:
* Source/WebCore/layout/floats/FloatingContext.h:
* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingGeometry.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h:
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
* Source/WebCore/loader/CrossOriginAccessControl.h:
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/loader/LinkLoader.h:
* Source/WebCore/loader/PingLoader.h:
* Source/WebCore/loader/ResourceLoadObserver.h:
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h:
* Source/WebCore/page/ios/ContentChangeObserver.h:
* Source/WebCore/platform/ReferrerPolicy.cpp:
* Source/WebCore/platform/audio/PlatformMediaSession.h:
* Source/WebCore/platform/graphics/ImageTypes.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateAnimations):
* Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListIterator.h:
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayoutState.h:
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderObjectEnums.h:
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/SelectionRangeData.h:
* Source/WebCore/rendering/TextAutoSizing.h:
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::collectDecoratingBoxesForTextBox):
* Source/WebCore/rendering/line/TrailingObjects.h:
* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
* Source/WebCore/style/StyleInvalidator.h:
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/workers/WorkerRunLoop.cpp:
* Source/WebCore/workers/service/SWClientConnection.h:
* Source/WebCore/workers/service/server/RegistrationDatabase.h:
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/ios/DragDropInteractionState.h:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/webpushd/PushService.mm:
* Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/URLParserTextEncoding.cpp:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessPreWarming.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSStylusSupport.mm:
* Tools/TestWebKitAPI/cocoa/HTTPServer.h:

Canonical link: <a href="https://commits.webkit.org/262018@main">https://commits.webkit.org/262018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3833f57442b703cf040ad20fa548b1f1a16e761

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/292 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/270 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/288 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/315 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/317 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/278 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/265 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/253 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/294 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/299 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/276 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/305 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/287 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/69 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/280 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/304 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/37 "Passed tests") | 
<!--EWS-Status-Bubble-End-->