### PR TITLE
Use smart pointers for ScriptExecutionContext and CanvasRenderingContext (m_context)

### DIFF
--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -196,6 +196,18 @@ inline bool is(const CheckedRef<ArgType, ArgPtrTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
+inline ExpectedType& downcast(CheckedRef<ArgType, ArgPtrTraits>& source)
+{
+    return downcast<ExpectedType>(source.get());
+}
+
+template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
+inline const ExpectedType& downcast(const CheckedRef<ArgType, ArgPtrTraits>& source)
+{
+    return downcast<ExpectedType>(source.get());
+}
+
 template<typename P> struct CheckedRefHashTraits : SimpleClassHashTraits<CheckedRef<P>> {
     static constexpr bool emptyValueIsZero = true;
     static CheckedRef<P> emptyValue() { return HashTableEmptyValue; }

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -276,6 +276,18 @@ inline bool is(const Ref<ArgType, PtrTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename Target, typename Source, typename PtrTraits>
+inline Target& downcast(Ref<Source, PtrTraits>& source)
+{
+    return downcast<Target>(source.get());
+}
+
+template<typename Target, typename Source, typename PtrTraits>
+inline Target& downcast(const Ref<Source, PtrTraits>& source)
+{
+    return downcast<Target>(source.get());
+}
+
 } // namespace WTF
 
 using WTF::Ref;

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -282,6 +282,18 @@ inline bool is(const RefPtr<ArgType, PtrTraits, RefDerefTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
+inline Target* downcast(RefPtr<Source, PtrTraits, RefDerefTraits>& source)
+{
+    return downcast<Target>(source.get());
+}
+
+template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
+inline Target* downcast(const RefPtr<Source, PtrTraits, RefDerefTraits>& source)
+{
+    return downcast<Target>(source.get());
+}
+
 template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename TargetRefDerefTraits = DefaultRefDerefTraits<Target>,
     typename SourcePtrTraits, typename SourceRefDerefTraits>
 inline RefPtr<Target, TargetPtrTraits, TargetRefDerefTraits> dynamicDowncast(const RefPtr<Source, SourcePtrTraits, SourceRefDerefTraits>& source)

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -338,6 +338,18 @@ inline bool is(const WeakPtr<ArgType, WeakPtrImpl>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename Target, typename Source, typename WeakPtrImpl>
+inline Target* downcast(WeakPtr<Source, WeakPtrImpl>& source)
+{
+    return downcase<Target>(source.get());
+}
+
+template<typename Target, typename Source, typename WeakPtrImpl>
+inline Target* downcast(const WeakPtr<Source, WeakPtrImpl>& source)
+{
+    return downcast<Target>(source.get());
+}
+
 template<typename T, typename U, typename WeakPtrImpl> inline bool operator==(const WeakPtr<T, WeakPtrImpl>& a, const WeakPtr<U, WeakPtrImpl>& b)
 {
     return a.get() == b.get();

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
@@ -90,7 +90,7 @@ private:
 
     void processPendingTasks();
 
-    ScriptExecutionContext& m_context;
+    WeakPtr<ScriptExecutionContext> m_context;
     WebSocketChannelClient* m_client;
     WorkerThreadableWebSocketChannel::Peer* m_peer;
     bool m_failedWebSocketChannelCreation;

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.h
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.h
@@ -59,7 +59,7 @@ public:
 
     UniqueRef<ScriptModuleLoader> shadowRealmLoader(JSC::JSGlobalObject* realmGlobal) const;
 
-    ScriptExecutionContext& context() { return m_context; }
+    ScriptExecutionContext& context() { return m_context.get(); }
 
     JSC::Identifier resolve(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue moduleName, JSC::JSValue importerModuleKey, JSC::JSValue scriptFetcher);
     JSC::JSInternalPromise* fetch(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue moduleKey, JSC::JSValue parameters, JSC::JSValue scriptFetcher);
@@ -73,7 +73,7 @@ private:
     URL moduleURL(JSC::JSGlobalObject&, JSC::JSValue);
     URL responseURLFromRequestURL(JSC::JSGlobalObject&, JSC::JSValue);
 
-    ScriptExecutionContext& m_context;
+    CheckedRef<ScriptExecutionContext> m_context;
     MemoryCompactRobinHoodHashMap<String, URL> m_requestURLToResponseURLMap;
     HashSet<Ref<ModuleScriptLoader>> m_loaders;
     OwnerType m_ownerType;

--- a/Source/WebCore/dom/RejectedPromiseTracker.cpp
+++ b/Source/WebCore/dom/RejectedPromiseTracker.cpp
@@ -126,7 +126,7 @@ void RejectedPromiseTracker::promiseHandled(JSDOMGlobalObject& globalObject, JSP
     if (!m_outstandingRejectedPromises.remove(&promise))
         return;
 
-    m_context.postTask([this, rejectedPromise = DOMPromise::create(globalObject, promise)] (ScriptExecutionContext&) mutable {
+    m_context->postTask([this, rejectedPromise = DOMPromise::create(globalObject, promise)] (ScriptExecutionContext&) mutable {
         reportRejectionHandled(WTFMove(rejectedPromise));
     });
 }
@@ -139,7 +139,7 @@ void RejectedPromiseTracker::processQueueSoon()
         return;
 
     Vector<UnhandledPromise> items = WTFMove(m_aboutToBeNotifiedRejectedPromises);
-    m_context.postTask([this, items = WTFMove(items)] (ScriptExecutionContext&) mutable {
+    m_context->postTask([this, items = WTFMove(items)] (ScriptExecutionContext&) mutable {
         reportUnhandledRejections(WTFMove(items));
     });
 }
@@ -148,7 +148,7 @@ void RejectedPromiseTracker::reportUnhandledRejections(Vector<UnhandledPromise>&
 {
     // https://html.spec.whatwg.org/multipage/webappapis.html#unhandled-promise-rejections
 
-    VM& vm = m_context.vm();
+    VM& vm = m_context->vm();
     JSC::JSLockHolder lock(vm);
 
     for (auto& unhandledPromise : unhandledPromises) {
@@ -167,11 +167,11 @@ void RejectedPromiseTracker::reportUnhandledRejections(Vector<UnhandledPromise>&
         initializer.reason = promise.result(vm);
 
         auto event = PromiseRejectionEvent::create(eventNames().unhandledrejectionEvent, initializer);
-        auto target = m_context.errorEventTarget();
+        auto target = m_context->errorEventTarget();
         target->dispatchEvent(event);
 
         if (!event->defaultPrevented())
-            m_context.reportUnhandledPromiseRejection(lexicalGlobalObject, promise, unhandledPromise.callStack());
+            m_context->reportUnhandledPromiseRejection(lexicalGlobalObject, promise, unhandledPromise.callStack());
 
         if (!promise.isHandled(vm))
             m_outstandingRejectedPromises.set(&promise, &promise);
@@ -182,7 +182,7 @@ void RejectedPromiseTracker::reportRejectionHandled(Ref<DOMPromise>&& rejectedPr
 {
     // https://html.spec.whatwg.org/multipage/webappapis.html#the-hostpromiserejectiontracker-implementation
 
-    VM& vm = m_context.vm();
+    VM& vm = m_context->vm();
     JSC::JSLockHolder lock(vm);
 
     if (rejectedPromise->isSuspended())
@@ -195,7 +195,7 @@ void RejectedPromiseTracker::reportRejectionHandled(Ref<DOMPromise>&& rejectedPr
     initializer.reason = promise.result(vm);
 
     auto event = PromiseRejectionEvent::create(eventNames().rejectionhandledEvent, initializer);
-    auto target = m_context.errorEventTarget();
+    auto target = m_context->errorEventTarget();
     target->dispatchEvent(event);
 }
 

--- a/Source/WebCore/dom/RejectedPromiseTracker.h
+++ b/Source/WebCore/dom/RejectedPromiseTracker.h
@@ -59,7 +59,7 @@ private:
     void reportUnhandledRejections(Vector<UnhandledPromise>&&);
     void reportRejectionHandled(Ref<DOMPromise>&&);
 
-    ScriptExecutionContext& m_context;
+    CheckedRef<ScriptExecutionContext> m_context;
     Vector<UnhandledPromise> m_aboutToBeNotifiedRejectedPromises;
     JSC::WeakGCMap<JSC::JSPromise*, JSC::JSPromise> m_outstandingRejectedPromises;
 };

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/HandleTypes.h>
 #include <pal/SessionID.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/CrossThreadTask.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
@@ -95,7 +96,7 @@ namespace IDBClient {
 class IDBConnectionProxy;
 }
 
-class ScriptExecutionContext : public SecurityContext, public CanMakeWeakPtr<ScriptExecutionContext> {
+class ScriptExecutionContext : public SecurityContext, public CanMakeWeakPtr<ScriptExecutionContext>, public CanMakeCheckedPtr {
 public:
     explicit ScriptExecutionContext(ScriptExecutionContextIdentifier = { });
     virtual ~ScriptExecutionContext();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -28,6 +28,7 @@
 #include "CanvasBase.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "ScriptWrappable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/IsoMalloc.h>
 #include <wtf/Lock.h>
@@ -49,7 +50,7 @@ class SVGImageElement;
 class WebGLObject;
 enum class PixelFormat : uint8_t;
 
-class CanvasRenderingContext : public ScriptWrappable {
+class CanvasRenderingContext : public ScriptWrappable, public CanMakeWeakPtr<CanvasRenderingContext>, public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(CanvasRenderingContext);
     WTF_MAKE_ISO_ALLOCATED(CanvasRenderingContext);
 public:

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -52,12 +52,13 @@ public:
 
     const String& identifier() const { return m_identifier; }
 
-    CanvasRenderingContext& canvasContext() const { return m_context; }
+    const CanvasRenderingContext& canvasContext() const { return m_context.get(); }
+    CanvasRenderingContext& canvasContext() { return m_context.get(); }
     HTMLCanvasElement* canvasElement() const;
 
     ScriptExecutionContext* scriptExecutionContext() const;
 
-    JSC::JSValue resolveContext(JSC::JSGlobalObject*) const;
+    JSC::JSValue resolveContext(JSC::JSGlobalObject*);
 
     HashSet<Element*> clientNodes() const;
 
@@ -130,7 +131,7 @@ private:
 
     String m_identifier;
 
-    CanvasRenderingContext& m_context;
+    CheckedRef<CanvasRenderingContext> m_context;
 
     RefPtr<Inspector::Protocol::Recording::InitialState> m_initialState;
     RefPtr<JSON::ArrayOf<Inspector::Protocol::Recording::Frame>> m_frames;

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -70,7 +70,7 @@ private:
 
     WEBCORE_EXPORT Seconds intervalClampedToMinimum() const;
 
-    bool isDOMTimersThrottlingEnabled(Document&) const;
+    bool isDOMTimersThrottlingEnabled(const Document&) const;
     void updateThrottlingStateIfNecessary(const DOMTimerFireState&);
 
     // SuspendableTimerBase


### PR DESCRIPTION
#### e233ab4568b25c084d63488de1ea116928aadc13
<pre>
Use smart pointers for ScriptExecutionContext and CanvasRenderingContext (m_context)
<a href="https://bugs.webkit.org/show_bug.cgi?id=254347">https://bugs.webkit.org/show_bug.cgi?id=254347</a>
rdar://107142041

Reviewed by Chris Dumez and Ryosuke Niwa.

This change adopts Ref&apos;s for m_context member variable to align with the
smart pointer usage guidelines.

* Source/WTF/wtf/CheckedRef.h:
(WTF::downcast):
* Source/WTF/wtf/Ref.h:
(WTF::downcast):
* Source/WTF/wtf/RefPtr.h:
(WTF::downcast):
* Source/WTF/wtf/WeakPtr.h:
(WTF::downcast):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.cpp:
(WebCore::ThreadableWebSocketChannelClientWrapper::processPendingTasks):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h:
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::shadowRealmLoader const):
(WebCore::ScriptModuleLoader::resolve):
(WebCore::ScriptModuleLoader::fetch):
(WebCore::ScriptModuleLoader::moduleURL):
(WebCore::ScriptModuleLoader::responseURLFromRequestURL):
(WebCore::ScriptModuleLoader::evaluate):
(WebCore::ScriptModuleLoader::importModule):
(WebCore::ScriptModuleLoader::notifyFinished):
* Source/WebCore/bindings/js/ScriptModuleLoader.h:
* Source/WebCore/dom/RejectedPromiseTracker.cpp:
(WebCore::RejectedPromiseTracker::promiseHandled):
(WebCore::RejectedPromiseTracker::processQueueSoon):
(WebCore::RejectedPromiseTracker::reportUnhandledRejections):
(WebCore::RejectedPromiseTracker::reportRejectionHandled):
* Source/WebCore/dom/RejectedPromiseTracker.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::InspectorCanvas):
(WebCore::InspectorCanvas::canvasElement const):
(WebCore::InspectorCanvas::scriptExecutionContext const):
(WebCore::InspectorCanvas::resolveContext const):
(WebCore:: const):
(WebCore::InspectorCanvas::canvasChanged):
(WebCore::InspectorCanvas::resetRecordingData):
(WebCore::InspectorCanvas::buildObjectForCanvas):
(WebCore::InspectorCanvas::buildInitialState):
* Source/WebCore/inspector/InspectorCanvas.h:
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimerFireState::DOMTimerFireState):
(WebCore::DOMTimerFireState::~DOMTimerFireState):

Canonical link: <a href="https://commits.webkit.org/262252@main">https://commits.webkit.org/262252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cba4ccb9a311393b5f4c3656b701a083a419b1bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1411 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1062 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1317 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/891 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/847 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/872 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/921 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1946 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/938 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/913 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/866 "4 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/983 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/903 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/197 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/249 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/927 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/986 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/191 "Passed tests") | 
<!--EWS-Status-Bubble-End-->