### PR TITLE
Web Inspector: (Regression: 254636@main) Mini console always opens when choosing "Inspect Element", even if it was previously closed

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
@@ -138,7 +138,7 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
 
         function saveResultCallback(savedResultIndex)
         {
-            let commandResultMessage = new WI.ConsoleCommandResultMessage(result.target, result, false, savedResultIndex, shouldRevealConsole);
+            let commandResultMessage = new WI.ConsoleCommandResultMessage(result.target, result, false, savedResultIndex, { shouldRevealConsole });
             let commandResultMessageView = new WI.ConsoleMessageView(commandResultMessage);
             this._appendConsoleMessageView(commandResultMessageView, true);
         }
@@ -242,8 +242,7 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
             if (!result || this._cleared)
                 return;
 
-            let shouldRevealConsole = true;
-            let commandResultMessage = new WI.ConsoleCommandResultMessage(result.target, result, wasThrown, savedResultIndex, shouldRevealConsole);
+            let commandResultMessage = new WI.ConsoleCommandResultMessage(result.target, result, wasThrown, savedResultIndex, { shouldRevealConsole: true });
             let commandResultMessageView = new WI.ConsoleMessageView(commandResultMessage);
             this._appendConsoleMessageView(commandResultMessageView, true);
         }

--- a/Source/WebInspectorUI/UserInterface/Models/ConsoleCommandResultMessage.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ConsoleCommandResultMessage.js
@@ -29,7 +29,7 @@
 
 WI.ConsoleCommandResultMessage = class ConsoleCommandResult extends WI.ConsoleMessage
 {
-    constructor(target, result, wasThrown, savedResultIndex, shouldRevealConsole = true)
+    constructor(target, result, wasThrown, savedResultIndex, { shouldRevealConsole } ={})
     {
         let source = WI.ConsoleMessage.MessageSource.JS;
         let level = wasThrown ? WI.ConsoleMessage.MessageLevel.Error : WI.ConsoleMessage.MessageLevel.Log;
@@ -38,7 +38,7 @@ WI.ConsoleCommandResultMessage = class ConsoleCommandResult extends WI.ConsoleMe
         super(target, source, level, "", type, undefined, undefined, undefined, 0, [result], undefined, undefined);
 
         this._savedResultIndex = savedResultIndex;
-        this._shouldRevealConsole = shouldRevealConsole;
+        this._shouldRevealConsole = !!shouldRevealConsole;
 
         if (this._savedResultIndex && this._savedResultIndex > WI.ConsoleCommandResultMessage.maximumSavedResultIndex)
             WI.ConsoleCommandResultMessage.maximumSavedResultIndex = this._savedResultIndex;

--- a/Source/WebInspectorUI/UserInterface/Views/AnimationContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/AnimationContentView.js
@@ -397,7 +397,7 @@ WI.AnimationContentView = class AnimationContentView extends WI.ContentView
                     return;
 
                 const text = WI.UIString("Selected Animation", "Appears as a label when a given web animation is logged to the Console");
-                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true});
+                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true, shouldRevealConsole: true});
             });
         });
 

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js
@@ -308,7 +308,7 @@ WI.CanvasContentView = class CanvasContentView extends WI.ContentView
                     return;
 
                 const text = WI.UIString("Selected Canvas Context");
-                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true});
+                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true, shouldRevealConsole: true});
             });
         });
 

--- a/Source/WebInspectorUI/UserInterface/Views/CanvasTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasTreeElement.js
@@ -93,7 +93,7 @@ WI.CanvasTreeElement = class CanvasTreeElement extends WI.FolderizedTreeElement
                     return;
 
                 const text = WI.UIString("Selected Canvas Context");
-                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true});
+                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true, shouldRevealConsole: true});
             });
         });
 

--- a/Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js
@@ -363,7 +363,7 @@ WI.appendContextMenuItemsForDOMNode = function(contextMenu, domNode, options = {
             contextMenu.appendItem(label, () => {
                 WI.RemoteObject.resolveNode(domNode, WI.RuntimeManager.ConsoleObjectGroup).then((remoteObject) => {
                     let text = isElement ? WI.UIString("Selected Element", "Selected DOM element") : WI.UIString("Selected Node", "Selected DOM node");
-                    WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true});
+                    WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true, shouldRevealConsole: true});
                 });
             });
         }

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js
@@ -295,7 +295,7 @@ WI.ObjectPreviewView = class ObjectPreviewView extends WI.Object
             if (!isImpossible)
                 WI.quickConsole.prompt.pushHistoryItem(text);
 
-            WI.consoleLogViewController.appendImmediateExecutionWithResult(text, this._remoteObject, {addSpecialUserLogClass: isImpossible});
+            WI.consoleLogViewController.appendImmediateExecutionWithResult(text, this._remoteObject, {addSpecialUserLogClass: isImpossible, shouldRevealConsole: true});
         });
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreeBaseTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreeBaseTreeElement.js
@@ -196,7 +196,7 @@ WI.ObjectTreeBaseTreeElement = class ObjectTreeBaseTreeElement extends WI.Genera
             return;
 
         var text = WI.UIString("Selected Symbol");
