### PR TITLE
Remove unused function declaration in WorkerCacheStorageConnection.h

### DIFF
--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
@@ -57,13 +57,6 @@ private:
     void reference(DOMCacheIdentifier) final;
     void dereference(DOMCacheIdentifier) final;
 
-    void doOpen(uint64_t requestIdentifier, const ClientOrigin&, const String& cacheName);
-    void doRemove(uint64_t requestIdentifier, uint64_t cacheIdentifier);
-    void doRetrieveCaches(uint64_t requestIdentifier, const ClientOrigin&, uint64_t updateCounter);
-    void doRetrieveRecords(uint64_t requestIdentifier, uint64_t cacheIdentifier, const URL&);
-    void doBatchDeleteOperation(uint64_t requestIdentifier, uint64_t cacheIdentifier, const WebCore::ResourceRequest&, WebCore::CacheQueryOptions&&);
-    void doBatchPutOperation(uint64_t requestIdentifier, uint64_t cacheIdentifier, Vector<DOMCacheEngine::Record>&&);
-
     void openCompleted(uint64_t requestIdentifier, const DOMCacheEngine::CacheIdentifierOrError&);
     void removeCompleted(uint64_t requestIdentifier, const DOMCacheEngine::RemoveCacheIdentifierOrError&);
     void retrieveCachesCompleted(uint64_t requestIdentifier, DOMCacheEngine::CacheInfosOrError&&);


### PR DESCRIPTION
#### 2c7ccb76ac1602de8b10e986fb67c456ed3fffcd
<pre>
Remove unused function declaration in WorkerCacheStorageConnection.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=254357">https://bugs.webkit.org/show_bug.cgi?id=254357</a>
rdar://107146101

Reviewed by Per Arne Vollan.

* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h:

Canonical link: <a href="https://commits.webkit.org/262047@main">https://commits.webkit.org/262047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31f161b1f7ab1118a557c092bc1dc5ef3df5ae43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/342 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/323 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/566 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/370 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/325 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/393 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/301 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/342 "9 failures") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/324 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/337 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/88 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/328 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->