### PR TITLE
[RemoteInspector][Socket] change RunLoop::cycle() to non-blocking

### DIFF
--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -126,12 +126,13 @@ void RunLoop::wakeUp()
 RunLoop::CycleResult RunLoop::cycle(RunLoopMode)
 {
     MSG message;
-    if (!::GetMessage(&message, nullptr, 0, 0))
-        return CycleResult::Stop;
+    while (::PeekMessage(&message, nullptr, 0, 0, PM_REMOVE)) {
+        if (message.message == WM_QUIT)
+            return CycleResult::Stop;
 
-    ::TranslateMessage(&message);
-    ::DispatchMessage(&message);
-
+        ::TranslateMessage(&message);
+        ::DispatchMessage(&message);
+    }
     return CycleResult::Continue;
 }
 


### PR DESCRIPTION
#### 677a38a7599f3dbe1e53daf03e96658ef6a6101a
<pre>
[RemoteInspector][Socket] change RunLoop::cycle() to non-blocking
<a href="https://bugs.webkit.org/show_bug.cgi?id=254396">https://bugs.webkit.org/show_bug.cgi?id=254396</a>

Reviewed by Kimmo Kinnunen.

RemoteInspector&apos;s thread for receiving socket data was processing messages via non-blocking RunLoop::iterate().
The RunLoop::cycle() that was replaced by iterate() by 254382@main was blocking, so it could no longer receive socket data.

The implementation of RunLoopGeneric and RunLoopGlib are non-blocking.
This patch changes cycle() of RunLoopWin to non-blocking as well.

* Source/WTF/wtf/win/RunLoopWin.cpp:
(WTF::RunLoop::cycle):

Canonical link: <a href="https://commits.webkit.org/262188@main">https://commits.webkit.org/262188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd8f997147e1fa225e34a7fd9a55bfcfc29aa3a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/931 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/632 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/863 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/900 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/694 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/631 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/645 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/691 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/706 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/664 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/738 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/676 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/158 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/199 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/687 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/738 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/151 "Passed tests") | 
<!--EWS-Status-Bubble-End-->