### PR TITLE
Change InteracitonRegion to hold an IntRect instead of a Region

### DIFF
--- a/LayoutTests/interaction-region/aria-roles-expected.txt
+++ b/LayoutTests/interaction-region/aria-roles-expected.txt
@@ -16,25 +16,15 @@ Menu option 3
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (0,0) width=800 height=20)
-)
+        (interaction (0,0) width=800 height=20)
         (borderRadius 8.00),
-        (interaction
-            (rect (0,20) width=800 height=20)
-)
+        (interaction (0,20) width=800 height=20)
         (borderRadius 8.00),
-        (interaction
-            (rect (40,56) width=760 height=20)
-)
+        (interaction (40,56) width=760 height=20)
         (borderRadius 8.00),
-        (interaction
-            (rect (40,76) width=760 height=20)
-)
+        (interaction (40,76) width=760 height=20)
         (borderRadius 8.00),
-        (interaction
-            (rect (40,96) width=760 height=20)
-)
+        (interaction (40,96) width=760 height=20)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt
@@ -11,9 +11,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (0,0) width=100 height=100)
-)
+        (interaction (0,0) width=100 height=100)
         (borderRadius 10.00)])
       )
     )

--- a/LayoutTests/interaction-region/click-handler-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-expected.txt
@@ -11,9 +11,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (0,0) width=100 height=100)
-)
+        (interaction (0,0) width=100 height=100)
         (borderRadius 10.00)])
       )
     )

--- a/LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt
+++ b/LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt
@@ -20,9 +20,7 @@
             (rect (28,28) width=200 height=200)
 
           (interaction regions [
-            (interaction
-                (rect (28,28) width=100 height=100)
-)
+            (interaction (28,28) width=100 height=100)
             (borderRadius 10.00)])
           )
         )

--- a/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
+++ b/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
@@ -12,25 +12,15 @@ Nested  Nested  Nested Secondary
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (0,0) width=125 height=100)
-)
+        (interaction (0,0) width=125 height=100)
         (borderRadius 12.00),
-        (interaction
-            (rect (128,0) width=125 height=100)
-)
+        (interaction (128,0) width=125 height=100)
         (borderRadius 12.00),
-        (interaction
-            (rect (148,20) width=85 height=60)
-)
+        (interaction (148,20) width=85 height=60)
         (borderRadius 8.00),
-        (interaction
-            (rect (256,0) width=126 height=100)
-)
+        (interaction (256,0) width=126 height=100)
         (borderRadius 12.00),
-        (interaction
-            (rect (293,20) width=69 height=20)
-)
+        (interaction (293,20) width=69 height=20)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/event-region-overflow-expected.txt
+++ b/LayoutTests/interaction-region/event-region-overflow-expected.txt
@@ -12,9 +12,7 @@ Hi
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (29,21) width=50 height=50)
-)
+        (interaction (29,21) width=50 height=50)
         (borderRadius 8.75)])
       )
     )

--- a/LayoutTests/interaction-region/full-page-overlay-expected.txt
+++ b/LayoutTests/interaction-region/full-page-overlay-expected.txt
@@ -21,9 +21,7 @@
                 (rect (0,0) width=1536 height=2008)
 
               (interaction regions [
-                (occlusion
-                    (rect (0,0) width=1536 height=2008)
-)
+                (occlusion (0,0) width=1536 height=2008)
                 (borderRadius 0.00)])
               )
             )
@@ -39,9 +37,7 @@
                 (rect (0,0) width=1536 height=2008)
 
               (interaction regions [
-                (occlusion
-                    (rect (0,0) width=1536 height=2008)
-)
+                (occlusion (0,0) width=1536 height=2008)
                 (borderRadius 0.00)])
               )
             )

--- a/LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt
+++ b/LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt
@@ -14,9 +14,7 @@ button
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (0,3) width=59 height=30)
-)
+        (interaction (0,3) width=59 height=30)
         (borderRadius 14.00)])
       )
     )

