### PR TITLE
Begin hardening NSAttributedString deserialization

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -177,6 +177,7 @@ editing/SelectionGeometryGatherer.cpp
 editing/SmartReplaceCF.cpp
 editing/cocoa/AlternativeTextContextController.mm
 editing/cocoa/AlternativeTextUIController.mm
+editing/cocoa/AttributedString.mm
 editing/cocoa/AutofillElements.cpp
 editing/cocoa/DataDetection.mm
 editing/cocoa/DictionaryLookup.mm
@@ -530,6 +531,7 @@ platform/ios/SelectionGeometry.cpp
 platform/ios/SystemMemoryIOS.cpp
 platform/ios/ThemeIOS.mm
 platform/ios/TileControllerMemoryHandlerIOS.cpp
+platform/ios/UIFoundationSoftLink.mm
 platform/ios/UserAgentIOS.mm
 platform/ios/ValidationBubbleIOS.mm
 platform/ios/VideoFullscreenInterfaceAVKit.mm @no-unify

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "AttributedString.h"
+
+#import "Logging.h"
+#import <Foundation/Foundation.h>
+#import <wtf/cocoa/VectorCocoa.h>
+#if PLATFORM(MAC)
+#import <AppKit/AppKit.h>
+#else
+#import <pal/ios/UIKitSoftLink.h>
+#import "UIFoundationSoftLink.h"
+#endif
+
+namespace WebCore {
+
+bool AttributedString::rangesAreSafe(const String& string, const Vector<std::pair<Range, HashMap<String, AttributeValue>>>& vector)
+{
+    auto stringLength = string.length();
+    for (auto& pair : vector) {
+        auto& range = pair.first;
+        if (range.location > stringLength
+            || range.length > stringLength
+            || range.location + range.length > stringLength)
+            return false;
+    }
+    return true;
+}
+
+static RetainPtr<NSObject> toNSObject(const AttributedString::AttributeValue& value)
+{
+    return WTF::switchOn(value.value, [] (double value) -> RetainPtr<NSObject> {
+        return adoptNS([[NSNumber alloc] initWithDouble:value]);
+    }, [] (const String& value) -> RetainPtr<NSObject> {
+        return (NSString *)value;
+    }, [] (const RetainPtr<NSParagraphStyle>& value) -> RetainPtr<NSObject> {
+        return value;
+    }, [] (const URL& value) -> RetainPtr<NSObject> {
+        return (NSURL *)value;
+    }, [] (const Vector<String>& value) -> RetainPtr<NSObject> {
+        return createNSArray(value, [] (const String& string) {
+            return (NSString *)string;
+        });
+    }, [] (const Vector<double>& value) -> RetainPtr<NSObject> {
+        return createNSArray(value, [] (double number) {
+            return adoptNS([[NSNumber alloc] initWithDouble:number]);
+        });
+    }, [] (const RetainPtr<NSTextAttachment>& value) -> RetainPtr<NSObject> {
+        return value;
+    }, [] (const RetainPtr<NSShadow>& value) -> RetainPtr<NSObject> {
+        return value;
+    }, [] (const RetainPtr<NSDate>& value) -> RetainPtr<NSObject> {
+        return value;
+#if PLATFORM(MAC)
+    }, [] (const RetainPtr<NSFont>& value) -> RetainPtr<NSObject> {
+        return value;
+    }, [] (const RetainPtr<NSColor>& value) -> RetainPtr<NSObject> {
+        return value;
+#else
+    }, [] (const RetainPtr<UIFont>& value) -> RetainPtr<NSObject> {
+        return value;
+    }, [] (const RetainPtr<UIColor>& value) -> RetainPtr<NSObject> {
+        return value;
+#endif
+    });
+}
+
+static RetainPtr<NSDictionary> toNSDictionary(const HashMap<String, AttributedString::AttributeValue>& map)
+{
+    auto result = adoptNS([[NSMutableDictionary alloc] initWithCapacity:map.size()]);
+    for (auto& pair : map)
+        [result setObject:toNSObject(pair.value).get() forKey:(NSString *)pair.key];
+    return result;
+}
+
+RetainPtr<NSDictionary> AttributedString::documentAttributesAsNSDictionary() const
+{
+    if (!documentAttributes)
+        return nullptr;
+    return toNSDictionary(*documentAttributes);
+}
+
+RetainPtr<NSAttributedString> AttributedString::nsAttributedString() const
+{
+    if (string.isNull())
+        return nullptr;
+
+    auto result = adoptNS([[NSMutableAttributedString alloc] initWithString:(NSString *)string]);
+    for (auto& pair : attributes) {
+        auto& map = pair.second;
+        auto& range = pair.first;
+        [result addAttributes:toNSDictionary(map).get() range:NSMakeRange(range.location, range.length)];
+    }
+    return result;
+}
+
+static std::optional<AttributedString::AttributeValue> extractArray(NSArray *array)
+{
+    size_t arrayLength = array.count;
+    if (!arrayLength)
+        return { { { Vector<String>() } } };
+    if ([array[0] isKindOfClass:NSString.class]) {
+        Vector<String> result;
+        result.reserveInitialCapacity(arrayLength);
+        for (id element in array) {
+            if ([element isKindOfClass:NSString.class])
+                result.uncheckedAppend((NSString *)element);
+            else
+                RELEASE_LOG_ERROR(Editing, "NSAttributedString extraction failed with array containing <%@>", NSStringFromClass([element class]));
+        }
+        return { { { WTFMove(result) } } };
+    }
+    if ([array[0] isKindOfClass:NSNumber.class]) {
+        Vector<double> result;
+        result.reserveInitialCapacity(arrayLength);
+        for (id element in array) {
+            if ([element isKindOfClass:NSNumber.class])
+                result.uncheckedAppend([(NSNumber *)element doubleValue]);
+            else
+                RELEASE_LOG_ERROR(Editing, "NSAttributedString extraction failed with array containing <%@>", NSStringFromClass([element class]));
+        }
+        return { { { WTFMove(result) } } };
+    }
+    RELEASE_LOG_ERROR(Editing, "NSAttributedString extraction failed with array of unknown values");
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+
+static std::optional<AttributedString::AttributeValue> extractValue(id value)
+{
+    if (auto* number = dynamic_objc_cast<NSNumber>(value))
+        return { { { number.doubleValue } } };
+    if (auto* string = dynamic_objc_cast<NSString>(value))
+        return { { { String { string } } } };
+    if (auto* url = dynamic_objc_cast<NSURL>(value))
+        return { { { URL { url } } } };
+    if (auto* array = dynamic_objc_cast<NSArray>(value))
+        return extractArray(array);
+    if (auto* date = dynamic_objc_cast<NSDate>(value))
+        return { { { RetainPtr { date } } } };
+#if PLATFORM(MAC)
+    if (auto* shadow = dynamic_objc_cast<NSShadow>(value))
+        return { { { RetainPtr { shadow } } } };
+    if (auto* paragraphStyle = dynamic_objc_cast<NSParagraphStyle>(value))
+        return { { { RetainPtr { paragraphStyle } } } };
+    if (auto* textAttachment = dynamic_objc_cast<NSTextAttachment>(value))
+        return { { { RetainPtr { textAttachment } } } };
+    if (auto* font = dynamic_objc_cast<NSFont>(value))
+        return { { { RetainPtr { font } } } };
+    if (auto* color = dynamic_objc_cast<NSColor>(value))
+        return { { { RetainPtr { color } } } };
+#else
+    if ([value isKindOfClass:WebCore::getNSShadowClass()])
+        return { { { RetainPtr { (NSShadow *)value } } } };
+    if ([value isKindOfClass:PAL::getNSParagraphStyleClass()])
+        return { { { RetainPtr { (NSParagraphStyle *)value } } } };
+    if ([value isKindOfClass:WebCore::getNSTextAttachmentClass()])
+        return { { { RetainPtr { (NSTextAttachment *)value } } } };
+    if ([value isKindOfClass:PAL::getUIFontClass()])
+        return { { { RetainPtr { (UIFont *)value } } } };
+    if ([value isKindOfClass:PAL::getUIColorClass()])
+        return { { { RetainPtr { (UIColor *)value } } } };
+#endif
+    if (value) {
+        RELEASE_LOG_ERROR(Editing, "NSAttributedString extraction failed for class <%@>", NSStringFromClass([value class]));
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+    return std::nullopt;
+}
+
+static HashMap<String, AttributedString::AttributeValue> extractDictionary(NSDictionary *dictionary)
+{
+    __block HashMap<String, AttributedString::AttributeValue> result;
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *) {
+        if (![key isKindOfClass:NSString.class]) {
+            ASSERT_NOT_REACHED();
+            return;
+        }
+        auto extractedValue = extractValue(value);
+        if (!extractedValue) {
+            ASSERT_NOT_REACHED();
+            return;
+        }
+        result.set((NSString *)key, WTFMove(*extractedValue));
+    }];
+    return result;
+}
+
+AttributedString AttributedString::fromNSAttributedString(RetainPtr<NSAttributedString>&& string)
+{
+    return fromNSAttributedStringAndDocumentAttributes(WTFMove(string), nullptr);
+}
+
+AttributedString AttributedString::fromNSAttributedStringAndDocumentAttributes(RetainPtr<NSAttributedString>&& string, RetainPtr<NSDictionary>&& dictionary)
+{
+    __block AttributedString result;
+    result.string = [string string];
+    [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired usingBlock: ^(NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
+        result.attributes.append({ Range { range.location, range.length }, extractDictionary(attributes) });
+    }];
+    if (dictionary)
+        result.documentAttributes = extractDictionary(dictionary.get());
+    return result;
+}
+
+}

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -151,7 +151,7 @@ static RetainPtr<NSAttributedString> selectionAsAttributedString(const Document&
     if (ImageOverlay::isInsideOverlay(selection))
         return selectionInImageOverlayAsAttributedString(selection);
     auto range = selection.firstRange();
-    return range ? attributedString(*range).string : adoptNS([[NSAttributedString alloc] init]);
+    return range ? attributedString(*range).nsAttributedString() : adoptNS([[NSAttributedString alloc] init]);
 }
 
 void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -78,20 +78,10 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "UIFoundationSoftLink.h"
 #import "WAKAppKitStubs.h"
 #import <pal/ios/UIKitSoftLink.h>
 #import <pal/spi/ios/UIKitSPI.h>
