### PR TITLE
Mark pipeThrough pipeTo promise as handled as per streams spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
 PASS Piping through a duck-typed pass-through transform stream should work
 PASS Piping through a transform errored on the writable end does not cause an unhandled promise rejection
 PASS pipeThrough should not call pipeTo on this

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any.serviceworker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
 PASS Piping through a duck-typed pass-through transform stream should work
 PASS Piping through a transform errored on the writable end does not cause an unhandled promise rejection
 PASS pipeThrough should not call pipeTo on this

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any.sharedworker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
 PASS Piping through a duck-typed pass-through transform stream should work
 PASS Piping through a transform errored on the writable end does not cause an unhandled promise rejection
 PASS pipeThrough should not call pipeTo on this

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any.worker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
 PASS Piping through a duck-typed pass-through transform stream should work
 PASS Piping through a transform errored on the writable end does not cause an unhandled promise rejection
 PASS pipeThrough should not call pipeTo on this

--- a/Source/WebCore/Modules/streams/ReadableStream.js
+++ b/Source/WebCore/Modules/streams/ReadableStream.js
@@ -152,7 +152,8 @@ function pipeThrough(streams, options)
     if (@isWritableStreamLocked(internalWritable))
         throw @makeTypeError("WritableStream is locked");
 
-    @readableStreamPipeToWritableStream(this, internalWritable, preventClose, preventAbort, preventCancel, signal);
+    const promise = @readableStreamPipeToWritableStream(this, internalWritable, preventClose, preventAbort, preventCancel, signal);
+    @markPromiseAsHandled(promise);
 
     return readable;
 }


### PR DESCRIPTION
#### 07e4b92acde0550b9212a8b93569b966c020e32f
<pre>
Mark pipeThrough pipeTo promise as handled as per streams spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=254400">https://bugs.webkit.org/show_bug.cgi?id=254400</a>
rdar://problem/107179072

Reviewed by Alex Christensen.

Implement <a href="https://streams.spec.whatwg.org/#rs-pipe-through">https://streams.spec.whatwg.org/#rs-pipe-through</a> step 5.

* LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/piping/pipe-through.any.worker-expected.txt:
* Source/WebCore/Modules/streams/ReadableStream.js:
(pipeThrough):

Canonical link: <a href="https://commits.webkit.org/262140@main">https://commits.webkit.org/262140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f12de45cc5caac0226c70e76c0d4d22caaa72eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/945 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/643 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/871 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/910 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/702 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/655 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/687 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/685 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/161 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/697 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->