### PR TITLE
[UI-side compositing] Two imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior tests fail

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -28,6 +28,21 @@
 
 namespace WebCore {
 
+void RequestedScrollData::merge(RequestedScrollData&& other)
+{
+    if (requestType == other.requestType && other.animated == ScrollIsAnimated::Yes) {
+        switch (animated) {
+        case ScrollIsAnimated::No:
+            other.requestedDataBeforeAnimatedScroll = { scrollPosition, scrollType, clamping };
+            break;
+        case ScrollIsAnimated::Yes:
+            other.requestedDataBeforeAnimatedScroll = requestedDataBeforeAnimatedScroll;
+            break;
+        }
+    }
+    *this = WTFMove(other);
+}
+
 TextStream& operator<<(TextStream& ts, SynchronousScrollingReason reason)
 {
     switch (reason) {

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -122,6 +122,9 @@ struct RequestedScrollData {
     ScrollType scrollType { ScrollType::User };
     ScrollClamping clamping { ScrollClamping::Clamped };
     ScrollIsAnimated animated { ScrollIsAnimated::No };
+    std::optional<std::tuple<FloatPoint, ScrollType, ScrollClamping>> requestedDataBeforeAnimatedScroll { };
+
+    void merge(RequestedScrollData&&);
 
     bool operator==(const RequestedScrollData& other) const
     {
@@ -129,7 +132,8 @@ struct RequestedScrollData {
             && scrollPosition == other.scrollPosition
             && scrollType == other.scrollType
             && clamping == other.clamping
-            && animated == other.animated;
+            && animated == other.animated
+            && requestedDataBeforeAnimatedScroll == other.requestedDataBeforeAnimatedScroll;
     }
 };
 

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -207,10 +207,15 @@ void ScrollingStateScrollingNode::setKeyboardScrollData(const RequestedKeyboardS
     setPropertyChanged(Property::KeyboardScrollData);
 }
 
-void ScrollingStateScrollingNode::setRequestedScrollData(const RequestedScrollData& scrollData)
+void ScrollingStateScrollingNode::setRequestedScrollData(RequestedScrollData&& scrollData)
 {
     // Scroll position requests are imperative, not stateful, so we can't early return here.
-    m_requestedScrollData = scrollData;
+    if (hasChangedProperty(Property::RequestedScrollPosition)) {
+        m_requestedScrollData.merge(WTFMove(scrollData));
+        return;
+    }
+
+    m_requestedScrollData = WTFMove(scrollData);
     setPropertyChanged(Property::RequestedScrollPosition);
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -79,7 +79,7 @@ public:
     WEBCORE_EXPORT void setKeyboardScrollData(const RequestedKeyboardScrollData&);
 
     const RequestedScrollData& requestedScrollData() const { return m_requestedScrollData; }
-    WEBCORE_EXPORT void setRequestedScrollData(const RequestedScrollData&);
+    WEBCORE_EXPORT void setRequestedScrollData(RequestedScrollData&&);
 
     WEBCORE_EXPORT bool hasScrollPositionRequest() const;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -220,7 +220,7 @@ void ArgumentCoder<ScrollingStateOverflowScrollProxyNode>::encode(Encoder& encod
         type decodedValue; \
         if (!decoder.decode(decodedValue)) \
             return false; \
-        node.setter(decodedValue); \
+        node.setter(WTFMove(decodedValue)); \
     }
 
 #define SCROLLING_NODE_DECODE_ENUM(property, type, setter) \

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3004,6 +3004,7 @@ header: <WebCore/ScrollingStateNode.h>
     WebCore::ScrollType scrollType;
     WebCore::ScrollClamping clamping;
     WebCore::ScrollIsAnimated animated;
+    std::optional<std::tuple<WebCore::FloatPoint, WebCore::ScrollType, WebCore::ScrollClamping>> requestedDataBeforeAnimatedScroll;
 }
 
 [Alias=struct ScrollSnapOffsetsInfo<float,WebCore::FloatRect>, CustomHeader] alias WebCore::FloatScrollSnapOffsetsInfo {


### PR DESCRIPTION
#### b6306634c70b5891fdec1b19f14f0b297453204d
<pre>
[UI-side compositing] Two imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior tests fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=254335">https://bugs.webkit.org/show_bug.cgi?id=254335</a>
rdar://106116027

Reviewed by Tim Horton and Simon Fraser.

When UI-side compositing is enabled, the following two WPT fail:

• imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-root.html
• imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-window.html

Both of these tests wait for an animated scroll to a specific scroll position `(x, y)` to finish
before resetting the scroll position to `(0, 0)` and immediately starting another animated scroll to
the same `(x, y)` destination. When UI-side compositing is enabled and scrolling tree updates are
propagated to the UI process in batches via remote layer tree commits, this means that the animated
scroll to `(x, y)` replaces the `m_requestedScrollData` set by the instant programmatic scroll to
`(0, 0)`.

However, because the UI process already thinks that the scroll position of the scrolling node is at
`(x, y)` due to the previous animated scroll (right before the page tries to instantly scroll to
`(0, 0)`), the next layer tree commit that contains the requested animated scroll to `(x, y)`
results in a no-op.

To address this, we add a new member to `RequestedScrollData` that carries information about the
previously requested scrolling update, which is only populated in the case where an animated scroll
immediately follows a non-animated scroll. We then use this data to perform an immediate scroll in
the UI process right before starting the animated scroll, such that the animated scroll begins from
the correct position.

* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::RequestedScrollData::merge):

Add a helper method to coalesce data from an incoming requested scroll into existing requested
scroll data. See changes in `ScrollingStateScrollingNode` for more details.

* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
(WebCore::RequestedScrollData::operator== const):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::setRequestedScrollData):

In the case where the scrolling tree state already holds a requested scrolling update, use the
helper method above to merge the incoming requested scroll data into the existing one. Typically,
this simply results in the incoming request replacing the existing one; however, in the case where
we have an incoming animated scrolling request that immediately follows a non-animated scrolling
request, we&apos;ll additionally set `requestedDataBeforeAnimatedScroll`.

* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::startPendingScrollAnimations):

If `requestedDataBeforeAnimatedScroll` exists, then use `ScrollingTreeScrollingNode::scrollTo` to
set the scroll position right before embarking on the animated scroll.

Canonical link: <a href="https://commits.webkit.org/262041@main">https://commits.webkit.org/262041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63caa1c62066e1719d2ce4e584d7b1d0a527cdc4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/313 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/543 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/313 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/338 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/367 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/273 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/314 "9 failures") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/296 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/306 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/83 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/299 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->