### PR TITLE
Fix @counter-style CSSOM update

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4884,9 +4884,6 @@ imported/w3c/web-platform-tests/css/css-counter-styles/lower-armenian/css3-count
 imported/w3c/web-platform-tests/css/css-counter-styles/lower-roman/css3-counter-styles-020.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-counter-styles/upper-roman/css3-counter-styles-024.html [ Pass ImageOnlyFailure ]
 
-# Tests that fail because @counter-style is not implemented yet. Skipping directory until rdar://107184142 is implemented.
-imported/w3c/web-platform-tests/css/css-counter-styles/cssom [ Skip ]
-
 # More @counter-style failures due to not being implemented.
 imported/w3c/web-platform-tests/css/css-conditional/at-media-content-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-conditional/at-supports-content-004.html [ ImageOnlyFailure ]

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-static CSSCounterStyleDescriptors::Ranges translateRangeFromStyleProperties(const StyleProperties& properties)
+CSSCounterStyleDescriptors::Ranges translateRangeFromStyleProperties(const StyleProperties& properties)
 {
     auto ranges = properties.getPropertyCSSValue(CSSPropertyRange);
     if (!ranges)
@@ -69,7 +69,7 @@ static String symbolToString(const CSSValue* value)
     return primitiveValue.stringValue();
 }
 
-static CSSCounterStyleDescriptors::AdditiveSymbols translateAdditiveSymbolsFromStyleProperties(const StyleProperties& properties)
+CSSCounterStyleDescriptors::AdditiveSymbols translateAdditiveSymbolsFromStyleProperties(const StyleProperties& properties)
 {
     auto value = properties.getPropertyCSSValue(CSSPropertyAdditiveSymbols);
     if (!value)
@@ -85,7 +85,7 @@ static CSSCounterStyleDescriptors::AdditiveSymbols translateAdditiveSymbolsFromS
     return result;
 }
 
