### PR TITLE
[media-controls] volume slider should animate when mute button is toggled

### DIFF
--- a/LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api-expected.txt
+++ b/LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api-expected.txt
@@ -4,7 +4,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS mediaController.controls.volumeSlider.value is 1
-PASS mediaController.controls.volumeSlider.value is 0.5
+PASS mediaController.controls.volumeSlider.value is 1
+PASS mediaController.controls.volumeSlider.value became 0.5
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api-mute-expected.txt
+++ b/LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api-mute-expected.txt
@@ -4,7 +4,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS mediaController.controls.volumeSlider.value is 1
-PASS mediaController.controls.volumeSlider.value is 0
+PASS mediaController.controls.volumeSlider.value is 1
+PASS mediaController.controls.volumeSlider.value became 0
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api-mute.html
+++ b/LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api-mute.html
@@ -15,8 +15,13 @@ const mediaController = createControls(shadowRoot, media, null);
 
 shouldBe("mediaController.controls.volumeSlider.value", "1");
 
-media.addEventListener("volumechange", () => {
-    shouldBe("mediaController.controls.volumeSlider.value", "0");
+media.addEventListener("volumechange", async () => {
+    // We'll animate the volume slider when muting, so we still be at 1 initially.
+    shouldBe("mediaController.controls.volumeSlider.value", "1");
+
+    // But animate to 0 eventually.
+    await new Promise(resolve => shouldBecomeEqual("mediaController.controls.volumeSlider.value", "0", resolve));
+
     debug("");
     shadowRoot.host.remove();
     media.remove();

--- a/LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api.html
+++ b/LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api.html
@@ -15,8 +15,13 @@ const mediaController = createControls(shadowRoot, media, null);
 
 shouldBe("mediaController.controls.volumeSlider.value", "1");
 
-media.addEventListener("volumechange", () => {
-    shouldBe("mediaController.controls.volumeSlider.value", "0.5");
+media.addEventListener("volumechange", async () => {
+    // We'll animate the volume slider when setting the volume, so we still be at 1 initially.
+    shouldBe("mediaController.controls.volumeSlider.value", "1");
+
+    // But animate to 0.5 eventually.
+    await new Promise(resolve => shouldBecomeEqual("mediaController.controls.volumeSlider.value", "0.5", resolve));
+
     debug("");
     shadowRoot.host.remove();
     media.remove();

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller-support.js
@@ -99,7 +99,7 @@ class MediaControllerSupport
     {
         // Implemented by subclasses.
         if (this.control)
-            this.syncControl();
+            this.syncControl(event);
     }
 
     syncControl()

--- a/Source/WebCore/Modules/modern-media-controls/media/volume-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/volume-support.js
@@ -49,10 +49,14 @@ class VolumeSupport extends MediaControllerSupport
         this.mediaController.media.muted = control.value === 0;
     }
 
-    syncControl()
+    syncControl(event)
     {
         const media = this.mediaController.media;
-        this.control.value = media.muted ? 0 : media.volume;
+        const controlValue = media.muted ? 0 : media.volume;
+        if (event)
+            this.control.setValueAnimated(controlValue);
+        else
+            this.control.value = controlValue;
     }
 
 }


### PR DESCRIPTION
#### bcf280115e84f94ff9f5da5596e20ffb0fceebf8
<pre>
[media-controls] volume slider should animate when mute button is toggled
<a href="https://bugs.webkit.org/show_bug.cgi?id=254350">https://bugs.webkit.org/show_bug.cgi?id=254350</a>
rdar://102427937

Reviewed by Dean Jackson.

We used to simply snap the volume slider value as the mute button is toggled. Now we use a short animation
by checking we have an event passed to syncControl(), which indicates this is not the initial call to syncControl()
where we do not want to animate as we just want to match the initial state of the media element.

* LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api-expected.txt:
* LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api-mute-expected.txt:
* LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api-mute.html:
* LayoutTests/media/modern-media-controls/volume-support/volume-support-media-api.html:
* Source/WebCore/Modules/modern-media-controls/controls/slider-base.js:
(SliderBase.prototype.set value):
(SliderBase.prototype.setValueAnimated):
(SliderBase.prototype._setValueInternal):
(SliderBase.prototype._handlePointerdownEvent):
* Source/WebCore/Modules/modern-media-controls/media/media-controller-support.js:
(MediaControllerSupport.prototype.handleEvent):
* Source/WebCore/Modules/modern-media-controls/media/volume-support.js:
(VolumeSupport.prototype.syncControl):
(VolumeSupport):

Canonical link: <a href="https://commits.webkit.org/262064@main">https://commits.webkit.org/262064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbabb8864efa759351e9e675d848f15c95a3116d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/396 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/532 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/642 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/453 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/484 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/423 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/391 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/440 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/420 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/434 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/428 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/50 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->