### PR TITLE
Only apply certain UA styles to HTML elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Popover is only effective on HTMLElement, not on svg element</title>
+<style>
+svg {
+  width: 100px;
+  height: 100px;
+  background-color:green;
+}
+</style>
+<svg ></svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Popover is only effective on HTMLElement, not on svg element</title>
+<style>
+svg {
+  width: 100px;
+  height: 100px;
+  background-color:green;
+}
+</style>
+<svg ></svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Popover is only effective on HTMLElement, not on svg element</title>
+<link rel="author" href="mailto:cathiechen@igalia.com">
+<link rel=help href="https://html.spec.whatwg.org/#the-popover-attribute">
+<link rel="match" href="popover-and-svg-ref.html">
+<style>
+svg {
+  width: 100px;
+  height: 100px;
+  background-color:green;
+}
+[popover] {
+  top: 100px;
+  bottom: auto;
+}
+</style>
+<svg popover></svg>

--- a/Source/WebCore/css/captions.css
+++ b/Source/WebCore/css/captions.css
@@ -1,3 +1,5 @@
+@namespace "http://www.w3.org/1999/xhtml";
+
 video::cue(*) {
     background-color: rgba(0, 0, 0, 0.8);
 }

--- a/Source/WebCore/css/dialog.css
+++ b/Source/WebCore/css/dialog.css
@@ -1,3 +1,5 @@
+@namespace "http://www.w3.org/1999/xhtml";
+
 dialog {
     position: absolute;
     inset-inline-start: 0;

--- a/Source/WebCore/css/mediaControls.css
+++ b/Source/WebCore/css/mediaControls.css
@@ -24,6 +24,8 @@
 
 #if defined(ENABLE_VIDEO) && ENABLE_VIDEO && !(defined(ENABLE_MODERN_MEDIA_CONTROLS) && ENABLE_MODERN_MEDIA_CONTROLS)
 
+@namespace "http://www.w3.org/1999/xhtml";
+
 /* media controls */
 
 audio {

--- a/Source/WebCore/css/plugIns.css
+++ b/Source/WebCore/css/plugIns.css
@@ -40,6 +40,8 @@
  *         </div>
  */
 
+@namespace "http://www.w3.org/1999/xhtml";
+
 embed::-webkit-snapshotted-plugin-content,
 object::-webkit-snapshotted-plugin-content
 {

--- a/Source/WebCore/css/popover.css
+++ b/Source/WebCore/css/popover.css
@@ -1,5 +1,7 @@
 /* https://html.spec.whatwg.org/#flow-content-3 */
 
+@namespace "http://www.w3.org/1999/xhtml";
+
 [popover]:closed:not(dialog[open]) {
     display: none;
 }

--- a/Source/WebCore/css/quirks.css
+++ b/Source/WebCore/css/quirks.css
@@ -21,6 +21,8 @@
  *
  */
 
+@namespace "http://www.w3.org/1999/xhtml";
+
 /* Give floated images margins of 3px */
 img[align="left"] {
     margin-right: 3px;


### PR DESCRIPTION
#### 31c95fe588a14d215f4b395c018a9c2bdd6124c0
<pre>
Only apply certain UA styles to HTML elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=254380">https://bugs.webkit.org/show_bug.cgi?id=254380</a>
rdar://107162842

Reviewed by Simon Fraser.

Some of these styles should not apply to elements with other namespaces than HTML (e.g. SVG).

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg.html: Added.
* Source/WebCore/css/captions.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
* Source/WebCore/css/dialog.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
* Source/WebCore/css/mediaControls.css:
(#if defined(ENABLE_VIDEO) &amp;&amp; ENABLE_VIDEO &amp;&amp; !(defined(ENABLE_MODERN_MEDIA_CONTROLS) &amp;&amp; ENABLE_MODERN_MEDIA_CONTROLS)):
* Source/WebCore/css/plugIns.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
(embed::-webkit-snapshotted-plugin-content,): Deleted.
* Source/WebCore/css/popover.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
([popover]:closed:not(dialog[open])): Deleted.
* Source/WebCore/css/quirks.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
(img[align=&quot;left&quot;]): Deleted.

Canonical link: <a href="https://commits.webkit.org/262053@main">https://commits.webkit.org/262053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c90ef8d93699654a34cfac0fbb8bcfc5e4201eac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/402 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/459 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/605 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/406 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/431 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/373 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/349 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/376 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/384 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/97 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/383 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->