### PR TITLE
web manifest: implement orientation member parsing

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -28,6 +28,8 @@
 #if ENABLE(APPLICATION_MANIFEST)
 
 #include "Color.h"
+#include "ScreenOrientationLockType.h"
+#include <optional>
 #include <wtf/EnumTraits.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -60,6 +62,7 @@ struct ApplicationManifest {
     String description;
     URL scope;
     Display display;
+    std::optional<ScreenOrientationLockType> orientation;
     URL startURL;
     URL id;
     Color backgroundColor;

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
@@ -28,6 +28,7 @@
 #if ENABLE(APPLICATION_MANIFEST)
 
 #include "ApplicationManifest.h"
+#include <optional>
 #include <wtf/JSONValues.h>
 
 namespace WebCore {
@@ -46,6 +47,7 @@ private:
 
     URL parseStartURL(const JSON::Object&, const URL&);
     ApplicationManifest::Display parseDisplay(const JSON::Object&);
+    const std::optional<ScreenOrientationLockType> parseOrientation(const JSON::Object&);
     String parseName(const JSON::Object&);
     String parseDescription(const JSON::Object&);
     String parseShortName(const JSON::Object&);

--- a/Source/WebCore/page/ScreenOrientationLockType.h
+++ b/Source/WebCore/page/ScreenOrientationLockType.h
@@ -41,21 +41,3 @@ enum class ScreenOrientationLockType : uint8_t {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ScreenOrientationLockType> {
-    using values = EnumValues<
-        WebCore::ScreenOrientationLockType,
-        WebCore::ScreenOrientationLockType::Any,
-        WebCore::ScreenOrientationLockType::Natural,
-        WebCore::ScreenOrientationLockType::Landscape,
-        WebCore::ScreenOrientationLockType::Portrait,
-        WebCore::ScreenOrientationLockType::PortraitPrimary,
-        WebCore::ScreenOrientationLockType::PortraitSecondary,
-        WebCore::ScreenOrientationLockType::LandscapePrimary,
-        WebCore::ScreenOrientationLockType::LandscapeSecondary
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -770,6 +770,18 @@ struct WebCore::ApplePayCouponCodeUpdate : WebCore::ApplePayDetailsUpdateBase {
 };
 #endif
 
+header: <WebCore/ScreenOrientationLockType.h>
+enum class WebCore::ScreenOrientationLockType : uint8_t {
+    Any
+    Natural
+    Landscape
+    Portrait
+    PortraitPrimary
+    PortraitSecondary
+    LandscapePrimary
+    LandscapeSecondary
+};
+
 #if ENABLE(APPLICATION_MANIFEST)
 [Nested] enum class WebCore::ApplicationManifest::Display : uint8_t {
     Browser
@@ -797,6 +809,7 @@ struct WebCore::ApplicationManifest {
     String description
     URL scope
     WebCore::ApplicationManifest::Display display
+    std::optional<WebCore::ScreenOrientationLockType> orientation
     URL startURL
     URL id
     WebCore::Color backgroundColor

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
@@ -42,6 +42,17 @@ typedef NS_ENUM(NSInteger, _WKApplicationManifestDisplayMode) {
     _WKApplicationManifestDisplayModeFullScreen,
 } WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
 
+typedef NS_ENUM(NSInteger, _WKApplicationManifestOrientation) {
+    _WKApplicationManifestOrientationAny,
+    _WKApplicationManifestOrientationLandscape,
+    _WKApplicationManifestOrientationLandscapePrimary,
+    _WKApplicationManifestOrientationLandscapeSecondary,
+    _WKApplicationManifestOrientationNatural,
+    _WKApplicationManifestOrientationPortrait,
+    _WKApplicationManifestOrientationPortraitPrimary,
+    _WKApplicationManifestOrientationPortraitSecondary,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 typedef NS_ENUM(NSInteger, _WKApplicationManifestIconPurpose) {
     _WKApplicationManifestIconPurposeAny = (1 << 0),
     _WKApplicationManifestIconPurposeMonochrome = (1 << 1),

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
@@ -47,6 +47,29 @@ static inline std::ostream& operator<<(std::ostream& os, const ApplicationManife
         return os << "ApplicationManifest::Display::Fullscreen";
     }
 }
+
+static inline std::ostream& operator<<(std::ostream& os, const ScreenOrientationLockType& orientation)
+{
+    switch (orientation) {
+    case WebCore::ScreenOrientationLockType::Any:
+        return os << "WebCore::ScreenOrientationLockType::Any";
+    case WebCore::ScreenOrientationLockType::Landscape:
+        return os << "WebCore::ScreenOrientationLockType::Landscape";
+    case WebCore::ScreenOrientationLockType::LandscapePrimary:
+        return os << "WebCore::ScreenOrientationLockType::LandscapePrimary";
+    case WebCore::ScreenOrientationLockType::LandscapeSecondary:
+        return os << "WebCore::ScreenOrientationLockType::LandscapeSecondary";
+    case WebCore::ScreenOrientationLockType::Natural:
+        return os << "WebCore::ScreenOrientationLockType::Natural";
+    case WebCore::ScreenOrientationLockType::Portrait:
+        return os << "WebCore::ScreenOrientationLockType::Portrait";
+    case WebCore::ScreenOrientationLockType::PortraitPrimary:
+        return os << "WebCore::ScreenOrientationLockType::PortraitPrimary";
+    case WebCore::ScreenOrientationLockType::PortraitSecondary:
+        return os << "WebCore::ScreenOrientationLockType::PortraitSecondary";
+    }
+}
+
 } // namespace WebCore
 
 class ApplicationManifestParserTest : public testing::Test {
@@ -103,6 +126,13 @@ public:
     {
         auto manifest = parseTopLevelProperty("display"_s, rawJSON);
         auto value = manifest.display;
+        EXPECT_EQ(expectedValue, value);
+    }
+
+    void testOrientation(const String& rawJSON, std::optional<WebCore::ScreenOrientationLockType> expectedValue)
+    {
+        auto manifest = parseTopLevelProperty("orientation"_s, rawJSON);
+        auto value = manifest.orientation;
         EXPECT_EQ(expectedValue, value);
     }
 
@@ -312,6 +342,27 @@ TEST_F(ApplicationManifestParserTest, Display)
     testDisplay("\"\t\nMINIMAL-UI \""_s, ApplicationManifest::Display::MinimalUI);
 }
 
+TEST_F(ApplicationManifestParserTest, Orientation)
+{
+    testOrientation(""_s, std::nullopt);
+    testOrientation("123"_s, std::nullopt);
+    testOrientation("null"_s, std::nullopt);
+    testOrientation("true"_s, std::nullopt);
+    testOrientation("{ }"_s, std::nullopt);
+    testOrientation("[ ]"_s, std::nullopt);
+    testOrientation("\"\""_s, std::nullopt);
+    testOrientation("\"garbage string\""_s, std::nullopt);
+
+    testOrientation("\"any\""_s, WebCore::ScreenOrientationLockType::Any);
+    testOrientation("\"natural\""_s, WebCore::ScreenOrientationLockType::Natural);
+    testOrientation("\"landscape\""_s, WebCore::ScreenOrientationLockType::Landscape);
+    testOrientation("\"landscape-primary\""_s, WebCore::ScreenOrientationLockType::LandscapePrimary);
+    testOrientation("\"landscape-secondary\""_s, WebCore::ScreenOrientationLockType::LandscapeSecondary);
+    testOrientation("\"portrait\""_s, WebCore::ScreenOrientationLockType::Portrait);
+    testOrientation("\"portrait-primary\""_s, WebCore::ScreenOrientationLockType::PortraitPrimary);
+    testOrientation("\"portrait-secondary\""_s, WebCore::ScreenOrientationLockType::PortraitSecondary);
+}
+
 TEST_F(ApplicationManifestParserTest, Name)
 {
     testName("123"_s, String());
@@ -467,7 +518,6 @@ TEST_F(ApplicationManifestParserTest, Icons)
     OptionSet<ApplicationManifest::Icon::Purpose> purposeMonochromeAny { ApplicationManifest::Icon::Purpose::Monochrome, ApplicationManifest::Icon::Purpose::Any };
 
     testIconsPurposes("\"monochrome any\""_s, purposeMonochromeAny);
-
 }
 
 #endif


### PR DESCRIPTION
#### f3713b3399174f5ce5a32b1e0b8b99a5f9956c7d
<pre>
web manifest: implement orientation member parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=247275">https://bugs.webkit.org/show_bug.cgi?id=247275</a>
rdar://101770484

Reviewed by Chris Dumez.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseManifest):
(WebCore::ApplicationManifestParser::parseOrientation):
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h:
* Source/WebCore/page/ScreenOrientationLockType.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithCoder:]):
(-[_WKApplicationManifest encodeWithCoder:]):
(-[_WKApplicationManifest orientation]):
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(WebCore::operator&lt;&lt;):
(ApplicationManifestParserTest::testOrientation):
(TEST_F):

Canonical link: <a href="https://commits.webkit.org/262241@main">https://commits.webkit.org/262241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20c856d532e96636254dc0468c61d60a035d1908

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/795 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/999 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/835 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/814 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1863 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/809 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/239 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/869 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->