### PR TITLE
[GStreamer] Harness: Support for output stream caps changes

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -305,6 +305,7 @@ bool GStreamerElementHarness::Stream::sendEvent(GstEvent* event)
 
 const GRefPtr<GstCaps>& GStreamerElementHarness::Stream::outputCaps()
 {
+    Locker locker { m_sinkEventQueueLock };
     if (m_outputCaps)
         return m_outputCaps;
 
@@ -324,6 +325,11 @@ GstFlowReturn GStreamerElementHarness::Stream::chainBuffer(GstBuffer* outputBuff
 bool GStreamerElementHarness::Stream::sinkEvent(GstEvent* event)
 {
     Locker locker { m_sinkEventQueueLock };
+
+    // Clear cached output caps when the pad receives a new caps event.
+    if (GST_EVENT_TYPE(event) == GST_EVENT_CAPS)
+        m_outputCaps = nullptr;
+
     m_sinkEventQueue.prepend(GRefPtr<GstEvent>(event));
     return true;
 }

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -67,13 +67,14 @@ public:
         RefPtr<GStreamerElementHarness> m_downstreamHarness;
 
         GRefPtr<GstPad> m_targetPad;
-        GRefPtr<GstCaps> m_outputCaps;
 
         Lock m_bufferQueueLock;
         Deque<GRefPtr<GstBuffer>> m_bufferQueue WTF_GUARDED_BY_LOCK(m_bufferQueueLock);
 
         Lock m_sinkEventQueueLock;
         Deque<GRefPtr<GstEvent>> m_sinkEventQueue WTF_GUARDED_BY_LOCK(m_sinkEventQueueLock);
+
+        GRefPtr<GstCaps> m_outputCaps WTF_GUARDED_BY_LOCK(m_sinkEventQueueLock);
     };
 
     using PadLinkCallback = Function<RefPtr<GStreamerElementHarness>(const GRefPtr<GstPad>&)>;


### PR DESCRIPTION
#### 4c3e2a4865d080ae74a85e16b5882ccabde11744
<pre>
[GStreamer] Harness: Support for output stream caps changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=254332">https://bugs.webkit.org/show_bug.cgi?id=254332</a>

Reviewed by Xabier Rodriguez-Calvar.

The harness was internally caching output stream pad caps but additional caps events were not taken
in account. We now clear the cached caps when the pad receives a caps event.

* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::Stream::outputCaps):
(WebCore::GStreamerElementHarness::Stream::sinkEvent):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:

Canonical link: <a href="https://commits.webkit.org/262066@main">https://commits.webkit.org/262066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/608a344073be51a4e42c810653522d6a14f379bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/544 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/460 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/490 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/429 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/397 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/446 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/427 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/440 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/107 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/435 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->