### PR TITLE
[GPUP][MSE] networkState doesn't move to NETWORK_IDLE once MediaSource.endOfStream() is called

### DIFF
--- a/LayoutTests/media/media-source/media-source-end-of-stream.html
+++ b/LayoutTests/media/media-source/media-source-end-of-stream.html
@@ -31,7 +31,7 @@
         source = new MediaSource();
         waitForEventOn(source, 'sourceopen', sourceOpen2, false, true);
         run('video.src = URL.createObjectURL(source)');
-    }    
+    }
 
     function sourceOpen2() {
         waitForEventOnce('error', videoError2);

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -96,6 +96,15 @@ struct LogArgument<WebCore::MediaSourcePrivate::AddStatus> {
     }
 };
 
+template<> struct EnumTraits<WebCore::MediaSourcePrivate::AddStatus> {
+    using values = EnumValues<
+        WebCore::MediaSourcePrivate::AddStatus,
+        WebCore::MediaSourcePrivate::AddStatus::Ok,
+        WebCore::MediaSourcePrivate::AddStatus::NotSupported,
+        WebCore::MediaSourcePrivate::AddStatus::ReachedIdLimit
+    >;
+};
+
 template <>
 struct LogArgument<WebCore::MediaSourcePrivate::EndOfStreamStatus> {
     static String toString(const WebCore::MediaSourcePrivate::EndOfStreamStatus status)
@@ -104,12 +113,12 @@ struct LogArgument<WebCore::MediaSourcePrivate::EndOfStreamStatus> {
     }
 };
 
-template<> struct EnumTraits<WebCore::MediaSourcePrivate::AddStatus> {
+template<> struct EnumTraits<WebCore::MediaSourcePrivate::EndOfStreamStatus> {
     using values = EnumValues<
-        WebCore::MediaSourcePrivate::AddStatus,
-        WebCore::MediaSourcePrivate::AddStatus::Ok,
-        WebCore::MediaSourcePrivate::AddStatus::NotSupported,
-        WebCore::MediaSourcePrivate::AddStatus::ReachedIdLimit
+        WebCore::MediaSourcePrivate::EndOfStreamStatus,
+        WebCore::MediaSourcePrivate::EndOfStreamStatus::EosNoError,
+        WebCore::MediaSourcePrivate::EndOfStreamStatus::EosNetworkError,
+        WebCore::MediaSourcePrivate::EndOfStreamStatus::EosDecodeError
     >;
 };
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -513,10 +513,10 @@ uint64_t SourceBufferPrivate::totalTrackBufferSizeInBytes() const
 void SourceBufferPrivate::addTrackBuffer(const AtomString& trackId, RefPtr<MediaDescription>&& description)
 {
     ASSERT(!m_trackBufferMap.contains(trackId));
-    
+
     m_hasAudio = m_hasAudio || description->isAudio();
     m_hasVideo = m_hasVideo || description->isVideo();
-    
+
     // 5.2.9 Add the track description for this track to the track buffer.
     auto trackBuffer = TrackBuffer::create(WTFMove(description), discontinuityTolerance);
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -134,6 +134,19 @@ void RemoteMediaSourceProxy::bufferedChanged(WebCore::PlatformTimeRanges&& buffe
         m_private->bufferedChanged(m_buffered);
 }
 
+void RemoteMediaSourceProxy::markEndOfStream(WebCore::MediaSourcePrivate::EndOfStreamStatus status )
+{
+    if (m_private)
+        m_private->markEndOfStream(status);
+}
+
+void RemoteMediaSourceProxy::unmarkEndOfStream()
+{
+    if (m_private)
+        m_private->unmarkEndOfStream();
+}
+
+
 void RemoteMediaSourceProxy::setReadyState(WebCore::MediaPlayerEnums::ReadyState readyState)
 {
     if (m_private)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -83,6 +83,8 @@ private:
     void addSourceBuffer(const WebCore::ContentType&, AddSourceBufferCallback&&);
     void durationChanged(const MediaTime&);
     void bufferedChanged(WebCore::PlatformTimeRanges&&);
+    void markEndOfStream(WebCore::MediaSourcePrivate::EndOfStreamStatus);
+    void unmarkEndOfStream();
     void setReadyState(WebCore::MediaPlayerEnums::ReadyState);
     void setIsSeeking(bool);
     void waitForSeekCompleted();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
@@ -34,6 +34,8 @@ messages -> RemoteMediaSourceProxy NotRefCounted {
     WaitForSeekCompleted()
     SeekCompleted()
     SetTimeFudgeFactor(MediaTime fudgeFactor)
+    MarkEndOfStream(WebCore::MediaSourcePrivate::EndOfStreamStatus status)
+    UnmarkEndOfStream()
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -125,20 +125,22 @@ void MediaSourcePrivateRemote::bufferedChanged(const PlatformTimeRanges& buffere
     m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::BufferedChanged(buffered), m_identifier);
 }
 
-void MediaSourcePrivateRemote::markEndOfStream(EndOfStreamStatus)
+void MediaSourcePrivateRemote::markEndOfStream(EndOfStreamStatus status)
 {
-    notImplemented();
+    m_ended = true;
+    m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::MarkEndOfStream(status), m_identifier);
 }
 
 void MediaSourcePrivateRemote::unmarkEndOfStream()
 {
-    notImplemented();
+    // FIXME(125159): implement unmarkEndOfStream()
+    m_ended = false;
+    m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::UnmarkEndOfStream(), m_identifier);
 }
 
 bool MediaSourcePrivateRemote::isEnded() const
 {
-    notImplemented();
-    return false;
+    return m_ended;
 }
 
 MediaPlayer::ReadyState MediaSourcePrivateRemote::readyState() const

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -93,6 +93,7 @@ private:
     WeakPtr<MediaPlayerPrivateRemote> m_mediaPlayerPrivate;
     WeakPtr<WebCore::MediaSourcePrivateClient> m_client;
     Vector<RefPtr<SourceBufferPrivateRemote>> m_sourceBuffers;
+    bool m_ended { false };
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override { return "MediaSourcePrivateRemote"; }


### PR DESCRIPTION
#### 39a3835b1f4151f2c7cf011e2f5df382b7a7e6b7
<pre>
[GPUP][MSE] networkState doesn&apos;t move to NETWORK_IDLE once MediaSource.endOfStream() is called
<a href="https://bugs.webkit.org/show_bug.cgi?id=254324">https://bugs.webkit.org/show_bug.cgi?id=254324</a>
rdar://107129124

Reviewed by Youenn Fablet.

The required methods weren&apos;t implemented in the
MediaSourcePrivateRemote/RemoteMediaSourceProxy combo of objects.
We implement them.

Covered in media/media-source/media-source-end-of-stream.html once
webkit.org/b/225367 is done.

* LayoutTests/media/media-source/media-source-end-of-stream.html: Fix whitespaces
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::addTrackBuffer): Whitespaces fix
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::markEndOfStream):
(WebKit::RemoteMediaSourceProxy::unmarkEndOfStream):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::markEndOfStream):
(WebKit::MediaSourcePrivateRemote::unmarkEndOfStream):
(WebKit::MediaSourcePrivateRemote::isEnded const):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/262016@main">https://commits.webkit.org/262016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c9d21ce24b0eda7931368d2ad1c443f07cfbf35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/296 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/320 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/297 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/321 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/283 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/257 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/299 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/280 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/292 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/66 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/284 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->