-static CSSCounterStyleDescriptors::Pad translatePadFromStyleProperties(const StyleProperties& properties)
+CSSCounterStyleDescriptors::Pad translatePadFromStyleProperties(const StyleProperties& properties)
 {
     auto value = properties.getPropertyCSSValue(CSSPropertyPad);
     if (!value)
@@ -98,7 +98,7 @@ static CSSCounterStyleDescriptors::Pad translatePadFromStyleProperties(const Sty
     return { static_cast<unsigned>(std::max(0, length)), symbolToString(&list[1]) };
 }
 
-static CSSCounterStyleDescriptors::NegativeSymbols translateNegativeSymbolsFromStyleProperties(const StyleProperties& properties)
+CSSCounterStyleDescriptors::NegativeSymbols translateNegativeSymbolsFromStyleProperties(const StyleProperties& properties)
 {
     auto negative = properties.getPropertyCSSValue(CSSPropertyNegative);
     if (!negative)
@@ -114,7 +114,7 @@ static CSSCounterStyleDescriptors::NegativeSymbols translateNegativeSymbolsFromS
     return result;
 }
 
-static Vector<CSSCounterStyleDescriptors::Symbol> translateSymbolsFromStyleProperties(const StyleProperties& properties)
+Vector<CSSCounterStyleDescriptors::Symbol> translateSymbolsFromStyleProperties(const StyleProperties& properties)
 {
     auto symbolsValues = properties.getPropertyCSSValue(CSSPropertySymbols);
     if (!symbolsValues)
@@ -129,7 +129,7 @@ static Vector<CSSCounterStyleDescriptors::Symbol> translateSymbolsFromStylePrope
     return result;
 }
 
-static CSSCounterStyleDescriptors::Name translateFallbackNameFromStyleProperties(const StyleProperties& properties)
+CSSCounterStyleDescriptors::Name translateFallbackNameFromStyleProperties(const StyleProperties& properties)
 {
     auto fallback = properties.getPropertyCSSValue(CSSPropertyFallback);
     if (!fallback)
@@ -137,7 +137,7 @@ static CSSCounterStyleDescriptors::Name translateFallbackNameFromStyleProperties
     return makeAtomString(symbolToString(fallback.get()));
 }
 
-static CSSCounterStyleDescriptors::Symbol translatePrefixFromStyleProperties(const StyleProperties& properties)
+CSSCounterStyleDescriptors::Symbol translatePrefixFromStyleProperties(const StyleProperties& properties)
 {
     auto prefix = properties.getPropertyCSSValue(CSSPropertyPrefix);
     if (!prefix)
@@ -145,7 +145,7 @@ static CSSCounterStyleDescriptors::Symbol translatePrefixFromStyleProperties(con
     return symbolToString(prefix.get());
 }
 
-static CSSCounterStyleDescriptors::Symbol translateSuffixFromStyleProperties(const StyleProperties& properties)
+CSSCounterStyleDescriptors::Symbol translateSuffixFromStyleProperties(const StyleProperties& properties)
 {
     auto suffix = properties.getPropertyCSSValue(CSSPropertySuffix);
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-suffix
@@ -155,7 +155,7 @@ static CSSCounterStyleDescriptors::Symbol translateSuffixFromStyleProperties(con
     return symbolToString(suffix.get());
 }
 
-static std::pair<CSSCounterStyleDescriptors::Name, int> extractDataFromSystemDescriptor(const StyleProperties& properties, CSSCounterStyleDescriptors::System system)
+std::pair<CSSCounterStyleDescriptors::Name, int> extractDataFromSystemDescriptor(const StyleProperties& properties, CSSCounterStyleDescriptors::System system)
 {
     auto systemValue = properties.getPropertyCSSValue(CSSPropertySystem);
     // If no value is provided after `fixed`, the first synbol value is implicitly 1 (https://www.w3.org/TR/css-counter-styles-3/#first-symbol-value).
@@ -254,4 +254,51 @@ bool CSSCounterStyleDescriptors::isValid() const
     return areSymbolsValidForSystem();
 }
 
+void CSSCounterStyleDescriptors::setNegative(CSSCounterStyleDescriptors::NegativeSymbols negative)
+{
+    m_negativeSymbols = WTFMove(negative);
+    m_explicitlySetDescriptors.set(ExplicitlySetDescriptors::Negative, true);
+}
+
+void CSSCounterStyleDescriptors::setPrefix(CSSCounterStyleDescriptors::Symbol prefix)
+{
+    m_prefix = WTFMove(prefix);
+    m_explicitlySetDescriptors.set(ExplicitlySetDescriptors::Prefix, true);
+}
+
+void CSSCounterStyleDescriptors::setSuffix(CSSCounterStyleDescriptors::Symbol suffix)
+{
+    m_suffix = WTFMove(suffix);
+    m_explicitlySetDescriptors.set(ExplicitlySetDescriptors::Suffix, true);
+}
+
+void CSSCounterStyleDescriptors::setRanges(CSSCounterStyleDescriptors::Ranges ranges)
+{
+    m_ranges = WTFMove(ranges);
+    m_explicitlySetDescriptors.set(ExplicitlySetDescriptors::Range, true);
+}
+
+void CSSCounterStyleDescriptors::setPad(CSSCounterStyleDescriptors::Pad pad)
+{
+    m_pad = WTFMove(pad);
+    m_explicitlySetDescriptors.set(ExplicitlySetDescriptors::Pad, true);
+}
+
+void CSSCounterStyleDescriptors::setFallbackName(CSSCounterStyleDescriptors::Name name)
+{
+    m_fallbackName = WTFMove(name);
+    m_explicitlySetDescriptors.set(ExplicitlySetDescriptors::Fallback, true);
+}
+
+void CSSCounterStyleDescriptors::setSymbols(Vector<CSSCounterStyleDescriptors::Symbol> symbols)
+{
+    m_symbols = WTFMove(symbols);
+    m_explicitlySetDescriptors.set(ExplicitlySetDescriptors::Symbols, true);
+}
+
+void CSSCounterStyleDescriptors::setAdditiveSymbols(CSSCounterStyleDescriptors::AdditiveSymbols additiveSymbols)
+{
+    m_additiveSymbols = WTFMove(additiveSymbols);
+    m_explicitlySetDescriptors.set(ExplicitlySetDescriptors::AdditiveSymbols, true);
+}
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -106,6 +106,17 @@ struct CSSCounterStyleDescriptors {
     bool isValid() const;
     bool areSymbolsValidForSystem() const;
 
+    void setName(Name name) { m_name = WTFMove(name); }
+    void setSystem(System);
+    void setNegative(NegativeSymbols);
+    void setPrefix(Symbol);
+    void setSuffix(Symbol);
+    void setRanges(Ranges);
+    void setPad(Pad);
+    void setFallbackName(Name);
+    void setSymbols(Vector<Symbol>);
+    void setAdditiveSymbols(AdditiveSymbols);
+
     Name m_name;
     System m_system;
     NegativeSymbols m_negativeSymbols;
@@ -122,4 +133,13 @@ struct CSSCounterStyleDescriptors {
     OptionSet<ExplicitlySetDescriptors> m_explicitlySetDescriptors;
 };
 
+CSSCounterStyleDescriptors::Ranges translateRangeFromStyleProperties(const StyleProperties&);
+CSSCounterStyleDescriptors::AdditiveSymbols translateAdditiveSymbolsFromStyleProperties(const StyleProperties&);
+CSSCounterStyleDescriptors::Pad translatePadFromStyleProperties(const StyleProperties&);
+CSSCounterStyleDescriptors::NegativeSymbols translateNegativeSymbolsFromStyleProperties(const StyleProperties&);
+Vector<CSSCounterStyleDescriptors::Symbol> translateSymbolsFromStyleProperties(const StyleProperties&);
+CSSCounterStyleDescriptors::Name translateFallbackNameFromStyleProperties(const StyleProperties&);
+CSSCounterStyleDescriptors::Symbol translatePrefixFromStyleProperties(const StyleProperties&);
+CSSCounterStyleDescriptors::Symbol translateSuffixFromStyleProperties(const StyleProperties&);
+std::pair<CSSCounterStyleDescriptors::Name, int> extractDataFromSystemDescriptor(const StyleProperties&, CSSCounterStyleDescriptors::System);
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -49,7 +49,7 @@ void CSSCounterStyleRegistry::resolveUserAgentReferences()
 }
 void CSSCounterStyleRegistry::resolveReferencesIfNeeded()
 {
-    if (!hasUnresolvedReferences)
+    if (!m_hasUnresolvedReferences)
         return;
 
     for (auto& [name, counter] : m_authorCounterStyles) {
@@ -58,7 +58,7 @@ void CSSCounterStyleRegistry::resolveReferencesIfNeeded()
         if (counter->isExtendsSystem() && counter->isExtendsUnresolved())
             resolveExtendsReference(*counter, &m_authorCounterStyles);
     }
-    hasUnresolvedReferences = false;
+    m_hasUnresolvedReferences = false;
 }
 
 void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counterStyle, CounterStyleMap* map)
@@ -107,7 +107,7 @@ void CSSCounterStyleRegistry::resolveFallbackReference(CSSCounterStyle& counter,
 
 void CSSCounterStyleRegistry::addCounterStyle(const CSSCounterStyleDescriptors& descriptors)
 {
-    hasUnresolvedReferences = true;
+    m_hasUnresolvedReferences = true;
     m_authorCounterStyles.set(descriptors.m_name, CSSCounterStyle::create(descriptors, false));
 }
 
@@ -227,6 +227,19 @@ bool isCounterStyleUnsupportedByUserAgent(CSSValueID valueID)
     default:
         return false;
     }
+}
+
+void CSSCounterStyleRegistry::clearAuthorCounterStyles()
+{
+    if (m_authorCounterStyles.isEmpty())
+        return;
+    m_authorCounterStyles.clear();
+    invalidate();
+}
+
+void CSSCounterStyleRegistry::invalidate()
+{
+    m_hasUnresolvedReferences = true;
 }
 
 }

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -41,6 +41,7 @@ using CounterStyleMap = HashMap<AtomString, RefPtr<CSSCounterStyle>>;
 class CSSCounterStyleRegistry {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    CSSCounterStyleRegistry() = default;
     RefPtr<CSSCounterStyle> resolvedCounterStyle(const ListStyleType&);
     static RefPtr<CSSCounterStyle> decimalCounter();
     static void addUserAgentCounterStyle(const CSSCounterStyleDescriptors&);
@@ -48,7 +49,7 @@ public:
     static void resolveUserAgentReferences();
     void resolveReferencesIfNeeded();
     bool operator==(const CSSCounterStyleRegistry& other) const;
-    CSSCounterStyleRegistry() = default;
+    void clearAuthorCounterStyles();
 
 private:
     static CounterStyleMap& userAgentCounterStyles();
@@ -57,9 +58,10 @@ private:
     static void resolveExtendsReference(CSSCounterStyle&, CounterStyleMap* = nullptr);
     static void resolveExtendsReference(CSSCounterStyle&, HashSet<CSSCounterStyle*>&, CounterStyleMap* = nullptr);
     static RefPtr<CSSCounterStyle> counterStyle(const AtomString&, CounterStyleMap* = nullptr);
+    void invalidate();
 
     CounterStyleMap m_authorCounterStyles;
-    bool hasUnresolvedReferences { true };
+    bool m_hasUnresolvedReferences { true };
 };
 
 bool isCounterStyleUnsupportedByUserAgent(CSSValueID);

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -41,6 +41,7 @@ public:
 
     const StyleProperties& properties() const { return m_properties; }
     const CSSCounterStyleDescriptors& descriptors() const { return m_descriptors; };
