### PR TITLE
[PlayStation] Fix assertion crash of libpas pthread implementation.

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_lock.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_lock.h
@@ -241,7 +241,7 @@ static inline bool pas_lock_try_lock(pas_lock* lock)
     bool unnamed;
     unnamed = (lock->mutex == PTHREAD_MUTEX_INITIALIZER);
     error = pthread_mutex_trylock(&lock->mutex);
-    PAS_ASSERT(!error || errno == EBUSY);
+    PAS_ASSERT(!error || error == EBUSY);
     if (!error) {
         pas_race_test_did_try_lock(lock);
         if (PAS_UNLIKELY(unnamed))


### PR DESCRIPTION
#### b387b3c61ceaf97fc854b64bbee510eeefb208e6
<pre>
[PlayStation] Fix assertion crash of libpas pthread implementation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254452">https://bugs.webkit.org/show_bug.cgi?id=254452</a>

Reviewed by Don Olmstead.

Fix trivial mistake which uses errno instead of returned error value.

* Source/bmalloc/libpas/src/libpas/pas_lock.h:
(pas_lock_try_lock):

Canonical link: <a href="https://commits.webkit.org/262107@main">https://commits.webkit.org/262107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0caba9767abf9c79b5193325d057abbc3f8f8e42

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/739 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/517 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/698 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/603 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/731 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/557 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/528 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/579 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/590 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/562 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/616 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/572 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/112 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/570 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/617 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/109 "Passed tests") | 
<!--EWS-Status-Bubble-End-->