### PR TITLE
REGRESSION: Top bar is jumpy and glitchy on scmp.com

### DIFF
--- a/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed-expected.txt
+++ b/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed-expected.txt
@@ -1,0 +1,39 @@
+Fixed inside scroller
+
+(Frame scrolling node
+  (scrollable area size 800 600)
+  (contents size 800 5021)
+  (scrollable area parameters
+    (horizontal scroll elasticity 1)
+    (vertical scroll elasticity 1)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0))
+  (layout viewport at (0,0) size 800x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,4421))
+  (behavior for fixed 1)
+  (children 1
+    (Overflow scrolling node
+      (scroll position 0 50)
+      (scrollable area size 440 440)
+      (contents size 440 2040)
+      (requested scroll position 0 50)
+      (requested scroll position represents programmatic scroll 1)
+      (scrollable area parameters
+        (horizontal scroll elasticity 1)
+        (vertical scroll elasticity 1)
+        (horizontal scrollbar mode 0)
+        (vertical scrollbar mode 0)
+        (allows vertical scrolling 1))
+      (children 1
+        (Positioned node
+          (layout constraints
+            (layer-position-at-last-layout (10,160)))
+          (related overflow nodes 1)
+        )
+      )
+    )
+  )
+)
+
+

--- a/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed-expected.txt
+++ b/LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed-expected.txt
@@ -1,0 +1,40 @@
+Fixed inside scroller
+
+(Frame scrolling node
+  (scrollable area size 785 600)
+  (contents size 785 5021)
+  (scrollable area parameters
+    (horizontal scroll elasticity 1)
+    (vertical scroll elasticity 1)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0)
+    (allows vertical scrolling 1))
+  (layout viewport at (0,0) size 785x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,4421))
+  (behavior for fixed 1)
+  (children 1
+    (Overflow scrolling node
+      (scroll position 0 50)
+      (scrollable area size 425 425)
+      (contents size 425 1965)
+      (requested scroll position 0 50)
+      (requested scroll position represents programmatic scroll 1)
+      (scrollable area parameters
+        (horizontal scroll elasticity 1)
+        (vertical scroll elasticity 1)
+        (horizontal scrollbar mode 0)
+        (vertical scrollbar mode 0)
+        (allows vertical scrolling 1))
+      (children 1
+        (Positioned node
+          (layout constraints
+            (layer-position-at-last-layout (10,160)))
+          (related overflow nodes 1)
+        )
+      )
+    )
+  )
+)
+
+

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed-expected.txt
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed-expected.txt
@@ -1,0 +1,40 @@
+Fixed inside scroller
+
+(Frame scrolling node
+  (scrollable area size 785 600)
+  (contents size 785 5021)
+  (scrollable area parameters
+    (horizontal scroll elasticity 2)
+    (vertical scroll elasticity 2)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0)
+    (allows vertical scrolling 1))
+  (layout viewport at (0,0) size 785x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,4421))
+  (behavior for fixed 1)
+  (children 1
+    (Overflow scrolling node
+      (scroll position 0 50)
+      (scrollable area size 425 425)
+      (contents size 425 1965)
+      (requested scroll position 0 50)
+      (requested scroll position represents programmatic scroll 1)
+      (scrollable area parameters
+        (horizontal scroll elasticity 0)
+        (vertical scroll elasticity 0)
+        (horizontal scrollbar mode 0)
+        (vertical scrollbar mode 0)
+        (allows vertical scrolling 1))
+      (children 1
+        (Positioned node
+          (layout constraints
+            (layer-position-at-last-layout (10,160)))
+          (related overflow nodes 1)
+        )
+      )
+    )
+  )
+)
+
+

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+
+        .container {
+            position: absolute;
+            margin: 20px;
+            transform: translateX(0);
+            padding: 10px;
+            border: 1px solid gray;
+        }
+        
+        .scroller {
+            position: relative;
+            z-index: 0;
+            margin: 20px;
+            width: 400px;
+            height: 400px;
+            overflow: scroll;
+            padding: 20px;
+            border: 10px solid gray;
+        }
+
+        .inner {
+            height: 500%;
+        }
+        
+        .inner-fixed {
+            position: fixed;
+            top: 150px;
+            left: 50px;
+            width: 400px;
+            height: 50px;
+            background-color: orange;
+        }
+        
+        .relative {
+            position: relative;
+        }
+
+        .box {
+            width: 100px;
+            height: 100px;
+            background-color: blue;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', async () => {
+            const scroller = document.getElementsByClassName('scroller')[0];
+            scroller.scrollTo(0, 50);
+            await UIHelper.renderingUpdate();
+            if (window.internals)
+                document.getElementById('scrollingTree').innerText = window.internals.scrollingStateTreeAsText() + "\n";
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+<div class="container">
+    <div class="scroller">
+        <div class="inner"></div>
+        <div class="relative">
+            <div class="inner-fixed">
+                Fixed inside scroller
+            </div>
+            
+        </div>
+    </div>
+</div>
+<pre id="scrollingTree"></pre>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3621,9 +3621,6 @@ static void collectStationaryLayerRelatedOverflowNodes(const RenderLayer& layer,
         if (isContainingBlockChain && isPaintOrderAncestor)
             return AncestorTraversal::Stop;
 
-        if (!ancestorLayer.isComposited())
-            return AncestorTraversal::Stop;
-
         if (seenPaintOrderAncestor && !isContainingBlockChain && ancestorLayer.hasCompositedScrollableOverflow())
             appendOverflowLayerNodeID(ancestorLayer);
 


### PR DESCRIPTION
#### cf604717c41c53cb1a1b0af630cd883b70fdbf72
<pre>
REGRESSION: Top bar is jumpy and glitchy on scmp.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=253503">https://bugs.webkit.org/show_bug.cgi?id=253503</a>
rdar://106407870

Reviewed by Alan Baradlay and Myles C. Maxfield.

The South China Morning Post has a content structure that looks like this:

&lt;div style=&quot;transform:translateZ(0)&quot;&gt;
  &lt;div style=&quot;overflow: scroll&quot;&gt;
    &lt;div style=&quot;position: relative&quot;&gt;
      &lt;div class=&quot;masthead&quot; style=&quot;position: fixed&quot;&gt;&lt;/div&gt;
      &lt;div style=&quot;something that triggers compositing&quot;&gt;&lt;/div&gt;
    &lt;/div&gt;
  &lt;/div&gt;
&lt;/div&gt;

So the position:fixed is inside a transformed ancestor (which becomes its containing block),
crossing the overflow boundary, and there&apos;s a relative position element in between.

In this configuration, the containing block tree walk done in
collectStationaryLayerRelatedOverflowNodes() for the fixedpos element would bail at the
non-composited relpos element, so failing to find the overflow scrolling ancestor. This means that
the scrolling tree would fail to reposition the &quot;fixed&quot; element on scrolling.

The check for a non-composted layer in this tree walk was added in 247609@main, but the relevant
content no longer hits this condition, probably because of other dialog-related fixes. So remove it.

* LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed-expected.txt: Added.
* LayoutTests/platform/wpe/scrollingcoordinator/scrolling-tree/fixed-inside-stacking-overflow-inside-transformed-expected.txt: Added.
* LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed-expected.txt: Added.
* LayoutTests/scrollingcoordinator/scrolling-tree/fixed-inside-relative-inside-stacking-overflow-inside-transformed.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::collectStationaryLayerRelatedOverflowNodes):

Canonical link: <a href="https://commits.webkit.org/262118@main">https://commits.webkit.org/262118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c089eaaae4816467a6689949523d16446831fbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/561 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/747 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/801 "1 flakes 114 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/788 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/594 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/633 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/576 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/616 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/601 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/609 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/146 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/617 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->