### PR TITLE
[JSC] Add ImplementationVisibility to Wasm::Callee

### DIFF
--- a/JSTests/wasm/function-tests/nameSection.js
+++ b/JSTests/wasm/function-tests/nameSection.js
@@ -64,9 +64,7 @@ assert.eq(result, 1 + 42);
 assert.truthy(stacktrace);
 stacktrace = stacktrace.split("\n");
 assert.falsy(stacktrace[0].indexOf("_silly") === -1);
-assert.eq(stacktrace[1], "wasm-stub@[wasm code]"); // the wasm->js stub
-assert.eq(stacktrace[2], "<?>.wasm-function[_eggs]@[wasm code]");
-assert.eq(stacktrace[3], "<?>.wasm-function[_bacon]@[wasm code]");
-assert.eq(stacktrace[4], "<?>.wasm-function[_spam]@[wasm code]");
-assert.eq(stacktrace[5], "<?>.wasm-function[_parrot]@[wasm code]");
-assert.eq(stacktrace[6], "wasm-stub@[wasm code]"); // wasm entry
+assert.eq(stacktrace[1], "<?>.wasm-function[_eggs]@[wasm code]");
+assert.eq(stacktrace[2], "<?>.wasm-function[_bacon]@[wasm code]");
+assert.eq(stacktrace[3], "<?>.wasm-function[_spam]@[wasm code]");
+assert.eq(stacktrace[4], "<?>.wasm-function[_parrot]@[wasm code]");

