### PR TITLE
Archives on https://webkit.org/build-archives lack content and don't work

### DIFF
--- a/Tools/CISupport/built-product-archive
+++ b/Tools/CISupport/built-product-archive
@@ -187,10 +187,13 @@ def createZip(directoryToZip, configuration, excludePatterns=None, embedParentDi
                         mkbom.stdin.write(archiveMemberName + '\n')
                 dirsToIgnore = {name for pattern in excludePatterns for name in fnmatch.filter(dirs, pattern)}
                 for name in reversed(dirs):
-                    if name not in dirsToIgnore:
-                        continue
-                    print('Ignoring:', os.path.join(relativePath, name))
-                    dirs.remove(name)
+                    if name in dirsToIgnore:
+                        print('Ignoring:', os.path.join(relativePath, name))
+                        dirs.remove(name)
+                    else:
+                        if os.path.islink(os.path.join(root, name)):
+                            archiveMemberName = os.path.join(relativePath, name)
+                            mkbom.stdin.write(archiveMemberName + '\n')
             mkbom.stdin.close()
             if mkbom.wait():
                 return 1


### PR DESCRIPTION
#### 0260b45d8d4d47674075fce82b068b0ddd3a02ae
<pre>
Archives on <a href="https://webkit.org/build-archives">https://webkit.org/build-archives</a> lack content and don&apos;t work
<a href="https://bugs.webkit.org/show_bug.cgi?id=254447">https://bugs.webkit.org/show_bug.cgi?id=254447</a>
rdar://103536499

Reviewed by Jonathan Bedard.

os.walk enumerates symlinks that point to directories as directories, so we need to add
them to the BOM for them to be included in the archive.

I&apos;m guessing that this is a regression from <a href="https://commits.webkit.org/251548@main.">https://commits.webkit.org/251548@main.</a>

* Tools/CISupport/built-product-archive:

Canonical link: <a href="https://commits.webkit.org/262127@main">https://commits.webkit.org/262127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b38ac306f63914746ae2a4c900f985cf7b339e64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/756 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/727 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/592 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/524 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/573 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/568 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/152 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/566 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->