### PR TITLE
[UI-side compositing] Add infrastructure to get scrollbar state in layout tests

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -130,6 +130,8 @@ public:
     
     OverscrollBehavior horizontalOverscrollBehavior() const { return m_scrollableAreaParameters.horizontalOverscrollBehavior; }
     OverscrollBehavior verticalOverscrollBehavior() const { return m_scrollableAreaParameters.verticalOverscrollBehavior; }
+    
+    virtual String scrollbarStateForOrientation(ScrollbarOrientation) const { return ""_s; }
 
 protected:
     ScrollingTreeScrollingNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -60,6 +60,7 @@ public:
     virtual void handleKeyboardScrollRequest(const RequestedKeyboardScrollData&) { }
 
     virtual FloatPoint adjustedScrollPosition(const FloatPoint& scrollPosition) const { return scrollPosition; }
+    virtual String scrollbarStateForOrientation(ScrollbarOrientation) const { return ""_s; }
 
 protected:
     WEBCORE_EXPORT ScrollingTree& scrollingTree() const;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -62,6 +62,8 @@ public:
     FloatPoint convertFromContent(const FloatPoint&) const;
 
     void updateValues();
+    
+    String scrollbarState() const;
 
 private:
     ScrollerPairMac& m_pair;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -372,6 +372,26 @@ FloatPoint ScrollerMac::convertFromContent(const FloatPoint& point) const
     return FloatPoint { [m_hostLayer convertPoint:point fromLayer:[m_hostLayer superlayer]] };
 }
 
+String ScrollerMac::scrollbarState() const
+{
+    StringBuilder result;
+    result.append([m_scrollerImp isEnabled] ? "enabled"_s: "disabled"_s);
+
+    if (!m_scrollerImp)
+        return result.toString();
+
+    if ([m_scrollerImp isExpanded])
+        result.append(",expanded"_s);
+
+    if ([m_scrollerImp trackAlpha] > 0)
+        result.append(",visible_track"_s);
+
+    if ([m_scrollerImp knobAlpha] > 0)
+        result.append(",visible_thumb"_s);
+
+    return result.toString();
+}
+
 }
 
 #endif

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -86,6 +86,8 @@ public:
     // Only for use by WebScrollerImpPairDelegateMac. Do not use elsewhere!
     ScrollerMac& verticalScroller() { return m_verticalScroller; }
     ScrollerMac& horizontalScroller() { return m_horizontalScroller; }
+    
+    String scrollbarStateForOrientation(ScrollbarOrientation) const;
 
 private:
     NSScrollerImp *scrollerImpHorizontal() { return horizontalScroller().scrollerImp(); }

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -297,6 +297,11 @@ void ScrollerPairMac::releaseReferencesToScrollerImpsOnTheMainThread()
     }
 }
 
+String ScrollerPairMac::scrollbarStateForOrientation(ScrollbarOrientation orientation) const
+{
+    return orientation == ScrollbarOrientation::Vertical ? m_verticalScroller.scrollbarState() : m_horizontalScroller.scrollbarState();
+}
+
 }
 
 #endif

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -66,6 +66,7 @@ public:
     void viewWillEndLiveResize() final;
     void viewSizeDidChange() final;
     void initScrollbars() final;
+    String scrollbarStateForOrientation(ScrollbarOrientation) const final;
 
 private:
     void updateFromStateNode(const ScrollingStateScrollingNode&) final;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -334,6 +334,12 @@ void ScrollingTreeScrollingNodeDelegateMac::viewSizeDidChange()
 {
     return m_scrollerPair.contentsSizeChanged();
 }
+
+String ScrollingTreeScrollingNodeDelegateMac::scrollbarStateForOrientation(ScrollbarOrientation orientation) const
+{
+    return m_scrollerPair.scrollbarStateForOrientation(orientation);
+}
+
 } // namespace WebCore
 
 #endif // PLATFORM(MAC) && ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3110,6 +3110,15 @@ ExceptionOr<uint64_t> Internals::layerIDForElement(Element& element)
     return backing->graphicsLayer()->primaryLayerID().object().toUInt64();
 }
 
