### PR TITLE
[UI-side compositing] Unpainted regions (missing tiles) when scrolling with the keyboard

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -140,11 +140,13 @@ bool RemoteLayerBackingStoreCollection::backingStoreWillBeDisplayed(RemoteLayerB
     ASSERT(m_inLayerFlush);
     m_reachableBackingStoreInLatestFlush.add(&backingStore);
 
-    if (backingStore.needsDisplay())
+    auto backingStoreIter = m_unparentedBackingStore.find(&backingStore);
+    bool wasUnparented = backingStoreIter != m_unparentedBackingStore.end();
+
+    if (backingStore.needsDisplay() || wasUnparented)
         m_backingStoresNeedingDisplay.add(&backingStore);
 
-    auto backingStoreIter = m_unparentedBackingStore.find(&backingStore);
-    if (backingStoreIter == m_unparentedBackingStore.end())
+    if (!wasUnparented)
         return false;
 
     m_liveBackingStore.add(&backingStore);


### PR DESCRIPTION
#### e2ffafdf3851abda0161f4adc5cfdc60fd826a28
<pre>
[UI-side compositing] Unpainted regions (missing tiles) when scrolling with the keyboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=254466">https://bugs.webkit.org/show_bug.cgi?id=254466</a>
rdar://107163092

Reviewed by Tim Horton.

When scrolling around a long page with Home/End keys, it&apos;s common for page tiles to be unparented
and reparented, exercising the logic in RemoteLayerBackingStoreCollection which maintains the
m_unparentedBackingStore set.

If a layer which does not need display (i.e. is &quot;clean&quot; and has not been made volatile) is
reparented, we&apos;d fail to fetch a new ImageBufferBackendHandle from the GPU Process, but set the
`BackingStoreChanged` dirty bit, so the UI process would try to set layer contents but to nil.

Fix by adding layers which are pulled out of `m_unparentedBackingStore` to the
`m_backingStoresNeedingDisplay` set, which results in them participating in
`RemoteRenderingBackend::prepareBuffersForDisplay()` which will ensure we get a new backend handle
from the GPU process.

This is hard to test, but I added an assertion in RemoteLayerBackingStore::encode() that we&apos;re
encoding a non-null handle which would have caught this.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::hasValue):
(WebKit::RemoteLayerBackingStore::encode const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::backingStoreWillBeDisplayed):

Canonical link: <a href="https://commits.webkit.org/262120@main">https://commits.webkit.org/262120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95681531d97e75a7b0140d7325eaeba2ece9ebdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/559 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/799 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/786 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/592 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/631 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/574 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/614 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/599 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/607 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/147 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/615 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->