### PR TITLE
fast/scrolling/mac/keyboard-scrolling-terminates.html doesn't verify that scrolling terminates after 258483@main

### DIFF
--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-terminates.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-terminates.html
@@ -1,30 +1,24 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
-
 <html>
-
 <head>
     <script src="../../../resources/ui-helper.js"></script>
     <script src="../../../resources/js-test.js"></script>
     <meta name="viewport" content="initial-scale=1.5, user-scalable=no">
     <script>
-        if (window.testRunner) {
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
-        }
-        
+        jsTestIsAsync = true;
+
         async function runTest()
         {
             if (window.eventSender) {
                 await UIHelper.startMonitoringWheelEvents();
                 eventSender.keyDown("downArrow");
 
-                UIHelper.waitForScrollCompletion();
-                testRunner.notifyDone();
+                await UIHelper.waitForScrollCompletion();
+                finishJSTest();
             }
         }
     </script>
 </head>
-
 <body onload="runTest()">
     <div style="height: 5000px;">
     </div>


### PR DESCRIPTION
#### 3f51f0bc4ecb5f4c47e5da90f817c51ed542438a
<pre>
fast/scrolling/mac/keyboard-scrolling-terminates.html doesn&apos;t verify that scrolling terminates after 258483@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=254444">https://bugs.webkit.org/show_bug.cgi?id=254444</a>

Reviewed by Simon Fraser.

Add a missing `await`, to ensure that the test actually waits for scrolling to finish after pressing
the down arrow key.

* LayoutTests/fast/scrolling/mac/keyboard-scrolling-terminates.html:

Canonical link: <a href="https://commits.webkit.org/262108@main">https://commits.webkit.org/262108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6287a3e5dac65e52cbfb3e77283d0bd38c370081

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/679 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/494 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/737 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/681 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/529 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/571 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/501 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/549 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/535 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/544 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/139 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/544 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->