### PR TITLE
The HTML fast parser may not parse HTML entities correctly

### DIFF
--- a/LayoutTests/fast/parser/fast-html-parser-consume-entity-expected.txt
+++ b/LayoutTests/fast/parser/fast-html-parser-consume-entity-expected.txt
@@ -1,0 +1,13 @@
+Tests for the HTML entity parsing by our HTML fast parser.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS div.innerHTML is "Genius Nicer Dicer Plus | 18&nbsp;…"
+PASS div.innerHTML is "&nbsp;&amp;a"
+PASS div.innerHTML is "&nbsp;&amp;"
+PASS div.innerHTML is "&nbsp;-"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ -

--- a/LayoutTests/fast/parser/fast-html-parser-consume-entity.html
+++ b/LayoutTests/fast/parser/fast-html-parser-consume-entity.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+<script src="../../resources/js-test.js"></script>
+<div id="testDiv"</div>
+<script>
+description("Tests for the HTML entity parsing by our HTML fast parser.");
+
+let div = document.getElementById("testDiv");
+div.innerHTML = "Genius Nicer Dicer Plus | 18&nbsp&hellip;";
+shouldBeEqualToString("div.innerHTML", "Genius Nicer Dicer Plus | 18&nbsp;…");
+div.innerHTML = "&nbsp&a";
+shouldBeEqualToString("div.innerHTML", "&nbsp;&amp;a");
+div.innerHTML = "&nbsp&";
+shouldBeEqualToString("div.innerHTML", "&nbsp;&amp;");
+div.innerHTML = "&nbsp-";
+shouldBeEqualToString("div.innerHTML", "&nbsp;-");
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -733,6 +733,13 @@ private:
             bool notEnoughCharacters = false;
             if (!consumeHTMLEntity(inputSegmented, out, notEnoughCharacters) || notEnoughCharacters)
                 return didFail(HTMLFastPathResult::FailedParsingCharacterReference);
+            // consumeHTMLEntity() may not have consumed all the input.
+            if (auto remainingLength = inputSegmented.length()) {
+                if (*(m_parsingBuffer.position() - 1) == ';')
+                    m_parsingBuffer.setPosition(m_parsingBuffer.position() - remainingLength - 1);
+                else
+                    m_parsingBuffer.setPosition(m_parsingBuffer.position() - remainingLength);
+            }
         }
     }
 


### PR DESCRIPTION
#### 609c58ee50173877e87adcd9e24ec2934db4e362
<pre>
The HTML fast parser may not parse HTML entities correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=254370">https://bugs.webkit.org/show_bug.cgi?id=254370</a>

Reviewed by Ryosuke Niwa.

The code was assuming consumeHTMLEntity() consumes all the input, which is not
necessarily the case. This fixes cases where the reference is only part of the
text.

This is a cherry-pick from Blink:
- <a href="https://chromium-review.googlesource.com/c/chromium/src/+/4305159">https://chromium-review.googlesource.com/c/chromium/src/+/4305159</a>

* LayoutTests/fast/parser/fast-html-parser-consume-entity-expected.txt: Added.
* LayoutTests/fast/parser/fast-html-parser-consume-entity.html: Added.
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanHTMLCharacterReference):

Canonical link: <a href="https://commits.webkit.org/262050@main">https://commits.webkit.org/262050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb44a9e2b14e286c92c4d46c38b286fa53547dd0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/368 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/585 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/372 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/397 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/346 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/324 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/363 "9 failures") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/348 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/357 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/94 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/353 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->