### PR TITLE
Animations inside a Details tag only fire once

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-canceled-by-parent-details-element-being-closed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-canceled-by-parent-details-element-being-closed-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A CSS Animation running on an element within a <details> element is canceled after the <details> element is closed.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-canceled-by-parent-details-element-being-closed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-canceled-by-parent-details-element-being-closed.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Animations: animation should be canceled when a parent details element is closed</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/testcommon.js"></script>
+<style>
+
+@keyframes anim {
+    to { margin-left: 100px }
+}
+
+</style>
+<div id="log"></div>
+<script>
+
+promise_test(async t => {
+  // create a <div> contained within a <details> element
+  const details = addElement(t, "details", { "open": "open" });
+  const div = addDiv(t);
+  details.appendChild(div);
+
+  // start an animation on the <div>
+  div.style.animation = 'anim 1s';
+  const animation = div.getAnimations()[0];
+  await animation.ready;
+
+  // ensure the animation running on the <div> is canceled as a result of closing the <details>
+  const canceled = new Promise(resolve => animation.addEventListener("cancel", resolve));
+  details.removeAttribute("open");
+  await canceled;
+}, 'A CSS Animation running on an element within a <details> element is canceled after the <details> element is closed.');
+
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -592,8 +592,6 @@ void RenderTreeUpdater::tearDownRenderers(Element& root, TeardownType teardownTy
         teardownStack.append(&element);
     };
 
-    auto& document = root.document();
-
     auto pop = [&] (unsigned depth) {
         while (teardownStack.size() > depth) {
             auto& element = *teardownStack.takeLast();
@@ -611,10 +609,10 @@ void RenderTreeUpdater::tearDownRenderers(Element& root, TeardownType teardownTy
                     styleable.willChangeRenderer();
                     break;
                 }
-                FALLTHROUGH;
+                element.clearHoverAndActiveStatusBeforeDetachingRenderer();
+                break;
             case TeardownType::Full:
-                if (document.renderTreeBeingDestroyed())
-                    styleable.cancelDeclarativeAnimations();
+                styleable.cancelDeclarativeAnimations();
                 element.clearHoverAndActiveStatusBeforeDetachingRenderer();
                 break;
             case TeardownType::RendererUpdateCancelingAnimations:


### PR DESCRIPTION
#### 46d8589593777d7e9f8f23c66beabb1217205ba7
<pre>
Animations inside a Details tag only fire once
<a href="https://bugs.webkit.org/show_bug.cgi?id=254401">https://bugs.webkit.org/show_bug.cgi?id=254401</a>

Reviewed by Antti Koivisto.

We should always cancel declarative animations in case of a Full teardown, and never
in the FullAfterSlotChange case. We remove the FALLTHROUGH to make this all clearer
and better distinguish the Full and FullAfterSlotChange cases.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-canceled-by-parent-details-element-being-closed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-canceled-by-parent-details-element-being-closed.html: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::tearDownRenderers):

Canonical link: <a href="https://commits.webkit.org/262076@main">https://commits.webkit.org/262076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6b675c19132557aa87fdf1beeaceac366eaf160

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/593 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/680 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/499 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/538 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/462 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/479 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/465 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/430 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/473 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/473 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/52 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->