### PR TITLE
[UI-Side Compositing] WebKit crashes when pressing Page Up/Fn Up key

### DIFF
--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-pagedown-pageup-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-pagedown-pageup-expected.txt
@@ -1,0 +1,5 @@
+PASS scrollOffsetAfterPageDown > scrollOffsetAfterPageUp is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-pagedown-pageup.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-pagedown-pageup.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<script>
+jsTestIsAsync = true;
+
+async function runTest()
+{
+    if (window.eventSender) {
+        await UIHelper.startMonitoringWheelEvents();
+        eventSender.keyDown("pageDown");
+        await UIHelper.waitForScrollCompletion();
+
+        scrollOffsetAfterPageDown = scrollY;
+
+        await UIHelper.startMonitoringWheelEvents();
+        eventSender.keyDown("pageUp");
+        await UIHelper.waitForScrollCompletion();
+
+        scrollOffsetAfterPageUp = scrollY;
+
+        shouldBeTrue("scrollOffsetAfterPageDown > scrollOffsetAfterPageUp");
+        finishJSTest();
+    }
+}
+</script>
+</head>
+<body onload="runTest()">
+<div style="height: 5000px;"></div>
+</body>
+</html>

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -249,14 +249,13 @@ bool ArgumentCoder<ScrollingStateScrollingNode>::decode(Decoder& decoder, Scroll
 #endif
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::IsMonitoringWheelEvents, bool, setIsMonitoringWheelEvents);
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::ScrollableAreaParams, ScrollableAreaParameters, setScrollableAreaParameters);
-    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::KeyboardScrollData, RequestedKeyboardScrollData, setKeyboardScrollData);
-
     if (node.hasChangedProperty(ScrollingStateNode::Property::RequestedScrollPosition)) {
         RequestedScrollData requestedScrollData;
         if (!decoder.decode(requestedScrollData))
             return false;
         node.setRequestedScrollData(WTFMove(requestedScrollData), ScrollingStateScrollingNode::CanMergeScrollData::No);
     }
+    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::KeyboardScrollData, RequestedKeyboardScrollData, setKeyboardScrollData);
 
     if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
         std::optional<PlatformLayerIdentifier> layerID;


### PR DESCRIPTION
#### 4d2490b20c7723522fa49719c8f48ded0fea99b7
<pre>
[UI-Side Compositing] WebKit crashes when pressing Page Up/Fn Up key
<a href="https://bugs.webkit.org/show_bug.cgi?id=254453">https://bugs.webkit.org/show_bug.cgi?id=254453</a>
rdar://107206783

Reviewed by Simon Fraser.

262105@main inadvertently changed the order in which a scrolling node&apos;s `RequestedScrollData` and
`KeyboardScrollData` are decoded, but not the order in which they&apos;re encoded. This means that if
both `RequestedScrollPosition` and `KeyboardScrollData` flags are set on a state node, we&apos;ll end up
failing to decode the state node properly.

Fix this by correcting the order in which these two members are decoded.

Test: fast/scrolling/mac/keyboard-scrolling-pagedown-pageup.html

* LayoutTests/fast/scrolling/mac/keyboard-scrolling-pagedown-pageup-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/keyboard-scrolling-pagedown-pageup.html: Added.
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(ArgumentCoder&lt;ScrollingStateScrollingNode&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/262110@main">https://commits.webkit.org/262110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ebf4ac41508e160e9bf586ec37f9dce9d965670

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/749 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/525 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/765 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/739 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/597 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/536 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/582 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/568 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/575 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/141 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/578 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->