### PR TITLE
Add VectorTraits for StringView and StringViewWithUnderlyingString

### DIFF
--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -1458,6 +1458,15 @@ inline Expected<std::invoke_result_t<Func, Span<const char>>, UTF8ConversionErro
     return StringImpl::tryGetUTF8ForCharacters(function, characters16(), length(), mode);
 }
 
+template<> struct VectorTraits<StringView> : VectorTraitsBase<false, void> {
+    static constexpr bool canMoveWithMemcpy = true;
+    static constexpr bool canCopyWithMemcpy = true;
+};
+
+template<> struct VectorTraits<StringViewWithUnderlyingString> : VectorTraitsBase<false, void> {
+    static constexpr bool canMoveWithMemcpy = true;
+};
+
 } // namespace WTF
 
 using WTF::append;


### PR DESCRIPTION
#### d495e50773bf6906e72e0aefe7b2b6753757ce18
<pre>
Add VectorTraits for StringView and StringViewWithUnderlyingString
<a href="https://bugs.webkit.org/show_bug.cgi?id=254469">https://bugs.webkit.org/show_bug.cgi?id=254469</a>

Reviewed by Darin Adler.

Add VectorTraits for StringView and StringViewWithUnderlyingString so that
Vector can deal with these types more efficiently.

JSStringJoiner - for example - uses a Vector&lt;StringViewWithUnderlyingString&gt;.

* Source/WTF/wtf/text/StringView.h:

Canonical link: <a href="https://commits.webkit.org/262128@main">https://commits.webkit.org/262128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/991b0bf71c7dc91533ebd6858c2c3588547db63f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/574 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/813 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/806 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/644 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/573 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/587 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/631 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/648 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/609 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/679 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/624 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/135 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/151 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/629 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/680 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/129 "Passed tests") | 
<!--EWS-Status-Bubble-End-->