-        WI.consoleLogViewController.appendImmediateExecutionWithResult(text, symbol, {addSpecialUserLogClass: true});
+        WI.consoleLogViewController.appendImmediateExecutionWithResult(text, symbol, {addSpecialUserLogClass: true, shouldRevealConsole: true});
     }
 
     _logValue(value)
@@ -212,7 +212,7 @@ WI.ObjectTreeBaseTreeElement = class ObjectTreeBaseTreeElement extends WI.Genera
         if (!isImpossible)
             WI.quickConsole.prompt.pushHistoryItem(text);
 
-        WI.consoleLogViewController.appendImmediateExecutionWithResult(text, resolvedValue, {addSpecialUserLogClass: isImpossible});
+        WI.consoleLogViewController.appendImmediateExecutionWithResult(text, resolvedValue, {addSpecialUserLogClass: isImpossible, shouldRevealConsole: true});
     }
 
     _appendMenusItemsForObject(contextMenu, resolvedValue)

--- a/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
+++ b/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
@@ -336,7 +336,7 @@ WI.QuickConsole = class QuickConsole extends WI.View
             WI.RemoteObject.resolveNode(domNode, WI.RuntimeManager.ConsoleObjectGroup)
             .then((remoteObject) => {
                 let text = domNode.nodeType() === Node.ELEMENT_NODE ? WI.UIString("Dropped Element") : WI.UIString("Dropped Node");
-                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true});
+                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true, shouldRevealConsole: true});
 
                 this.prompt.focus();
             });

--- a/Source/WebInspectorUI/UserInterface/Views/WebSocketResourceTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/WebSocketResourceTreeElement.js
@@ -51,7 +51,7 @@ WI.WebSocketResourceTreeElement = class WebSocketResourceTreeElement extends WI.
                     return;
 
                 const text = WI.UIString("Selected WebSocket");
-                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true});
+                WI.consoleLogViewController.appendImmediateExecutionWithResult(text, remoteObject, {addSpecialUserLogClass: true, shouldRevealConsole: true});
             });
         });
 


### PR DESCRIPTION
#### ed99b93877dd9c47942db5a0f56a82acc4adeebd
<pre>
Web Inspector: (Regression: 254636@main) Mini console always opens when choosing &quot;Inspect Element&quot;, even if it was previously closed
<a href="https://bugs.webkit.org/show_bug.cgi?id=253273">https://bugs.webkit.org/show_bug.cgi?id=253273</a>
rdar://106260652

Reviewed by Devin Rousso.

When console snippets were introduced, the function signature of `appendImmediateExecutionWithResult` was updated so
that optional values were part of an options object. However, in changing that it appears it was assumed that the
default would be flipped to `false`, but that never happened. The parameter was no longer being provided by DOMManger
when inspecting an element, and therefor we fell back to the default of showing the quick console.

To fix this, we correct the `shouldRevealConsole` to be `false` by default, matching other option objects, and then
clean up other places where we were assuming it would still be true (mostly anywhere that a &quot;Log [thing]&quot; option was
present).

* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js:
(WI.JavaScriptLogViewController.prototype.appendImmediateExecutionWithResult.saveResultCallback):
(WI.JavaScriptLogViewController.prototype.appendImmediateExecutionWithResult):
- Use the new options object of the ConsoleCommandResultMessage constructor.

* Source/WebInspectorUI/UserInterface/Models/ConsoleCommandResultMessage.js:
- Make `shouldRevealConsole` part of an options object, and make it default to false instead.

* Source/WebInspectorUI/UserInterface/Views/AnimationContentView.js:
(WI.AnimationContentView.prototype._populateAnimationTargetButtonContextMenu):
(WI.AnimationContentView):
* Source/WebInspectorUI/UserInterface/Views/CanvasContentView.js:
(WI.CanvasContentView.prototype._populateCanvasElementButtonContextMenu):
* Source/WebInspectorUI/UserInterface/Views/CanvasTreeElement.js:
(WI.CanvasTreeElement.prototype.populateContextMenu):
* Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js:
* Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js:
(WI.ObjectPreviewView.prototype._contextMenuHandler):
(WI.ObjectPreviewView):
* Source/WebInspectorUI/UserInterface/Views/ObjectTreeBaseTreeElement.js:
(WI.ObjectTreeBaseTreeElement.prototype._logSymbolProperty):
(WI.ObjectTreeBaseTreeElement.prototype._logValue):
* Source/WebInspectorUI/UserInterface/Views/QuickConsole.js:
(WI.QuickConsole.prototype._handleDrop):
* Source/WebInspectorUI/UserInterface/Views/WebSocketResourceTreeElement.js:
(WI.WebSocketResourceTreeElement.prototype.populateContextMenu):

Canonical link: <a href="https://commits.webkit.org/262106@main">https://commits.webkit.org/262106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c527a774b4689d6b0032b86a96e08275195c7d18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/686 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/740 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/685 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/574 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/506 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/565 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/540 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/492 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/549 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/136 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/549 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->