### PR TITLE
REGRESSION(261977@main): TestWebKitAPI.ProcessSwap.ResizeWebViewDuringCrossSiteProvisionalNavigation is a constant crash

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -92,7 +92,8 @@ void RemoteLayerTreeDrawingAreaProxy::sizeDidChange()
 {
     if (!m_webPageProxy.hasRunningProcess())
         return;
-    m_webPageProxy.scrollingCoordinatorProxy()->viewSizeDidChange();
+    if (auto scrollingCoordinator = m_webPageProxy.scrollingCoordinatorProxy())
+        scrollingCoordinator->viewSizeDidChange();
 
     if (m_isWaitingForDidUpdateGeometry)
         return;
@@ -101,12 +102,14 @@ void RemoteLayerTreeDrawingAreaProxy::sizeDidChange()
 
 void RemoteLayerTreeDrawingAreaProxy::viewWillStartLiveResize()
 {
-    m_webPageProxy.scrollingCoordinatorProxy()->viewWillStartLiveResize();
+    if (auto scrollingCoordinator = m_webPageProxy.scrollingCoordinatorProxy())
+        scrollingCoordinator->viewWillStartLiveResize();
 }
 
 void RemoteLayerTreeDrawingAreaProxy::viewWillEndLiveResize()
 {
-    m_webPageProxy.scrollingCoordinatorProxy()->viewWillEndLiveResize();
+    if (auto scrollingCoordinator = m_webPageProxy.scrollingCoordinatorProxy())
+        scrollingCoordinator->viewWillEndLiveResize();
 }
 
 void RemoteLayerTreeDrawingAreaProxy::deviceScaleFactorDidChange()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -382,17 +382,20 @@ void RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForR
 
 void RemoteScrollingCoordinatorProxy::viewWillStartLiveResize()
 {
-    m_scrollingTree->viewWillStartLiveResize();
+    if (m_scrollingTree)
+        m_scrollingTree->viewWillStartLiveResize();
 }
 
 void RemoteScrollingCoordinatorProxy::viewWillEndLiveResize()
 {
-    m_scrollingTree->viewWillEndLiveResize();
+    if (m_scrollingTree)
+        m_scrollingTree->viewWillEndLiveResize();
 }
 
 void RemoteScrollingCoordinatorProxy::viewSizeDidChange()
 {
-    m_scrollingTree->viewSizeDidChange();
+    if (m_scrollingTree)
+        m_scrollingTree->viewSizeDidChange();
 }
 
 String RemoteScrollingCoordinatorProxy::scrollbarStateForScrollingNodeID(WebCore::ScrollingNodeID scrollingNodeID, bool isVertical)


### PR DESCRIPTION
#### b0a8888016324e0191a3569a7f65624b3d0a4b89
<pre>
REGRESSION(261977@main): TestWebKitAPI.ProcessSwap.ResizeWebViewDuringCrossSiteProvisionalNavigation is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=254378">https://bugs.webkit.org/show_bug.cgi?id=254378</a>
rdar://107161569

Reviewed by Simon Fraser.

Add null checks for ScrollingCoordinator and ScrollingTree.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::sizeDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxy::viewWillStartLiveResize):
(WebKit::RemoteLayerTreeDrawingAreaProxy::viewWillEndLiveResize):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::viewWillStartLiveResize):
(WebKit::RemoteScrollingCoordinatorProxy::viewWillEndLiveResize):
(WebKit::RemoteScrollingCoordinatorProxy::viewSizeDidChange):

Canonical link: <a href="https://commits.webkit.org/262099@main">https://commits.webkit.org/262099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/341c74a84599993a6f5a5bb041434dfed027ec93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/368 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/611 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/390 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/437 "Failed to print configuration") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/380 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/437 "Failed to print configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/355 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/396 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/437 "Failed to print configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/376 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/391 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/389 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/65 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->