### PR TITLE
Remove use of raw pointers in cachedResourceLoader class, IconLoader, ApplicationManifestLoader.

### DIFF
--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -53,7 +53,7 @@ ApplicationManifestLoader::~ApplicationManifestLoader()
 bool ApplicationManifestLoader::startLoading()
 {
     ASSERT(!m_resource);
-    auto* frame = m_documentLoader.frame();
+    auto* frame = m_documentLoader->frame();
     if (!frame)
         return false;
 
@@ -107,8 +107,8 @@ std::optional<ApplicationManifest>& ApplicationManifestLoader::processManifest()
 {
     if (!m_processedManifest && m_resource) {
         auto manifestURL = m_url;
-        auto documentURL = m_documentLoader.url();
-        auto frame = m_documentLoader.frame();
+        auto documentURL = m_documentLoader->url();
+        auto frame = m_documentLoader->frame();
         auto document = frame ? frame->document() : nullptr;
         m_processedManifest = m_resource->process(manifestURL, documentURL, document);
     }
@@ -118,7 +118,7 @@ std::optional<ApplicationManifest>& ApplicationManifestLoader::processManifest()
 void ApplicationManifestLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
 {
     ASSERT_UNUSED(resource, &resource == m_resource);
-    m_documentLoader.finishedLoadingApplicationManifest(*this);
+    m_documentLoader->finishedLoadingApplicationManifest(*this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/ApplicationManifestLoader.h
+++ b/Source/WebCore/loader/ApplicationManifestLoader.h
@@ -30,6 +30,7 @@
 #include "ApplicationManifest.h"
 #include "CachedRawResourceClient.h"
 #include "CachedResourceHandle.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/URL.h>
 
@@ -54,7 +55,7 @@ public:
 private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&);
 
-    DocumentLoader& m_documentLoader;
+    CheckedRef<DocumentLoader> m_documentLoader;
     std::optional<ApplicationManifest> m_processedManifest;
     URL m_url;
     bool m_useCredentials;

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1568,9 +1568,11 @@ CachePolicy CachedResourceLoader::cachePolicy(CachedResource::Type type, const U
     }
 }
 
+void CachedResourceLoader::clearDocumentLoader() { m_documentLoader = nullptr; }
+
 void CachedResourceLoader::loadDone(LoadCompletionType type, bool shouldPerformPostLoadActions)
 {
-    RefPtr<DocumentLoader> protectDocumentLoader(m_documentLoader);
+    RefPtr protectedDocumentLoader { m_documentLoader.get() };
     RefPtr<Document> protectDocument(m_document.get());
 
     ASSERT(shouldPerformPostLoadActions || type == LoadCompletionType::Cancel);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -33,6 +33,7 @@
 #include "KeepaliveRequestTracker.h"
 #include "ResourceTimingInformation.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Expected.h>
 #include <wtf/HashMap.h>
 #include <wtf/RobinHoodHashSet.h>
@@ -139,8 +140,7 @@ public:
     LocalFrame* frame() const; // Can be null
     Document* document() const { return m_document.get(); } // Can be null
     void setDocument(Document* document) { m_document = document; }
-    void clearDocumentLoader() { m_documentLoader = nullptr; }
-
+    void clearDocumentLoader(); 
     void loadDone(LoadCompletionType, bool shouldPerformPostLoadActions = true);
 
     WEBCORE_EXPORT void garbageCollectDocumentResources();
@@ -207,7 +207,7 @@ private:
     MemoryCompactRobinHoodHashSet<URL> m_cachedSVGImagesURLs;
     mutable DocumentResourceMap m_documentResources;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
-    DocumentLoader* m_documentLoader;
+    CheckedPtr<DocumentLoader>  m_documentLoader;
 
     int m_requestCount { 0 };
 

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -59,7 +59,7 @@ void IconLoader::startLoading()
     if (m_resource)
         return;
 
-    auto* frame = m_documentLoader.frame();
+    auto* frame = m_documentLoader->frame();
     if (!frame)
         return;
 
@@ -125,7 +125,7 @@ void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetri
 
     // DocumentLoader::finishedLoadingIcon destroys this IconLoader as it finishes. This will automatically
     // trigger IconLoader::stopLoading() during destruction, so we should just return here.
-    m_documentLoader.finishedLoadingIcon(*this, data);
+    m_documentLoader->finishedLoadingIcon(*this, data);
 }
 
 }

--- a/Source/WebCore/loader/icon/IconLoader.h
+++ b/Source/WebCore/loader/icon/IconLoader.h
@@ -27,6 +27,7 @@
 
 #include "CachedRawResourceClient.h"
 #include "CachedResourceHandle.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/URL.h>
@@ -49,7 +50,7 @@ public:
 private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
 
-    DocumentLoader& m_documentLoader;
+    CheckedRef<DocumentLoader> m_documentLoader;
     URL m_url;
     CachedResourceHandle<CachedRawResource> m_resource;
 };


### PR DESCRIPTION
#### ad9f1876e28f6497dfe297d81d3f396efef6b7dc
<pre>
Remove use of raw pointers in cachedResourceLoader class, IconLoader, ApplicationManifestLoader.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254437.">https://bugs.webkit.org/show_bug.cgi?id=254437.</a>
rdar://107196321.

Reviewed by Chris Dumez.

Changed m_documentLoader ivar to CheckedPtr/CheckedRef instead of raw pointer..

* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
(WebCore::CachedResourceLoader::clearDocumentLoader):
(WebCore::CachedResourceLoader::loadDone):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
(WebCore::CachedResourceLoader::clearDocumentLoader): Deleted.

Canonical link: <a href="https://commits.webkit.org/262238@main">https://commits.webkit.org/262238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54416fa4f960400d1eea92457f2ee103b60b62f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1401 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1054 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/887 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/870 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1928 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/862 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/241 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/924 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->