### PR TITLE
[UI-side compositing] Safari occasionally crashes when scrolling underneath `NSScrollerImpPair`

### DIFF
--- a/LayoutTests/tiled-drawing/scrolling/fast-scroll-div-latched-mainframe-with-handler.html
+++ b/LayoutTests/tiled-drawing/scrolling/fast-scroll-div-latched-mainframe-with-handler.html
@@ -112,6 +112,7 @@
         ];
 
         await UIHelper.mouseWheelSequence({ events: events });
+        await UIHelper.renderingUpdate();
         checkForScroll();
         // We should finish via the scroll event; this will fire in the case of failure when the page doesn't scroll.
     }

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC)
 
+#import "ScrollTypesMac.h"
 #import "ScrollerPairMac.h"
 #import <QuartzCore/CALayer.h>
 #import <WebCore/FloatPoint.h>
@@ -329,9 +330,7 @@ ScrollerMac::~ScrollerMac()
 void ScrollerMac::attach()
 {
     m_scrollerImpDelegate = adoptNS([[WebScrollerImpDelegateMac alloc] initWithScroller:this]);
-
-    NSScrollerStyle newStyle = [m_pair.scrollerImpPair() scrollerStyle];
-    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:newStyle controlSize:NSControlSizeRegular horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil];
+    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:NSControlSizeRegular horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil];
     [m_scrollerImp setDelegate:m_scrollerImpDelegate.get()];
 }
 
@@ -339,17 +338,16 @@ void ScrollerMac::setHostLayer(CALayer *layer)
 {
     if (m_hostLayer == layer)
         return;
-    
-    Locker locker { m_pair.scrollerImpPairLock() };
 
     m_hostLayer = layer;
 
     [m_scrollerImp setLayer:layer];
 
+    NSScrollerImp *scrollerImp = layer ? m_scrollerImp.get() : nil;
     if (m_orientation == ScrollbarOrientation::Vertical)
-        [m_pair.scrollerImpPair() setVerticalScrollerImp:layer ? m_scrollerImp.get() : nil];
+        m_pair.setVerticalScrollerImp(scrollerImp);
     else
-        [m_pair.scrollerImpPair() setHorizontalScrollerImp:layer ?  m_scrollerImp.get() : nil];
+        m_pair.setHorizontalScrollerImp(scrollerImp);
 }
 
 void ScrollerMac::updateValues()

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -83,7 +83,7 @@ private:
     void rubberBandingStateChanged(bool) final;
     bool scrollPositionIsNotRubberbandingEdge(const FloatPoint&) const;
 
-    ScrollerPairMac m_scrollerPair;
+    Ref<ScrollerPairMac> m_scrollerPair;
 
     bool m_inMomentumPhase { false };
 };

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -42,13 +42,13 @@ namespace WebCore {
 
 ScrollingTreeScrollingNodeDelegateMac::ScrollingTreeScrollingNodeDelegateMac(ScrollingTreeScrollingNode& scrollingNode)
     : ThreadedScrollingTreeScrollingNodeDelegate(scrollingNode)
-    , m_scrollerPair(scrollingNode)
+    , m_scrollerPair(ScrollerPairMac::create(scrollingNode))
 {
 }
 
 ScrollingTreeScrollingNodeDelegateMac::~ScrollingTreeScrollingNodeDelegateMac()
 {
-    m_scrollerPair.releaseReferencesToScrollerImpsOnTheMainThread();
+    m_scrollerPair->releaseReferencesToScrollerImpsOnTheMainThread();
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::nodeWillBeDestroyed()
@@ -62,26 +62,26 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
         auto horizontalScrollbar = scrollingStateNode.horizontalScrollerImp();
         auto verticalScrollbar = scrollingStateNode.verticalScrollerImp();
         if (horizontalScrollbar || verticalScrollbar) {
-            m_scrollerPair.releaseReferencesToScrollerImpsOnTheMainThread();
-            m_scrollerPair.horizontalScroller().setScrollerImp(horizontalScrollbar);
-            m_scrollerPair.verticalScroller().setScrollerImp(verticalScrollbar);
+            m_scrollerPair->releaseReferencesToScrollerImpsOnTheMainThread();
+            m_scrollerPair->horizontalScroller().setScrollerImp(horizontalScrollbar);
+            m_scrollerPair->verticalScroller().setScrollerImp(verticalScrollbar);
         }
     }
     
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer) && scrollingNode().horizontalNativeScrollbarVisibility() == NativeScrollbarVisibility::Visible)
-        m_scrollerPair.horizontalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
+        m_scrollerPair->horizontalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
     
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer) && scrollingNode().verticalNativeScrollbarVisibility() == NativeScrollbarVisibility::Visible)
-        m_scrollerPair.verticalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
+        m_scrollerPair->verticalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
         if (scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
-            m_scrollerPair.horizontalScroller().setHostLayer(nullptr);
+            m_scrollerPair->horizontalScroller().setHostLayer(nullptr);
         if (scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
-            m_scrollerPair.verticalScroller().setHostLayer(nullptr);
+            m_scrollerPair->verticalScroller().setHostLayer(nullptr);
     }
     
-    m_scrollerPair.updateValues();
+    m_scrollerPair->updateValues();
 
     ThreadedScrollingTreeScrollingNodeDelegate::updateFromStateNode(scrollingStateNode);
 }
