### PR TITLE
ReadableStream.tee should make sure to have its internal pull promises handled

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any-expected.txt
@@ -1,11 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: undefined is not an object (evaluating 'c.byobRequest.view')
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: undefined is not an object (evaluating 'c.byobRequest.view')
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-
-Harness Error (FAIL), message = Unhandled rejection
 
 PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
 FAIL ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other promise_test: Unhandled rejection with value: object "TypeError: ReadableStreamBYOBReader needs a ReadableByteStreamController"

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.serviceworker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
 PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
 FAIL ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other promise_test: Unhandled rejection with value: object "TypeError: ReadableStreamBYOBReader needs a ReadableByteStreamController"
 FAIL ReadableStream teeing with byte source: chunks should be cloned for each branch assert_not_equals: chunks should have different buffers got disallowed value object "[object ArrayBuffer]"

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.sharedworker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
 PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
 FAIL ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other promise_test: Unhandled rejection with value: object "TypeError: ReadableStreamBYOBReader needs a ReadableByteStreamController"
 FAIL ReadableStream teeing with byte source: chunks should be cloned for each branch assert_not_equals: chunks should have different buffers got disallowed value object "[object ArrayBuffer]"

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.worker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
 PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
 FAIL ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other promise_test: Unhandled rejection with value: object "TypeError: ReadableStreamBYOBReader needs a ReadableByteStreamController"
 FAIL ReadableStream teeing with byte source: chunks should be cloned for each branch assert_not_equals: chunks should have different buffers got disallowed value object "[object ArrayBuffer]"

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any-expected.txt
@@ -1,12 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-CONSOLE MESSAGE: Unhandled Promise Rejection: [object Object]
-
-Harness Error (FAIL), message = Unhandled rejection
 
 PASS ReadableStream teeing: rs.tee() returns an array of two ReadableStreams
 PASS ReadableStream teeing: should be able to read one branch to the end without affecting the other

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any.serviceworker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
 PASS ReadableStream teeing: rs.tee() returns an array of two ReadableStreams
 PASS ReadableStream teeing: should be able to read one branch to the end without affecting the other
 PASS ReadableStream teeing: values should be equal across each branch

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any.sharedworker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
 PASS ReadableStream teeing: rs.tee() returns an array of two ReadableStreams
 PASS ReadableStream teeing: should be able to read one branch to the end without affecting the other
 PASS ReadableStream teeing: values should be equal across each branch

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any.worker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection
-
 PASS ReadableStream teeing: rs.tee() returns an array of two ReadableStreams
 PASS ReadableStream teeing: should be able to read one branch to the end without affecting the other
 PASS ReadableStream teeing: values should be equal across each branch

--- a/Source/WebCore/Modules/streams/ReadableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamInternals.js
@@ -454,7 +454,7 @@ function readableStreamTeePullFunction(teeState, reader, shouldClone)
                 @readableStreamDefaultControllerEnqueue(teeState.branch1.@readableStreamController, result.value);
             if (!teeState.canceled2)
                 @readableStreamDefaultControllerEnqueue(teeState.branch2.@readableStreamController, shouldClone ? @structuredCloneForStream(result.value) : result.value);
-        });
+        }, () => { });
     }
 }
 


### PR DESCRIPTION
#### 44e1ce63f4c05e126cc819df8b71b633e837285b
<pre>
ReadableStream.tee should make sure to have its internal pull promises handled
<a href="https://bugs.webkit.org/show_bug.cgi?id=254407">https://bugs.webkit.org/show_bug.cgi?id=254407</a>
rdar://problem/107183268

Reviewed by Alex Christensen.

Make sure that the read promise used for teeing is handled.
We do not currently use the rejection handler as we handle closure with the closed promise.
A follow-up patch should update the tee algorithm to the latest specification.

* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/tee.any.worker-expected.txt:
* Source/WebCore/Modules/streams/ReadableStreamInternals.js:
(readableStreamTeePullFunction):

Canonical link: <a href="https://commits.webkit.org/262079@main">https://commits.webkit.org/262079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8deedd5ac28fbe84d7c870e78c6bac08b4007e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/677 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/532 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/504 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/431 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/471 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/461 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/118 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/469 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->