### PR TITLE
[UI-side compositing] tiled-drawing/tiled-backing-in-window.html fails when run on a 2x display

### DIFF
--- a/LayoutTests/tiled-drawing/tiled-backing-in-window.html
+++ b/LayoutTests/tiled-drawing/tiled-backing-in-window.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ deviceScaleFactor=1.0 ] -->
 
 <html>
 <head>


### PR DESCRIPTION
#### e74aa7f36cbd532f681b2c015002264a7d756b52
<pre>
[UI-side compositing] tiled-drawing/tiled-backing-in-window.html fails when run on a 2x display
<a href="https://bugs.webkit.org/show_bug.cgi?id=254387">https://bugs.webkit.org/show_bug.cgi?id=254387</a>
rdar://107038034

Reviewed by Simon Fraser.

This test fails when UI-side compositing is enabled. Consider the following sequence of events,
immediately upon unparenting the web view via `UIScriptController`, when running the test on a 2x
display with GPUP and UI-side compositing enabled:

1.  In the UI process, we schedule an activity state change (to tell the web process that the view
    is no longer in a window).

2.  At the same time, we send an IPC message `WebPage::SetDeviceScaleFactor(2.0)` (the intrinsic
    device scale is 2.0 in the UI process after unparenting the web view, since we fall back to the
    main `NSScreen`&apos;s `-backingScaleFactor`).

3.  In the web process, we receive the new device scale of 2.0, and mark each graphics layer with a
    dirty bit: `LayerChange::ContentsScaleChanged`.

4.  In the web process, we then perform a rendering update that was previously scheduled (for any
    reason). This causes us to `flushCompositingState` on the root layer, and recursively apply the
    new contents scale to all sublayers.

5.  In the UI process, we then (finally) dispatch the activity state change that was scheduled in
    step (1).

6.  In the web process, we receive the new activity state, and detach the root layer underneath
    `RenderLayerCompositor::setIsInWindow`, with `isInWindow := false`.

Thus, each `PlatformCALayerRemote` ends up with a scale of 2.0 instead of 1.0 after unparenting the
web view, which is reflected in the output of `layerTreeAsText`. In contrast, when GPUP and UI-side
compositing are disabled, step (4) occurs after (5-6) above, which causes us to bail earlier before
flushing the new backing store scale to the layer tree:

```
void RenderLayerCompositor::flushPendingLayerChanges(bool isFlushRoot)
{
…
    if (rootLayerAttachment() == RootLayerUnattached) {
        m_shouldFlushOnReattach = true;
        return;      // &lt;---------------- We early return here in the non-GPUP case.
    }
…
```

...which allows the layers to retain a device scale of 1. Due to the fact that it&apos;s unclear whether
the post-GPUP behavior is better or worse (as the old behavior effectively leaves the layer content
scales out of sync with the device scale factor in the UI process), it&apos;s probably best to just fix
this test by making the test itself by forcing a `deviceScaleFactor` of 1.0.

* LayoutTests/tiled-drawing/tiled-backing-in-window.html:
* Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm:
(WTR::PlatformWebView::changeWindowScaleIfNeeded):

Ensure that we actually call into `-_setOverrideDeviceScaleFactor:` when specifying a
`deviceScaleFactor=1.0` test runner option, by adjusting the implementation of this helper method
to not early return from the entire function if only the window&apos;s `-backingScaleFactor` matches.

Canonical link: <a href="https://commits.webkit.org/262086@main">https://commits.webkit.org/262086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f918335c7773290ce86f7add23715ebf049d5e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/378 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/626 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/457 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/449 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/368 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/420 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/397 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/415 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/124 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/405 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->