### PR TITLE
[UI-side compositing] css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-sticky.html fails

### DIFF
--- a/LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-sticky.html
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-sticky.html
@@ -73,6 +73,8 @@
                 eventSender.mouseMoveTo(20, 190);
                 eventSender.mouseDown();
                 eventSender.mouseMoveTo(100, 190);
+
+                await UIHelper.ensurePresentationUpdate();
                 eventSender.mouseUp();
 
                 let horizontalContainer = document.getElementById("horizontal-container");


### PR DESCRIPTION
#### 9d4e4d8d9dd62689a55ed6e9dd61262f87549b9e
<pre>
[UI-side compositing] css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-sticky.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=254344">https://bugs.webkit.org/show_bug.cgi?id=254344</a>
rdar://106115142

Reviewed by Tim Horton.

Adjust this layout test to wait for the next presentation update before releasing the mouse button,
after performing the mouse drag. This gives us an opportunity to sync the new scrollbar position to
the UI process after the mouse drag, so that the closest scroll snap offset is 1020 instead of 0.

* LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-sticky.html:

Canonical link: <a href="https://commits.webkit.org/262035@main">https://commits.webkit.org/262035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ada3a7c19796d2f9fcf09049aab0856f2f42f76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/312 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/556 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/359 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/315 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/290 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/332 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/313 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/327 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/80 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/317 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->