### PR TITLE
[MSE] video's readyState keeps incorrectly switching between

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -30,6 +30,7 @@
 
 #include "Event.h"
 #include "EventNames.h"
+#include "MediaSourcePrivate.h"
 #include "SourceBufferList.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -80,7 +81,7 @@ void ManagedMediaSource::setStreaming(bool streaming)
 
 bool ManagedMediaSource::isBuffered(const PlatformTimeRanges& ranges) const
 {
-    if (ranges.length() < 1)
+    if (ranges.length() < 1 || isClosed())
         return true;
 
     ASSERT(ranges.length() == 1);
@@ -94,7 +95,7 @@ bool ManagedMediaSource::isBuffered(const PlatformTimeRanges& ranges) const
         return false;
 
     auto hasBufferedTime = [&] (const MediaTime& time) {
-        return abs(bufferedRanges->nearest(time) - time) <= currentTimeFudgeFactor();
+        return abs(bufferedRanges->nearest(time) - time) <= m_private->timeFudgeFactor();
     };
 
     if (!hasBufferedTime(ranges.minimumBufferedTime()) || !hasBufferedTime(ranges.maximumBufferedTime()))
@@ -105,7 +106,7 @@ bool ManagedMediaSource::isBuffered(const PlatformTimeRanges& ranges) const
 
     // Ensure that if we have a gap in the buffered range, it is smaller than the fudge factor;
     for (unsigned i = 1; i < bufferedRanges->length(); i++) {
-        if (bufferedRanges->end(i) - bufferedRanges->start(i-1) > currentTimeFudgeFactor())
+        if (bufferedRanges->end(i) - bufferedRanges->start(i-1) > m_private->timeFudgeFactor())
             return false;
     }
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -140,6 +140,7 @@ protected:
     void scheduleEvent(const AtomString& eventName);
     void notifyElementUpdateMediaState() const;
 
+    RefPtr<MediaSourcePrivate> m_private;
 private:
     // ActiveDOMObject.
     void stop() final;
@@ -170,7 +171,6 @@ private:
 
     static URLRegistry* s_registry;
 
-    RefPtr<MediaSourcePrivate> m_private;
     RefPtr<SourceBufferList> m_sourceBuffers;
     RefPtr<SourceBufferList> m_activeSourceBuffers;
     UniqueRef<PlatformTimeRanges> m_buffered;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2204,6 +2204,7 @@ platform/graphics/LayoutSize.cpp
 platform/graphics/MIMETypeCache.cpp
 platform/graphics/MediaPlayer.cpp
 platform/graphics/MediaPlayerPrivate.cpp
+platform/graphics/MediaSourcePrivate.cpp
 platform/graphics/Model.cpp
 platform/graphics/NamedImageGeneratedImage.cpp
 platform/graphics/NativeImage.cpp
@@ -3099,7 +3100,7 @@ JSAudioWorkletGlobalScope.cpp
 JSAudioWorkletNode.cpp
 JSAudioWorkletNodeOptions.cpp
 JSAudioWorkletProcessor.cpp
-JSAudioWorkletProcessorConstructor.cpp 
+JSAudioWorkletProcessorConstructor.cpp
 JSAuthenticationExtensionsClientInputs.cpp
 JSAuthenticationExtensionsClientOutputs.cpp
 JSAuthenticatorAssertionResponse.cpp

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -772,6 +772,11 @@ MediaTime MediaPlayer::currentTime() const
     return m_private->currentMediaTime();
 }
 
+bool MediaPlayer::currentTimeMayProgress() const
+{
+    return m_private->currentMediaTimeMayProgress();
+}
+
 bool MediaPlayer::setCurrentTimeDidChangeCallback(CurrentTimeDidChangeCallback&& callback)
 {
     return m_private->setCurrentTimeDidChangeCallback(WTFMove(callback));
@@ -938,7 +943,7 @@ MediaPlayer::NetworkState MediaPlayer::networkState()
     return m_private->networkState();
 }
 
-MediaPlayer::ReadyState MediaPlayer::readyState()
+MediaPlayer::ReadyState MediaPlayer::readyState() const
 {
     return m_private->readyState();
 }

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -190,7 +190,7 @@ public:
 
     // A characteristic of the media file, eg. video, audio, closed captions, etc, has changed.
     virtual void mediaPlayerCharacteristicChanged() { }
