### PR TITLE
Regression(262103@main) JSRopeString::resolveRopeToAtomString() no longer reports extra memory

### DIFF
--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -191,10 +191,12 @@ AtomString JSRopeString::resolveRopeToAtomString(JSGlobalObject* globalObject) c
     } else
         atomString = StringView { substringBase()->valueInternal() }.substring(substringOffset(), length()).toAtomString();
 
-    convertToNonRope(String { atomString });
     // If we resolved a string that didn't previously exist, notify the heap that we've grown.
-    if (valueInternal().impl()->hasOneRef())
-        vm.heap.reportExtraMemoryAllocated(valueInternal().impl()->cost());
+    if (atomString.impl()->hasOneRef())
+        vm.heap.reportExtraMemoryAllocated(atomString.impl()->cost());
+
+    convertToNonRope(String { atomString });
+
     return atomString;
 }
 


### PR DESCRIPTION
#### 0a0fdf90f82f7457cf030541a55c249443805005
<pre>
Regression(262103@main) JSRopeString::resolveRopeToAtomString() no longer reports extra memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=254474">https://bugs.webkit.org/show_bug.cgi?id=254474</a>

Reviewed by Yusuke Suzuki.

JSRopeString::resolveRopeToAtomString() no longer reports extra memory since 262103@main.
Because we&apos;re holding the resolved rope as an AtomString, `valueInternal().impl()-&gt;hasOneRef()`
could never be true.

* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSRopeString::resolveRopeToAtomString const):

Canonical link: <a href="https://commits.webkit.org/262158@main">https://commits.webkit.org/262158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7b3be807c5ff4120b3f2c215e375fd003fa76d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/580 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/819 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/813 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/650 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/579 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/593 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/642 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/654 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/615 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/685 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/630 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/136 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/635 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/686 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/80 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/130 "Passed tests") | 
<!--EWS-Status-Bubble-End-->