### PR TITLE
Platform should support showing more descriptive label instead of name.

### DIFF
--- a/Websites/perf.webkit.org/init-database.sql
+++ b/Websites/perf.webkit.org/init-database.sql
@@ -45,6 +45,7 @@ CREATE TABLE platform_groups (
 CREATE TABLE platforms (
     platform_id serial PRIMARY KEY,
     platform_name varchar(64) NOT NULL,
+    platform_label varchar(128) DEFAULT NULL UNIQUE,
     platform_group integer REFERENCES platform_groups DEFAULT NULL,
     platform_hidden boolean NOT NULL DEFAULT FALSE);
 

--- a/Websites/perf.webkit.org/migrate-database.sql
+++ b/Websites/perf.webkit.org/migrate-database.sql
@@ -11,6 +11,7 @@ END IF;
 
 ALTER TABLE build_requests ADD COLUMN IF NOT EXISTS request_status_description varchar(1024) DEFAULT NULL;
 ALTER TABLE platforms ADD COLUMN IF NOT EXISTS platform_group integer REFERENCES platform_groups DEFAULT NULL;
+ALTER TABLE platforms ADD COLUMN IF NOT EXISTS platform_label varchar(128) DEFAULT NULL UNIQUE;
 ALTER TABLE commits ADD COLUMN IF NOT EXISTS commit_revision_identifier varchar(64) DEFAULT NULL;
 ALTER TABLE analysis_test_groups ADD COLUMN IF NOT EXISTS testgroup_repetition_type analysis_test_group_repetition_type NOT NULL DEFAULT 'alternating';
 ALTER TABLE commits DROP CONSTRAINT IF EXISTS commit_string_identifier_in_repository_must_be_unique;

--- a/Websites/perf.webkit.org/public/admin/platforms.php
+++ b/Websites/perf.webkit.org/public/admin/platforms.php
@@ -59,6 +59,7 @@ function merge_platforms($platform_to_merge, $destination_platform) {
 if ($db) {
     if ($action == 'update') {
         if (update_field('platforms', 'platform', 'name')
+            || update_field('platforms', 'platform', 'label')
             || update_field('platforms', 'platform', 'group')
             || update_boolean_field('platforms', 'platform', 'hidden'))
             regenerate_manifest();
@@ -124,6 +125,7 @@ END;
 
     $page = new AdministrativePage($db, 'platforms', 'platform', array(
         'name' => array('editing_mode' => 'string'),
+        'label' => array('editing_mode' => 'string'),
         'hidden' => array('editing_mode' => 'boolean'),
         'platform group' => array('custom' => function ($platform_row) { return platform_group_list($platform_row); }),
         'merge into' => array('custom' => function ($platform_row) { return merge_list($platform_row); }),

--- a/Websites/perf.webkit.org/public/include/manifest-generator.php
+++ b/Websites/perf.webkit.org/public/include/manifest-generator.php
@@ -127,6 +127,7 @@ class ManifestGenerator {
                 if (array_key_exists($id, $platform_metrics)) {
                     $platforms[$id] = array(
                         'name' => $platform_row['platform_name'],
+                        'label' => $platform_row['platform_label'],
                         'metrics' => $platform_metrics[$id]['metrics'],
                         'group' => $platform_row['platform_group'],
                         'hidden' => Database::is_true($platform_row['platform_hidden']),

--- a/Websites/perf.webkit.org/public/v3/components/chart-styles.js
+++ b/Websites/perf.webkit.org/public/v3/components/chart-styles.js
@@ -9,7 +9,7 @@ class ChartStyles {
 
         var lastModified = platform.lastModified(metric);
         if (!lastModified)
-            return {platform: platform, metric: metric, error: `No results on ${platform.name()}`};
+            return {platform: platform, metric: metric, error: `No results on ${platform.label()}`};
 
         return {
             platform: platform,

--- a/Websites/perf.webkit.org/public/v3/components/custom-analysis-task-configurator.js
+++ b/Websites/perf.webkit.org/public/v3/components/custom-analysis-task-configurator.js
@@ -297,7 +297,7 @@ class CustomAnalysisTaskConfigurator extends ComponentBase {
                 const matchingTestNames = [...matchingTests].map((test) => test.fullName()).sort().join('", "');
                 const mismathingTestNames = [...mismatchingTests].map((test) => test.fullName()).sort().join('", "');
                 error = `Tests "${matchingTestNames}" and "${mismathingTestNames}" cannot be scheduled
-                    simultenosuly on "${platform.name()}". Please select one of them at a time.`;
+                    simultenosuly on "${platform.label()}". Please select one of them at a time.`;
             }
         }
 

--- a/Websites/perf.webkit.org/public/v3/components/custom-configuration-test-group-form.js
+++ b/Websites/perf.webkit.org/public/v3/components/custom-configuration-test-group-form.js
@@ -79,7 +79,7 @@ class CustomConfigurationTestGroupForm extends TestGroupForm {
     {
         if (!platform || !tests.length)
             return;
-        this.content('group-name').value = `${tests.map((test) => test.name()).join(', ')} on ${platform.name()}`;
+        this.content('group-name').value = `${tests.map((test) => test.name()).join(', ')} on ${platform.label()}`;
     }
 
     static cssTemplate()

--- a/Websites/perf.webkit.org/public/v3/models/platform.js
+++ b/Websites/perf.webkit.org/public/v3/models/platform.js
@@ -4,6 +4,7 @@ class Platform extends LabeledObject {
     constructor(id, object)
     {
         super(id, object);
+        this._label = object.label;
         this._metrics = object.metrics;
         this._lastModifiedByMetric = object.lastModifiedByMetric;
         this._isHidden = object.hidden;
@@ -23,6 +24,11 @@ class Platform extends LabeledObject {
     {
         var map = this.namedStaticMap('name');
         return map ? map[name] : null;
+    }
+
+    label()
+    {
+        return this._label || this.name();
     }
 
     isInSameGroupAs(other)

--- a/Websites/perf.webkit.org/public/v3/pages/chart-pane.js
+++ b/Websites/perf.webkit.org/public/v3/pages/chart-pane.js
@@ -277,7 +277,7 @@ class ChartPane extends ChartPaneBase {
             var platform = this._platform;
 
             this.renderReplace(this.content().querySelector('.chart-pane-title'),
-                metric.fullName() + ' on ' + platform.name());
+                metric.fullName() + ' on ' + platform.label());
         }
 
         if (this._mainChartStatus)

--- a/Websites/perf.webkit.org/public/v3/pages/summary-page.js
+++ b/Websites/perf.webkit.org/public/v3/pages/summary-page.js
@@ -137,7 +137,7 @@ class SummaryPage extends PageWithHeading {
     {
         function mapAndSortByName(platforms)
         {
-            return platforms && platforms.map(function (platform) { return platform.name(); }).sort();
+            return platforms && platforms.map(function (platform) { return platform.label(); }).sort();
         }
 
         function pluralizeIfNeeded(singularWord, platforms) { return singularWord + (platforms.length > 1 ? 's' : ''); }

--- a/Websites/perf.webkit.org/public/v3/pages/test-freshness-page.js
+++ b/Websites/perf.webkit.org/public/v3/pages/test-freshness-page.js
@@ -251,7 +251,7 @@ class TestFreshnessPage extends PageWithHeading {
         let tableContent = [element('tr', element('td', {colspan: 2}, buildSummary))];
 
         if (chartURL) {
-            const linkDescription = `${metric.test().name()} on ${platform.name()}`;
+            const linkDescription = `${metric.test().name()} on ${platform.label()}`;
             tableContent.push(element('tr', [
                 element('td', 'Chart'),
                 element('td', {colspan: 2}, link(linkDescription, linkDescription, chartURL, true, tabIndex))

--- a/Websites/perf.webkit.org/server-tests/api-manifest-tests.js
+++ b/Websites/perf.webkit.org/server-tests/api-manifest-tests.js
@@ -190,7 +190,7 @@ describe('/api/manifest', function () {
             db.insert('test_metrics', {id: 9, test: 4, name: 'Time'}),
             db.insert('platform_groups', {id: 1, name: 'ios'}),
             db.insert('platform_groups', {id: 2, name: 'mac'}),
-            db.insert('platforms', {id: 23, name: 'iOS 9 iPhone 5s', group: 1}),
+            db.insert('platforms', {id: 23, name: 'iOS 9 iPhone 5s', label: 'iOS 9 iPhone 5s (2013)', group: 1}),
             db.insert('platforms', {id: 46, name: 'Trunk Mavericks', group: 2}),
             db.insert('test_configurations', {id: 101, metric: 5, platform: 46, type: 'current'}),
             db.insert('test_configurations', {id: 102, metric: 6, platform: 46, type: 'current'}),
@@ -245,6 +245,7 @@ describe('/api/manifest', function () {
             assert(macGroup);
 
             assert.strictEqual(mavericks.name(), 'Trunk Mavericks');
+            assert.strictEqual(mavericks.label(), 'Trunk Mavericks');
             assert(mavericks.hasTest(someTest));
             assert(mavericks.hasTest(someOtherTest));
             assert(mavericks.hasTest(childTest));
@@ -256,6 +257,7 @@ describe('/api/manifest', function () {
             assert.strictEqual(mavericks.group(), macGroup);
 
             assert.strictEqual(ios9iphone5s.name(), 'iOS 9 iPhone 5s');
+            assert.strictEqual(ios9iphone5s.label(), 'iOS 9 iPhone 5s (2013)');
             assert(ios9iphone5s.hasTest(someTest));
             assert(!ios9iphone5s.hasTest(someOtherTest));
             assert(!ios9iphone5s.hasTest(childTest));


### PR DESCRIPTION
#### 14694378eb0cc9e6f21841c5cd22ca976883adae
<pre>
Platform should support showing more descriptive label instead of name.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254360">https://bugs.webkit.org/show_bug.cgi?id=254360</a>
rdar://107119770

Reviewed by Alexey Proskuryakov.

Add label field to &apos;platform&apos; table to have the ability to show more decriptive
content for the platform with more flexibility.

* Websites/perf.webkit.org/init-database.sql: Added &apos;platform_label&apos; to &apos;platform&apos; table.
* Websites/perf.webkit.org/migrate-database.sql: Added migration sql.
* Websites/perf.webkit.org/public/admin/platforms.php: Added support to edit platform.label in admin page.
* Websites/perf.webkit.org/public/include/manifest-generator.php: Expose platform.label to manifest.
* Websites/perf.webkit.org/public/v3/components/chart-styles.js:
(ChartStyles.resolveConfiguration): Use platform.label instead of platform.name.
* Websites/perf.webkit.org/public/v3/components/custom-analysis-task-configurator.js:
(CustomAnalysisTaskConfigurator.prototype._updateTriggerable):
* Websites/perf.webkit.org/public/v3/components/custom-configuration-test-group-form.js:
(CustomConfigurationTestGroupForm.prototype._updateTestGroupName): Use platform.label instead of platform.name.
* Websites/perf.webkit.org/public/v3/models/platform.js:
(Platform):
(Platform.prototype.label): Added label function to expose label information and fallback to platform name when
platform label is not specified.
* Websites/perf.webkit.org/public/v3/pages/chart-pane.js:
(ChartPane.prototype.render):
* Websites/perf.webkit.org/public/v3/pages/summary-page.js: Use platform.label instead of platform.name.
(SummaryPage.prototype._warningTextForGroup.mapAndSortByName):
* Websites/perf.webkit.org/public/v3/pages/test-freshness-page.js: Use platform.label instead of platform.name.
(TestFreshnessPage.prototype._renderTooltip):
* Websites/perf.webkit.org/server-tests/api-manifest-tests.js: Updated unit tests.

Canonical link: <a href="https://commits.webkit.org/262091@main">https://commits.webkit.org/262091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41411852b4aa89dc9f6aa8774737b1aa6ac0405e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/380 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/625 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/459 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/451 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/370 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/414 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/399 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/409 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/100 "The change is no longer eligible for processing.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/407 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/60 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->