### PR TITLE
REGRESSION (262041@main): Keyboard scrolling animates from (0, 0) when smooth keyboard scrolling is disabled and UI-side compositing is enabled

### DIFF
--- a/LayoutTests/fast/scrolling/programmatic-smooth-scroll-from-nonzero-offset-expected.txt
+++ b/LayoutTests/fast/scrolling/programmatic-smooth-scroll-from-nonzero-offset-expected.txt
@@ -1,0 +1,6 @@
+PASS observedScrollLeftBelow1000 is false
+PASS scrollContainer.scrollLeft is 2000
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/programmatic-smooth-scroll-from-nonzero-offset.html
+++ b/LayoutTests/fast/scrolling/programmatic-smooth-scroll-from-nonzero-offset.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroll-container {
+            height: 250px;
+            width: 300px;
+            border: 1px solid black;
+            overflow-y: scroll;
+        }
+
+        .contents {
+            height: 100%;
+            width: 4000px;
+            background-image: repeating-linear-gradient(to right, white, silver 250px);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        observedScrollLeftBelow1000 = false;
+
+        addEventListener("load", async () => {
+            scrollContainer = document.querySelector(".scroll-container");
+            scrollContainer.scrollTo(1000, 0);
+            await UIHelper.ensurePresentationUpdate();
+
+            scrollContainer.addEventListener("scroll", () => {
+                if (scrollContainer.scrollLeft < 1000)
+                    observedScrollLeftBelow1000 = true;
+            });
+
+            await UIHelper.startMonitoringWheelEvents();
+            scrollContainer.scrollBy({ top: 0, left: 1000, behavior: "smooth" });
+            await UIHelper.waitForScrollCompletion();
+
+            shouldBeFalse("observedScrollLeftBelow1000");
+            shouldBe("scrollContainer.scrollLeft", "2000");
+            finishJSTest();
+        });
+    </script>
+</head>
+<body>
+    <div class="scroll-container">
+        <div class="contents"></div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -891,6 +891,7 @@ imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-
 webkit.org/b/212202 fast/events/wheel/platform-wheelevent-in-scrolling-div.html [ Skip ]
 webkit.org/b/212202 fast/events/wheel/redispatched-wheel-event.html [ Skip ]
 webkit.org/b/212202 fast/scrolling/programmatic-smooth-scroll-after-focus.html [ Skip ]
+webkit.org/b/212202 fast/scrolling/programmatic-smooth-scroll-from-nonzero-offset.html [ Skip ]
 
 webkit.org/b/218931 fast/events/wheel/first-wheel-event-cancelable.html [ Timeout ]
 webkit.org/b/218931 fast/events/wheel/wheel-event-listeners-on-body-made-passive.html [ Timeout ]

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -30,7 +30,11 @@ namespace WebCore {
 
 void RequestedScrollData::merge(RequestedScrollData&& other)
 {
-    if (requestType == other.requestType && other.animated == ScrollIsAnimated::Yes) {
+    if (other.requestType == ScrollRequestType::CancelAnimatedScroll && animated == ScrollIsAnimated::No) {
+        // Carry over the previously requested scroll position so that we can set `requestedDataBeforeAnimatedScroll`
+        // below in the case where the cancelled animated scroll is immediately followed by another animated scroll.
+        other.scrollPosition = scrollPosition;
+    } else if (other.requestType == ScrollRequestType::PositionUpdate && other.animated == ScrollIsAnimated::Yes) {
         switch (animated) {
         case ScrollIsAnimated::No:
             other.requestedDataBeforeAnimatedScroll = { scrollPosition, scrollType, clamping };

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -207,10 +207,10 @@ void ScrollingStateScrollingNode::setKeyboardScrollData(const RequestedKeyboardS
     setPropertyChanged(Property::KeyboardScrollData);
 }
 
-void ScrollingStateScrollingNode::setRequestedScrollData(RequestedScrollData&& scrollData)
+void ScrollingStateScrollingNode::setRequestedScrollData(RequestedScrollData&& scrollData, CanMergeScrollData canMergeScrollData)
 {
     // Scroll position requests are imperative, not stateful, so we can't early return here.
-    if (hasChangedProperty(Property::RequestedScrollPosition)) {
+    if (hasChangedProperty(Property::RequestedScrollPosition) && canMergeScrollData == CanMergeScrollData::Yes) {
         m_requestedScrollData.merge(WTFMove(scrollData));
         return;
     }

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -79,7 +79,9 @@ public:
     WEBCORE_EXPORT void setKeyboardScrollData(const RequestedKeyboardScrollData&);
 
     const RequestedScrollData& requestedScrollData() const { return m_requestedScrollData; }
-    WEBCORE_EXPORT void setRequestedScrollData(RequestedScrollData&&);
+
+    enum class CanMergeScrollData : bool { No, Yes };
+    WEBCORE_EXPORT void setRequestedScrollData(RequestedScrollData&&, CanMergeScrollData = CanMergeScrollData::Yes);
 
     WEBCORE_EXPORT bool hasScrollPositionRequest() const;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -249,8 +249,14 @@ bool ArgumentCoder<ScrollingStateScrollingNode>::decode(Decoder& decoder, Scroll
 #endif
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::IsMonitoringWheelEvents, bool, setIsMonitoringWheelEvents);
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::ScrollableAreaParams, ScrollableAreaParameters, setScrollableAreaParameters);
-    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::RequestedScrollPosition, RequestedScrollData, setRequestedScrollData);
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::KeyboardScrollData, RequestedKeyboardScrollData, setKeyboardScrollData);
+
+    if (node.hasChangedProperty(ScrollingStateNode::Property::RequestedScrollPosition)) {
+        RequestedScrollData requestedScrollData;
+        if (!decoder.decode(requestedScrollData))
+            return false;
+        node.setRequestedScrollData(WTFMove(requestedScrollData), ScrollingStateScrollingNode::CanMergeScrollData::No);
+    }
 
     if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
         std::optional<PlatformLayerIdentifier> layerID;


### PR DESCRIPTION
#### e94fbc9c6f2ad75e234c67d3642c0756c19679c8
<pre>
REGRESSION (262041@main): Keyboard scrolling animates from (0, 0) when smooth keyboard scrolling is disabled and UI-side compositing is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=254428">https://bugs.webkit.org/show_bug.cgi?id=254428</a>

Reviewed by Tim Horton.

My previous patch in 262041@main had a serious flaw — when decoding `ScrollingStateScrollingNode`,
we&apos;ll decode a `RequestedScrollData` and use `ScrollingStateScrollingNode::setRequestedScrollData`
to set the decoded data on the scrolling node. However, since:

- `setRequestedScrollData()` contains the request merging logic I added in 262041@main, and...
- We decode the changed property flags before calling `setRequestedScrollData`.

...we end up treating all animated scrolling as starting from the origin. This patch fixes that by
keeping the merging logic in the web process, by passing in a `CanMergeScrollData::No` flag when
deserializing the scrolling state node.

Test: fast/scrolling/programmatic-smooth-scroll-from-nonzero-offset.html

* LayoutTests/fast/scrolling/programmatic-smooth-scroll-from-nonzero-offset-expected.txt: Added.
* LayoutTests/fast/scrolling/programmatic-smooth-scroll-from-nonzero-offset.html: Added.

Add a new layout test to exercise the bug, by scrolling (without animation) to a nonzero offset and
then performing an animated scroll from that offset, verifying that we don&apos;t attempt to start from
(0, 0) when performing the animated scroll.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::RequestedScrollData::merge):

After fixing the above issue, I also discovered that with UI-side compositing enabled, the original
tests in `imported/w3c/web-platform-tests/css/cssom-view` that I tried to fix started failing again;
this is because of another subtle corner case that wasn&apos;t covered in when merging `RequestedScrollData`,
wherein the following sequence of programmatic scroll requests:

1. ScrollRequestType::PositionUpdate (Non-Animated)
2. ScrollRequestType::CancelAnimatedScroll
3. ScrollRequestType::PositionUpdate (Animated)

...caused us to stomp over the `requestedDataBeforeAnimatedScroll` in step (2), when merging the
animated scroll cancellation request into the position update. To address this and keep the WPT
passing with UI-side compositing enabled, I&apos;ve adjusted the merging logic to preserve `scrollPosition`
after step (2), so that we can stash it in the `requestedDataBeforeAnimatedScroll` in step (3).

* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::setRequestedScrollData):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(ArgumentCoder&lt;ScrollingStateScrollingNode&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/262105@main">https://commits.webkit.org/262105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/840546f3e1e387746ae5794825ec0688cf5d679e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/675 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/492 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/668 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/736 "3 flakes 110 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/676 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/567 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/499 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/548 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/543 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/542 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->