-
-SOFT_LINK_CLASS(UIFoundation, NSColor)
-SOFT_LINK_CLASS(UIFoundation, NSShadow)
-SOFT_LINK_CLASS(UIFoundation, NSTextAttachment)
-SOFT_LINK_CLASS(UIFoundation, NSMutableParagraphStyle)
-SOFT_LINK_CLASS(UIFoundation, NSParagraphStyle)
-SOFT_LINK_CLASS(UIFoundation, NSTextList)
-SOFT_LINK_CLASS(UIFoundation, NSTextBlock)
-SOFT_LINK_CLASS(UIFoundation, NSTextTableBlock)
-SOFT_LINK_CLASS(UIFoundation, NSTextTable)
-SOFT_LINK_CLASS(UIFoundation, NSTextTab)
 
 #define PlatformNSShadow            getNSShadowClass()
 #define PlatformNSTextAttachment    getNSTextAttachmentClass()
@@ -416,7 +406,7 @@ AttributedString HTMLConverter::convert()
     if (_domRangeStartIndex > 0 && _domRangeStartIndex <= [_attrStr length])
         [_attrStr deleteCharactersInRange:NSMakeRange(0, _domRangeStartIndex)];
 
-    return { WTFMove(_attrStr), WTFMove(_documentAttrs) };
+    return AttributedString::fromNSAttributedStringAndDocumentAttributes(WTFMove(_attrStr), WTFMove(_documentAttrs));
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -2459,7 +2449,7 @@ AttributedString editingAttributedString(const SimpleRange& range, IncludeImages
         stringLength += currentTextLength;
     }
 