--- a/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-dark-background-expected.txt
@@ -12,9 +12,7 @@ This is a link.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (-4,-4) width=37 height=27)
-)
+        (interaction (-4,-4) width=37 height=27)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/inline-link-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-expected.txt
@@ -12,9 +12,7 @@ This is a link.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (-4,-4) width=37 height=27)
-)
+        (interaction (-4,-4) width=37 height=27)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt
@@ -13,9 +13,7 @@ This is a link, outside the frame.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (-4,-4) width=37 height=27)
-)
+        (interaction (-4,-4) width=37 height=27)
         (borderRadius 8.00)])
       )
       (children 1
@@ -27,9 +25,7 @@ This is a link, outside the frame.
             (rect (2,2) width=200 height=200)
 
           (interaction regions [
-            (interaction
-                (rect (6,6) width=37 height=27)
-)
+            (interaction (6,6) width=37 height=27)
             (borderRadius 8.00)])
           )
         )

--- a/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-layer-expected.txt
@@ -13,9 +13,7 @@ This is a link, inside the layer.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (-4,-4) width=37 height=27)
-)
+        (interaction (-4,-4) width=37 height=27)
         (borderRadius 8.00)])
       )
       (children 1
@@ -27,9 +25,7 @@ This is a link, inside the layer.
             (rect (0,0) width=200 height=200)
 
           (interaction regions [
-            (interaction
-                (rect (-4,-4) width=37 height=27)
-)
+            (interaction (-4,-4) width=37 height=27)
             (borderRadius 8.00)])
           )
         )

--- a/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt
@@ -13,13 +13,9 @@ This is a link, outside the frame.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (-4,-4) width=37 height=27)
-)
+        (interaction (-4,-4) width=37 height=27)
         (borderRadius 8.00),
-        (interaction
-            (rect (6,26) width=37 height=27)
-)
+        (interaction (6,26) width=37 height=27)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt
@@ -12,9 +12,7 @@ Link Child Disabled Link
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (-4,-4) width=78 height=27)
-)
+        (interaction (-4,-4) width=78 height=27)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/input-type-file-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-file-region-expected.txt
@@ -12,9 +12,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (1,2) width=84 height=18)
-)
+        (interaction (1,2) width=84 height=18)
         (borderRadius 9.00)])
       )
     )

--- a/LayoutTests/interaction-region/input-type-range-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-range-region-expected.txt
@@ -12,9 +12,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (58,2) width=17 height=16)
-)
+        (interaction (58,2) width=17 height=16)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/nested-composited-text-painter-expected.txt
+++ b/LayoutTests/interaction-region/nested-composited-text-painter-expected.txt
@@ -11,9 +11,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (0,0) width=100 height=100)
-)
+        (interaction (0,0) width=100 height=100)
         (borderRadius 10.00)])
       )
       (children 1

--- a/LayoutTests/interaction-region/overlap-expected.txt
+++ b/LayoutTests/interaction-region/overlap-expected.txt
@@ -11,13 +11,9 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (occlusion
-            (rect (0,0) width=200 height=100)
-)
+        (occlusion (0,0) width=200 height=100)
         (borderRadius 0.00),
-        (interaction
-            (rect (0,0) width=200 height=100)
-)
+        (interaction (0,0) width=200 height=100)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/overlap-same-group-expected.txt
+++ b/LayoutTests/interaction-region/overlap-same-group-expected.txt
@@ -11,14 +11,11 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (46,-4) width=158 height=108)
-)
+        (interaction (46,-4) width=158 height=108)
         (borderRadius 8.00),
-        (interaction
-            (rect (204,21) width=50 height=83)
-            (rect (96,104) width=158 height=25)
-)
+        (interaction (204,21) width=50 height=83)
+        (borderRadius 8.00),
+        (interaction (96,104) width=158 height=25)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/overlay-expected.txt
+++ b/LayoutTests/interaction-region/overlay-expected.txt
@@ -11,13 +11,9 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (occlusion
-            (rect (0,0) width=200 height=100)
-)
+        (occlusion (0,0) width=200 height=100)
         (borderRadius 0.00),
-        (occlusion
-            (rect (0,200) width=200 height=100)
-)
+        (occlusion (0,200) width=200 height=100)
         (borderRadius 0.00)])
       )
     )

