### PR TITLE
make all remaining { No, Yes } and { Yes, No } enums use bool as underlying type

### DIFF
--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -204,10 +204,7 @@ namespace JSC {
     };
 
 #if CPU(ARM64E)
-    enum class ShouldSign {
-        Yes,
-        No
-    };
+    enum class ShouldSign : bool { No, Yes };
     template <ShouldSign shouldSign>
     class ARM64EHash {
         WTF_MAKE_NONCOPYABLE(ARM64EHash);

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -180,10 +180,7 @@ public:
     bool isLinked() const { return stub() || m_calleeOrCodeBlock; }
     void unlink(VM&);
 
-    enum class UseDataIC : uint8_t {
-        Yes,
-        No
-    };
+    enum class UseDataIC : bool { No, Yes };
 
 #if ENABLE(JIT)
 protected:

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/channel_unittest.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/channel_unittest.cc
@@ -68,7 +68,7 @@ const uint32_t kSsrc3 = 0x3333;
 const uint32_t kSsrc4 = 0x4444;
 const int kAudioPts[] = {0, 8};
 const int kVideoPts[] = {97, 99};
-enum class NetworkIsWorker { Yes, No };
+enum class NetworkIsWorker : bool { No, Yes };
 
 }  // namespace
 

--- a/Source/WTF/wtf/playstation/FileSystemPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/FileSystemPlayStation.cpp
@@ -37,7 +37,7 @@ namespace WTF {
 
 namespace FileSystemImpl {
 
-enum class ShouldFollowSymbolicLinks { No, Yes };
+enum class ShouldFollowSymbolicLinks : bool { No, Yes };
 static std::optional<FileType> fileTypePotentiallyFollowingSymLinks(const String& path, ShouldFollowSymbolicLinks shouldFollowSymbolicLinks)
 {
     CString fsRep = fileSystemRepresentation(path);

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -66,7 +66,7 @@ public:
     void startPendingActivity() { m_pendingActivity = makePendingActivity(*this); }
     void start(Ref<RTCRtpTransformBackend>&&);
 
-    enum class ClearCallback { No, Yes};
+    enum class ClearCallback : bool { No, Yes };
     void clear(ClearCallback);
 
 private:

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -322,7 +322,7 @@ static GstWebRTCSignalingState fetchSignalingState(GstElement* webrtcBin)
     return state;
 }
 
-enum class GatherSignalingState { No, Yes };
+enum class GatherSignalingState : bool { No, Yes };
 static std::optional<PeerConnectionBackend::DescriptionStates> descriptionsFromWebRTCBin(GstElement* webrtcBin, GatherSignalingState gatherSignalingState = GatherSignalingState::No)
 {
     std::optional<RTCSdpType> currentLocalDescriptionSdpType, pendingLocalDescriptionSdpType, currentRemoteDescriptionSdpType, pendingRemoteDescriptionSdpType;

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -156,10 +156,7 @@ protected:
     bool isDetached() const override { return !m_node; }
 
     virtual AccessibilityRole determineAccessibilityRole();
-    enum class TreatStyleFormatGroupAsInline {
-        No,
-        Yes
-    };
+    enum class TreatStyleFormatGroupAsInline : bool { No, Yes };
     AccessibilityRole determineAccessibilityRoleFromNode(TreatStyleFormatGroupAsInline = TreatStyleFormatGroupAsInline::No) const;
     AccessibilityRole ariaRoleAttribute() const override { return m_ariaRole; }
     virtual AccessibilityRole determineAriaRoleAttribute() const;

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAES_CBC.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAES_CBC.h
@@ -36,10 +36,7 @@ class CryptoKeyAES;
 
 class CryptoAlgorithmAES_CBC final : public CryptoAlgorithm {
 public:
-    enum class Padding : uint8_t {
-        Yes,
-        No
-    };
+    enum class Padding : bool { No, Yes };
 
     static constexpr ASCIILiteral s_name = "AES-CBC"_s;
     static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::AES_CBC;

--- a/Source/WebCore/css/parser/CSSParserEnum.h
+++ b/Source/WebCore/css/parser/CSSParserEnum.h
@@ -32,10 +32,7 @@ namespace WebCore {
 
 namespace CSSParserEnum {
 
-enum class IsNestedContext : bool {
-    Yes,
-    No
-};
+enum class IsNestedContext : bool { No, Yes };
 
 } // namespace CSSParserEnum
 

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -158,10 +158,7 @@ private:
     RefPtr<StyleRuleBase> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     ParsedPropertyVector consumeDeclarationListInNewNestingContext(CSSParserTokenRange, StyleRuleType);
 
-    enum class OnlyDeclarations {
-        Yes,
-        No
-    };
+    enum class OnlyDeclarations : bool { No, Yes };
 
     enum class ParsingStyleDeclarationsInRuleList : bool { No, Yes };
 

--- a/Source/WebCore/dom/DocumentStorageAccess.h
+++ b/Source/WebCore/dom/DocumentStorageAccess.h
@@ -37,15 +37,9 @@ class DeferredPromise;
 class Document;
 class UserGestureIndicator;
 
-enum class StorageAccessWasGranted : bool {
-    No,
-    Yes
-};
+enum class StorageAccessWasGranted : bool { No, Yes };
 
-enum class StorageAccessPromptWasShown : bool {
-    No,
-    Yes
-};
+enum class StorageAccessPromptWasShown : bool { No, Yes };
 
 enum class StorageAccessScope : bool {
     PerFrame,

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -79,7 +79,7 @@ class RTCDataChannelRemoteHandlerConnection;
 class ResourceRequest;
 class SocketProvider;
 class WebCoreOpaqueRoot;
-enum class LoadedFromOpaqueSource : uint8_t;
+enum class LoadedFromOpaqueSource : bool;
 enum class TaskSource : uint8_t;
 
 #if ENABLE(NOTIFICATIONS)

--- a/Source/WebCore/loader/FrameLoaderTypes.h
+++ b/Source/WebCore/loader/FrameLoaderTypes.h
@@ -77,10 +77,7 @@ enum LocalPolicyCheckIdentifierType { };
 using LocalPolicyCheckIdentifier = ObjectIdentifier<LocalPolicyCheckIdentifierType>;
 using PolicyCheckIdentifier = ProcessQualified<LocalPolicyCheckIdentifier>;
 
-enum class ShouldContinuePolicyCheck : bool {
-    Yes,
-    No
-};
+enum class ShouldContinuePolicyCheck : bool { No, Yes };
 
 enum class NewFrameOpenerPolicy : uint8_t {
     Suppress,
@@ -107,10 +104,7 @@ enum class InitiatedByMainFrame : uint8_t {
     Unknown,
 };
 
-enum class ClearProvisionalItem : bool {
-    Yes,
-    No
-};
+enum class ClearProvisionalItem : bool { No, Yes };
 
 enum class StopLoadingPolicy {
     PreventDuringUnloadEvents,

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -152,16 +152,10 @@ enum class PreflightPolicy : uint8_t {
 };
 static constexpr unsigned bitWidthOfPreflightPolicy = 2;
 
-enum class LoadedFromOpaqueSource : uint8_t {
-    Yes,
-    No
-};
+enum class LoadedFromOpaqueSource : bool { No, Yes };
 static constexpr unsigned bitWidthOfLoadedFromOpaqueSource = 1;
 
-enum class LoadedFromPluginElement : bool {
-    No,
-    Yes
-};
+enum class LoadedFromPluginElement : bool { No, Yes };
 static constexpr unsigned bitWidthOfLoadedFromPluginElement = 1;
 
 struct ResourceLoaderOptions : public FetchOptions {

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -303,10 +303,7 @@ public:
     WEBCORE_EXPORT LayoutPoint minStableLayoutViewportOrigin() const;
     WEBCORE_EXPORT LayoutPoint maxStableLayoutViewportOrigin() const;
 
-    enum class TriggerLayoutOrNot {
-        No,
-        Yes
-    };
+    enum class TriggerLayoutOrNot : bool { No, Yes };
     // This origin can be overridden by setLayoutViewportOverrideRect.
     void setBaseLayoutViewportOrigin(LayoutPoint, TriggerLayoutOrNot = TriggerLayoutOrNot::Yes);
     // This size can be overridden by setLayoutViewportOverrideRect.

--- a/Source/WebCore/platform/ScrollAnimator.h
+++ b/Source/WebCore/platform/ScrollAnimator.h
@@ -104,9 +104,7 @@ public:
 
     void contentsSizeChanged();
 
-    enum NotifyScrollableArea : bool {
-        No, Yes
-    };
+    enum NotifyScrollableArea : bool { No, Yes };
     void setCurrentPosition(const FloatPoint&, NotifyScrollableArea = NotifyScrollableArea::No);
     const FloatPoint& currentPosition() const { return m_currentPosition; }
 

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -73,10 +73,7 @@ enum class ScrollAnimationStatus : uint8_t {
     Animating,
 };
 
-enum class ScrollIsAnimated : uint8_t {
-    No,
-    Yes
-};
+enum class ScrollIsAnimated : bool { No, Yes };
 
 enum class OverflowAnchor : uint8_t {
     Auto,

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
@@ -55,8 +55,7 @@ public:
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;
 
-    enum class ShouldMakeGamepadsVisible : bool { No,
-        Yes };
+    enum class ShouldMakeGamepadsVisible : bool { No, Yes };
     void scheduleInputNotification(GamepadLibWPE&, ShouldMakeGamepadsVisible);
 
     struct wpe_view_backend* inputView();

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -142,10 +142,7 @@ public:
     // On the other hand, if we're invalidating because the set of installed fonts changed,
     // or if some accessibility text settings were altered, we should run a style recalc
     // so the user can immediately see the effect of the new environment.
-    enum class ShouldRunInvalidationCallback : bool {
-        No,
-        Yes
-    };
+    enum class ShouldRunInvalidationCallback : bool { No, Yes };
     WEBCORE_EXPORT static void invalidateAllFontCaches(ShouldRunInvalidationCallback = ShouldRunInvalidationCallback::Yes);
 
     WEBCORE_EXPORT size_t fontCount();

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1019,10 +1019,7 @@ public:
         DOMSourceNone,
     };
 
-    enum class FlipY : bool {
-        No,
-        Yes
-    };
+    enum class FlipY : bool { No, Yes };
 
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() = 0;
 

--- a/Source/WebCore/platform/graphics/ShouldLocalizeAxisNames.h
+++ b/Source/WebCore/platform/graphics/ShouldLocalizeAxisNames.h
@@ -29,9 +29,6 @@
 
 namespace WebCore {
 
-enum class ShouldLocalizeAxisNames : uint8_t {
-    No,
-    Yes
-};
+enum class ShouldLocalizeAxisNames : bool { No, Yes };
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
@@ -67,10 +67,7 @@ enum class FontTypeForPreparation : bool {
     SystemFont,
     NonSystemFont
 };
-enum class ApplyTraitsVariations : bool {
-    No,
-    Yes
-};
+enum class ApplyTraitsVariations : bool { No, Yes };
 RetainPtr<CTFontRef> preparePlatformFont(UnrealizedCoreTextFont&&, const FontDescription&, const FontCreationContext&, FontTypeForPreparation = FontTypeForPreparation::NonSystemFont, ApplyTraitsVariations = ApplyTraitsVariations::Yes);
 enum class ShouldComputePhysicalTraits : bool { No, Yes };
 SynthesisPair computeNecessarySynthesis(CTFontRef, const FontDescription&, ShouldComputePhysicalTraits = ShouldComputePhysicalTraits::No, bool isPlatformFont = false);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -134,7 +134,7 @@ protected:
         static const char* elementFactoryTypeToString(Type);
         GList* factory(Type) const;
 
-        enum class CheckHardwareClassifier { No, Yes };
+        enum class CheckHardwareClassifier : bool { No, Yes };
         RegistryLookupResult hasElementForMediaType(Type, const char* capsString, CheckHardwareClassifier = CheckHardwareClassifier::No, std::optional<Vector<String>> disallowedList = std::nullopt) const;
         RegistryLookupResult hasElementForCaps(Type, const GRefPtr<GstCaps>&, CheckHardwareClassifier = CheckHardwareClassifier::No, std::optional<Vector<String>> disallowedList = std::nullopt) const;
 

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -77,10 +77,7 @@ enum class ClearSiteDataValue : uint8_t {
     Storage = 1 << 3,
 };
 
-enum class RangeAllowWhitespace : bool {
-    No,
-    Yes
-};
+enum class RangeAllowWhitespace : bool { No, Yes };
 
 bool isValidReasonPhrase(const String&);
 bool isValidHTTPHeaderValue(const String&);

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -486,10 +486,7 @@ enum class FontStyleAxis : uint8_t {
     ital
 };
 
-enum class AllowUserInstalledFonts : uint8_t {
-    No,
-    Yes
-};
+enum class AllowUserInstalledFonts : bool { No, Yes };
 
 using FeaturesMap = HashMap<FontTag, int, FourCharacterTagHash, FourCharacterTagHashTraits>;
 FeaturesMap computeFeatureSettingsFromVariants(const FontVariantSettings&, RefPtr<FontFeatureValues>);

--- a/Source/WebCore/rendering/BreakLines.h
+++ b/Source/WebCore/rendering/BreakLines.h
@@ -40,10 +40,7 @@ enum class NonBreakingSpaceBehavior {
     TreatNonBreakingSpaceAsBreak,
 };
 
-enum class CanUseShortcut {
-    Yes,
-    No
-};
+enum class CanUseShortcut : bool { No, Yes };
 
 template<NonBreakingSpaceBehavior nonBreakingSpaceBehavior>
 static inline bool isBreakableSpace(UChar character)

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -486,7 +486,7 @@ public:
     virtual LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred  = ComputeActual) const;
     virtual LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const;
 
-    enum class UpdatePercentageHeightDescendants { Yes , No };
+    enum class UpdatePercentageHeightDescendants : bool { No, Yes };
     std::optional<LayoutUnit> computePercentageLogicalHeight(const Length& height, UpdatePercentageHeightDescendants = UpdatePercentageHeightDescendants::Yes) const;
 
     LayoutUnit availableLogicalWidth() const { return contentLogicalWidth(); }

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -198,9 +198,7 @@ public:
     // Update event regions, which only needs to happen once per rendering update.
     void updateEventRegions();
 
-    enum class LayoutUpToDate {
-        Yes, No
-    };
+    enum class LayoutUpToDate : bool { No, Yes };
 
     struct RequiresCompositingData {
         LayoutUpToDate layoutUpToDate { LayoutUpToDate::Yes };

--- a/Source/WebCore/rendering/style/StyleCursorImage.h
+++ b/Source/WebCore/rendering/style/StyleCursorImage.h
@@ -34,7 +34,7 @@ class Document;
 class WeakPtrImplWithEventTargetData;
 class SVGCursorElement;
 
-enum class LoadedFromOpaqueSource : uint8_t;
+enum class LoadedFromOpaqueSource : bool;
 
 class StyleCursorImage final : public StyleMultiImage {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -412,10 +412,7 @@ static inline void writeSVGInlineTextBoxes(TextStream& ts, const RenderText& tex
     }
 }
 
-enum class WriteIndentOrNot {
-    No,
-    Yes
-};
+enum class WriteIndentOrNot : bool { No, Yes };
 
 static void writeStandardPrefix(TextStream& ts, const RenderObject& object, OptionSet<RenderAsTextFlag> behavior, WriteIndentOrNot writeIndent = WriteIndentOrNot::Yes)
 {

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -46,10 +46,7 @@ class BuilderState;
 
 void maybeUpdateFontForLetterSpacing(BuilderState&, CSSValue&);
 
-enum class ForVisitedLink : bool {
-    No,
-    Yes
-};
+enum class ForVisitedLink : bool { No, Yes };
 
 struct BuilderContext {
     Ref<const Document> document;

--- a/Source/WebDriver/Session.h
+++ b/Source/WebDriver/Session.h
@@ -59,7 +59,7 @@ public:
 
     enum class FindElementsMode { Single, Multiple };
     enum class ExecuteScriptMode { Sync, Async };
-    enum class ElementIsShadowRoot { No, Yes };
+    enum class ElementIsShadowRoot : bool { No, Yes };
 
     struct Cookie {
         String name;

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -363,7 +363,7 @@ static std::optional<uint64_t> unsignedValue(JSON::Value& value)
     return intValue;
 }
 
-enum class IgnoreUnknownTimeout { No, Yes };
+enum class IgnoreUnknownTimeout : bool { No, Yes };
 
 static std::optional<Timeouts> deserializeTimeouts(JSON::Object& timeoutsObject, IgnoreUnknownTimeout ignoreUnknownTimeout)
 {

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
@@ -65,7 +65,7 @@ private:
     void startTimeout();
     void stopTimeout();
 
-    enum class WasBlockingCookies { No, Yes };
+    enum class WasBlockingCookies : bool { No, Yes };
     void createRequest(WebCore::ResourceRequest&&, WasBlockingCookies);
     void clearRequest();
 

--- a/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
@@ -40,10 +40,7 @@ public:
     std::optional<Span<uint8_t>> tryAcquire(Timeout);
     std::optional<Span<uint8_t>> tryAcquireAll(Timeout);
 
-    enum class WakeUpServer : bool {
-        No,
-        Yes
-    };
+    enum class WakeUpServer : bool { No, Yes };
     WakeUpServer release(size_t writeSize);
     void resetClientOffset();
     Span<uint8_t> alignedSpan(size_t offset, size_t limit);

--- a/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h
@@ -38,10 +38,7 @@ public:
     StreamServerConnectionBuffer& operator=(StreamServerConnectionBuffer&&) = default;
     std::optional<Span<uint8_t>> tryAcquire();
     Span<uint8_t> acquireAll();
-    enum class WakeUpClient : bool {
-        No,
-        Yes
-    };
+    enum class WakeUpClient : bool { No, Yes };
     WakeUpClient release(size_t readSize);
     WakeUpClient releaseAll();
 

--- a/Source/WebKit/Shared/TextFlags.serialization.in
+++ b/Source/WebKit/Shared/TextFlags.serialization.in
@@ -43,10 +43,7 @@ enum class WebCore::FontStyleAxis : uint8_t {
     ital
 };
 
-enum class WebCore::AllowUserInstalledFonts : uint8_t {
-    No,
-    Yes
-};
+enum class WebCore::AllowUserInstalledFonts : bool;
 
 enum class WebCore::FontVariantEastAsianVariant : uint8_t {
     Normal,

--- a/Source/WebKit/Shared/ios/GestureTypes.h
+++ b/Source/WebKit/Shared/ios/GestureTypes.h
@@ -71,10 +71,7 @@ enum SelectionFlags : uint8_t {
     PhraseBoundaryChanged = 1 << 2,
 };
 
-enum class RespectSelectionAnchor : bool {
-    No,
-    Yes
-};
+enum class RespectSelectionAnchor : bool { No, Yes };
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.h
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.h
@@ -32,7 +32,7 @@ namespace WebKit {
 
 class IconDatabase : public ThreadSafeRefCounted<IconDatabase> {
 public:
-    enum class AllowDatabaseWrite { No, Yes };
+    enum class AllowDatabaseWrite : bool { No, Yes };
 
     static Ref<IconDatabase> create(const String& path, AllowDatabaseWrite allowDatabaseWrite)
     {

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBaseInternal.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBaseInternal.h
@@ -41,7 +41,7 @@ enum class MouseEventType { Press, Release, Motion };
 WK_EXPORT void webkitWebViewBaseSynthesizeMouseEvent(WebKitWebViewBase*, MouseEventType type, unsigned button, unsigned short buttons, int x, int y, unsigned modifiers, int clickCount, const String& pointerType = "mouse"_s, WebCore::PlatformMouseEvent::IsTouch isTouchEvent = WebCore::PlatformMouseEvent::IsTouch::No);
 
 enum class KeyEventType { Press, Release, Insert };
-enum class ShouldTranslateKeyboardState { No, Yes };
+enum class ShouldTranslateKeyboardState : bool { No, Yes };
 WK_EXPORT void webkitWebViewBaseSynthesizeKeyEvent(WebKitWebViewBase*, KeyEventType, unsigned keyVal, unsigned modifiers, ShouldTranslateKeyboardState);
 
 enum class WheelEventPhase { NoPhase, Began, Changed, Ended, Cancelled, MayBegin };

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -115,7 +115,7 @@ enum class TextIndicatorLifetime : uint8_t;
 enum class TextIndicatorDismissalAnimation : uint8_t;
 enum class DOMPasteAccessCategory : uint8_t;
 enum class DOMPasteAccessResponse : uint8_t;
-enum class ScrollIsAnimated : uint8_t;
+enum class ScrollIsAnimated : bool;
 
 struct AppHighlight;
 struct DataDetectorElementInfo;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h
@@ -41,10 +41,7 @@ class HidConnection {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(HidConnection);
 public:
-    enum class DataSent {
-        No,
-        Yes
-    };
+    enum class DataSent : bool { No, Yes };
 
     using DataSentCallback = CompletionHandler<void(DataSent)>;
     using DataReceivedCallback = Function<void(Vector<uint8_t>&&)>;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -146,10 +146,7 @@ public:
     typedef HashMap<WebCore::FrameIdentifier, WeakPtr<WebFrameProxy>> WebFrameProxyMap;
     typedef HashMap<uint64_t, RefPtr<API::UserInitiatedAction>> UserInitiatedActionMap;
 
-    enum class IsPrewarmed {
-        No,
-        Yes
-    };
+    enum class IsPrewarmed : bool { No, Yes };
 
     enum class ShouldLaunchProcess : bool { No, Yes };
     enum class LockdownMode : bool { Disabled, Enabled };

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -259,10 +259,7 @@ struct RemoveBackgroundData {
     String preferredMIMEType;
 };
 
-enum class ProceedWithTextSelectionInImage : bool {
-    No,
-    Yes
-};
+enum class ProceedWithTextSelectionInImage : bool { No, Yes };
 
 enum ImageAnalysisRequestIdentifierType { };
 using ImageAnalysisRequestIdentifier = ObjectIdentifier<ImageAnalysisRequestIdentifierType>;

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -41,10 +41,7 @@ public:
     static WebCore::HistoryItem* itemForID(const WebCore::BackForwardItemIdentifier&);
     static void removeItem(const WebCore::BackForwardItemIdentifier&);
 
-    enum class OverwriteExistingItem {
-        Yes,
-        No
-    };
+    enum class OverwriteExistingItem : bool { No, Yes };
     void addItemFromUIProcess(const WebCore::BackForwardItemIdentifier&, Ref<WebCore::HistoryItem>&&, WebCore::PageIdentifier, OverwriteExistingItem);
 
     void clear();

--- a/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
@@ -260,10 +260,7 @@ void PrintTo(TestImageBufferOptions value, ::std::ostream* o)
         *o << "Unknown";
 }
 
-enum class TestPreserveResolution {
-    No,
-    Yes
-};
+enum class TestPreserveResolution : bool { No, Yes };
 
 void PrintTo(TestPreserveResolution value, ::std::ostream* o)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -567,7 +567,7 @@ static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
     return processPoolConfiguration;
 }
 
-enum class SchemeHandlerShouldBeAsync { No, Yes };
+enum class SchemeHandlerShouldBeAsync : bool { No, Yes };
 static void runBasicTest(SchemeHandlerShouldBeAsync schemeHandlerShouldBeAsync)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();


### PR DESCRIPTION
#### cebd0f9727d7493fbbea4ebf321799bc0152642e
<pre>
make all remaining { No, Yes } and { Yes, No } enums use bool as underlying type
<a href="https://bugs.webkit.org/show_bug.cgi?id=254358">https://bugs.webkit.org/show_bug.cgi?id=254358</a>

Reviewed by Chris Dumez.

Missed a few, such as multiline declarations, in 262018@main.

* Source/JavaScriptCore/assembler/AssemblerBuffer.h:
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/channel_unittest.cc:
* Source/WTF/wtf/playstation/FileSystemPlayStation.cpp:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAES_CBC.h:
* Source/WebCore/css/parser/CSSParserEnum.h:
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/dom/DocumentStorageAccess.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/loader/FrameLoaderTypes.h:
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/platform/ScrollAnimator.h:
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h:
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/ShouldLocalizeAxisNames.h:
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/network/HTTPParsers.h:
* Source/WebCore/platform/text/TextFlags.h:
* Source/WebCore/rendering/BreakLines.h:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/style/StyleCursorImage.h:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebDriver/Session.h:
* Source/WebDriver/WebDriverService.cpp:
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h:
* Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h:
* Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h:
* Source/WebKit/Shared/TextFlags.serialization.in:
* Source/WebKit/Shared/ios/GestureTypes.h:
* Source/WebKit/UIProcess/API/glib/IconDatabase.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBaseInternal.h:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:

Canonical link: <a href="https://commits.webkit.org/262062@main">https://commits.webkit.org/262062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98382879811f8af191058e888ea58026d12d0520

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/327 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/347 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/572 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/377 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/398 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/316 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/306 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/345 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/356 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/330 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/364 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/340 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/334 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/363 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/49 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/48 "Passed tests") | 
<!--EWS-Status-Bubble-End-->