### PR TITLE
Implement URL.canParse()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/historical.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/historical.any-expected.txt
@@ -4,4 +4,7 @@ PASS <a> and <area>.searchParams should be undefined
 PASS Setting URL's href attribute and base URLs
 PASS URL.domainToASCII should be undefined
 PASS URL.domainToUnicode should be undefined
+PASS URL: no structured serialize/deserialize support
+PASS URLSearchParams: no structured serialize/deserialize support
+PASS Constructor only takes strings
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/historical.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/historical.any.js
@@ -28,4 +28,19 @@ test(function() {
   assert_equals(URL.domainToUnicode, undefined);
 }, "URL.domainToUnicode should be undefined");
 
+test(() => {
+  assert_throws_dom("DataCloneError", () => self.structuredClone(new URL("about:blank")));
+}, "URL: no structured serialize/deserialize support");
+
+test(() => {
+  assert_throws_dom("DataCloneError", () => self.structuredClone(new URLSearchParams()));
+}, "URLSearchParams: no structured serialize/deserialize support");
+
+test(() => {
+  const url = new URL("about:blank");
+  url.toString = () => { throw 1 };
+  assert_throws_exactly(1, () => new URL(url), "url argument");
+  assert_throws_exactly(1, () => new URL("about:blank", url), "base argument");
+}, "Constructor only takes strings");
+
 done();

--- a/LayoutTests/imported/w3c/web-platform-tests/url/historical.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/historical.any.worker-expected.txt
@@ -3,4 +3,7 @@ PASS searchParams on location object
 PASS Setting URL's href attribute and base URLs
 PASS URL.domainToASCII should be undefined
 PASS URL.domainToUnicode should be undefined
+PASS URL: no structured serialize/deserialize support
+PASS URLSearchParams: no structured serialize/deserialize support
+PASS Constructor only takes strings
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-canparse.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-canparse.any-expected.txt
@@ -1,0 +1,9 @@
+
+PASS URL.canParse(undefined, undefined)
+PASS URL.canParse(a:b, undefined)
+PASS URL.canParse(undefined, a:b)
+PASS URL.canParse(a:/b, undefined)
+PASS URL.canParse(undefined, a:/b)
+PASS URL.canParse(https://test:test, undefined)
+PASS URL.canParse(a, https://b/)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-canparse.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-canparse.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-canparse.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-canparse.any.js
@@ -1,0 +1,42 @@
+// This intentionally does not use resources/urltestdata.json to preserve resources.
+[
+  {
+    "url": undefined,
+    "base": undefined,
+    "expected": false
+  },
+  {
+    "url": "a:b",
+    "base": undefined,
+    "expected": true
+  },
+  {
+    "url": undefined,
+    "base": "a:b",
+    "expected": false
+  },
+  {
+    "url": "a:/b",
+    "base": undefined,
+    "expected": true
+  },
+  {
+    "url": undefined,
+    "base": "a:/b",
+    "expected": true
+  },
+  {
+    "url": "https://test:test",
+    "base": undefined,
+    "expected": false
+  },
+  {
+    "url": "a",
+    "base": "https://b/",
+    "expected": true
+  }
+].forEach(({ url, base, expected }) => {
+  test(() => {
+    assert_equals(URL.canParse(url, base), expected);
+  }, `URL.canParse(${url}, ${base})`);
+});

--- a/Source/WebCore/html/DOMURL.cpp
+++ b/Source/WebCore/html/DOMURL.cpp
@@ -62,12 +62,16 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const String& base)
     return create(url, baseURL);
 }
 
-ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const DOMURL& base)
-{
-    return create(url, base.href());
-}
-
 DOMURL::~DOMURL() = default;
+
+bool DOMURL::canParse(const String& url, const String& base)
+{
+    URL baseURL { base };
+    if (!base.isNull() && !baseURL.isValid())
+        return false;
+    URL completeURL { baseURL, url };
+    return completeURL.isValid();
+}
 
 ExceptionOr<void> DOMURL::setHref(const String& url)
 {
@@ -107,7 +111,7 @@ URLSearchParams& DOMURL::searchParams()
         m_searchParams = URLSearchParams::create(search(), this);
     return *m_searchParams;
 }
-    
+
 void DOMURL::revokeObjectURL(ScriptExecutionContext& scriptExecutionContext, const String& urlString)
 {
     URL url { urlString };

--- a/Source/WebCore/html/DOMURL.h
+++ b/Source/WebCore/html/DOMURL.h
@@ -41,8 +41,9 @@ class URLSearchParams;
 class DOMURL final : public RefCounted<DOMURL>, public CanMakeWeakPtr<DOMURL>, public URLDecomposition {
 public:
     static ExceptionOr<Ref<DOMURL>> create(const String& url, const String& base);
-    static ExceptionOr<Ref<DOMURL>> create(const String& url, const DOMURL& base);
     ~DOMURL();
+
+    static bool canParse(const String& url, const String& base);
 
     const URL& href() const { return m_url; }
     ExceptionOr<void> setHref(const String&);

--- a/Source/WebCore/html/DOMURL.idl
+++ b/Source/WebCore/html/DOMURL.idl
@@ -33,7 +33,8 @@
     LegacyWindowAlias=webkitURL,
 ] interface DOMURL {
     constructor(USVString url, optional USVString base);
-    constructor(USVString url, DOMURL base);
+
+    static boolean canParse(USVString url, optional USVString base);
 
     [URL] stringifier attribute USVString href;
     readonly attribute USVString origin;


### PR DESCRIPTION
#### b88c11e4a3a5cb6c39f145d059412aedae8e581b
<pre>
Implement URL.canParse()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254147">https://bugs.webkit.org/show_bug.cgi?id=254147</a>
rdar://106934916

Reviewed by Chris Dumez.

Additionally removes an overload that&apos;s not supported by the URL Standard.

* LayoutTests/imported/w3c/web-platform-tests/url/historical.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/historical.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/url/historical.any.worker-expected.txt:

Changes exported via <a href="https://github.com/web-platform-tests/wpt/pull/39177.">https://github.com/web-platform-tests/wpt/pull/39177.</a>

* LayoutTests/imported/w3c/web-platform-tests/url/url-statics-canparse.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/url/url-statics-canparse.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/url/url-statics-canparse.any.js: Added.
(forEach):

Imported from upstream.

* Source/WebCore/html/DOMURL.cpp:
(WebCore::DOMURL::canParse):
* Source/WebCore/html/DOMURL.h:
* Source/WebCore/html/DOMURL.idl:

Canonical link: <a href="https://commits.webkit.org/262072@main">https://commits.webkit.org/262072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46b52a1149ec3a983c55a118decc46698e9ea0cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/418 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/663 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/508 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/443 "1 flakes 8 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/490 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/413 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/460 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/443 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/454 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/113 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/451 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->