-    return { WTFMove(string), nil };
+    return AttributedString::fromNSAttributedString(WTFMove(string));
 }
 
 #endif

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -184,10 +184,10 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (pasteboardType == String(legacyRTFDPasteboardType()))
-        return dataInRTFDFormat(attributedString(*adjustedSelectionRange()).string.get());
+        return dataInRTFDFormat(attributedString(*adjustedSelectionRange()).nsAttributedString().get());
 
     if (pasteboardType == String(legacyRTFPasteboardType())) {
-        auto string = attributedString(*adjustedSelectionRange()).string;
+        auto string = attributedString(*adjustedSelectionRange()).nsAttributedString();
         // FIXME: Why is this stripping needed here, but not in writeSelectionToPasteboard?
         if ([string containsAttachments])
             string = attributedStringByStrippingAttachmentCharacters(string.get());

--- a/Source/WebCore/platform/ios/UIFoundationSoftLink.h
+++ b/Source/WebCore/platform/ios/UIFoundationSoftLink.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY)
+
+#import <pal/spi/ios/UIKitSPI.h>
+#import <wtf/SoftLinking.h>
+
+SOFT_LINK_FRAMEWORK_FOR_HEADER(WebCore, UIFoundation)
+
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSColor)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSShadow)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSTextAttachment)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSMutableParagraphStyle)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSParagraphStyle)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSTextList)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSTextBlock)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSTextTableBlock)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSTextTable)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, NSTextTab)
+
+#endif

