### PR TITLE
[MSE] media/media-source/media-source-video-playback-quality.html is a constant failure with MockMSE in GPUP

### DIFF
--- a/LayoutTests/media/media-source/media-source-video-playback-quality-expected.txt
+++ b/LayoutTests/media/media-source/media-source-video-playback-quality-expected.txt
@@ -14,8 +14,11 @@ EXPECTED (quality.droppedVideoFrames == '1') OK
 EXPECTED (quality.totalFrameDelay == '0') OK
 RUN(sourceBuffer.appendBuffer(samples))
 EVENT(updateend)
+RUN(source.endOfStream())
+RUN(video.play())
+EVENT(ended)
 RUN(quality = video.getVideoPlaybackQuality())
-EXPECTED (quality.totalVideoFrames == '8') OK
+EXPECTED (quality.totalVideoFrames == '9') OK
 EXPECTED (quality.corruptedVideoFrames == '1') OK
 EXPECTED (quality.droppedVideoFrames == '2') OK
 EXPECTED (quality.totalFrameDelay == '3') OK

--- a/LayoutTests/media/media-source/media-source-video-playback-quality.html
+++ b/LayoutTests/media/media-source/media-source-video-playback-quality.html
@@ -51,6 +51,8 @@
             makeASample(0, 0, 1, 1, 1, SAMPLE_FLAG.SYNC),
             makeASample(1, 1, 1, 1, 1, SAMPLE_FLAG.CORRUPTED),
             makeASample(2, 2, 1, 1, 1, SAMPLE_FLAG.DROPPED),
+            makeASample(2, 2, 1, 1, 1, SAMPLE_FLAG.SYNC),
+            makeASample(3, 3, 1, 1, 1, SAMPLE_FLAG.NONE),
             makeASample(4, 4, 1, 1, 1, SAMPLE_FLAG.DELAYED),
             makeASample(5, 5, 1, 1, 1, SAMPLE_FLAG.DELAYED),
             makeASample(6, 6, 1, 1, 1, SAMPLE_FLAG.DELAYED),
@@ -60,10 +62,18 @@
         run('sourceBuffer.appendBuffer(samples)');
     }
 
-    function samplesAdded()
+    async function samplesAdded()
+    {
+        run('source.endOfStream()');
+        run('video.play()');
+        await waitFor(video, 'ended');
+        setTimeout(videoEnded, 50); // VideoPlaybackQuality is refreshed every 0.25s, wait a bit.
+    }
+
+    function videoEnded()
     {
         run('quality = video.getVideoPlaybackQuality()');
-        testExpected('quality.totalVideoFrames', 8);
+        testExpected('quality.totalVideoFrames', 9);
         testExpected('quality.corruptedVideoFrames', 1);
         testExpected('quality.droppedVideoFrames', 2);
         testExpected('quality.totalFrameDelay', 3);


### PR DESCRIPTION
#### ad2552fcc7cd07baec962277407e66dffa2c33d7
<pre>
[MSE] media/media-source/media-source-video-playback-quality.html is a constant failure with MockMSE in GPUP
<a href="https://bugs.webkit.org/show_bug.cgi?id=254405">https://bugs.webkit.org/show_bug.cgi?id=254405</a>
rdar://107182984

Reviewed by Youenn Fablet.

To get a valid VideoPlaybackQuality object about all the frames contained
in the SourceBuffer we must get the entire content first.
We modify the test so that the video is played to the end first and only
then get the VideoPlaybackQuality.

* LayoutTests/media/media-source/media-source-video-playback-quality-expected.txt:
* LayoutTests/media/media-source/media-source-video-playback-quality.html:

Canonical link: <a href="https://commits.webkit.org/262071@main">https://commits.webkit.org/262071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36a5457eab079888c46b0afd69c4e70fb00a6297

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/427 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/579 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/670 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/485 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/520 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/422 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/467 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/452 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/461 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/112 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/460 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->