--- a/JSTests/wasm/function-tests/stack-trace.js
+++ b/JSTests/wasm/function-tests/stack-trace.js
@@ -42,7 +42,6 @@ for (let i = 0; i < 10000; ++i) {
     assert.truthy(stacktrace);
     stacktrace = stacktrace.split("\n");
     assert.truthy(stacktrace[0].indexOf("imp") !== -1); // the arrow function import named "imp".
-    assert.eq(stacktrace[1], "wasm-stub@[wasm code]"); // the wasm->js stub
     let found = false;
     for (let i = 0; i < stacktrace.length; ++i) {
         let str = stacktrace[i];

--- a/JSTests/wasm/function-tests/trap-after-cross-instance-call.js
+++ b/JSTests/wasm/function-tests/trap-after-cross-instance-call.js
@@ -58,7 +58,7 @@ function wasmFrameCountFromError(e) {
 
 for (let i = 0; i < 1000; i++) {
     const e1 = assert.throws(() => foo1(numPages * pageSize + 1), WebAssembly.RuntimeError, "Out of bounds memory access");
-    assert.eq(wasmFrameCountFromError(e1), 2);
+    assert.eq(wasmFrameCountFromError(e1), 1);
     const e2 = assert.throws(() => foo2(numPages * pageSize + 1), WebAssembly.RuntimeError, "Out of bounds memory access");
-    assert.eq(wasmFrameCountFromError(e2), 2);
+    assert.eq(wasmFrameCountFromError(e2), 1);
 }

--- a/JSTests/wasm/function-tests/trap-load-2.js
+++ b/JSTests/wasm/function-tests/trap-load-2.js
@@ -70,6 +70,6 @@ function wasmFrameCountFromError(e) {
         // There are 5 total calls, and each call does:
         // JS entry, wasm entry, js call stub.
         // The last call that traps just has JS entry and wasm entry.
-        assert.eq(wasmFrameCountFromError(e), 5 * 3 + 2);
+        assert.eq(wasmFrameCountFromError(e), 6);
     }
 }

--- a/JSTests/wasm/function-tests/trap-load-shared.js
+++ b/JSTests/wasm/function-tests/trap-load-shared.js
@@ -32,5 +32,5 @@ function wasmFrameCountFromError(e) {
 
 for (let i = 0; i < 1000; i++) {
     const e = assert.throws(() => foo(numPages * pageSize + 1), WebAssembly.RuntimeError, "Out of bounds memory access");
-    assert.eq(wasmFrameCountFromError(e), 2);
+    assert.eq(wasmFrameCountFromError(e), 1);
 }

--- a/JSTests/wasm/function-tests/trap-load.js
+++ b/JSTests/wasm/function-tests/trap-load.js
@@ -30,5 +30,5 @@ function wasmFrameCountFromError(e) {
 
 for (let i = 0; i < 1000; i++) {
     const e = assert.throws(() => foo(numPages * pageSize + 1), WebAssembly.RuntimeError, "Out of bounds memory access");
-    assert.eq(wasmFrameCountFromError(e), 2);
+    assert.eq(wasmFrameCountFromError(e), 1);
 }

--- a/JSTests/wasm/stress/simple-inline-stacktrace-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-2.js
@@ -11,10 +11,10 @@ for (let i = 0; i < 10000; ++i) {
     } catch (e) {
         let str = e.stack.toString()
         let trace = str.split('\n')
-        let expected = ["*", "wasm-stub@[wasm code]", "<?>.wasm-function[g]@[wasm code]",
+        let expected = ["*", "<?>.wasm-function[g]@[wasm code]",
         "<?>.wasm-function[f]@[wasm code]", "<?>.wasm-function[e]@[wasm code]", "<?>.wasm-function[d]@[wasm code]",
         "<?>.wasm-function[c]@[wasm code]", "<?>.wasm-function[b]@[wasm code]", "<?>.wasm-function[a]@[wasm code]",
-        "<?>.wasm-function[main]@[wasm code]", "wasm-stub@[wasm code]", "*"]
+        "<?>.wasm-function[main]@[wasm code]", "*"]
         if (trace.length != expected.length)
             throw "unexpected length"
         for (let i = 0; i < trace.length; ++i) {

--- a/JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js
@@ -16,10 +16,10 @@ const iterCount = 9
 function verifyStack(stack, e) {
     let str = e.stack.toString()
     let trace = str.split('\n')
-    let expected = ["*", "wasm-stub@[wasm code]"]
+    let expected = ["*"]
     for (let i of stack)
         expected.push(`<?>.wasm-function[${i}]@[wasm code]`)
-    expected = expected.concat(["wasm-stub@[wasm code]", "*"])
+    expected = expected.concat(["*"])
 
     if (trace.length != expected.length)
         throw "unexpected length, got: \n" + str + "\nExpected:\n" + expected.join("\n")

--- a/JSTests/wasm/stress/simple-inline-stacktrace-with-catch.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-with-catch.js
@@ -14,10 +14,10 @@ const iterCount = 9
 function verifyStack(stack, e) {
     let str = e.stack.toString()
     let trace = str.split('\n')
-    let expected = ["*", "wasm-stub@[wasm code]"]
+    let expected = ["*"]
     for (let i of stack)
         expected.push(`<?>.wasm-function[${i}]@[wasm code]`)
-    expected = expected.concat(["wasm-stub@[wasm code]", "*"])
+    expected = expected.concat(["*"])
 
     if (trace.length != expected.length)
         throw "unexpected length, got: \n" + str + "\nExpected:\n" + expected.join("\n")

--- a/JSTests/wasm/stress/simple-inline-stacktrace.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace.js
@@ -8,10 +8,10 @@ for (let i = 0; i < 10000; ++i) {
     } catch (e) {
         let str = e.stack.toString()
         let trace = str.split('\n')
-        let expected = ["*", "wasm-stub@[wasm code]", "<?>.wasm-function[g]@[wasm code]",
+        let expected = ["*", "<?>.wasm-function[g]@[wasm code]",
             "<?>.wasm-function[f]@[wasm code]", "<?>.wasm-function[e]@[wasm code]", "<?>.wasm-function[d]@[wasm code]",
             "<?>.wasm-function[c]@[wasm code]", "<?>.wasm-function[b]@[wasm code]", "<?>.wasm-function[a]@[wasm code]",
-            "<?>.wasm-function[main]@[wasm code]", "wasm-stub@[wasm code]", "*"]
+            "<?>.wasm-function[main]@[wasm code]", "*"]
         if (trace.length != expected.length)
             throw "unexpected length"
         for (let i = 0; i < trace.length; ++i) {

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -459,23 +459,31 @@ void StackVisitor::Frame::setToEnd()
 
 bool StackVisitor::Frame::isImplementationVisibilityPrivate() const
 {
-    auto* executable = [&] () -> ExecutableBase* {
-        if (auto* codeBlock = this->codeBlock())
-            return codeBlock->ownerExecutable();
+    ImplementationVisibility implementationVisibility = [&] () -> ImplementationVisibility {
+        if (auto* codeBlock = this->codeBlock()) {
+            if (auto* executable = codeBlock->ownerExecutable())
+                return executable->implementationVisibility();
+            return ImplementationVisibility::Public;
+        }
+
+#if ENABLE(WEBASSEMBLY)
+        if (isWasmFrame())
+            return callee().asWasmCallee()->implementationVisibility();
+#endif
 
         if (callee().isCell()) {
             if (auto* callee = this->callee().asCell()) {
-                if (auto* jsFunction = jsDynamicCast<JSFunction*>(callee))
-                    return jsFunction->executable();
+                if (auto* jsFunction = jsDynamicCast<JSFunction*>(callee)) {
+                    if (auto* executable = jsFunction->executable())
+                        return executable->implementationVisibility();
+                    return ImplementationVisibility::Public;
+                }
             }
         }
 
-        return nullptr;
+        return ImplementationVisibility::Public;
     }();
-    if (!executable)
-        return false;
-
-    switch (executable->implementationVisibility()) {
+    switch (implementationVisibility) {
     case ImplementationVisibility::Public:
         return false;
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -37,6 +37,7 @@ namespace JSC { namespace Wasm {
 
 Callee::Callee(Wasm::CompilationMode compilationMode)
     : m_compilationMode(compilationMode)
+    , m_implementationVisibility(ImplementationVisibility::Private)
 {
 }
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -52,6 +52,7 @@ class Callee : public ThreadSafeRefCounted<Callee> {
 public:
     IndexOrName indexOrName() const { return m_indexOrName; }
     CompilationMode compilationMode() const { return m_compilationMode; }
+    ImplementationVisibility implementationVisibility() const { return m_implementationVisibility; }
 
     CodePtr<WasmEntryPtrTag> entrypoint() const;
     RegisterAtOffsetList* calleeSaveRegisters();
@@ -76,6 +77,7 @@ protected:
 
 private:
     const CompilationMode m_compilationMode;
+    ImplementationVisibility m_implementationVisibility { ImplementationVisibility::Public };
     const IndexOrName m_indexOrName;
 
 protected:


### PR DESCRIPTION
#### 88070f054a4e88c1dbfc9eb2718256c3e41d0ce2
<pre>
[JSC] Add ImplementationVisibility to Wasm::Callee
<a href="https://bugs.webkit.org/show_bug.cgi?id=254455">https://bugs.webkit.org/show_bug.cgi?id=254455</a>
rdar://107213008

Reviewed by Justin Michaud.

Add ImplementationVisibility to Wasm::Callee, and hide internal wasm-stubs from stacktrace.
This will be extended to be used for non visible other native callees like IC callee.

* JSTests/wasm/function-tests/nameSection.js:
* JSTests/wasm/function-tests/stack-trace.js:
* JSTests/wasm/function-tests/trap-after-cross-instance-call.js:
* JSTests/wasm/function-tests/trap-load-2.js:
* JSTests/wasm/function-tests/trap-load-shared.js:
* JSTests/wasm/function-tests/trap-load.js:
* JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js:
(let.readMem.new.Int32Array.wasm_instance.exports.mem.buffer.const.iterCount.9.verifyStack):
(readMem.0.0):
* JSTests/wasm/stress/simple-inline-stacktrace-with-catch.js:
(let.readMem.new.Int32Array.wasm_instance.exports.mem.buffer.const.iterCount.9.verifyStack):
(readMem.0.0):
* JSTests/wasm/stress/simple-inline-stacktrace.js:
(i.catch):
* Source/JavaScriptCore/interpreter/StackVisitor.cpp:
(JSC::StackVisitor::Frame::isImplementationVisibilityPrivate const):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::Callee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
(JSC::Wasm::Callee::implementationVisibility const):

Canonical link: <a href="https://commits.webkit.org/262191@main">https://commits.webkit.org/262191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df4e33eb72dc4220e34751b9091f83bce31cf9e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/585 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/823 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/820 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/654 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/584 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/598 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/645 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/659 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/621 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/690 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/634 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/139 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/640 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/691 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/90 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/133 "Passed tests") | 
<!--EWS-Status-Bubble-End-->