### PR TITLE
[WGSL] Add missing Texture entries to the AST dumping

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-007-expected.txt
@@ -20,15 +20,9 @@ PASS .test 18
 PASS .test 19
 PASS .test 20
 PASS .test 21
-FAIL .test 22 assert_equals:
-<svg class="test auto-width" data-expected-client-width="300" data-expected-client-height="0"></svg>
-clientWidth expected 300 but got 0
-FAIL .test 23 assert_equals:
-<svg class="test auto-height" data-expected-client-width="0" data-expected-client-height="150"></svg>
-clientHeight expected 150 but got 0
-FAIL .test 24 assert_equals:
-<svg class="test auto-both" data-expected-client-width="300" data-expected-client-height="150"></svg>
-clientWidth expected 300 but got 0
+PASS .test 22
+PASS .test 23
+PASS .test 24
 PASS .test 25
 PASS .test 26
 PASS .test 27

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-with-css-box-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-with-css-box-001-expected.txt
@@ -1,6 +1,6 @@
 
 PASS ResizeObserver implemented
 PASS guard
-FAIL test0: observe `foreignObject` SVG in HTML document assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
-FAIL test1: observe inline SVG in HTML assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
+PASS test0: observe `foreignObject` SVG in HTML document
+PASS test1: observe inline SVG in HTML
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-with-css-box-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/svg-with-css-box-002-expected.txt
@@ -1,6 +1,6 @@
 
 PASS ResizeObserver implemented
 PASS guard
-FAIL test0: Root SVG resize observed assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
-FAIL test1: `foreignObject` SVG resize observed assert_unreached: Timed out waiting for notification. (1000ms) Reached unreachable code
+PASS test0: Root SVG resize observed
+PASS test1: `foreignObject` SVG resize observed
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1615,20 +1615,10 @@ int Element::scrollHeight()
 inline bool shouldObtainBoundsFromSVGModel(const Element* element)
 {
     ASSERT(element);
-    if (!element->isSVGElement() || !element->renderer())
-        return false;
+    if (auto* svg = dynamicDowncast<SVGElement>(element))
+        return svg->hasAssociatedSVGLayoutBox();
 
-    // Legacy SVG engine specific condition.
-    if (element->renderer()->isLegacySVGRoot())
-        return false;
-
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-    // LBSE specific condition.
-    if (element->document().settings().layerBasedSVGEngineEnabled())
-        return false;
-#endif
-
-    return true;
+    return false;
 }
 
 inline bool shouldObtainBoundsFromBoxModel(const Element* element)

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -60,12 +60,17 @@ void ResizeObservation::resetObservationSize()
 
 auto ResizeObservation::computeObservedSizes() const -> std::optional<BoxSizes>
 {
-    if (m_target->isSVGElement()) {
-        if (auto svgRect = downcast<SVGElement>(*m_target).getBoundingBox()) {
-            auto size = LayoutSize(svgRect->width(), svgRect->height());
+    if (auto* svg = dynamicDowncast<SVGElement>(target())) {
+        if (svg->hasAssociatedSVGLayoutBox()) {
+            LayoutSize size;
+            if (auto svgRect = svg->getBoundingBox()) {
+                size.setWidth(svgRect->width());
+                size.setHeight(svgRect->height());
+            }
             return { { size, size, size } };
         }
     }
+
     auto* box = m_target->renderBox();
     if (box) {
         if (box->isSkippedContent())

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1099,4 +1099,21 @@ SVGConditionalProcessingAttributes* SVGElement::conditionalProcessingAttributesI
     return m_svgRareData->conditionalProcessingAttributesIfExists();
 }
 
+bool SVGElement::hasAssociatedSVGLayoutBox() const
+{
+    if (!renderer())
+        return false;
+
+    // Legacy SVG engine specific condition.
+    if (renderer()->isLegacySVGRoot())
+        return false;
+
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    // LBSE specific condition.
+    if (document().settings().layerBasedSVGEngineEnabled())
+        return false;
+#endif
+    return true;
+}
+
 }

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -167,6 +167,8 @@ public:
     SVGConditionalProcessingAttributes& conditionalProcessingAttributes();
     SVGConditionalProcessingAttributes* conditionalProcessingAttributesIfExists() const;
 
+    bool hasAssociatedSVGLayoutBox() const;
+
 protected:
     SVGElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&, ConstructionType = CreateSVGElement);
     virtual ~SVGElement();

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -345,22 +345,7 @@ void StringDumper::visit(NamedTypeName& type)
 
 void StringDumper::visit(ParameterizedTypeName& type)
 {
-    constexpr ASCIILiteral base[] = {
-        "Vec2"_s,
-        "Vec3"_s,
-        "Vec4"_s,
-        "Mat2x2"_s,
-        "Mat2x3"_s,
-        "Mat2x4"_s,
-        "Mat3x2"_s,
-        "Mat3x3"_s,
-        "Mat3x4"_s,
-        "Mat4x2"_s,
-        "Mat4x3"_s,
-        "Mat4x4"_s
-    };
-    auto b = WTF::enumToUnderlyingType(type.base());
-    m_out.print(base[b], "<");
+    m_out.print(ParameterizedTypeName::baseToString(type.base()), "<");
     visit(type.elementType());
     m_out.print(">");
 }

--- a/Source/WebGPU/WGSL/AST/ASTTypeName.h
+++ b/Source/WebGPU/WGSL/AST/ASTTypeName.h
@@ -177,6 +177,58 @@ public:
         return std::nullopt;
     }
 