--- a/Source/WebCore/platform/ios/UIFoundationSoftLink.mm
+++ b/Source/WebCore/platform/ios/UIFoundationSoftLink.mm
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import <pal/spi/ios/UIKitSPI.h>
+#import <wtf/SoftLinking.h>
+
+// FIXME: Remove SOFT_LINK_PRIVATE_FRAMEWORK(UIFoundation) and move symbols from NSAttributedStringSPI.h to here.
+SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE(WebCore, UIFoundation)
+
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSColor)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSShadow)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextAttachment)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSMutableParagraphStyle)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSParagraphStyle)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextList)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextBlock)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextTableBlock)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextTable)
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, UIFoundation, NSTextTab)
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -59,10 +59,6 @@
 @property (nonatomic, readonly) CGColorRef wrappedColor;
 @end
 
-@interface NSAttributedString (NSAttributedString_SecureCoding)
-@property (class, readonly) NSSet<Class> *allowedSecureCodingClasses;
-@end
-
 @implementation WKSecureCodingArchivingDelegate
 
 - (id)archiver:(NSKeyedArchiver *)archiver willEncodeObject:(id)object
@@ -496,9 +492,6 @@ static std::optional<RetainPtr<id>> decodeSecureCodingInternal(Decoder& decoder,
     auto allowedClassSet = adoptNS([[NSMutableSet alloc] initWithArray:allowedClasses]);
     [allowedClassSet addObject:WKSecureCodingURLWrapper.class];
     [allowedClassSet addObject:WKSecureCodingCGColorWrapper.class];
-
-    if ([allowedClasses containsObject:NSAttributedString.class])
-        [allowedClassSet unionSet:NSAttributedString.allowedSecureCodingClasses];
 
     @try {
         id result = [unarchiver decodeObjectOfClasses:allowedClassSet.get() forKey:NSKeyedArchiveRootObjectKey];

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -35,11 +35,25 @@ header: <WebCore/ResourceRequest.h>
     std::optional<WebCore::ResourceRequestRequester> m_requester
 };
 
-struct WebCore::AttributedString {
-    RetainPtr<NSAttributedString> string;
-    RetainPtr<NSDictionary> documentAttributes;
-};
+[Nested] struct WebCore::AttributedString::AttributeValue {
+#if PLATFORM(MAC)
+    std::variant<double, String, URL, Vector<String>, Vector<double>, RetainPtr<NSParagraphStyle>, RetainPtr<NSTextAttachment>, RetainPtr<NSShadow>, RetainPtr<NSDate>, RetainPtr<NSFont>, RetainPtr<NSColor>> value;
 #endif
+#if PLATFORM(IOS_FAMILY)
+    std::variant<double, String, URL, Vector<String>, Vector<double>, RetainPtr<NSParagraphStyle>, RetainPtr<NSTextAttachment>, RetainPtr<NSShadow>, RetainPtr<NSDate>, RetainPtr<UIFont>, RetainPtr<UIColor>> value;
+#endif
+}
+
+[Nested] struct WebCore::AttributedString::Range {
+    size_t location
+    size_t length
+};
+
+struct WebCore::AttributedString {
+    String string;
+    [Validator='WebCore::AttributedString::rangesAreSafe(*string, *attributes)'] Vector<std::pair<WebCore::AttributedString::Range, HashMap<String, WebCore::AttributedString::AttributeValue>>> attributes;
+    std::optional<HashMap<String, WebCore::AttributedString::AttributeValue>> documentAttributes;
+};
 
 #if ENABLE(MEDIA_RECORDER)
 struct WebCore::MediaRecorderPrivateOptions {

--- a/Source/WebKit/Shared/DocumentEditingContext.mm
+++ b/Source/WebKit/Shared/DocumentEditingContext.mm
@@ -45,15 +45,15 @@ UIWKDocumentContext *DocumentEditingContext::toPlatformContext(OptionSet<Documen
     auto platformContext = adoptNS([[UIWKDocumentContext alloc] init]);
 
     if (options.contains(DocumentEditingContextRequest::Options::AttributedText)) {
-        [platformContext setContextBefore:contextBefore.string.get()];
-        [platformContext setSelectedText:selectedText.string.get()];
-        [platformContext setContextAfter:contextAfter.string.get()];
-        [platformContext setMarkedText:markedText.string.get()];
+        [platformContext setContextBefore:contextBefore.nsAttributedString().get()];
+        [platformContext setSelectedText:selectedText.nsAttributedString().get()];
+        [platformContext setContextAfter:contextAfter.nsAttributedString().get()];
+        [platformContext setMarkedText:markedText.nsAttributedString().get()];
     } else if (options.contains(DocumentEditingContextRequest::Options::Text)) {
-        [platformContext setContextBefore:[contextBefore.string string]];
-        [platformContext setSelectedText:[selectedText.string string]];
-        [platformContext setContextAfter:[contextAfter.string string]];
-        [platformContext setMarkedText:[markedText.string string]];
+        [platformContext setContextBefore:[contextBefore.nsAttributedString() string]];
+        [platformContext setSelectedText:[selectedText.nsAttributedString() string]];
+        [platformContext setContextAfter:[contextAfter.nsAttributedString() string]];
+        [platformContext setMarkedText:[markedText.nsAttributedString() string]];
     }
 
     [platformContext setSelectedRangeInMarkedText:toNSRange(selectedRangeInMarkedText)];
@@ -61,7 +61,7 @@ UIWKDocumentContext *DocumentEditingContext::toPlatformContext(OptionSet<Documen
     for (const auto& rect : textRects)
         [platformContext addTextRect:rect.rect forCharacterRange:toNSRange(rect.range)];
 
-    [platformContext setAnnotatedText:annotatedText.string.get()];
+    [platformContext setAnnotatedText:annotatedText.nsAttributedString().get()];
 
     return platformContext.autorelease();
 #else

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3300,8 +3300,8 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 {
     THROW_IF_SUSPENDED;
     _page->getContentsAsAttributedString([handler = makeBlockPtr(completionHandler)](auto& attributedString) {
-        if (attributedString.string)
-            handler(attributedString.string.get(), attributedString.documentAttributes.get(), nil);
+        if (auto string = attributedString.nsAttributedString())
+            handler(string.get(), attributedString.documentAttributesAsNSDictionary().get(), nil);
         else
             handler(nil, nil, createNSError(WKErrorUnknown).get());
     });

--- a/Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm
@@ -44,7 +44,7 @@ void TextCheckingController::replaceRelativeToSelection(NSAttributedString *anno
     if (!m_page.hasRunningProcess())
         return;
 
-    m_page.send(Messages::TextCheckingControllerProxy::ReplaceRelativeToSelection({ annotatedString, nil }, selectionOffset, length, relativeReplacementLocation, relativeReplacementLength));
+    m_page.send(Messages::TextCheckingControllerProxy::ReplaceRelativeToSelection(WebCore::AttributedString::fromNSAttributedString(annotatedString), selectionOffset, length, relativeReplacementLocation, relativeReplacementLength));
 }
 
 void TextCheckingController::removeAnnotationRelativeToSelection(NSString *annotationName, int64_t selectionOffset, uint64_t length)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4910,8 +4910,9 @@ void WebViewImpl::attributedSubstringForProposedRange(NSRange proposedRange, voi
 {
     LOG(TextInput, "attributedSubstringFromRange:(%u, %u)", proposedRange.location, proposedRange.length);
     m_page->attributedSubstringForCharacterRangeAsync(proposedRange, [completionHandler = makeBlockPtr(completionHandler)](const WebCore::AttributedString& string, const EditingRange& actualRange) {
-        LOG(TextInput, "    -> attributedSubstringFromRange returned %@", string.string.get());
-        completionHandler(string.string.get(), actualRange);
+        auto attributedString = string.nsAttributedString();
+        LOG(TextInput, "    -> attributedSubstringFromRange returned %@", attributedString.get());
+        completionHandler(attributedString.get(), actualRange);
     });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
@@ -114,7 +114,7 @@ void TextCheckingControllerProxy::replaceRelativeToSelection(const WebCore::Attr
         if (auto rangeAndOffsetOfReplacement = rangeAndOffsetRelativeToSelection(selectionOffset + relativeReplacementLocation, relativeReplacementLength)) {
             bool restoreSelection = frameSelection.selection().isRange();
 
-            frame->editor().replaceRangeForSpellChecking(rangeAndOffsetOfReplacement->range, [[annotatedString.string string] substringWithRange:NSMakeRange(relativeReplacementLocation, relativeReplacementLength + [annotatedString.string length] - length)]);
+            frame->editor().replaceRangeForSpellChecking(rangeAndOffsetOfReplacement->range, [annotatedString.string substringWithRange:NSMakeRange(relativeReplacementLocation, relativeReplacementLength + [annotatedString.string length] - length)]);
 
             if (restoreSelection) {
                 uint64_t selectionLocationToRestore = locationInRoot - selectionOffset;
@@ -124,7 +124,7 @@ void TextCheckingControllerProxy::replaceRelativeToSelection(const WebCore::Attr
         }
     }
 
-    [annotatedString.string enumerateAttributesInRange:NSMakeRange(0, [annotatedString.string length]) options:0 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, NSRange attributeRange, BOOL *stop) {
+    [annotatedString.nsAttributedString() enumerateAttributesInRange:NSMakeRange(0, [annotatedString.string length]) options:0 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, NSRange attributeRange, BOOL *stop) {
         auto attributeCoreRange = resolveCharacterRange(makeRangeSelectingNodeContents(*root), { locationInRoot + attributeRange.location, attributeRange.length });
 
         [attrs enumerateKeysAndObjectsUsingBlock:^(NSAttributedStringKey key, id value, BOOL *stop) {
@@ -188,7 +188,7 @@ WebCore::AttributedString TextCheckingControllerProxy::annotatedSubstringBetween
         }
     }
 
-    return { { WTFMove(string) } };
+    return WebCore::AttributedString::fromNSAttributedString(WTFMove(string));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -213,7 +213,7 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
     dictionaryPopupInfo.platformData.options = options;
 
 #if PLATFORM(MAC)
-    auto attributedString = editingAttributedString(range, IncludeImages::No).string;
+    auto attributedString = editingAttributedString(range, IncludeImages::No).nsAttributedString();
     auto scaledAttributedString = adoptNS([[NSMutableAttributedString alloc] initWithString:[attributedString string]]);
     NSFontManager *fontManager = [NSFontManager sharedFontManager];
     [attributedString enumerateAttributesInRange:NSMakeRange(0, [attributedString length]) options:0 usingBlock:^(NSDictionary *attributes, NSRange range, BOOL *stop) {

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4770,7 +4770,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest reques
         if (!range || range->collapsed())
             return { };
         // FIXME: This should return editing-offset-compatible attributed strings if that option is requested.
-        return { adoptNS([[NSAttributedString alloc] initWithString:WebCore::plainTextReplacingNoBreakSpace(*range, TextIteratorBehavior::EmitsOriginalText)]), nil };
+        return WebCore::AttributedString::fromNSAttributedString(adoptNS([[NSAttributedString alloc] initWithString:WebCore::plainTextReplacingNoBreakSpace(*range, TextIteratorBehavior::EmitsOriginalText)]));
     };
 
     DocumentEditingContext context;

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -346,7 +346,7 @@ void WebPage::attributedSubstringForCharacterRangeAsync(const EditingRange& edit
         return;
     }
 
-    auto attributedString = editingAttributedString(*range, IncludeImages::No).string;
+    auto attributedString = editingAttributedString(*range, IncludeImages::No).nsAttributedString();
 
     // WebCore::editingAttributedStringFromRange() insists on inserting a trailing
     // whitespace at the end of the string which breaks the ATOK input method.  <rdar://problem/5400551>
@@ -361,11 +361,11 @@ void WebPage::attributedSubstringForCharacterRangeAsync(const EditingRange& edit
     ASSERT(rangeToSend.isValid());
     if (!rangeToSend.isValid()) {
         // Send an empty EditingRange as a last resort for <rdar://problem/27078089>.
-        completionHandler({ WTFMove(attributedString), nil }, EditingRange());
+        completionHandler(WebCore::AttributedString::fromNSAttributedString(WTFMove(attributedString)), EditingRange());
         return;
     }
 
-    completionHandler({ WTFMove(attributedString), nil }, rangeToSend);
+    completionHandler(WebCore::AttributedString::fromNSAttributedString(WTFMove(attributedString)), rangeToSend);
 }
 
 #if ENABLE(PDFKIT_PLUGIN)
@@ -748,7 +748,7 @@ void WebPage::handleSelectionServiceClick(FrameSelection& selection, const Vecto
     if (!range)
         return;
 
-    auto attributedSelection = attributedString(*range).string;
+    auto attributedSelection = attributedString(*range).nsAttributedString();
     if (!attributedSelection)
         return;
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm
@@ -50,7 +50,7 @@ void WebSelectionServiceController::handleSelectionServiceClick(WebCore::FrameSe
     if (!range)
         return;
 
-    auto attributedSelection = attributedString(*range).string;
+    auto attributedSelection = attributedString(*range).nsAttributedString();
     if (!attributedSelection)
         return;
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -271,7 +271,7 @@ static RetainPtr<NSArray> createNSArray(const HashSet<String, ASCIICaseInsensiti
     if (!startNode || !endNode)
         return adoptNS([[NSAttributedString alloc] init]).autorelease();
     auto range = SimpleRange { { *core(startNode), static_cast<unsigned>(startOffset) }, { *core(endNode), static_cast<unsigned>(endOffset) } };
-    return editingAttributedString(range).string.autorelease();
+    return editingAttributedString(range).nsAttributedString().autorelease();
 }
 
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -6416,7 +6416,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return nil;
     }
 
-    auto result = editingAttributedString(*range).string;
+    auto result = editingAttributedString(*range).nsAttributedString();
     
     // WebCore::editingAttributedStringFromRange() insists on inserting a trailing
     // whitespace at the end of the string which breaks the ATOK input method.  <rdar://problem/5400551>
@@ -7003,7 +7003,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
     if (!startContainer || !endContainer)
         return adoptNS([[NSAttributedString alloc] init]).autorelease();
     return attributedString(WebCore::SimpleRange { { *core(startContainer), static_cast<unsigned>(startOffset) },
-        { *core(endContainer), static_cast<unsigned>(endOffset) } }).string.autorelease();
+        { *core(endContainer), static_cast<unsigned>(endOffset) } }).nsAttributedString().autorelease();
 }
 
 - (NSAttributedString *)attributedString
@@ -7012,9 +7012,9 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
     if (!document)
         return adoptNS([[NSAttributedString alloc] init]).autorelease();
     auto range = makeRangeSelectingNodeContents(*document);
-    if (auto result = attributedString(range).string)
+    if (auto result = attributedString(range).nsAttributedString())
         return result.autorelease();
-    return editingAttributedString(range).string.autorelease();
+    return editingAttributedString(range).nsAttributedString().autorelease();
 }
 
 - (NSAttributedString *)selectedAttributedString
@@ -7025,9 +7025,9 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
     auto range = frame->selection().selection().firstRange();
     if (!range)
         return adoptNS([[NSAttributedString alloc] init]).autorelease();
-    if (auto result = attributedString(*range).string)
+    if (auto result = attributedString(*range).nsAttributedString())
         return result.autorelease();
-    return editingAttributedString(*range).string.autorelease();
+    return editingAttributedString(*range).nsAttributedString().autorelease();
 }
 
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -532,7 +532,7 @@ static WebCore::IntRect elementBoundingBoxInWindowCoordinatesFromNode(WebCore::N
     popupInfo.origin = NSMakePoint(rangeRect.x(), rangeRect.y() + scaledDescent);
     popupInfo.platformData.options = lookupOptions;
 
-    auto attributedString = editingAttributedString(range, WebCore::IncludeImages::No).string;
+    auto attributedString = editingAttributedString(range, WebCore::IncludeImages::No).nsAttributedString();
     auto scaledAttributedString = adoptNS([[NSMutableAttributedString alloc] initWithString:[attributedString string]]);
     NSFontManager *fontManager = [NSFontManager sharedFontManager];
 


### PR DESCRIPTION
#### 391c01e102feba390f1bef16336ae485ab4022bf
<pre>
Begin hardening NSAttributedString deserialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=254250">https://bugs.webkit.org/show_bug.cgi?id=254250</a>
rdar://107033670

Reviewed by Tim Hatcher.

We get NSAttributedStrings in the web process to send to the UI process from two
different places: WKPDFLayerControllerDelegate and HTMLConverter.  After manually
looking through the code that generates those attributes, I created a structure
that more closely reflects the possible values that we might want to decode,
with more hardening possible in the future to harden the deserialization of each
value type.

A previous version of this PR broke the Catalyst build and returned an empty
NSAttributedString and NSDictionary instead of nil after serialization.  This
version fixes both issues.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebCore/editing/cocoa/AttributedString.mm: Added.
(WebCore::AttributedString::rangesAreSafe):
(WebCore::toNSObject):
(WebCore::toNSDictionary):
(WebCore::AttributedString::documentAttributesAsNSDictionary const):
(WebCore::AttributedString::nsAttributedString const):
(WebCore::extractValue):
(WebCore::extractDictionary):
(WebCore::AttributedString::fromNSAttributedString):
(WebCore::AttributedString::fromNSAttributedStringAndDocumentAttributes):
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::selectionAsAttributedString):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::convert):
(WebCore::editingAttributedString):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::dataSelectionForPasteboard):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::decodeSecureCodingInternal):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/DocumentEditingContext.mm:
(WebKit::DocumentEditingContext::toPlatformContext):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _getContentsAsAttributedStringWithCompletionHandler:]):
* Source/WebKit/UIProcess/Cocoa/TextCheckingController.mm:
(WebKit::TextCheckingController::replaceRelativeToSelection):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::attributedSubstringForProposedRange):
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
(WebKit::TextCheckingControllerProxy::replaceRelativeToSelection):
(WebKit::TextCheckingControllerProxy::annotatedSubstringBetweenPositions):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::dictionaryPopupInfoForRange):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestDocumentEditingContext):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::attributedSubstringForCharacterRangeAsync):
(WebKit::WebPage::handleSelectionServiceClick):
* Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm:
(WebSelectionServiceController::handleSelectionServiceClick):
* Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm:
(-[WebHTMLRepresentation attributedStringFrom:startOffset:to:endOffset:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView attributedSubstringFromRange:]):
(-[WebHTMLView _legacyAttributedStringFrom:offset:to:offset:]):
(-[WebHTMLView attributedString]):
(-[WebHTMLView selectedAttributedString]):
* Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm:
(+[WebImmediateActionController _dictionaryPopupInfoForRange:inFrame:withLookupOptions:indicatorOptions:transition:]):

Canonical link: <a href="https://commits.webkit.org/262192@main">https://commits.webkit.org/262192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33faa06d21373fcbbc0b758d8f3e53114a59f20f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1220 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/975 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1166 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/808 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/780 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1832 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/821 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/819 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/834 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/91 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->