### PR TITLE
Cleanup / optimize InteractionRegion layers updates

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -94,9 +94,9 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     };
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if ([layer valueForKey:@"WKInteractionRegion"])
+    if ([layer valueForKey:@"WKInteractionRegionGroupName"])
         ts.dumpProperty("type", "interaction");
-    if ([layer valueForKey:@"WKInteractionRegionOcclusion"])
+    else if ([layer valueForKey:@"WKInteractionRegionType"])
         ts.dumpProperty("type", "occlusion");
 #endif
 


### PR DESCRIPTION
#### 7d3bebcc9fa4ccadd6c850c79e39994a274997d0
<pre>
Cleanup / optimize InteractionRegion layers updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=254409">https://bugs.webkit.org/show_bug.cgi?id=254409</a>
&lt;rdar://105196721&gt;

Reviewed by Tim Horton.

Limit the number of CA operations we make while updating the
InteractionRegions part of the RemoteLayerTree.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
Only re-parent the root InteractionRegion layer when the rootNode changes
or changes hierarchy.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::interactionRegionTypeForLayer):
(WebKit::isInteractionLayer):
(WebKit::isOcclusionLayer):
(WebKit::isAnyInteractionRegionLayer):
(WebKit::setInteractionRegion):
(WebKit::setInteractionRegionOcclusion):
Store the InteractionRegion type on the layer to simplify the
type-dependant logic.

(WebKit::interactionRegionGroupNameForLayer):
(WebKit::interactionRegionForLayer): Deleted.
(WebKit::interactionRegionGroupNameForRegion):
(WebKit::updateLayersForInteractionRegions):
Only re-parent an existing layer if it moved.
Only re-configure an Interaction layer if the groupName changed.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(dumpCALayer):
Update the Interaction/Occlusion detection logic with the new keys.

Canonical link: <a href="https://commits.webkit.org/262131@main">https://commits.webkit.org/262131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d1c619fa56bd91f5c604330e77d22c82ac2a616

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/596 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/467 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/708 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/604 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/536 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/468 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/518 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/515 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/512 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/154 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/506 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->