### PR TITLE
@counter-style rule can't redefine certain predefined styles.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/name-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/name-syntax-expected.txt
@@ -12,8 +12,8 @@ PASS @counter-style name inherit is invalid
 PASS @counter-style name unset is invalid
 PASS @counter-style name decimal is invalid
 PASS @counter-style name disc is invalid
-FAIL @counter-style name square is invalid assert_equals: expected (undefined) undefined but got (object) object "[object CSSCounterStyleRule]"
-FAIL @counter-style name circle is invalid assert_equals: expected (undefined) undefined but got (object) object "[object CSSCounterStyleRule]"
-FAIL @counter-style name disclosure-open is invalid assert_equals: expected (undefined) undefined but got (object) object "[object CSSCounterStyleRule]"
-FAIL @counter-style name disclosure-closed is invalid assert_equals: expected (undefined) undefined but got (object) object "[object CSSCounterStyleRule]"
+PASS @counter-style name square is invalid
+PASS @counter-style name circle is invalid
+PASS @counter-style name disclosure-open is invalid
+PASS @counter-style name disclosure-closed is invalid
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -4775,10 +4775,10 @@ AtomString consumeCounterStyleNameInPrelude(CSSParserTokenRange& prelude, CSSPar
     if (nameToken.type() != IdentToken || !isValidCustomIdentifier(nameToken.id()))
         return AtomString();
     // In the context of the prelude of an @counter-style rule, a <counter-style-name> must not be an ASCII
-    // case-insensitive match for "decimal" or "disc". No <counter-style-name>, prelude or not, may be an ASCII
+    // case-insensitive match for "decimal", "disc", "square", "circle", "disclosure-open" and "disclosure-closed". No <counter-style-name>, prelude or not, may be an ASCII
     // case-insensitive match for "none".
     auto id = nameToken.id();
-    if (identMatches<CSSValueNone>(id) || (mode != CSSParserMode::UASheetMode && identMatches<CSSValueDecimal, CSSValueDisc>(id)))
+    if (identMatches<CSSValueNone>(id) || (mode != CSSParserMode::UASheetMode && identMatches<CSSValueDecimal, CSSValueDisc, CSSValueCircle, CSSValueSquare, CSSValueDisclosureOpen, CSSValueDisclosureClosed>(id)))
         return AtomString();
     auto name = nameToken.value();
     return isPredefinedCounterStyle(nameToken.id()) ? name.convertToASCIILowercaseAtom() : name.toAtomString();


### PR DESCRIPTION
#### 5507daf4822fa4cda38fbd5e70eb81b3bf9ed533
<pre>
@counter-style rule can&apos;t redefine certain predefined styles.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254339">https://bugs.webkit.org/show_bug.cgi?id=254339</a>
rdar://107138989

User is allowed to redefine @counter-style rules predefined by user-agent,
except if the rules are:
&quot;decimal, disc, square, circle, disclosure-open, and disclosure-closed&quot;,
according to <a href="https://w3c.github.io/csswg-drafts/css-counter-styles/#the-counter-style-rule.">https://w3c.github.io/csswg-drafts/css-counter-styles/#the-counter-style-rule.</a>

We currently just avoid &apos;decimal&apos; and &apos;disc&apos; from being redefined.
This patch add the remaining styles that must be excluded from redefinition.

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/name-syntax-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleNameInPrelude):

Canonical link: <a href="https://commits.webkit.org/262038@main">https://commits.webkit.org/262038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11d7d7255218c5076e9b280ebd16b8897b4011d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/337 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/318 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/378 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/563 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/340 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/365 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/318 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/296 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/335 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/319 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/330 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/82 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/323 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->