+    CSSCounterStyleDescriptors& mutableDescriptors() { return m_descriptors; };
     RefPtr<CSSValue> getPropertyCSSValue(CSSPropertyID id) const { return m_properties->getPropertyCSSValue(id); }
     MutableStyleProperties& mutableProperties();
 
@@ -63,6 +64,7 @@ private:
     explicit StyleRuleCounterStyle(const AtomString&, Ref<StyleProperties>&&, CSSCounterStyleDescriptors&&);
 
     AtomString m_name;
+    // FIXME: we can get rid of m_properties and use only m_descriptors for storing the descriptors data (rdar://107267784).
     Ref<StyleProperties> m_properties;
     CSSCounterStyleDescriptors m_descriptors;
 };
@@ -103,7 +105,7 @@ public:
 private:
     CSSCounterStyleRule(StyleRuleCounterStyle&, CSSStyleSheet* parent);
 
-    void setterInternal(CSSPropertyID, const String&);
+    bool setterInternal(CSSPropertyID, const String&);
 
     Ref<StyleRuleCounterStyle> m_counterStyleRule;
 };

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -411,8 +411,6 @@ void RuleSetBuilder::addMutatingRulesToResolver()
                 continue;
             auto& registry = m_resolver->document().styleScope().counterStyleRegistry();
             registry.addCounterStyle(downcast<StyleRuleCounterStyle>(rule.get()).descriptors());