-    
+
     // whether the rendering system can accelerate the display of this MediaPlayer.
     virtual bool mediaPlayerRenderingCanBeAccelerated() { return false; }
 
@@ -213,7 +213,7 @@ public:
     virtual void mediaPlayerInitializationDataEncountered(const String&, RefPtr<ArrayBuffer>&&) { }
     virtual void mediaPlayerWaitingForKeyChanged() { }
 #endif
-    
+
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     virtual void mediaPlayerCurrentPlaybackTargetIsWirelessChanged(bool) { };
 #endif
@@ -421,6 +421,7 @@ public:
 
     using CurrentTimeDidChangeCallback = std::function<void(const MediaTime&)>;
     bool setCurrentTimeDidChangeCallback(CurrentTimeDidChangeCallback&&);
+    bool currentTimeMayProgress() const;
 
     MediaTime startTime() const;
     MediaTime initialTime() const;
@@ -494,7 +495,7 @@ public:
     NetworkState networkState();
 
     using MediaPlayerEnums::ReadyState;
-    ReadyState readyState();
+    ReadyState readyState() const;
 
     using MediaPlayerEnums::MovieLoadType;
     MovieLoadType movieLoadType() const;

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -121,6 +121,7 @@ public:
     virtual float currentTime() const { return 0; }
     virtual double currentTimeDouble() const { return currentTime(); }
     virtual MediaTime currentMediaTime() const { return MediaTime::createWithDouble(currentTimeDouble()); }
+    virtual bool currentMediaTimeMayProgress() const { return readyState() >= MediaPlayer::ReadyState::HaveFutureData; }
 
     virtual bool setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&&) { return false; }
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaSourcePrivate.h"
+
+#if ENABLE(MEDIA_SOURCE)
+
+namespace WebCore {
+
+bool MediaSourcePrivate::hasFutureTime(const MediaTime& currentTime, const MediaTime& duration, const PlatformTimeRanges& ranges) const
+{
+    if (currentTime > duration)
+        return false;
+
+    MediaTime nearest = ranges.nearest(currentTime);
+    if (abs(nearest - currentTime) > timeFudgeFactor())
+        return false;
+
+    size_t found = ranges.find(nearest);
+    if (found == notFound)
+        return false;
+
+    MediaTime localEnd = ranges.end(found);
+    if (localEnd == duration)
+        return true;
+
+    return localEnd - currentTime > timeFudgeFactor();
+}
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -70,9 +70,11 @@ public:
     virtual void seekCompleted() = 0;
 
     virtual void setTimeFudgeFactor(const MediaTime& fudgeFactor) { m_timeFudgeFactor = fudgeFactor; }
-
     MediaTime timeFudgeFactor() const { return m_timeFudgeFactor; }
+
     bool isSeeking() const { return m_isSeeking; }
+
+    bool hasFutureTime(const MediaTime& currentTime, const MediaTime& duration, const PlatformTimeRanges&) const;
 
 private:
     MediaTime m_timeFudgeFactor;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -111,6 +111,7 @@ public:
     void characteristicsChanged();
 
     MediaTime currentMediaTime() const override;
+    bool currentMediaTimeMayProgress() const override;
     AVSampleBufferDisplayLayer* sampleBufferDisplayLayer() const { return m_sampleBufferDisplayLayer.get(); }
     WebCoreDecompressionSession* decompressionSession() const { return m_decompressionSession.get(); }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -490,6 +490,15 @@ MediaTime MediaPlayerPrivateGStreamerMSE::maxMediaTimeSeekable() const
     return result;
 }
 
+bool MediaPlayerPrivateGStreamerMSE::currentMediaTimeMayProgress() const
+{
+    if (!m_mediaSourcePrivate)
+        return false;
+    if (auto ranges = buffered())
+        return m_mediaSourcePrivate->hasFutureTime(currentMediaTime(), durationMediaTime(), *ranges);
+    return false;
+}
+
 } // namespace WebCore.
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if ENABLE(VIDEO) && USE(GSTREAMER) && ENABLE(MEDIA_SOURCE) 
+#if ENABLE(VIDEO) && USE(GSTREAMER) && ENABLE(MEDIA_SOURCE)
 
 #include "GStreamerCommon.h"
 #include "MediaPlayerPrivateGStreamer.h"
