### PR TITLE
GPU Process spends time decoding DestinationColorSpace on Cocoa

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ColorSpaceCG.h
+++ b/Source/WebCore/platform/graphics/cg/ColorSpaceCG.h
@@ -133,7 +133,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::OKLCH> { };
 template<> struct CGColorSpaceMapping<ColorSpace::XYZ_D65> { };
 
 
-std::optional<ColorSpace> colorSpaceForCGColorSpace(CGColorSpaceRef);
+WEBCORE_EXPORT std::optional<ColorSpace> colorSpaceForCGColorSpace(CGColorSpaceRef);
 
 
 template<ColorSpace, typename = void> inline constexpr bool HasCGColorSpaceMapping = false;
@@ -153,7 +153,7 @@ template<ColorSpace space> CGColorSpaceRef cachedNullableCGColorSpace()
     return CGColorSpaceMappingOrNullGetter<space>::colorSpace();
 }
 
-static inline CGColorSpaceRef cachedNullableCGColorSpace(ColorSpace colorSpace)
+inline CGColorSpaceRef cachedNullableCGColorSpace(ColorSpace colorSpace)
 {
     switch (colorSpace) {
     case ColorSpace::A98RGB:

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
@@ -35,6 +35,8 @@
 #include "StreamConnectionEncoder.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <WebCore/Color.h>
+#include <WebCore/ColorSpace.h>
+#include <WebCore/ColorSpaceCG.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/HashSet.h>
 #include <wtf/ProcessPrivilege.h>
@@ -742,17 +744,29 @@ std::optional<RetainPtr<CFURLRef>> ArgumentCoder<RetainPtr<CFURLRef>>::decode(De
     return WTFMove(result);
 }
 
-enum class CGColorSpaceEncodingScheme : bool { Name, PropertyList };
+namespace {
+using CGColorSpaceSerialization = std::variant<WebCore::ColorSpace, RetainPtr<CFStringRef>, RetainPtr<CFTypeRef>>;
+}
 
 template<typename Encoder>
-void ArgumentCoder<CGColorSpaceRef>::encode(Encoder& encoder, CGColorSpaceRef colorSpace)
+void ArgumentCoder<CGColorSpaceRef>::encode(Encoder& encoder, CGColorSpaceRef cgColorSpace)
 {
-    if (auto name = CGColorSpaceGetName(colorSpace)) {
-        encoder << CGColorSpaceEncodingScheme::Name << name;
+    if (auto colorSpace = colorSpaceForCGColorSpace(cgColorSpace)) {
+        encoder << CGColorSpaceSerialization { *colorSpace };
         return;
     }
-
-    encoder << CGColorSpaceEncodingScheme::PropertyList << adoptCF(CGColorSpaceCopyPropertyList(colorSpace));
+    if (RetainPtr<CFStringRef> name = CGColorSpaceGetName(cgColorSpace)) {
+        // This is a bit slow, hence we use the above if possible.
+        encoder << CGColorSpaceSerialization { WTFMove(name) };
+        return;
+    }
+    if (auto propertyList = adoptCF(CGColorSpaceCopyPropertyList(cgColorSpace))) {
+        encoder << CGColorSpaceSerialization { WTFMove(propertyList) };
+        return;
+    }
+    // FIXME: This should be removed once we can prove only non-null cgColorSpaces.
+    encoder << CGColorSpaceSerialization { WebCore::ColorSpace::SRGB };
+    ASSERT_NOT_REACHED(); // NOLINT
 }
 
 template void ArgumentCoder<CGColorSpaceRef>::encode<Encoder>(Encoder&, CGColorSpaceRef);
@@ -760,40 +774,23 @@ template void ArgumentCoder<CGColorSpaceRef>::encode<StreamConnectionEncoder>(St
 
 std::optional<RetainPtr<CGColorSpaceRef>> ArgumentCoder<RetainPtr<CGColorSpaceRef>>::decode(Decoder& decoder)
 {
-    std::optional<CGColorSpaceEncodingScheme> encodingScheme;
-    decoder >> encodingScheme;
-    if (!encodingScheme)
+    auto colorSpaceFormat = decoder.decode<CGColorSpaceSerialization>();
+    if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
-
-    switch (*encodingScheme) {
-    case CGColorSpaceEncodingScheme::Name: {
-        std::optional<RetainPtr<CFStringRef>> name;
-        decoder >> name;
-        if (!name)
-            return std::nullopt;
-
-        auto colorSpace = adoptCF(CGColorSpaceCreateWithName(name->get()));
-        if (!colorSpace)
-            return std::nullopt;
-
-        return WTFMove(colorSpace);
-    }
-    case CGColorSpaceEncodingScheme::PropertyList: {
-        std::optional<RetainPtr<CFTypeRef>> propertyList;
-        decoder >> propertyList;
-        if (!propertyList)
-            return std::nullopt;
-
-        auto colorSpace = adoptCF(CGColorSpaceCreateWithPropertyList(propertyList->get()));
-        if (!colorSpace)
-            return std::nullopt;
-
-        return WTFMove(colorSpace);
-    }
-    }
-
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
+    auto colorSpace = WTF::switchOn(*colorSpaceFormat,
+        [](WebCore::ColorSpace colorSpace) -> RetainPtr<CGColorSpaceRef> {
+            return RetainPtr { cachedNullableCGColorSpace(colorSpace) };
+        },
+        [](RetainPtr<CFStringRef> name) -> RetainPtr<CGColorSpaceRef> {
+            return adoptCF(CGColorSpaceCreateWithName(name.get()));
+        },
+        [](RetainPtr<CFTypeRef> propertyList) -> RetainPtr<CGColorSpaceRef> {
+            return adoptCF(CGColorSpaceCreateWithPropertyList(propertyList.get()));
+        }
+    );
+    if (UNLIKELY(!colorSpace))
+        return std::nullopt;
+    return colorSpace;
 }
 
 template<typename Encoder>


### PR DESCRIPTION
#### 274d47f99ab8deedfaadb83d67f96d87efaffe82
<pre>
GPU Process spends time decoding DestinationColorSpace on Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=254406">https://bugs.webkit.org/show_bug.cgi?id=254406</a>
rdar://107183239

Reviewed by Simon Fraser.

Decode CGColorSpaceRef via the WebCore::ColorSpace enum if possible.
This avoids slower CFStringRef, CFPropertyListRef encodings.

* Source/WebCore/platform/graphics/cg/ColorSpaceCG.h:
(WebCore::cachedNullableCGColorSpace):
* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
(IPC::ArgumentCoder&lt;CGColorSpaceRef&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CGColorSpaceRef&gt;&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/262141@main">https://commits.webkit.org/262141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a85a7fe1ec6b966db3a97fa8876db299a7cf3f0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/660 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/503 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/498 "2 api tests failed or timed out") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/441 "7 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/487 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/458 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/439 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/459 "3 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/452 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/162 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/447 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->