### PR TITLE
Assertion failure in CompositeEditCommand::moveParagraph via InsertListCommand::listifyParagraph

### DIFF
--- a/LayoutTests/editing/execCommand/insert-list-move-paragraph-display-contents-crash-expected.txt
+++ b/LayoutTests/editing/execCommand/insert-list-move-paragraph-display-contents-crash-expected.txt
@@ -1,0 +1,4 @@
+
+Pass if no crash.
+
+

--- a/LayoutTests/editing/execCommand/insert-list-move-paragraph-display-contents-crash.html
+++ b/LayoutTests/editing/execCommand/insert-list-move-paragraph-display-contents-crash.html
@@ -1,0 +1,14 @@
+<style>
+*+* {display:contents}
+</style>
+<script>
+function main() {
+  if (window.testRunner)
+      testRunner.dumpAsText();
+  document.designMode = "on";
+  window.find(" ");
+  document.execCommand("insertOrderedList",false,null);
+}
+</script>
+<body onload="main()">
+<input><p>Pass if no crash.</p>

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -431,8 +431,8 @@ RefPtr<HTMLElement> InsertListCommand::listifyParagraph(const VisiblePosition& o
 
     // Inserting list element and list item list may change start of pargraph to move. We calculate start of paragraph again.
     document().updateLayoutIgnorePendingStylesheets();
-    start = startOfParagraph(start, CanSkipOverEditingBoundary);
-    end = endOfParagraph(start, CanSkipOverEditingBoundary);
+    start = startOfParagraph(startOfParagraph(start, CanSkipOverEditingBoundary));
+    end = endOfParagraph(endOfParagraph(start, CanSkipOverEditingBoundary));
     moveParagraph(start, end, positionBeforeNode(placeholder.ptr()), true);
 
     if (listElement)


### PR DESCRIPTION
#### 6e4c6ef4ca8a761a76514b825a3f79e8bd63413d
<pre>
Assertion failure in CompositeEditCommand::moveParagraph via InsertListCommand::listifyParagraph
<a href="https://bugs.webkit.org/show_bug.cgi?id=254375">https://bugs.webkit.org/show_bug.cgi?id=254375</a>

Reviewed by Wenson Hsieh.

<a href="https://commits.webkit.org/70668@main">https://commits.webkit.org/70668@main</a> made InsertListCommand::listifyParagraph to cross editing boundaries
to look for the start &amp; the end of the current paragraph so that we can include non-editable inline content.
This, however, is inconsistent with CompositeEditCommand::moveParagraph&apos;s precondition that startOfParagraph
is the start of paragraph without crossing editing boundaries.

This patch addresses this precondition by calling startOfParagraph and endOfParagraph for the second time
without specifying CanSkipOverEditingBoundary.

* LayoutTests/editing/execCommand/insert-list-move-paragraph-display-contents-crash-expected.txt: Added.
* LayoutTests/editing/execCommand/insert-list-move-paragraph-display-contents-crash.html: Added.
* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::InsertListCommand::listifyParagraph):

Canonical link: <a href="https://commits.webkit.org/262051@main">https://commits.webkit.org/262051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa9017eccc3e1c4c72b5d56c0e68a5623de2f737

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/380 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/591 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/383 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/409 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/353 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/333 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/369 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/358 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/364 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/363 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/45 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->