@@ -96,7 +96,7 @@ bool ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent(const PlatformWheel
         m_inMomentumPhase = false;
     
     if (wasInMomentumPhase != m_inMomentumPhase)
-        m_scrollerPair.setUsePresentationValues(m_inMomentumPhase);
+        m_scrollerPair->setUsePresentationValues(m_inMomentumPhase);
 
     auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { scrollingTree(), scrollingNode().scrollingNodeID(), WheelEventTestMonitor::HandlingWheelEvent };
 
@@ -285,15 +285,15 @@ void ScrollingTreeScrollingNodeDelegateMac::rubberBandingStateChanged(bool inRub
 
 void ScrollingTreeScrollingNodeDelegateMac::updateScrollbarPainters()
 {
-    if (m_inMomentumPhase && m_scrollerPair.hasScrollerImp() && m_scrollerPair.isUsingPresentationValues()) {
+    if (m_inMomentumPhase && m_scrollerPair->hasScrollerImp() && m_scrollerPair->isUsingPresentationValues()) {
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         [CATransaction lock];
 
-        auto horizontalValues = m_scrollerPair.valuesForOrientation(ScrollbarOrientation::Horizontal);
-        m_scrollerPair.setHorizontalScrollbarPresentationValue(horizontalValues.value);
+        auto horizontalValues = m_scrollerPair->valuesForOrientation(ScrollbarOrientation::Horizontal);
+        m_scrollerPair->setHorizontalScrollbarPresentationValue(horizontalValues.value);
 
-        auto verticalValues = m_scrollerPair.valuesForOrientation(ScrollbarOrientation::Vertical);
-        m_scrollerPair.setVerticalScrollbarPresentationValue(verticalValues.value);
+        auto verticalValues = m_scrollerPair->valuesForOrientation(ScrollbarOrientation::Vertical);
+        m_scrollerPair->setVerticalScrollbarPresentationValue(verticalValues.value);
 
         [CATransaction unlock];
         END_BLOCK_OBJC_EXCEPTIONS
@@ -302,42 +302,42 @@ void ScrollingTreeScrollingNodeDelegateMac::updateScrollbarPainters()
 
 void ScrollingTreeScrollingNodeDelegateMac::initScrollbars()
 {
-    m_scrollerPair.init();
+    m_scrollerPair->init();
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::updateScrollbarLayers()
 {
-    m_scrollerPair.updateValues();
+    m_scrollerPair->updateValues();
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::handleWheelEventPhase(const PlatformWheelEventPhase wheelEventPhase)
 {
-    m_scrollerPair.handleWheelEventPhase(wheelEventPhase);
+    m_scrollerPair->handleWheelEventPhase(wheelEventPhase);
 }
 
 bool ScrollingTreeScrollingNodeDelegateMac::handleMouseEventForScrollbars(const PlatformMouseEvent& mouseEvent)
 {
-    return m_scrollerPair.handleMouseEvent(mouseEvent);
+    return m_scrollerPair->handleMouseEvent(mouseEvent);
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::viewWillStartLiveResize()
 {
-    return m_scrollerPair.viewWillStartLiveResize();
+    return m_scrollerPair->viewWillStartLiveResize();
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::viewWillEndLiveResize()
 {
-    return m_scrollerPair.viewWillEndLiveResize();
+    return m_scrollerPair->viewWillEndLiveResize();
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::viewSizeDidChange()
 {
-    return m_scrollerPair.contentsSizeChanged();
+    return m_scrollerPair->contentsSizeChanged();
 }
 
 String ScrollingTreeScrollingNodeDelegateMac::scrollbarStateForOrientation(ScrollbarOrientation orientation) const
 {
-    return m_scrollerPair.scrollbarStateForOrientation(orientation);
+    return m_scrollerPair->scrollbarStateForOrientation(orientation);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mac/ScrollTypesMac.h
+++ b/Source/WebCore/platform/mac/ScrollTypesMac.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ScrollTypes.h"
+#import <AppKit/AppKit.h>
+
+namespace WebCore {
+
+inline NSScrollerStyle nsScrollerStyle(ScrollbarStyle style)
+{
+    switch (style) {
+    case ScrollbarStyle::AlwaysVisible:
+        return NSScrollerStyleLegacy;
+    case ScrollbarStyle::Overlay:
+        return NSScrollerStyleOverlay;
+    }
+    ASSERT_NOT_REACHED();
+    return NSScrollerStyleLegacy;
+}
+
+inline ScrollbarStyle scrollbarStyle(NSScrollerStyle style)
+{
+    switch (style) {
+    case NSScrollerStyleLegacy:
+        return ScrollbarStyle::AlwaysVisible;
+    case NSScrollerStyleOverlay:
+        return ScrollbarStyle::Overlay;
+    }
+    ASSERT_NOT_REACHED();
+    return ScrollbarStyle::AlwaysVisible;
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### b2362a5d6b0dcee521bbc38c226ea2216e2422e7
<pre>
[UI-side compositing] Safari occasionally crashes when scrolling underneath `NSScrollerImpPair`
<a href="https://bugs.webkit.org/show_bug.cgi?id=254484">https://bugs.webkit.org/show_bug.cgi?id=254484</a>
rdar://107139674

Reviewed by Simon Fraser.

After the changes in 259592@main, we now update `NSScrollerImpPair` in response to various scrolling
-related events off of the scrolling thread, with a lock (`m_scrollerImpPairLock`) to prevent us
from concurrently updating the `NSScrollerImpPair`. However, this is actually insufficient to ensure
thread safety since `NSScrollerImpPair` internally schedules work on the main thread underneath
`-[NSScrollerImpPair endScrollGesture]`. As such, it&apos;s possible to end up calling methods on an
`NSTimer` that has already been destroyed.

Since we can&apos;t prevent `NSScrollerImpPair` from rescheduling its hide timer on the main thread, we
need to instead dispatch all of our other calls to update the imp pair on the main thread. To
achieve this, we introduce a new helper method on `ScrollerPairMac` to asynchronously dispatch to
the main thread from the scrolling thread with the `NSScrollerImpPair`, or call the block
immediately in the case where we&apos;re already on the main thread, and deploy this in all the places
where we currently update the `NSScrollerImpPair`. See below for more details.

I wasn&apos;t able to reproduce the crash in either a test, or manually in MiniBrowser/Safari, but I was
able to reproduce it and verify this fix by injecting a `sleep()` in `NSScrollerImpPair`, after the
hiding timer is deallocated but before the pointer is reset to nil.

* LayoutTests/tiled-drawing/scrolling/fast-scroll-div-latched-mainframe-with-handler.html:

Adjust a test to avoid flakiness after this change, since we now dispatch to the main thread before
updating the imp pair.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::attach):

Make this use the new getter for `scrollbarStyle()`.

(WebCore::ScrollerMac::setHostLayer):

Use another helper method here to avoid mutating `NSScrollerImpPair` from a background thread.

* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:

Make `ScrollerPairMac` thread-safe ref-counted, so that we can safely create references to it
from the scrolling thread, for blocks that are dispatched to the main thread.

We also remove `m_scrollerImpPairLock`, since all access to the `NSScrollerImpPair` now happens on
the main thread.

(WebCore::ScrollerPairMac::create):
(WebCore::ScrollerPairMac::lastKnownMousePosition const):
(WebCore::ScrollerPairMac::scrollbarStyle const):
(WebCore::ScrollerPairMac::scrollerImpVertical):
(WebCore::ScrollerPairMac::scrollerImpPair): Deleted.
(WebCore::ScrollerPairMac::WTF_RETURNS_LOCK): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(-[WebScrollerImpPairDelegateMac scrollerImpPair:updateScrollerStyleForNewRecommendedScrollerStyle:]):

Make this use the new `setScrollbarStyle` helpers, which internally dispatch onto the main thread
before attempting to access `NSScrollerImpPair`.

(WebCore::ScrollerPairMac::ScrollerPairMac):
(WebCore::ScrollerPairMac::init):

Drive-by adjustments: remove some unnecessary `WebCore::` namespacing, now that this entire class is
already in the WebCore namespace.

(WebCore::ScrollerPairMac::~ScrollerPairMac):

Also ensure that the underlying `NSScrollerImpPair` is also destroyed on the main thread.

(WebCore::ScrollerPairMac::handleWheelEventPhase):
(WebCore::ScrollerPairMac::viewWillStartLiveResize):
(WebCore::ScrollerPairMac::viewWillEndLiveResize):
(WebCore::ScrollerPairMac::contentsSizeChanged):
(WebCore::ScrollerPairMac::handleMouseEvent):
(WebCore::ScrollerPairMac::updateValues):

Deploy `ensureOnMainThreadWithProtectedThis` in various places where we update `NSScrollerImpPair`.

(WebCore::ScrollerPairMac::visibleSize const):
(WebCore::ScrollerPairMac::valuesForOrientation):
(WebCore::ScrollerPairMac::setVerticalScrollerImp):
(WebCore::ScrollerPairMac::setHorizontalScrollerImp):
(WebCore::ScrollerPairMac::setScrollbarStyle):
(WebCore::ScrollerPairMac::ensureOnMainThreadWithProtectedThis):

Add a helper here to make it easier to dispatch methods that mutate or update the `NSScrollerImpPair`
onto the main thread. If we&apos;re on the scrolling thread, this dispatches asynchronously on to the
main thread; otherwise, we&apos;ll run the block right away if we&apos;re already on the main thread.

* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:

Turn `m_scrollerPair` into a `Ref`, now that the class is ref-counted.

* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::ScrollingTreeScrollingNodeDelegateMac):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::~ScrollingTreeScrollingNodeDelegateMac):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateScrollbarPainters):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::initScrollbars):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateScrollbarLayers):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleWheelEventPhase):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleMouseEventForScrollbars):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::viewWillStartLiveResize):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::viewWillEndLiveResize):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::viewSizeDidChange):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::scrollbarStateForOrientation const):
* Source/WebCore/platform/mac/ScrollTypesMac.h: Added.
(WebCore::nsScrollerStyle):
(WebCore::scrollbarStyle):

Update all these call sites to use `-&gt;` instead of `.` when accessing `m_scrollerPair`.

Canonical link: <a href="https://commits.webkit.org/262194@main">https://commits.webkit.org/262194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc5580f805ab418722fc74222fec1eb625dd3cd0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/759 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/972 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1142 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/805 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/777 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1823 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/817 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/817 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/201 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/830 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->