--- a/LayoutTests/interaction-region/paused-video-regions-expected.txt
+++ b/LayoutTests/interaction-region/paused-video-regions-expected.txt
@@ -38,9 +38,7 @@
                     (rect (51,98) width=34 height=5)
 
                   (interaction regions [
-                    (interaction
-                        (rect (33,33) width=70 height=70)
-)
+                    (interaction (33,33) width=70 height=70)
                     (borderRadius 35.00)])
                   )
                   (children 3

--- a/LayoutTests/interaction-region/pseudo-element-expected.txt
+++ b/LayoutTests/interaction-region/pseudo-element-expected.txt
@@ -11,9 +11,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (0,0) width=100 height=100)
-)
+        (interaction (0,0) width=100 height=100)
         (borderRadius 10.00)])
       )
     )

--- a/LayoutTests/interaction-region/split-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/split-inline-link-expected.txt
@@ -13,13 +13,9 @@ short second line.
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (197,-4) width=33 height=27)
-)
+        (interaction (197,-4) width=33 height=27)
         (borderRadius 8.00),
-        (interaction
-            (rect (-4,16) width=117 height=27)
-)
+        (interaction (-4,16) width=117 height=27)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
@@ -15,21 +15,13 @@ Line
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction
-            (rect (-4,-4) width=38 height=27)
-)
+        (interaction (-4,-4) width=38 height=27)
         (borderRadius 8.00),
-        (interaction
-            (rect (-4,23) width=38 height=20)
-)
+        (interaction (-4,23) width=38 height=20)
         (borderRadius 8.00),
-        (interaction
-            (rect (-4,43) width=38 height=20)
-)
+        (interaction (-4,43) width=38 height=20)
         (borderRadius 8.00),
-        (interaction
-            (rect (-4,63) width=38 height=20)
-)
+        (interaction (-4,63) width=38 height=20)
         (borderRadius 8.00)])
       )
     )

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -185,12 +185,9 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     if (!hasListener || !hasPointer || isTooBigForInteraction) {
         bool isOverlay = checkedRegionArea.value() <= frameViewArea && (renderer.style().specifiedZIndex() > 0 || renderer.isFixedPositioned());
         if (isOverlay && isOriginalMatch) {
-            Region boundsRegion;
-            boundsRegion.unite(bounds);
-
             return { {
                 matchedElement->identifier(),
-                boundsRegion,
+                bounds,
                 0,
                 InteractionRegion::Type::Occlusion
             } };
@@ -221,13 +218,10 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         }
     }
     borderRadius = std::max<float>(borderRadius, regionRenderer.document().settings().interactionRegionMinimumCornerRadius());
-
-    Region boundsRegion;
-    boundsRegion.unite(bounds);
-
+    
     return { {
         matchedElement->identifier(),
-        boundsRegion,
+        bounds,
         borderRadius,
         InteractionRegion::Type::Interaction
     } };
