### PR TITLE
WritableStreamDefaultController constructor should throw if called directly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/writable-streams/constructor.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/writable-streams/constructor.any-expected.txt
@@ -7,8 +7,8 @@ PASS WritableStream should be writable and ready should fulfill immediately if t
 PASS WritableStream should be constructible with no arguments
 PASS underlyingSink argument should be converted after queuingStrategy argument
 PASS WritableStream instances should have standard methods and properties
-FAIL WritableStreamDefaultController constructor should throw assert_throws_js: constructor should throw a TypeError exception function "() => new WritableStreamDefaultController({})" did not throw
-FAIL WritableStreamDefaultController constructor should throw when passed an initialised WritableStream assert_throws_js: constructor should throw a TypeError exception function "() => new WritableStreamDefaultController(stream)" did not throw
+PASS WritableStreamDefaultController constructor should throw
+PASS WritableStreamDefaultController constructor should throw when passed an initialised WritableStream
 PASS WritableStreamDefaultWriter should throw unless passed a WritableStream
 PASS WritableStreamDefaultWriter constructor should throw when stream argument is locked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/writable-streams/constructor.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/writable-streams/constructor.any.worker-expected.txt
@@ -7,8 +7,8 @@ PASS WritableStream should be writable and ready should fulfill immediately if t
 PASS WritableStream should be constructible with no arguments
 PASS underlyingSink argument should be converted after queuingStrategy argument
 PASS WritableStream instances should have standard methods and properties
-FAIL WritableStreamDefaultController constructor should throw assert_throws_js: constructor should throw a TypeError exception function "() => new WritableStreamDefaultController({})" did not throw
-FAIL WritableStreamDefaultController constructor should throw when passed an initialised WritableStream assert_throws_js: constructor should throw a TypeError exception function "() => new WritableStreamDefaultController(stream)" did not throw
+PASS WritableStreamDefaultController constructor should throw
+PASS WritableStreamDefaultController constructor should throw when passed an initialised WritableStream
 PASS WritableStreamDefaultWriter should throw unless passed a WritableStream
 PASS WritableStreamDefaultWriter constructor should throw when stream argument is locked
 

--- a/Source/WebCore/Modules/streams/WritableStreamDefaultController.js
+++ b/Source/WebCore/Modules/streams/WritableStreamDefaultController.js
@@ -28,7 +28,7 @@ function initializeWritableStreamDefaultController()
 {
     "use strict";
 
-    if (arguments.length !== 1 && arguments[0] !== @isWritableStream)
+    if (arguments.length !== 1 || arguments[0] !== @isWritableStream)
         @throwTypeError("WritableStreamDefaultController constructor should not be called directly");
 
     @putByIdDirectPrivate(this, "queue", @newQueue());


### PR DESCRIPTION
#### d711341632f4ca031f5a5d2e6088b21e6a3fb0cc
<pre>
WritableStreamDefaultController constructor should throw if called directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=254418">https://bugs.webkit.org/show_bug.cgi?id=254418</a>
rdar://problem/107185937

Reviewed by Alex Christensen.

Fix the check in initializeWritableStreamDefaultController to make sure the constructor will throw.

* LayoutTests/imported/w3c/web-platform-tests/streams/writable-streams/constructor.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/writable-streams/constructor.any.worker-expected.txt:
* Source/WebCore/Modules/streams/WritableStreamDefaultController.js:
(initializeWritableStreamDefaultController):

Canonical link: <a href="https://commits.webkit.org/262078@main">https://commits.webkit.org/262078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dd26ecf1c3c35b02dba260e886b71987386321c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/438 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/679 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/497 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/533 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/505 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/433 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/474 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/463 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/117 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/471 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->