### PR TITLE
[WGSL] Add overloads for textureSample

### DIFF
--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -45,8 +45,9 @@ struct TypeVariable {
 
         I32 = 1 << 3,
         U32 = 1 << 4,
+        ConcreteInteger = I32 | U32,
         AbstractInt = 1 << 5,
-        Integer = I32 | U32 | AbstractInt,
+        Integer = ConcreteInteger | AbstractInt,
 
         Number = Float | Integer,
     };

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -11,3 +11,18 @@ operator :*, {
     [T < Float, C, R].(Matrix[T, C, R], Vector[T, C]) => Vector[T, R],
     [T < Float, C, R].(Vector[T, R], Matrix[T, C, R]) => Vector[T, C],
 }
+
+operator :textureSample, {
+    [].(Texture[F32, Texture1d], Sampler, F32) => Vector[F32, 4],
+    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2]) => Vector[F32, 4],
+    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], Vector[I32, 2]) => Vector[F32, 4],
+    [T < ConcreteInteger].(Texture[F32, Texture2dArray], Sampler, Vector[F32, 2], T) => Vector[F32, 4],
+    [T < ConcreteInteger].(Texture[F32, Texture2dArray], Sampler, Vector[F32, 2], T, Vector[I32, 2]) => Vector[F32, 4],
+    [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3]) => Vector[F32, 4],
+    [].(Texture[F32, TextureCube], Sampler, Vector[F32, 3]) => Vector[F32, 4],
+    [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3], Vector[I32, 3]) => Vector[F32, 4],
+    [T < ConcreteInteger].(Texture[F32, TextureCubeArray], Sampler, Vector[F32, 3], T) => Vector[F32, 4],
+
+    # FIXME: add overloads for texture_depth
+    # https://bugs.webkit.org/show_bug.cgi?id=254515
+}

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -43,3 +43,59 @@ fn testMultiply() {
   let r1 = m * v2;
   let r2 = v4 * m;
 }
+
+fn testTextureSample() {
+  {
+    let t: texture_1d<f32>;
+    let s: sampler;
+    let r = textureSample(t, s, 1);
+  }
+
+  {
+    let t: texture_2d<f32>;
+    let s: sampler;
+    let r = textureSample(t, s, vec2<f32>(0, 0));
+  }
+
+  {
+    let t: texture_2d<f32>;
+    let s: sampler;
+    let r = textureSample(t, s, vec2<f32>(0, 0), vec2<i32>(1, 1));
+  }
+
+  {
+    let t: texture_2d_array<f32>;
+    let s: sampler;
+    let r = textureSample(t, s, vec2<f32>(0, 0), 0);
+  }
+
+  {
+    let t: texture_2d_array<f32>;
+    let s: sampler;
+    let r = textureSample(t, s, vec2<f32>(0, 0), 0, vec2<i32>(1, 1));
+  }
+
+  {
+    let t: texture_3d<f32>;
+    let s: sampler;
+    let r = textureSample(t, s, vec3<f32>(0, 0, 0));
+  }
+
+  {
+    let t: texture_cube<f32>;
+    let s: sampler;
+    let r = textureSample(t, s, vec3<f32>(0, 0, 0));
+  }
+
+  {
+    let t: texture_3d<f32>;
+    let s: sampler;
+    let r = textureSample(t, s, vec3<f32>(0, 0, 0), vec3<i32>(0, 0, 0));
+  }
+
+  {
+    let t: texture_cube_array<f32>;
+    let s: sampler;
+    let r = textureSample(t, s, vec3<f32>(0, 0, 0), 0);
+  }
+}


### PR DESCRIPTION
#### 9b4dfecb36d9c7e97ca6dc7b489425889d37254b
<pre>
[WGSL] Add overloads for textureSample
<a href="https://bugs.webkit.org/show_bug.cgi?id=254431">https://bugs.webkit.org/show_bug.cgi?id=254431</a>
rdar://107190590

Reviewed by Myles C. Maxfield.

Add the definitions for the overloads of textureSample that operate on non-depth
textures. This requires minor modifications to the DSL to support concrete instances
of types that can also be abstract (i.e. Vector and Matrix). The definitions are a
little hard to read, and I might revisit it soon, but for now it matches the existing
definitions.

* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:

Canonical link: <a href="https://commits.webkit.org/262204@main">https://commits.webkit.org/262204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/803292fa13332617eb097ab9747d864e5c2eb882

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1316 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/806 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1015 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/921 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1246 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/854 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/828 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1883 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/869 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/865 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/209 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/883 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->