+ExceptionOr<uint64_t> Internals::scrollingNodeIDForNode(Node* node)
+{
+    auto areaOrException = scrollableAreaForNode(node);
+    if (areaOrException.hasException())
+        return areaOrException.releaseException();
+    auto* scrollableArea = areaOrException.releaseReturnValue();
+    return scrollableArea->scrollingNodeID();
+}
+
 static OptionSet<PlatformLayerTreeAsTextFlags> toPlatformLayerTreeFlags(unsigned short flags)
 {
     OptionSet<PlatformLayerTreeAsTextFlags> platformLayerTreeFlags = { };

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -470,6 +470,8 @@ public:
     ExceptionOr<String> layerTreeAsText(Document&, unsigned short flags) const;
     ExceptionOr<uint64_t> layerIDForElement(Element&);
     ExceptionOr<String> repaintRectsAsText() const;
+        
+    ExceptionOr<uint64_t> scrollingNodeIDForNode(Node*);
 
     enum {
         // Values need to be kept in sync with Internals.idl.

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -602,6 +602,8 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     DOMString layerTreeAsText(Document document, optional unsigned short flags = 0);
 
     unsigned long long layerIDForElement(Element element);
+    
+    unsigned long long scrollingNodeIDForNode(optional Node? node = null);
 
     // Flags for platformLayerTreeAsText.
     const unsigned short PLATFORM_LAYER_TREE_DEBUG = 1;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -51,6 +51,8 @@ struct WKAppPrivacyReportTestingData {
 
 @property (nonatomic, readonly) NSString *_caLayerTreeAsText;
 
+- (NSString*)_scrollbarStateForScrollingNodeID:(uint64_t)scrollingNodeID isVertical:(bool)isVertical;
+
 - (void)_addEventAttributionWithSourceID:(uint8_t)sourceID destinationURL:(NSURL *)destination sourceDescription:(NSString *)sourceDescription purchaser:(NSString *)purchaser reportEndpoint:(NSURL *)reportEndpoint optionalNonce:(nullable NSString *)nonce applicationBundleID:(NSString *)bundleID ephemeral:(BOOL)ephemeral WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 - (void)_setPageScale:(CGFloat)scale withOrigin:(CGPoint)origin;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -397,6 +397,13 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     return _page && _page->process().hasSleepDisabler();
 }
 
+- (NSString*)_scrollbarStateForScrollingNodeID:(uint64_t)scrollingNodeID isVertical:(bool)isVertical
+{
+    if (_page)
+        return _page->scrollbarStateForScrollingNodeID(scrollingNodeID, isVertical);
+    return @"";
+}
+
 - (WKWebViewAudioRoutingArbitrationStatus)_audioRoutingArbitrationStatus
 {
 #if ENABLE(ROUTING_ARBITRATION)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -395,6 +395,15 @@ void RemoteScrollingCoordinatorProxy::viewSizeDidChange()
     m_scrollingTree->viewSizeDidChange();
 }
 
+String RemoteScrollingCoordinatorProxy::scrollbarStateForScrollingNodeID(WebCore::ScrollingNodeID scrollingNodeID, bool isVertical)
+{
+    if (auto node = m_scrollingTree->nodeForID(scrollingNodeID)) {
+        if (auto* scrollingNode = dynamicDowncast<ScrollingTreeScrollingNode>(*node))
+            return scrollingNode->scrollbarStateForOrientation(isVertical ? ScrollbarOrientation::Vertical : ScrollbarOrientation::Horizontal);
+    }
+    return ""_s;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -153,6 +153,7 @@ public:
     void viewWillStartLiveResize();
     void viewWillEndLiveResize();
     void viewSizeDidChange();
+    String scrollbarStateForScrollingNodeID(WebCore::ScrollingNodeID, bool isVertical);
 
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -86,6 +86,11 @@ void ScrollingTreeFrameScrollingNodeRemoteMac::viewSizeDidChange()
     m_delegate->viewSizeDidChange();
 }
 
+String ScrollingTreeFrameScrollingNodeRemoteMac::scrollbarStateForOrientation(ScrollbarOrientation orientation) const
+{
+    return m_delegate->scrollbarStateForOrientation(orientation);
+}
+
 }
 
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
@@ -51,7 +51,7 @@ private:
     void viewWillStartLiveResize() override;
     void viewWillEndLiveResize() override;
     void viewSizeDidChange() override;
-
+    String scrollbarStateForOrientation(WebCore::ScrollbarOrientation) const override;
 };
 
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
@@ -73,6 +73,11 @@ bool ScrollingTreeOverflowScrollingNodeRemoteMac::handleMouseEvent(const Platfor
     return m_delegate->handleMouseEventForScrollbars(mouseEvent);
 }
 
+String ScrollingTreeOverflowScrollingNodeRemoteMac::scrollbarStateForOrientation(ScrollbarOrientation orientation) const
+{
+    return m_delegate->scrollbarStateForOrientation(orientation);
+}
+
 }
 
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h
@@ -46,6 +46,7 @@ private:
     void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
     void handleWheelEventPhase(const WebCore::PlatformWheelEventPhase) override;
     void repositionRelatedLayers() override;
