### PR TITLE
Add more logging to iOS print preview generation

### DIFF
--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -27,6 +27,7 @@
 #include "LengthBox.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "Logging.h"
 #include "RenderView.h"
 #include "StyleInheritedData.h"
 #include "StyleResolver.h"
@@ -50,6 +51,8 @@ void PrintContext::computePageRects(const FloatRect& printRect, float headerHeig
 {
     if (!frame())
         return;
+
+    RELEASE_LOG(Printing, "Computing page rects and clearing existing page rects. Existing page rects size = %zu", m_pageRects.size());
 
     auto& frame = *this->frame();
     m_pageRects.clear();
@@ -109,6 +112,7 @@ FloatSize PrintContext::computedPageSize(FloatSize pageSize, FloatBoxExtent prin
 
 void PrintContext::computePageRectsWithPageSize(const FloatSize& pageSizeInPixels, bool allowHorizontalTiling)
 {
+    RELEASE_LOG(Printing, "Computing page rects with page size and clearing existing page rects. Existing page rects size = %zu", m_pageRects.size());
     m_pageRects.clear();
     computePageRectsWithPageSizeInternal(pageSizeInPixels, allowHorizontalTiling);
 }
@@ -184,6 +188,8 @@ void PrintContext::computePageRectsWithPageSizeInternal(const FloatSize& pageSiz
             m_pageRects.append(pageRect);
         }
     }
+
+    RELEASE_LOG(Printing, "Computed page rects with page size. Page rects count = %zu pageCount = %u", m_pageRects.size(), pageCount);
 }
 
 void PrintContext::begin(float width, float height)
@@ -232,6 +238,8 @@ void PrintContext::spoolPage(GraphicsContext& ctx, int pageNumber, float width)
     auto& frame = *this->frame();
     if (!frame.view())
         return;
+
+    RELEASE_LOG(Printing, "Spooling page. pageNumber = %d pageRects size = %zu", pageNumber, m_pageRects.size());
 
     // FIXME: Not correct for vertical text.
     IntRect pageRect = m_pageRects[pageNumber];

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -97,6 +97,7 @@ namespace WebCore {
     M(PlatformLeaks) \
     M(Plugins) \
     M(PopupBlocking) \
+    M(Printing) \
     M(PrivateClickMeasurement) \
     M(Process) \
     M(Progress) \

--- a/Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm
+++ b/Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm
@@ -153,6 +153,7 @@
 {
     [self _invalidatePrintRenderingState];
     NSUInteger pageCount = [self._webView._printProvider _wk_pageCountForPrintFormatter:self];
+    RELEASE_LOG(Printing, "Recalculated page count. Page count = %zu", pageCount);
     return std::min<NSUInteger>(pageCount, NSIntegerMax);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5806,6 +5806,8 @@ void WebPage::unfreezeLayerTreeDueToSwipeAnimation()
 
 void WebPage::beginPrinting(FrameIdentifier frameID, const PrintInfo& printInfo)
 {
+    RELEASE_LOG(Printing, "Begin printing.");
+
     PrintContextAccessScope scope { *this };
 
     WebFrame* frame = WebProcess::singleton().webFrame(frameID);
@@ -5851,6 +5853,8 @@ void WebPage::beginPrinting(FrameIdentifier frameID, const PrintInfo& printInfo)
 
 void WebPage::endPrinting()
 {
+    RELEASE_LOG(Printing, "End printing.");
+
     if (m_inActivePrintContextAccessScope) {
         m_shouldEndPrintingImmediately = true;
         return;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4376,6 +4376,8 @@ void WebPage::computePagesForPrintingiOS(WebCore::FrameIdentifier frameID, const
     auto margin = printInfo.margin;
     computePagesForPrintingImpl(frameID, printInfo, pageRects, totalScaleFactor, margin);
 
+    RELEASE_LOG(Printing, "Computing pages for printing. Page rects size = %zu", pageRects.size());
+
     ASSERT(pageRects.size() >= 1);
     reply(pageRects.size());
 }
@@ -4386,6 +4388,8 @@ void WebPage::drawToImage(WebCore::FrameIdentifier frameID, const PrintInfo& pri
     double totalScaleFactor;
     auto margin = printInfo.margin;
     computePagesForPrintingImpl(frameID, printInfo, pageRects, totalScaleFactor, margin);
+
+    RELEASE_LOG(Printing, "Drawing to image. Page rects size = %zu", pageRects.size());
 
     ASSERT(pageRects.size() >= 1);
 


### PR DESCRIPTION
#### 6fbc6c232e8b153cf99f89483fea48716ba58bc4
<pre>
Add more logging to iOS print preview generation
<a href="https://bugs.webkit.org/show_bug.cgi?id=254377">https://bugs.webkit.org/show_bug.cgi?id=254377</a>
rdar://107159671

Reviewed by Tim Horton and Aditya Keerthi.

* Source/WebCore/page/PrintContext.cpp:
(WebCore::PrintContext::computePageRects):
(WebCore::PrintContext::computePageRectsWithPageSize):
(WebCore::PrintContext::computePageRectsWithPageSizeInternal):
(WebCore::PrintContext::spoolPage):
* Source/WebCore/platform/Logging.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _attributesForPrintFormatter:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::beginPrinting):
(WebKit::WebPage::endPrinting):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computePagesForPrintingiOS):
(WebKit::WebPage::drawToImage):

Canonical link: <a href="https://commits.webkit.org/262097@main">https://commits.webkit.org/262097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed5de3ee088517db02603d83ff0eb8539d3e4351

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/666 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/663 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/568 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/665 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/494 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/528 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/537 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/129 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/537 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->