@@ -235,7 +229,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
 
 TextStream& operator<<(TextStream& ts, const InteractionRegion& interactionRegion)
 {
-    ts.dumpProperty(interactionRegion.type == InteractionRegion::Type::Occlusion ? "occlusion" : "interaction", interactionRegion.regionInLayerCoordinates);
+    ts.dumpProperty(interactionRegion.type == InteractionRegion::Type::Occlusion ? "occlusion" : "interaction", interactionRegion.rectInLayerCoordinates);
     ts.dumpProperty("borderRadius", interactionRegion.borderRadius);
 
     return ts;

--- a/Source/WebCore/page/InteractionRegion.h
+++ b/Source/WebCore/page/InteractionRegion.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "ElementIdentifier.h"
-#include "FloatRect.h"
+#include "IntRect.h"
 #include "Region.h"
 
 namespace IPC {
@@ -48,7 +48,7 @@ struct InteractionRegion {
     enum class Type : bool { Interaction, Occlusion };
 
     ElementIdentifier elementIdentifier;
-    Region regionInLayerCoordinates;
+    IntRect rectInLayerCoordinates;
     float borderRadius { 0 };
     Type type;
 
@@ -58,7 +58,7 @@ struct InteractionRegion {
 inline bool operator==(const InteractionRegion& a, const InteractionRegion& b)
 {
     return a.elementIdentifier == b.elementIdentifier
-        && a.regionInLayerCoordinates == b.regionInLayerCoordinates
+        && a.rectInLayerCoordinates == b.rectInLayerCoordinates
         && a.borderRadius == b.borderRadius
         && a.type == b.type;
 }

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -174,7 +174,7 @@ public:
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     const Vector<InteractionRegion>& interactionRegions() const { return m_interactionRegions; }
-    void uniteInteractionRegions(const Vector<InteractionRegion>&);
+    void appendInteractionRegions(const Vector<InteractionRegion>&);
 #endif
 
 private:

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3692,11 +3692,10 @@ void RenderLayerBacking::paintDebugOverlays(const GraphicsLayer* graphicsLayer, 
         context.setStrokeThickness(1);
 
         for (const auto& region : eventRegion.interactionRegions()) {
-            for (auto rect : region.regionInLayerCoordinates.rects()) {
-                Path path;
-                path.addRoundedRect(rect, { region.borderRadius, region.borderRadius });
-                context.strokePath(path);
-            }
+            auto rect = region.rectInLayerCoordinates;
+            Path path;
+            path.addRoundedRect(rect, { region.borderRadius, region.borderRadius });
+            context.strokePath(path);
         }
     }
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4733,7 +4733,7 @@ struct WebCore::GlobalWindowIdentifier {
 
 struct WebCore::InteractionRegion {
     WebCore::ElementIdentifier elementIdentifier;
-    WebCore::Region regionInLayerCoordinates;
+    WebCore::IntRect rectInLayerCoordinates;
     float borderRadius;
     WebCore::InteractionRegion::Type type;
 };


### PR DESCRIPTION
#### f51974aa4007bbd070c94d507d472bddd1e95745
<pre>
Change InteracitonRegion to hold an IntRect instead of a Region
<a href="https://bugs.webkit.org/show_bug.cgi?id=254456">https://bugs.webkit.org/show_bug.cgi?id=254456</a>
rdar://107216144

Reviewed by Tim Horton.

InteractionRegion currently has a Region as the way that it holds
the data about the interaction. However, Region is a large
data structure, and we only ever put a single Rect into it,
so to save space and performance, we should switch to just using a
Rect instead of a Region.

* LayoutTests/interaction-region/aria-roles-expected.txt:
* LayoutTests/interaction-region/click-handler-dynamically-added-expected.txt:
* LayoutTests/interaction-region/click-handler-expected.txt:
* LayoutTests/interaction-region/click-handler-in-shadowed-layer-expected.txt:
* LayoutTests/interaction-region/consolidated-nested-regions-expected.txt:
* LayoutTests/interaction-region/event-region-overflow-expected.txt:
* LayoutTests/interaction-region/full-page-overlay-expected.txt:
* LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt:
* LayoutTests/interaction-region/inline-link-dark-background-expected.txt:
* LayoutTests/interaction-region/inline-link-expected.txt:
* LayoutTests/interaction-region/inline-link-in-composited-iframe-expected.txt:
* LayoutTests/interaction-region/inline-link-in-layer-expected.txt:
* LayoutTests/interaction-region/inline-link-in-non-composited-iframe-expected.txt:
* LayoutTests/interaction-region/inline-link-with-pointer-events-none-content-expected.txt:
* LayoutTests/interaction-region/input-type-file-region-expected.txt:
* LayoutTests/interaction-region/input-type-range-region-expected.txt:
* LayoutTests/interaction-region/nested-composited-text-painter-expected.txt:
* LayoutTests/interaction-region/overlap-expected.txt:
* LayoutTests/interaction-region/overlay-expected.txt:
* LayoutTests/interaction-region/paused-video-regions-expected.txt:
* LayoutTests/interaction-region/pseudo-element-expected.txt:
* LayoutTests/interaction-region/split-inline-link-expected.txt:
* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::pathsForRect):
(WebCore::InteractionRegionOverlay::activeRegion const):
(WebCore::InteractionRegionOverlay::drawRect):
(WebCore::pathsForRegion): Deleted.
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/InteractionRegion.h:
(WebCore::operator==):
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
(WebCore::EventRegionContext::copyInteractionRegionsToEventRegion):
(WebCore::EventRegion::translate):
(WebCore::EventRegion::appendInteractionRegions):
(WebCore::EventRegion::uniteInteractionRegions): Deleted.
* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::paintDebugOverlays):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):

Canonical link: <a href="https://commits.webkit.org/262242@main">https://commits.webkit.org/262242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee145ef460c279fb119d138945f6e1e5eb8cddcc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1483 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1095 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/991 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1383 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/919 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/898 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/947 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/1959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/939 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/928 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/238 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/954 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->