### PR TITLE
m_styleScope should be a WeakPtr in InlineStyleSheetOwner

### DIFF
--- a/Source/WebCore/dom/InlineStyleSheetOwner.h
+++ b/Source/WebCore/dom/InlineStyleSheetOwner.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "CSSStyleSheet.h"
+#include "StyleScope.h"
 #include <wtf/text/TextPosition.h>
 
 namespace WebCore {
@@ -49,7 +50,7 @@ public:
     void childrenChanged(Element&);
     void finishParsingChildren(Element&);
 
-    Style::Scope* styleScope() { return m_styleScope; }
+    Style::Scope* styleScope() { return m_styleScope.get(); }
 
     static void clearCache();
 
@@ -64,7 +65,7 @@ private:
     AtomString m_contentType;
     AtomString m_media;
     RefPtr<CSSStyleSheet> m_sheet;
-    Style::Scope* m_styleScope { nullptr };
+    WeakPtr<Style::Scope> m_styleScope;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### e6597f549cfd91df23cf7273a3eac8dd053a3887
<pre>
m_styleScope should be a WeakPtr in InlineStyleSheetOwner
<a href="https://bugs.webkit.org/show_bug.cgi?id=254397">https://bugs.webkit.org/show_bug.cgi?id=254397</a>

Reviewed by Chris Dumez.

Use WeakPtr instead of a raw pointer in InlineStyleSheetOwner for Style::Scope.

* Source/WebCore/dom/InlineStyleSheetOwner.cpp:
(WebCore::InlineStyleSheetOwner::insertedIntoDocument):
(WebCore::InlineStyleSheetOwner::removedFromDocument):
(WebCore::InlineStyleSheetOwner::clearDocumentData):
(WebCore::InlineStyleSheetOwner::createSheet):
(WebCore::InlineStyleSheetOwner::sheetLoaded):
(WebCore::InlineStyleSheetOwner::startLoadingDynamicSheet):
* Source/WebCore/dom/InlineStyleSheetOwner.h:
(WebCore::InlineStyleSheetOwner::styleScope):

Canonical link: <a href="https://commits.webkit.org/262070@main">https://commits.webkit.org/262070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec70b77cd0dbd55013a75bb141ec98c8394721ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/435 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/387 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/634 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/469 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/461 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/378 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/427 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/408 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/421 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/114 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/416 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->