### PR TITLE
Switch to upward linking ARKit

### DIFF
--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -62,8 +62,8 @@ WK_APPLE_PUSH_SERVICE_LDFLAGS_macosx = $(WK_APPLE_PUSH_SERVICE_LDFLAGS$(WK_MACOS
 WK_APPLE_PUSH_SERVICE_LDFLAGS_MACOS_SINCE_1300 = -framework ApplePushService;
 
 WK_ARKIT_LDFLAGS = $(WK_ARKIT_LDFLAGS_$(WK_PLATFORM_NAME));
-WK_ARKIT_LDFLAGS_iphoneos = -weak_framework ARKit;
-WK_ARKIT_LDFLAGS_iphonesimulator = -weak_framework ARKit;
+WK_ARKIT_LDFLAGS_iphoneos = -Wl,-upward_framework,ARKit;
+WK_ARKIT_LDFLAGS_iphonesimulator = -Wl,-upward_framework,ARKit;
 
 WK_BACKBOARD_SERVICES_LDFLAGS = $(WK_BACKBOARD_SERVICES_LDFLAGS_$(WK_PLATFORM_NAME));
 WK_BACKBOARD_SERVICES_LDFLAGS_iphoneos = -framework BackBoardServices;


### PR DESCRIPTION
#### 5b5924f8b5a83f99076684a8cb27ee9f3f749975
<pre>
Switch to upward linking ARKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=254355">https://bugs.webkit.org/show_bug.cgi?id=254355</a>
rdar://107141566

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Configurations/WebKit.xcconfig:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b5924f8b5a83f99076684a8cb27ee9f3f749975

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/319 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/379 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/341 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/366 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/320 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/297 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/337 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/320 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/332 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/324 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->