### PR TITLE
Signal ARQL when a download fails

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/SystemPreviewSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/SystemPreviewSPI.h
@@ -129,8 +129,9 @@ typedef void (^ASVSetIsPlayingReplyBlock) (BOOL isPlaying, NSError * _Nullable e
 @end
 
 @interface ASVLaunchPreview : NSObject
-+ (void)beginPreviewApplicationWithURLs:(nonnull NSArray *)urls is3DContent:(BOOL)is3DContent completion:(nonnull void (^)(NSError * _Nullable))handler;
-+ (void)launchPreviewApplicationWithURLs:(nonnull NSArray *)urls completion:(nonnull void (^)(NSError * _Nullable))handler;
++ (void)beginPreviewApplicationWithURLs:(NSArray *)urls is3DContent:(BOOL)is3DContent websiteURL:(NSURL *)websiteURL completion:(void (^)(NSError *))handler;
++ (void)launchPreviewApplicationWithURLs:(NSArray *)urls completion:(void (^)(NSError *))handler;
++ (void)cancelPreviewApplicationWithURLs:(NSArray *)urls error:(NSError *)error completion:(void (^)(NSError *))handler;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -56,7 +56,8 @@ public:
 
     void begin(const URL&, const WebCore::SystemPreviewInfo&);
     void updateProgress(float);
-    void loadCompleted(const URL& downloadedFile);
+    void loadStarted(const URL& localFileURL);
+    void loadCompleted(const URL& localFileURL);
     void loadFailed();
     void end();
 
@@ -75,8 +76,9 @@ private:
 
     WebPageProxy& m_webPageProxy;
     WebCore::SystemPreviewInfo m_systemPreviewInfo;
-    URL m_destinationURL;
-    URL m_originatingPageURL;
+    URL m_downloadURL;
+    URL m_localFileURL;
+    String m_fragmentIdentifier;
 #if USE(QUICK_LOOK)
     RetainPtr<QLPreviewController> m_qlPreviewController;
     RetainPtr<_WKPreviewControllerDelegate> m_qlPreviewControllerDelegate;


### PR DESCRIPTION
#### 345d5c9e9dae6bcdf0a7cb4d9ddc34d5e921e348
<pre>
Signal ARQL when a download fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=254451">https://bugs.webkit.org/show_bug.cgi?id=254451</a>
rdar://104039022

Reviewed by Tim Horton.

ARQL doesn&apos;t get told when a download fails. Add this using their new SPI.

* Source/WebCore/PAL/pal/spi/ios/SystemPreviewSPI.h: Add the new SPI.
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
    - Open the file handle as soon as we start downloading, so that
      we can make a URL.
    - ARQL fails if you give it a .reality file that doesn&apos;t
      have the right file extension, so add that if necessary.
    - Close the file handle if we fail the download. Also, tell
      ARQL that the load failed.
    - Lastly, make sure we always attach the fragment identifier, so
      ARQL knows that the cancel is related to a previous launch call.
* Source/WebKit/UIProcess/SystemPreviewController.h:

Canonical link: <a href="https://commits.webkit.org/263479@main">https://commits.webkit.org/263479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bf1d8492a9ac0de951e0631243ea61f4ea4a083

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6264 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4886 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4844 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4913 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/4255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6275 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2401 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/4250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5887 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4731 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8300 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/542 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->