### PR TITLE
InteractionRegions grouped together should not overlap

### DIFF
--- a/LayoutTests/interaction-region/overlap-same-group-expected.txt
+++ b/LayoutTests/interaction-region/overlap-same-group-expected.txt
@@ -1,8 +1,4 @@
-Line
-Line
-Line
-Line
-(GraphicsLayer
+ (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
   (children 1
@@ -16,19 +12,12 @@ Line
 
       (interaction regions [
         (interaction
-            (rect (-4,-4) width=38 height=27)
+            (rect (46,-4) width=158 height=108)
 )
         (borderRadius 8.00),
         (interaction
-            (rect (-4,23) width=38 height=20)
-)
-        (borderRadius 8.00),
-        (interaction
-            (rect (-4,43) width=38 height=20)
-)
-        (borderRadius 8.00),
-        (interaction
-            (rect (-4,63) width=38 height=20)
+            (rect (204,21) width=50 height=83)
+            (rect (96,104) width=158 height=25)
 )
         (borderRadius 8.00)])
       )

--- a/LayoutTests/interaction-region/overlap-same-group.html
+++ b/LayoutTests/interaction-region/overlap-same-group.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    div {
+        position: absolute;
+        top: 0;
+        left: 50px;
+        width: 150px;
+        height: 100px;
+        background: rgba(255, 0, 0, 0.5);
+    }
+    div:last-child {
+        top: 25px;
+        left: 100px;
+        background: rgba(0, 0, 255, 0.5);
+    }
+</style>
+<body>
+<a href="#">
+    <div></div>
+    <div></div>
+</a>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -75,7 +75,7 @@ private:
     Vector<InteractionRegion> m_interactionRegions;
     HashSet<IntRect> m_interactionRects;
     HashSet<IntRect> m_occlusionRects;
-    HashMap<ElementIdentifier, IntRect> m_discoveredInteractionRectsByElement;
+    HashMap<ElementIdentifier, Region> m_discoveredRegionsByElement;
 #endif
 };
 


### PR DESCRIPTION
#### 9754b3656efb55b786edb512082216d48d3b2ee2
<pre>
InteractionRegions grouped together should not overlap
<a href="https://bugs.webkit.org/show_bug.cgi?id=254435">https://bugs.webkit.org/show_bug.cgi?id=254435</a>
&lt;rdar://107135607&gt;

Reviewed by Tim Horton.

De-duplicate overlapping rects for InteractionRegions that have the same
element identifier.

* Source/WebCore/rendering/EventRegion.h:
Store discovered `Region`s instead of `IntRect`s.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
(WebCore::EventRegionContext::shouldConsolidateInteractionRegion):
Keep track of the full united region per element.
Subtract the known region from the new InteractionRegion&apos;s
`regionInLayerCoordinates` to avoid overlap.

* LayoutTests/interaction-region/overlap-same-group-expected.txt: Copied from LayoutTests/interaction-region/wrapped-inline-link-expected.txt.
* LayoutTests/interaction-region/overlap-same-group.html: Added.
Add a new test covering the change.
* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
Update text expectation now that inline fragments don&apos;t overlap.

Canonical link: <a href="https://commits.webkit.org/262142@main">https://commits.webkit.org/262142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd61df9dd1a55d416d547a40d5a9508af0994749

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/876 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/917 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/686 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/707 "149 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1667 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/694 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/692 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/160 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/704 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->