### PR TITLE
Default MotionMark runner should be able to specify subtests to run

### DIFF
--- a/PerformanceTests/MotionMark/resources/runner/motionmark.js
+++ b/PerformanceTests/MotionMark/resources/runner/motionmark.js
@@ -462,6 +462,28 @@ window.sectionsManager =
     }
 };
 
+window.suitesManager = {
+    constructSuitesFromTestList: function(testNames)
+    {
+        var suites = [];
+        for (const testName of testNames) {
+            var testRegExp = new RegExp(testName, "i");
+            for (const suite of Suites) {
+                var test;
+                for (const suiteTest of suite.tests) {
+                    if (Utilities.stripUnwantedCharactersForURL(suiteTest.name).match(testRegExp)) {
+                        test = new Suite(suite.name, [suiteTest]);
+                        break;
+                    }
+                }
+            }
+            if (test)
+                suites.push(test)
+        }
+        return suites
+    }
+};
+
 window.benchmarkController = {
     benchmarkDefaultParameters: {
         "test-interval": 30,
@@ -549,8 +571,19 @@ window.benchmarkController = {
 
     startBenchmark: function()
     {
-        var options = this.benchmarkDefaultParameters;
-        this._startBenchmark(Suites, options, "test-container");
+        var suites;
+        if (typeof(URLSearchParams) !== "undefined") {
+            const urlParameters = new URLSearchParams(window.location.search);
+            if (urlParameters.has('test-name')) {
+                customTestList = urlParameters.getAll("test-name");
+                var suites = suitesManager.constructSuitesFromTestList(customTestList);
+            }
+        }
+
+        if (!suites || suites.length === 0)
+            suites = Suites
+        var options = this.benchmarkDefaultParameters
+        this._startBenchmark(suites, options, "test-container");
     },
 
     showResults: function()
@@ -665,4 +698,3 @@ window.benchmarkController = {
 };
 
 window.addEventListener("load", function() { benchmarkController.initialize(); });
-


### PR DESCRIPTION
#### 167a3a52db0ea8810f260a1fdc301f35ffe92d9e
<pre>
Default MotionMark runner should be able to specify subtests to run
<a href="https://bugs.webkit.org/show_bug.cgi?id=254434">https://bugs.webkit.org/show_bug.cgi?id=254434</a>
rdar://107193496

Reviewed by NOBODY (OOPS!).

This patch adds a new URL parameter to the default MotionMark runner, `test-name`, that runs a given list of tests. This allows us to be able to run multiple subtests using the default options and iterations without using the debug runner.

Because the default runner only comes loaded with the MotionMark suite of tests, we can omit the `suite-name` parameter that the debug runner has.

Eventually, we&apos;d like to be able to add profiling/ARTrace support to MotionMark, and being able to measure individual subtests would be useful as measuring the whole test may be too long and costly.

* PerformanceTests/MotionMark/resources/runner/motionmark.js:
(window.suitesManager.constructSuitesFromTestList):
(this.clear):
(window.benchmarkController.startBenchmark):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/167a3a52db0ea8810f260a1fdc301f35ffe92d9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/642 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/482 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/722 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/560 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/529 "1 flakes 12 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/673 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/589 "3 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/511 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/563 "19 flakes 115 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/489 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/532 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/533 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/527 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/530 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->