@@ -65,6 +65,7 @@ public:
 
     std::unique_ptr<PlatformTimeRanges> buffered() const override;
     MediaTime maxMediaTimeSeekable() const override;
+    bool currentMediaTimeMayProgress() const override;
 
     void sourceSetup(GstElement*) override;
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -29,6 +29,7 @@
 #if ENABLE(MEDIA_SOURCE)
 
 #include "MediaPlayer.h"
+#include "MediaSourcePrivate.h"
 #include "MediaSourcePrivateClient.h"
 #include "MockMediaSourcePrivate.h"
 #include <wtf/MainThread.h>
@@ -203,6 +204,15 @@ void MockMediaPlayerMediaSource::paint(GraphicsContext&, const FloatRect&)
 MediaTime MockMediaPlayerMediaSource::currentMediaTime() const
 {
     return m_currentTime;
+}
+
+bool MockMediaPlayerMediaSource::currentMediaTimeMayProgress() const
+{
+    if (!m_mediaSourcePrivate)
+        return false;
+    if (auto ranges = buffered())
+        return m_mediaSourcePrivate->hasFutureTime(currentMediaTime(), durationMediaTime(), *ranges);
+    return false;
 }
 
 MediaTime MockMediaPlayerMediaSource::durationMediaTime() const

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -51,6 +51,7 @@ public:
 
     void advanceCurrentTime();
     MediaTime currentMediaTime() const override;
+    bool currentMediaTimeMayProgress() const override;
     void updateDuration(const MediaTime&);
 
     MediaPlayer::ReadyState readyState() const override;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -913,7 +913,7 @@ void RemoteMediaPlayerProxy::timerFired()
 
 bool RemoteMediaPlayerProxy::mediaPlayerPausedOrStalled() const
 {
-    return m_player->paused() || m_player->readyState() < MediaPlayer::ReadyState::HaveFutureData;
+    return m_player->paused() || !m_player->currentTimeMayProgress();
 }
 
 void RemoteMediaPlayerProxy::currentTimeChanged(const MediaTime& mediaTime)


### PR DESCRIPTION
#### f78ee0bea7233a1479a018b549d71c827e4e6769
<pre>
[MSE] video&apos;s readyState keeps incorrectly switching between
 HAVE_CURRENT_DATA and HAVE_METADATA
 <a href="https://bugs.webkit.org/show_bug.cgi?id=254399">https://bugs.webkit.org/show_bug.cgi?id=254399</a> rdar://107178961

Reviewed by Youenn Fablet.

Stop using the MediaPlayer&apos;s readyState value to determine if the currentTime is progressing.
Instead use MediaSource&apos;s buffered ranges to determine if we have playable
data in the future.
readyState is asynchronously set and decoupled from currentMediaTime since bug
225396 and may not be up to date at the time we check the currentMediaTime.

Additionally, do not update the cached time when pausing if it&apos;s marked
as not-progressing.

Testing covered in media/media-source/media-source-monitor-source-buffers.html
once webkit.org/b/225367 is done.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::isBuffered const):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::hasBufferedTime):
(WebCore::MediaSource::hasFutureTime):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::currentTimeMayProgress const):
(WebCore::MediaPlayer::readyState const):
(WebCore::MediaPlayer::readyState): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::currentMediaTimeMayProgress const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp: Added.
(WebCore::MediaSourcePrivate::hasFutureTime const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
(WebCore::MediaSourcePrivate::setTimeFudgeFactor):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::currentMediaTimeMayProgress const):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::currentMediaTimeMayProgress const):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::currentMediaTimeMayProgress const):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerPausedOrStalled const):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::pause):
(WebKit::MediaPlayerPrivateRemote::currentTimeChanged):

Canonical link: <a href="https://commits.webkit.org/262112@main">https://commits.webkit.org/262112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b53dcc377e770ebe31ca264768c05116a788d210

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/764 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/774 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/752 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/548 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/594 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/580 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/142 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/590 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->