+    String scrollbarStateForOrientation(WebCore::ScrollbarOrientation) const override;
 };
 
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12054,6 +12054,17 @@ void WebPageProxy::adjustLayersForLayoutViewport(const FloatPoint& scrollPositio
 #endif
 }
 
+String WebPageProxy::scrollbarStateForScrollingNodeID(int scrollingNodeID, bool isVertical)
+{
+#if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)
+    if (!m_scrollingCoordinatorProxy)
+        return ""_s;
+    return m_scrollingCoordinatorProxy->scrollbarStateForScrollingNodeID(scrollingNodeID, isVertical);
+#else
+    return ""_s;
+#endif
+}
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2230,6 +2230,7 @@ public:
     bool allowsAnyAnimationToPlay() { return m_allowsAnyAnimationToPlay; }
     void isAnyAnimationAllowedToPlayDidChange(bool anyAnimationCanPlay) { m_allowsAnyAnimationToPlay = anyAnimationCanPlay; }
 #endif
+    String scrollbarStateForScrollingNodeID(int scrollingNodeID, bool isVertical);
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
     PlatformXRSystem* xrSystem() const { return m_xrSystem.get(); }

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -343,6 +343,8 @@ interface UIScriptController {
     boolean mayContainEditableElementsInRect(unsigned long x, unsigned long y, unsigned long width, unsigned long height);
 
     object propertiesOfLayerWithID(unsigned long long layerID);
+    
+    DOMString scrollbarStateForScrollingNodeID(unsigned long long scrollingNodeID, boolean isVertical);
 
     undefined retrieveSpeakSelectionContent(object callback);
     readonly attribute DOMString accessibilitySpeakSelectionContent;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -154,6 +154,8 @@ public:
     virtual JSRetainPtr<JSStringRef> scrollingTreeAsText() const { notImplemented(); return nullptr; }
     virtual JSRetainPtr<JSStringRef> uiViewTreeAsText() const { notImplemented(); return nullptr; }
     virtual JSRetainPtr<JSStringRef> caLayerTreeAsText() const { notImplemented(); return nullptr; }
+    
+    virtual JSRetainPtr<JSStringRef> scrollbarStateForScrollingNodeID(unsigned long long, bool) const { notImplemented(); return nullptr; }
 
     // Touches
 

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.h
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.h
@@ -69,6 +69,8 @@ private:
     void sendEventStream(JSStringRef, JSValueRef) override;
 
     NSTableView *dataListSuggestionsTableView() const;
+    JSRetainPtr<JSStringRef> scrollbarStateForScrollingNodeID(unsigned long long, bool) const override;
+
 };
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -434,5 +434,9 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
     });
 }
 
+JSRetainPtr<JSStringRef> UIScriptControllerMac::scrollbarStateForScrollingNodeID(unsigned long long scrollingNodeID, bool isVertical) const
+{
+    return adopt(JSStringCreateWithCFString((CFStringRef) [webView() _scrollbarStateForScrollingNodeID:scrollingNodeID isVertical:isVertical]));
+}
 
 } // namespace WTR


### PR DESCRIPTION
#### 0d254e93fc60fdfa8b1d64540af11826969c31c6
<pre>
[UI-side compositing] Add infrastructure to get scrollbar state in layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=254372">https://bugs.webkit.org/show_bug.cgi?id=254372</a>
rdar://107154212

Reviewed by Simon Fraser.

Add UI-script controller function for getting scrollbar state for a scrolling tree
node id. Add an internals function for getting the scrolling tree node id from a
node.

* LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollbarStateForOrientation const):
* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::scrollbarState const):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::scrollbarStateForOrientation const):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::scrollbarStateForOrientation const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::scrollingNodeIDForNode):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _scrollbarStateForScrollingNodeID:isVertical:]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::scrollbarStateForScrollingNodeID):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::scrollbarStateForOrientation const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeOverflowScrollingNodeRemoteMac::scrollbarStateForOrientation const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::scrollbarStateForScrollingNodeID):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::scrollbarStateForScrollingNodeID const):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.h:
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::scrollbarStateForScrollingNodeID const):

Canonical link: <a href="https://commits.webkit.org/262082@main">https://commits.webkit.org/262082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f19c27aac893529e607aa667b2b51cab16529bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/408 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/409 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/612 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/439 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/440 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/356 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/400 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/383 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/375 "2 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/395 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/390 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/54 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->