### PR TITLE
[GLib] Allow application to provide its ID to the WebContext

### DIFF
--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp
@@ -79,6 +79,7 @@ Ref<ProcessPoolConfiguration> ProcessPoolConfiguration::copy()
 #if PLATFORM(GTK) || PLATFORM(WPE)
     copy->m_memoryPressureHandlerConfiguration = this->m_memoryPressureHandlerConfiguration;
     copy->m_disableFontHintingForTesting = this->m_disableFontHintingForTesting;
+    copy->m_applicationIdentifier = this->m_applicationIdentifier;
 #endif
 #if HAVE(AUDIT_TOKEN)
     copy->m_presentingApplicationProcessToken = this->m_presentingApplicationProcessToken;

--- a/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h
@@ -159,6 +159,9 @@ public:
 
     bool disableFontHintingForTesting() const { return m_disableFontHintingForTesting; }
     void setDisableFontHintingForTesting(bool override) { m_disableFontHintingForTesting = override; }
+
+    void setApplicationIdentifier(const WTF::String& applicationIdentifier) { m_applicationIdentifier = applicationIdentifier; }
+    const WTF::String& applicationIdentifier() const { return m_applicationIdentifier; }
 #endif
 
     void setTimeZoneOverride(const WTF::String& timeZoneOverride) { m_timeZoneOverride = timeZoneOverride; }
@@ -201,6 +204,7 @@ private:
 #if PLATFORM(GTK) || PLATFORM(WPE)
     std::optional<MemoryPressureHandler::Configuration> m_memoryPressureHandlerConfiguration;
     bool m_disableFontHintingForTesting { false };
+    WTF::String m_applicationIdentifier;
 #endif
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> m_presentingApplicationProcessToken;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -640,7 +640,7 @@ static void webkit_web_context_class_init(WebKitWebContextClass* webContextClass
      * WebKitWebContext:application-id:
      *
      * The reverse DNS application ID for this web context. Setting this property is specially
-     * required when the Application creating WebViews is not spawned using #GApplication nor
+     * required when the application creating web views is not spawned using #GApplication or
      * Flatpak. In this scenario the internal WebKit process launcher spawns its sub-processes in a
      * Bubblewrap sandbox that requires some form of application identifier.
      *

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -645,9 +645,7 @@ static void webkit_web_context_class_init(WebKitWebContextClass* webContextClass
      * Bubblewrap sandbox that requires some form of application identifier.
      *
      * If no application ID is provided the WebContext will attempt to use the #GApplication
-     * identifier. If that fails and the WebProcess sandbox remains enabled (which is the default
-     * behavior since 2.40) the UIProcess will crash, unless the user has explicitly opted-out of
-     * sandboxing using the `WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1` environment variable.
+     * identifier. If that fails and the web process sandbox remains enabled, the application will crash.
      *
      * Since: 2.40.1
      */

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -422,6 +422,9 @@ webkit_web_context_get_use_system_appearance_for_scrollbars (WebKitWebContext   
 WEBKIT_API const gchar*
 webkit_web_context_get_time_zone_override           (WebKitWebContext              *context);
 
+WEBKIT_API const gchar*
+webkit_web_context_get_application_id               (WebKitWebContext              *context);
+
 G_END_DECLS
 
 #endif

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -111,9 +111,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 
     parameters.disableFontHintingForTesting = m_configuration->disableFontHintingForTesting();
 
-    GApplication* app = g_application_get_default();
-    if (app)
-        parameters.applicationID = String::fromLatin1(g_application_get_application_id(app));
+    parameters.applicationID = m_configuration->applicationIdentifier();
     parameters.applicationName = String::fromLatin1(g_get_application_name());
 
 #if ENABLE(REMOTE_INSPECTOR)

--- a/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
@@ -40,6 +40,7 @@ using namespace WebCore;
 void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& launchOptions)
 {
     launchOptions.extraInitializationData.set("enable-sandbox"_s, m_processPool->sandboxEnabled() ? "true"_s : "false"_s);
+    launchOptions.extraInitializationData.set("application-id"_s, m_processPool->configuration().applicationIdentifier());
 
     if (m_processPool->sandboxEnabled()) {
         WebsiteDataStore* dataStore = websiteDataStore();


### PR DESCRIPTION
#### c9d14b9f48402410be4621e7a4db7108200abea9
<pre>
[GLib] Allow application to provide its ID to the WebContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=254482">https://bugs.webkit.org/show_bug.cgi?id=254482</a>

Reviewed by NOBODY (OOPS!).

Setting the application-id property on the WebContext is specially required when the Application
creating WebViews is not spawned using #GApplication nor Flatpak. In this scenario the internal
WebKit process launcher spawns its sub-processes in a Bubblewrap sandbox that requires some form of
application identifier.

If no application ID is provided the WebContext will attempt to use the #GApplication identifier. If
that fails and the WebProcess sandbox remains enabled (which is the default behavior since 2.40) the
UIProcess will crash, unless the user has explicitly opted-out of sandboxing using the
`WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1` environment variable.

* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.cpp:
(API::ProcessPoolConfiguration::copy):
* Source/WebKit/UIProcess/API/APIProcessPoolConfiguration.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkitWebContextGetProperty):
(webkitWebContextSetProperty):
(webkitWebContextConstructed):
(webkit_web_context_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in:
* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::createFlatpakInfo):
(WebKit::bubblewrapSpawn):
(WebKit::applicationId): Deleted.
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp:
(WebKit::WebProcessProxy::platformGetLaunchOptions):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a13625d658a410b0b973c414c636273010fb4c7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/873 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/913 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/705 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/658 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/702 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/675 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/643 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/687 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/700 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->