### PR TITLE
Avoid doing event-related work for CSS transition & animation playback events when no event listener is registered

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-events-with-document-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-events-with-document-change-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS transition events for an element changing document
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-events-with-document-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-events-with-document-change.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<title>CSS Transitions: transition events for an element changing document</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions">
+<script src="/resources/testharness.js" type="text/javascript"></script>
+<script src="/resources/testharnessreport.js" type="text/javascript"></script>
+<div id="target"></div>
+<iframe src="about:blank"></iframe>
+<script>
+promise_test(async () => {
+    const target = document.getElementById("target");
+    target.style.transition = "margin-left 100ms";
+    
+    const transitionMarginLeft = async value => {
+        getComputedStyle(target).marginLeft;
+        target.style.marginLeft = value;
+        await target.getAnimations()[0].ready;
+    }
+    
+    // start an initial transition.
+    await transitionMarginLeft("100px");
+
+    // move the target to new frame, this should cancel the transition.
+    const transitionWasCanceled = new Promise(resolve => target.addEventListener("transitioncancel", resolve, { once: true }));
+    document.querySelector("iframe").contentDocument.body.appendChild(target);
+    await transitionWasCanceled;
+
+    // Start a new transition and ensure it triggers a transitionend event.
+    const transitionEnded = new Promise(resolve => target.addEventListener("transitionend", resolve, { once: true }));
+    await transitionMarginLeft("0px");
+    await transitionEnded;
+}, "transition events for an element changing document");
+</script>

--- a/Source/WebCore/animation/DeclarativeAnimation.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimation.cpp
@@ -293,7 +293,7 @@ void DeclarativeAnimation::invalidateDOMEvents(Seconds elapsedTime)
     bool isBefore = currentPhase == AnimationEffectPhase::Before;
     bool isIdle = currentPhase == AnimationEffectPhase::Idle;
 
-    if (is<CSSAnimation>(this)) {
+    if (is<CSSAnimation>(*this)) {
         // https://drafts.csswg.org/css-animations-2/#events
         if ((wasIdle || wasBefore) && isActive)
             enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
@@ -317,7 +317,7 @@ void DeclarativeAnimation::invalidateDOMEvents(Seconds elapsedTime)
             enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
         } else if ((!wasIdle && !wasAfter) && isIdle)
             enqueueDOMEvent(eventNames().animationcancelEvent, elapsedTime, elapsedTime);
-    } else if (is<CSSTransition>(this)) {
+    } else if (is<CSSTransition>(*this) && m_owningElement->document().hasListenerType(Document::TRANSITION_ANIMATION_LISTENER)) {
         // https://drafts.csswg.org/css-transitions-2/#transition-events
         if (wasIdle && (isPending || isBefore))
             enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5481,6 +5481,8 @@ void Document::addListenerTypeIfNeeded(const AtomString& eventType)
         addListenerType(FOCUSIN_LISTENER);
     else if (eventType == eventNames.focusoutEvent)
         addListenerType(FOCUSOUT_LISTENER);
+    else if (eventNames.isCSSTransitionEventType(eventType))
+        addListenerType(TRANSITION_ANIMATION_LISTENER);
 }
 
 HTMLFrameOwnerElement* Document::ownerElement() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -958,6 +958,7 @@ public:
         FORCEUP_LISTENER                     = 1 << 12,
         FOCUSIN_LISTENER                     = 1 << 13,
         FOCUSOUT_LISTENER                    = 1 << 14,
+        TRANSITION_ANIMATION_LISTENER        = 1 << 15
     };
 
     bool hasListenerType(ListenerType listenerType) const { return (m_listenerTypes & listenerType); }

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -379,6 +379,7 @@ public:
     bool isTouchScrollBlockingEventType(const AtomString& eventType) const;
     bool isMouseClickRelatedEventType(const AtomString& eventType) const;
     bool isMouseMoveRelatedEventType(const AtomString& eventType) const;
+    bool isCSSTransitionEventType(const AtomString& eventType) const;
 #if ENABLE(GAMEPAD)
     bool isGamepadEventType(const AtomString& eventType) const;
 #endif
@@ -455,6 +456,15 @@ inline bool EventNames::isMouseMoveRelatedEventType(const AtomString& eventType)
     return eventType == mousemoveEvent
         || eventType == mouseoverEvent
         || eventType == mouseoutEvent;
+}
+
+inline bool EventNames::isCSSTransitionEventType(const AtomString& eventType) const
+{
+    return eventType == transitioncancelEvent
+        || eventType == transitionendEvent
+        || eventType == transitionrunEvent
+        || eventType == transitionstartEvent
+        || eventType == webkitTransitionEndEvent;
 }
 
 inline std::array<std::reference_wrapper<const AtomString>, 13> EventNames::touchRelatedEventNames() const


### PR DESCRIPTION
#### 43ea8744bc6065aad7ae5988e32d31d253905e5f
<pre>
Avoid doing event-related work for CSS transition &amp; animation playback events when no event listener is registered
<a href="https://bugs.webkit.org/show_bug.cgi?id=254454">https://bugs.webkit.org/show_bug.cgi?id=254454</a>
rdar://107077986

Reviewed by Antoine Quint.

Avoid doing event-related work for CSS transition &amp; animation playback events
when no event listener is registered for these.

We should probably do the same for CSS Animation events. I&apos;ll evaluate these
separately and follow-up.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-events-with-document-change-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-events-with-document-change.html: Added.
* Source/WebCore/animation/DeclarativeAnimation.cpp:
(WebCore::DeclarativeAnimation::invalidateDOMEvents):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::removeReplacedAnimations):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::cancel):
(WebCore::WebAnimation::finishNotificationSteps):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::addListenerTypeIfNeeded):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EventNames.h:
(WebCore::EventNames::isCSSTransitionEventType const):

Canonical link: <a href="https://commits.webkit.org/262123@main">https://commits.webkit.org/262123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30f4f624995a285945e4d7e5634b15b7acc126c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/572 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/811 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/802 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/643 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/585 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/630 "8 failures") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/617 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/623 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/148 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/627 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->