### PR TITLE
[MSE] media/media-source/media-source-fudge-factor.html times out

### DIFF
--- a/LayoutTests/media/media-source/media-source-fudge-factor-expected.txt
+++ b/LayoutTests/media/media-source/media-source-fudge-factor-expected.txt
@@ -1,10 +1,12 @@
 
 RUN(video.src = URL.createObjectURL(source))
 EVENT(loadedmetadata)
+EVENT(update)
 Samples with presentation times after currentTime should not cause loadedData.
 EXPECTED (video.readyState == '1') OK
 Samples with presentation times very close to currentTime should cause loadedData.
 EVENT(loadeddata)
+EVENT(update)
 EXPECTED (video.readyState == '2') OK
 Samples with presentation end times very close to currentTime should not cause canPlay.
 EXPECTED (video.readyState == '2') OK

--- a/LayoutTests/media/media-source/media-source-fudge-factor.html
+++ b/LayoutTests/media/media-source/media-source-fudge-factor.html
@@ -22,30 +22,26 @@
         run('video.src = URL.createObjectURL(source)');
     }
 
-    function startLoad() {
+    async function startLoad() {
         sourceBuffer = source.addSourceBuffer('video/mock; codecs="mock"');
 
         // Make an init segment with 1 video track
         var init = makeAInit(100, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
-        waitForEventOnce('loadedmetadata', loadedMetadata);
         sourceBuffer.appendBuffer(init)
-    }
+        await Promise.all([waitFor(video, 'loadedmetadata'), waitFor(sourceBuffer, 'update')]);
 
-    function loadedMetadata() {
         consoleWrite('Samples with presentation times after currentTime should not cause loadedData.');
         sourceBuffer.appendBuffer(makeASample(500, 500, 500, 1000, 1, SAMPLE_FLAG.SYNC));
         setTimeout(notLoadedData, 50);
     }
 
-    function notLoadedData() {
+    async function notLoadedData() {
         testExpected('video.readyState', HTMLMediaElement.HAVE_METADATA);
 
         consoleWrite('Samples with presentation times very close to currentTime should cause loadedData.');
         sourceBuffer.appendBuffer(makeASample(10, 10, 10, 1000, 1, SAMPLE_FLAG.SYNC));
-        waitForEvent('loadeddata', loadedData);
-    }
+        await Promise.all([waitFor(video, 'loadeddata'), waitFor(sourceBuffer, 'update')]);
 
-    function loadedData() {
         testExpected('video.readyState', HTMLMediaElement.HAVE_CURRENT_DATA);
 
         consoleWrite('Samples with presentation end times very close to currentTime should not cause canPlay.');


### PR DESCRIPTION
#### 99cbb993489c885e378a78ee4cf6186268393d4c
<pre>
[MSE] media/media-source/media-source-fudge-factor.html times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=254385">https://bugs.webkit.org/show_bug.cgi?id=254385</a>
rdar://107162814

Reviewed by Jer Noble.

The test assumed that it assumes that the `SourceBuffer.updating` attribute
will be false when `loadedmetadata` or `loadeddata` are fired.
This isn&apos;t guaranteed, only once `updateend` has fired would the updating
attribute be false, allowing to append more data again to the sourceBuffer.

* LayoutTests/media/media-source/media-source-fudge-factor-expected.txt:
* LayoutTests/media/media-source/media-source-fudge-factor.html:

Canonical link: <a href="https://commits.webkit.org/262069@main">https://commits.webkit.org/262069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/388beca33cb7e0fd279c9ade1cf5a6b3fc12eda7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/366 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/604 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/432 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/433 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/350 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/387 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/370 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/382 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/110 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/384 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->