-            // FIXME: we probably need a cache solultion like fontSelector (invalidateMatchedDeclarations)
-            // KeyFrame does it differently, search for keyframesRuleDidChange. (rdar://103018993)
             continue;
         }
         if (is<StyleRuleProperty>(rule)) {

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -165,6 +165,7 @@ void Scope::clearResolver()
 {
     m_resolver = nullptr;
     customPropertyRegistry().clearRegisteredFromStylesheets();
+    counterStyleRegistry().clearAuthorCounterStyles();
 }
 
 void Scope::releaseMemory()
@@ -602,6 +603,7 @@ void Scope::updateResolver(Vector<RefPtr<CSSStyleSheet>>& activeStyleSheets, Res
 
     if (updateType == ResolverUpdateType::Reset) {
         customPropertyRegistry().clearRegisteredFromStylesheets();
+        counterStyleRegistry().clearAuthorCounterStyles();
         m_resolver->ruleSets().resetAuthorStyle();
         m_resolver->appendAuthorStyleSheets(activeStyleSheets);
         return;


### PR DESCRIPTION
#### 3fa329db6badd1d45b3c3769182fa41059aded67
<pre>
Fix @counter-style CSSOM update
<a href="https://bugs.webkit.org/show_bug.cgi?id=254411">https://bugs.webkit.org/show_bug.cgi?id=254411</a>
rdar://107184142

Reviewed by Antti Koivisto.

We were not updating the CounterStyles descriptors when
the related CSSOM descriptor was updated.

Now, we define setters for each descriptor of CSSCounterStyleDescriptors.
The setters at CSSCounterStyleRule still use setterInternal()
to set the associated property at StyleProperties. The function
setterInternal() was modified to return true if it did set a new value.

The function newValueInvalidOrEqual() had a small bug in which
it would return symbolsValidForSystem(...). The right thing to do is
return !symbolsValidForSystem(...), since it should true for a invalid
value.

Each setter at CSSCounterStyleRule now returns early if setterInternal()
didn&apos;t set a value. If it did set a value we proceed to set the associated
descriptor stored at the rule with the newly created setters.

Ideally, storing only the descriptors
would be enough and we could stop storing StyleProperties. This would
require definining a serializer for each descriptor and modifying the
the CSSCounterStyleRule setters to set the descriptor directly,
without modifying the property first. This improvement should come in
a separated PR and it was was reported at
<a href="https://bugs.webkit.org/show_bug.cgi?id=254524">https://bugs.webkit.org/show_bug.cgi?id=254524</a>
which is tracked by rdar://107267784.

Minor change:
We are also renaming hasUnresolvedReferences to m_hasUnresolvedReferences,
for following webkit&apos;s style.

* LayoutTests/TestExpectations:
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::translateRangeFromStyleProperties):
(WebCore::translateAdditiveSymbolsFromStyleProperties):
(WebCore::translatePadFromStyleProperties):
(WebCore::translateNegativeSymbolsFromStyleProperties):
(WebCore::translateSymbolsFromStyleProperties):
(WebCore::translateFallbackNameFromStyleProperties):
(WebCore::translatePrefixFromStyleProperties):
(WebCore::translateSuffixFromStyleProperties):
(WebCore::extractDataFromSystemDescriptor):
(WebCore::CSSCounterStyleDescriptors::setNegative):
(WebCore::CSSCounterStyleDescriptors::setPrefix):
(WebCore::CSSCounterStyleDescriptors::setSuffix):
(WebCore::CSSCounterStyleDescriptors::setRanges):
(WebCore::CSSCounterStyleDescriptors::setPad):
(WebCore::CSSCounterStyleDescriptors::setFallbackName):
(WebCore::CSSCounterStyleDescriptors::setSymbols):
(WebCore::CSSCounterStyleDescriptors::setAdditiveSymbols):
* Source/WebCore/css/CSSCounterStyleDescriptors.h:
(WebCore::CSSCounterStyleDescriptors::setName):
* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
(WebCore::CSSCounterStyleRegistry::resolveReferencesIfNeeded):
(WebCore::CSSCounterStyleRegistry::addCounterStyle):
(WebCore::CSSCounterStyleRegistry::clearAuthorCounterStyles):
(WebCore::CSSCounterStyleRegistry::invalidate):
* Source/WebCore/css/CSSCounterStyleRegistry.h:
* Source/WebCore/css/CSSCounterStyleRule.cpp:
(WebCore::StyleRuleCounterStyle::newValueInvalidOrEqual const):
(WebCore::CSSCounterStyleRule::setName):
(WebCore::CSSCounterStyleRule::setterInternal):
(WebCore::CSSCounterStyleRule::setSystem):
(WebCore::CSSCounterStyleRule::setNegative):
(WebCore::CSSCounterStyleRule::setPrefix):
(WebCore::CSSCounterStyleRule::setSuffix):
(WebCore::CSSCounterStyleRule::setRange):
(WebCore::CSSCounterStyleRule::setPad):
(WebCore::CSSCounterStyleRule::setFallback):
(WebCore::CSSCounterStyleRule::setSymbols):
(WebCore::CSSCounterStyleRule::setAdditiveSymbols):
* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addMutatingRulesToResolver):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::clearResolver):
(WebCore::Style::Scope::updateResolver):

Canonical link: <a href="https://commits.webkit.org/262203@main">https://commits.webkit.org/262203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3265578152258a38e13b69c7078acf40df6a7819

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/924 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/752 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1015 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/754 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/714 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1769 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/751 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/745 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/210 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/762 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->