+    static ASCIILiteral baseToString(Base base)
+    {
+        switch (base) {
+        case Base::Vec2:
+            return "vec2"_s;
+        case Base::Vec3:
+            return "vec3"_s;
+        case Base::Vec4:
+            return "vec4"_s;
+        case Base::Mat2x2:
+            return "mat2x2"_s;
+        case Base::Mat2x3:
+            return "mat2x3"_s;
+        case Base::Mat2x4:
+            return "mat2x4"_s;
+        case Base::Mat3x2:
+            return "mat3x2"_s;
+        case Base::Mat3x3:
+            return "mat3x3"_s;
+        case Base::Mat3x4:
+            return "mat3x4"_s;
+        case Base::Mat4x2:
+            return "mat4x2"_s;
+        case Base::Mat4x3:
+            return "mat4x3"_s;
+        case Base::Mat4x4:
+            return "mat4x4"_s;
+        case Base::Texture1d:
+            return "texture_1d"_s;
+        case Base::Texture2d:
+            return "texture_2d"_s;
+        case Base::Texture2dArray:
+            return "texture_2d_array"_s;
+        case Base::Texture3d:
+            return "texture_3d"_s;
+        case Base::TextureCube:
+            return "texture_cube"_s;
+        case Base::TextureCubeArray:
+            return "texture_cube_array"_s;
+        case Base::TextureMultisampled2d:
+            return "texture_multisampled_2d"_s;
+        case Base::TextureStorage1d:
+            return "texture_storage_1d"_s;
+        case Base::TextureStorage2d:
+            return "texture_storage_2d"_s;
+        case Base::TextureStorage2dArray:
+            return "texture_storage_2d_array"_s;
+        case Base::TextureStorage3d:
+            return "texture_storage_3d"_s;
+        }
+    }
+
     NodeKind kind() const override;
     Base base() const { return m_base; }
     TypeName& elementType() { return m_elementType; }


### PR DESCRIPTION
#### 0d25214798937779c36c96b86b359221ca451deb
<pre>
[WGSL] Add missing Texture entries to the AST dumping
<a href="https://bugs.webkit.org/show_bug.cgi?id=254421">https://bugs.webkit.org/show_bug.cgi?id=254421</a>
rdar://107186502

Reviewed by Myles C. Maxfield.

In <a href="https://commits.webkit.org/262063@main">https://commits.webkit.org/262063@main</a> we added support for Textures in the compiler,
which required adding extra entries to ParameterizedTypeName::Base, but I missed adding
the same entries to ASTStringDuper. To avoid running into the same problem in the future
I moved the toString logic next to the enum definition and used an explicit switch, that
way the compiler will warns us about unhandled entries.

* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTTypeName.h:
(WGSL::AST::ParameterizedTypeName::baseToString):

Canonical link: <a href="https://commits.webkit.org/262146@main">https://commits.webkit.org/262146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25c8a008a7f1f1180c97adc1355fc0ec72946b12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/665 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/891 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/713 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/713 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/941 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/698 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/722 "6 flakes 139 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/678 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1689 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/709 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/704 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/169 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/719 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->