### PR TITLE
Make RemoteRenderingData::cacheFont reconstruct a Font using Attributes, and a reference to FontCustomPlatformData.

### DIFF
--- a/Source/WebCore/css/CSSFontFaceSource.h
+++ b/Source/WebCore/css/CSSFontFaceSource.h
@@ -90,10 +90,10 @@ private:
 
     RefPtr<SharedBuffer> m_generatedOTFBuffer;
     RefPtr<JSC::ArrayBufferView> m_immediateSource;
-    std::unique_ptr<FontCustomPlatformData> m_immediateFontCustomPlatformData;
+    RefPtr<FontCustomPlatformData> m_immediateFontCustomPlatformData;
 
     WeakPtr<SVGFontFaceElement, WeakPtrImplWithEventTargetData> m_svgFontFaceElement;
-    std::unique_ptr<FontCustomPlatformData> m_inDocumentCustomPlatformData;
+    RefPtr<FontCustomPlatformData> m_inDocumentCustomPlatformData;
 
     Status m_status { Status::Pending };
     bool m_hasSVGFontFaceElement { false };

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -141,7 +141,7 @@ bool CachedFont::ensureCustomFontData(SharedBuffer* data)
     return m_fontCustomPlatformData.get();
 }
 
-std::unique_ptr<FontCustomPlatformData> CachedFont::createCustomFontData(SharedBuffer& bytes, const String& itemInCollection, bool& wrapping)
+RefPtr<FontCustomPlatformData> CachedFont::createCustomFontData(SharedBuffer& bytes, const String& itemInCollection, bool& wrapping)
 {
     RefPtr buffer = { &bytes };
     wrapping = !convertWOFFToSfntIfNecessary(buffer);

--- a/Source/WebCore/loader/cache/CachedFont.h
+++ b/Source/WebCore/loader/cache/CachedFont.h
@@ -54,7 +54,7 @@ public:
     bool stillNeedsLoad() const override { return !m_loadInitiated; }
 
     virtual bool ensureCustomFontData();
-    static std::unique_ptr<FontCustomPlatformData> createCustomFontData(SharedBuffer&, const String& itemInCollection, bool& wrapping);
+    static RefPtr<FontCustomPlatformData> createCustomFontData(SharedBuffer&, const String& itemInCollection, bool& wrapping);
     static FontPlatformData platformDataFromCustomData(FontCustomPlatformData&, const FontDescription&, bool bold, bool italic, const FontCreationContext&);
 
     virtual RefPtr<Font> createFont(const FontDescription&, bool syntheticBold, bool syntheticItalic, const FontCreationContext&);
@@ -84,7 +84,7 @@ private:
     bool m_loadInitiated;
     bool m_hasCreatedFontDataWrappingResource;
 
-    std::unique_ptr<FontCustomPlatformData> m_fontCustomPlatformData;
+    RefPtr<FontCustomPlatformData> m_fontCustomPlatformData;
 
     friend class MemoryCache;
 };

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -76,12 +76,8 @@ Ref<Font> Font::create(Ref<SharedBuffer>&& fontFaceData, Font::Origin origin, fl
 
 Font::Font(const FontPlatformData& platformData, Origin origin, Interstitial interstitial, Visibility visibility, OrientationFallback orientationFallback, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
     : m_platformData(platformData)
-    , m_renderingResourceIdentifier(renderingResourceIdentifier)
-    , m_origin(origin)
-    , m_visibility(visibility)
+    , m_attributes({ renderingResourceIdentifier, origin, interstitial, visibility, orientationFallback })
     , m_treatAsFixedPitch(false)
-    , m_isInterstitial(interstitial == Interstitial::Yes)
-    , m_isTextOrientationFallback(orientationFallback == OrientationFallback::Yes)
     , m_isBrokenIdeographFallback(false)
     , m_hasVerticalGlyphs(false)
     , m_isUsedInSystemFallbackFontCache(false)
@@ -179,9 +175,14 @@ Font::~Font()
 
 RenderingResourceIdentifier Font::renderingResourceIdentifier() const
 {
-    if (!m_renderingResourceIdentifier)
-        m_renderingResourceIdentifier = RenderingResourceIdentifier::generate();
-    return *m_renderingResourceIdentifier;
+    return m_attributes.ensureRenderingResourceIdentifier();
+}
+
+RenderingResourceIdentifier Font::Attributes::ensureRenderingResourceIdentifier() const
+{
+    if (!renderingResourceIdentifier)
+        renderingResourceIdentifier = RenderingResourceIdentifier::generate();
+    return *renderingResourceIdentifier;
 }
 
 static bool fillGlyphPage(GlyphPage& pageToFill, UChar* buffer, unsigned bufferLength, const Font& font)

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -134,7 +134,7 @@ public:
     const Font& invisibleFont() const;
 
     bool hasVerticalGlyphs() const { return m_hasVerticalGlyphs; }
-    bool isTextOrientationFallback() const { return m_isTextOrientationFallback; }
+    bool isTextOrientationFallback() const { return m_attributes.isTextOrientationFallback == OrientationFallback::Yes; }
 
     const FontMetrics& fontMetrics() const { return m_fontMetrics; }
     float sizePerUnit() const { return platformData().size() / (fontMetrics().unitsPerEm() ? fontMetrics().unitsPerEm() : 1); }
@@ -179,9 +179,9 @@ public:
     void determinePitch();
     Pitch pitch() const { return m_treatAsFixedPitch ? FixedPitch : VariablePitch; }
 
-    Origin origin() const { return m_origin; }
-    bool isInterstitial() const { return m_isInterstitial; }
-    Visibility visibility() const { return m_visibility; }
+    Origin origin() const { return m_attributes.origin; }
+    bool isInterstitial() const { return m_attributes.isInterstitial == Interstitial::Yes; }
+    Visibility visibility() const { return m_attributes.visibility; }
     bool allowsAntialiasing() const { return m_allowsAntialiasing; }
 
 #if !LOG_DISABLED
@@ -214,6 +214,18 @@ public:
 
     void setIsUsedInSystemFallbackFontCache() { m_isUsedInSystemFallbackFontCache = true; }
     bool isUsedInSystemFallbackFontCache() const { return m_isUsedInSystemFallbackFontCache; }
+
+    class Attributes {
+    public:
+        WEBCORE_EXPORT RenderingResourceIdentifier ensureRenderingResourceIdentifier() const;
+
+        mutable std::optional<RenderingResourceIdentifier> renderingResourceIdentifier;
+        Font::Origin origin : 1;
+        Font::Interstitial isInterstitial : 1;
+        Font::Visibility visibility : 1;
+        Font::OrientationFallback isTextOrientationFallback : 1;
+    };
+    const Attributes& attributes() const { return m_attributes; }
 
 private:
     WEBCORE_EXPORT Font(const FontPlatformData&, Origin, Interstitial, Visibility, OrientationFallback, std::optional<RenderingResourceIdentifier>);
@@ -289,7 +301,7 @@ private:
     RefPtr<OpenTypeVerticalData> m_verticalData;
 #endif
 
-    mutable std::optional<RenderingResourceIdentifier> m_renderingResourceIdentifier;
+    Attributes m_attributes;
 
     struct DerivedFonts {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
@@ -331,13 +343,7 @@ private:
     float m_spaceWidth { 0 };
     float m_syntheticBoldOffset { 0 };
 
-    Origin m_origin; // Whether or not we are custom font loaded via @font-face
-    Visibility m_visibility; // @font-face's internal timer can cause us to show fonts even when a font is being downloaded.
-
     unsigned m_treatAsFixedPitch : 1;
-    unsigned m_isInterstitial : 1; // Whether or not this custom font is the last resort placeholder for a loading font
-
-    unsigned m_isTextOrientationFallback : 1;
     unsigned m_isBrokenIdeographFallback : 1;
     unsigned m_hasVerticalGlyphs : 1;
 

--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "FontPlatformData.h"
+#include "RenderingResourceIdentifier.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 
@@ -53,7 +54,7 @@ class FragmentedSharedBuffer;
 template <typename T> class FontTaggedSettings;
 typedef FontTaggedSettings<int> FontFeatureSettings;
 
-struct FontCustomPlatformData {
+struct FontCustomPlatformData : public RefCounted<FontCustomPlatformData> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(FontCustomPlatformData);
 public:
@@ -63,6 +64,7 @@ public:
     FontCustomPlatformData(CTFontDescriptorRef fontDescriptor, FontPlatformData::CreationData&& creationData)
         : fontDescriptor(fontDescriptor)
         , creationData(WTFMove(creationData))
+        , m_renderingResourceIdentifier(RenderingResourceIdentifier::generateThreadSafe())
     {
     }
 #else
@@ -83,8 +85,10 @@ public:
 #else
     RefPtr<cairo_font_face_t> m_fontFace;
 #endif
+
+    RenderingResourceIdentifier m_renderingResourceIdentifier;
 };
 
-WEBCORE_EXPORT std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer&, const String&);
+WEBCORE_EXPORT RefPtr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer&, const String&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -21,7 +21,9 @@
 #include "config.h"
 #include "FontPlatformData.h"
 
+
 #include "FontCache.h"
+#include "FontCustomPlatformData.h"
 #include "FontDescription.h"
 #include "RenderStyleConstants.h"
 #include "StyleFontSizeFunctions.h"
@@ -39,16 +41,20 @@ FontPlatformData::FontPlatformData()
 {
 }
 
-FontPlatformData::FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const CreationData* creationData)
+FontPlatformData::FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData)
     : m_size(size)
     , m_orientation(orientation)
     , m_widthVariant(widthVariant)
     , m_textRenderingMode(textRenderingMode)
-    , m_creationData(makeOptionalFromPointer(creationData))
+    , m_customPlatformData(customPlatformData)
     , m_syntheticBold(syntheticBold)
     , m_syntheticOblique(syntheticOblique)
 {
 }
+
+FontPlatformData::~FontPlatformData() = default;
+FontPlatformData::FontPlatformData(const FontPlatformData&) = default;
+FontPlatformData& FontPlatformData::operator=(const FontPlatformData&) = default;
 
 #if !USE(FREETYPE)
 FontPlatformData FontPlatformData::cloneWithOrientation(const FontPlatformData& source, FontOrientation orientation)
@@ -93,6 +99,15 @@ void FontPlatformData::updateSizeWithFontSizeAdjust(const std::optional<float>& 
         return;
 
     updateSize(std::min(adjustedFontSize, maximumAllowedFontSize));
+}
+
+const FontPlatformData::CreationData* FontPlatformData::creationData() const
+{
+#if PLATFORM(WIN) || USE(CORE_TEXT)
+    return m_customPlatformData ? &m_customPlatformData->creationData : nullptr;
+#else
+    return nullptr;
+#endif
 }
 
 #if !PLATFORM(COCOA) && !USE(FREETYPE)

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -56,6 +56,7 @@ OBJC_CLASS NSFont;
 #endif
 
 #if USE(CORE_TEXT)
+#include <pal/spi/cf/CoreTextSPI.h>
 typedef const struct __CTFont* CTFontRef;
 #endif
 
@@ -73,6 +74,7 @@ interface IDWriteFontFace;
 namespace WebCore {
 
 class FontDescription;
+struct FontCustomPlatformData;
 
 // This class is conceptually immutable. Once created, no instances should ever change (in an observable way).
 class FontPlatformData {
@@ -107,20 +109,56 @@ public:
     FontPlatformData(WTF::HashTableDeletedValueType);
     FontPlatformData();
 
-    FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation = FontOrientation::Horizontal, FontWidthVariant = FontWidthVariant::RegularWidth, TextRenderingMode = TextRenderingMode::AutoTextRendering, const CreationData* = nullptr);
+    FontPlatformData(float size, bool syntheticBold, bool syntheticOblique, FontOrientation = FontOrientation::Horizontal, FontWidthVariant = FontWidthVariant::RegularWidth, TextRenderingMode = TextRenderingMode::AutoTextRendering, const FontCustomPlatformData* = nullptr);
 
 #if USE(CORE_TEXT)
-    WEBCORE_EXPORT FontPlatformData(RetainPtr<CTFontRef>&&, float size, bool syntheticBold = false, bool syntheticOblique = false, FontOrientation = FontOrientation::Horizontal, FontWidthVariant = FontWidthVariant::RegularWidth, TextRenderingMode = TextRenderingMode::AutoTextRendering, const CreationData* = nullptr);
+    WEBCORE_EXPORT FontPlatformData(RetainPtr<CTFontRef>&&, float size, bool syntheticBold = false, bool syntheticOblique = false, FontOrientation = FontOrientation::Horizontal, FontWidthVariant = FontWidthVariant::RegularWidth, TextRenderingMode = TextRenderingMode::AutoTextRendering, const FontCustomPlatformData* = nullptr);
 #endif
 
 #if PLATFORM(WIN)
-    WEBCORE_EXPORT FontPlatformData(GDIObject<HFONT>, float size, bool syntheticBold, bool syntheticOblique, const CreationData* = nullptr);
-    FontPlatformData(GDIObject<HFONT>, cairo_font_face_t*, float size, bool bold, bool italic, const CreationData* = nullptr);
+    WEBCORE_EXPORT FontPlatformData(GDIObject<HFONT>, float size, bool syntheticBold, bool syntheticOblique, const FontCustomPlatformData* = nullptr);
+    FontPlatformData(GDIObject<HFONT>, cairo_font_face_t*, float size, bool bold, bool italic, const FontCustomPlatformData* = nullptr);
 #endif
 
 #if USE(FREETYPE)
     FontPlatformData(cairo_font_face_t*, RefPtr<FcPattern>&&, float size, bool fixedWidth, bool syntheticBold, bool syntheticOblique, FontOrientation);
 #endif
+
+    class Attributes {
+    public:
+        Attributes(float size, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, bool syntheticBold, bool syntheticOblique)
+            : m_size(size)
+            , m_orientation(orientation)
+            , m_widthVariant(widthVariant)
+            , m_textRenderingMode(textRenderingMode)
+            , m_syntheticBold(syntheticBold)
+            , m_syntheticOblique(syntheticOblique)
+        { }
+
+        float m_size { 0 };
+
+        FontOrientation m_orientation { FontOrientation::Horizontal };
+        FontWidthVariant m_widthVariant { FontWidthVariant::RegularWidth };
+        TextRenderingMode m_textRenderingMode { TextRenderingMode::AutoTextRendering };
+
+        bool m_syntheticBold { false };
+        bool m_syntheticOblique { false };
+
+#if PLATFORM(WIN)
+        LOGFONT m_font;
+#elif USE(CORE_TEXT)
+        RetainPtr<CFDictionaryRef> m_attributes;
+        CTFontDescriptorOptions m_options;
+        RetainPtr<CFStringRef> m_url;
+        RetainPtr<CFStringRef> m_psName;
+#endif
+    };
+
+    WEBCORE_EXPORT static FontPlatformData create(const Attributes&, const FontCustomPlatformData*);
+
+    WEBCORE_EXPORT FontPlatformData(const FontPlatformData&);
+    WEBCORE_EXPORT FontPlatformData& operator=(const FontPlatformData&);
+    WEBCORE_EXPORT ~FontPlatformData();
 
     static FontPlatformData cloneWithOrientation(const FontPlatformData&, FontOrientation);
     static FontPlatformData cloneWithSyntheticOblique(const FontPlatformData&, bool);
@@ -216,10 +254,13 @@ public:
 #endif
     };
 
-    const CreationData* creationData() const
+    WEBCORE_EXPORT const CreationData* creationData() const;
+    const FontCustomPlatformData* customPlatformData() const
     {
-        return m_creationData ? &m_creationData.value() : nullptr;
+        return m_customPlatformData.get();
     }
+
+    WEBCORE_EXPORT Attributes attributes() const;
 
 private:
     bool platformIsEqual(const FontPlatformData&) const;
@@ -262,7 +303,7 @@ private:
 
     // This is conceptually const, but we can't make it actually const,
     // because FontPlatformData is used as a key in a HashMap.
-    std::optional<CreationData> m_creationData;
+    RefPtr<const FontCustomPlatformData> m_customPlatformData;
 
     bool m_syntheticBold { false };
     bool m_syntheticOblique { false };

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -793,10 +793,10 @@ RefPtr<Font> FontCache::systemFallbackForCharacters(const FontDescription& descr
 
     auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(substituteFont, description, ShouldComputePhysicalTraits::No, isForPlatformFont == IsForPlatformFont::Yes).boldObliquePair();
 
-    const FontPlatformData::CreationData* creationData = nullptr;
+    const FontCustomPlatformData* customPlatformData = nullptr;
     if (safeCFEqual(platformData.font(), substituteFont))
-        creationData = platformData.creationData();
-    FontPlatformData alternateFont(substituteFont, platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), creationData);
+        customPlatformData = platformData.customPlatformData();
+    FontPlatformData alternateFont(substituteFont, platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), customPlatformData);
 
     return fontForPlatformData(alternateFont);
 }

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -381,7 +381,7 @@ bool Font::supportsAllPetiteCaps() const
 }
 #endif
 
-static RefPtr<Font> createDerivativeFont(CTFontRef font, float size, FontOrientation orientation, CTFontSymbolicTraits fontTraits, bool syntheticBold, bool syntheticItalic, FontWidthVariant fontWidthVariant, TextRenderingMode textRenderingMode, const FontPlatformData::CreationData* creationData)
+static RefPtr<Font> createDerivativeFont(CTFontRef font, float size, FontOrientation orientation, CTFontSymbolicTraits fontTraits, bool syntheticBold, bool syntheticItalic, FontWidthVariant fontWidthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData)
 {
     if (!font)
         return nullptr;
@@ -395,7 +395,7 @@ static RefPtr<Font> createDerivativeFont(CTFontRef font, float size, FontOrienta
 
     bool usedSyntheticBold = (fontTraits & kCTFontBoldTrait) && !(scaledFontTraits & kCTFontTraitBold);
     bool usedSyntheticOblique = (fontTraits & kCTFontItalicTrait) && !(scaledFontTraits & kCTFontTraitItalic);
-    FontPlatformData scaledFontData(font, size, usedSyntheticBold, usedSyntheticOblique, orientation, fontWidthVariant, textRenderingMode, creationData);
+    FontPlatformData scaledFontData(font, size, usedSyntheticBold, usedSyntheticOblique, orientation, fontWidthVariant, textRenderingMode, customPlatformData);
 
     return Font::create(scaledFontData);
 }
@@ -535,7 +535,7 @@ RefPtr<Font> Font::createFontWithoutSynthesizableFeatures() const
     float size = m_platformData.size();
     CTFontSymbolicTraits fontTraits = CTFontGetSymbolicTraits(m_platformData.font());
     RetainPtr<CTFontRef> ctFont = createCTFontWithoutSynthesizableFeatures(m_platformData.font());
-    return createDerivativeFont(ctFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.creationData());
+    return createDerivativeFont(ctFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.customPlatformData());
 }
 
 RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleFactor) const
@@ -545,7 +545,7 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleF
     RetainPtr<CTFontDescriptorRef> fontDescriptor = adoptCF(CTFontCopyFontDescriptor(m_platformData.font()));
     RetainPtr<CTFontRef> scaledFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), size, nullptr));
 
-    return createDerivativeFont(scaledFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.creationData());
+    return createDerivativeFont(scaledFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.customPlatformData());
 }
 
 float Font::platformWidthForGlyph(Glyph glyph) const

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -24,6 +24,7 @@
 #include "FontPlatformData.h"
 
 #include "Font.h"
+#include "FontCustomPlatformData.h"
 #include "SharedBuffer.h"
 #include <CoreText/CoreText.h>
 #include <pal/spi/cf/CoreTextSPI.h>
@@ -32,8 +33,8 @@
 
 namespace WebCore {
 
-FontPlatformData::FontPlatformData(RetainPtr<CTFontRef>&& font, float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const CreationData* creationData)
-    : FontPlatformData(size, syntheticBold, syntheticOblique, orientation, widthVariant, textRenderingMode, creationData)
+FontPlatformData::FontPlatformData(RetainPtr<CTFontRef>&& font, float size, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, FontWidthVariant widthVariant, TextRenderingMode textRenderingMode, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(size, syntheticBold, syntheticOblique, orientation, widthVariant, textRenderingMode, customPlatformData)
 {
     ASSERT_ARG(font, font);
     m_font = font;
@@ -45,6 +46,59 @@ FontPlatformData::FontPlatformData(RetainPtr<CTFontRef>&& font, float size, bool
 #if PLATFORM(IOS_FAMILY)
     m_isEmoji = CTFontIsAppleColorEmoji(m_font.get());
 #endif
+}
+
+static RetainPtr<CTFontDescriptorRef> findFontDescriptor(CFStringRef referenceURL, CFStringRef postScriptName)
+{
+    auto url = adoptCF(CFURLCreateWithString(kCFAllocatorDefault, referenceURL, nullptr));
+    if (!url)
+        return nullptr;
+    auto fontDescriptors = adoptCF(CTFontManagerCreateFontDescriptorsFromURL(url.get()));
+    if (!fontDescriptors || !CFArrayGetCount(fontDescriptors.get()))
+        return nullptr;
+    if (CFArrayGetCount(fontDescriptors.get()) == 1)
+        return static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(fontDescriptors.get(), 0));
+
+    for (CFIndex i = 0; i < CFArrayGetCount(fontDescriptors.get()); ++i) {
+        auto fontDescriptor = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(fontDescriptors.get(), i));
+        auto currentPostScriptName = adoptCF(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontNameAttribute));
+        if (CFEqual(currentPostScriptName.get(), postScriptName))
+            return fontDescriptor;
+    }
+    return nullptr;
+}
+
+static RetainPtr<CTFontRef> createCTFont(CFDictionaryRef attributes, float size, CTFontDescriptorOptions options, CFStringRef referenceURL, CFStringRef desiredPostScriptName)
+{
+    auto fontDescriptor = adoptCF(CTFontDescriptorCreateWithAttributes(attributes));
+    if (fontDescriptor) {
+        auto font = adoptCF(CTFontCreateWithFontDescriptorAndOptions(fontDescriptor.get(), size, nullptr, options));
+        auto actualPostScriptName = adoptCF(CTFontCopyPostScriptName(font.get()));
+        if (CFEqual(actualPostScriptName.get(), desiredPostScriptName))
+            return font;
+    }
+
+    // CoreText couldn't round-trip the font.
+    // We can fall back to doing our best to find it ourself.
+    fontDescriptor = findFontDescriptor(referenceURL, desiredPostScriptName);
+    if (!fontDescriptor)
+        fontDescriptor = adoptCF(CTFontDescriptorCreateLastResort());
+    ASSERT(fontDescriptor);
+    return adoptCF(CTFontCreateWithFontDescriptorAndOptions(fontDescriptor.get(), size, nullptr, options));
+}
+
+FontPlatformData FontPlatformData::create(const Attributes& data, const FontCustomPlatformData* custom)
+{
+    RetainPtr<CTFontRef> ctFont;
+    if (custom) {
+        auto baseFontDescriptor = custom->fontDescriptor.get();
+        RELEASE_ASSERT(baseFontDescriptor);
+        auto fontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(baseFontDescriptor, data.m_attributes.get()));
+        ctFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), data.m_size, nullptr));
+    } else
+        ctFont = createCTFont(data.m_attributes.get(), data.m_size, data.m_options, data.m_url.get(), data.m_psName.get());
+
+    return WebCore::FontPlatformData(ctFont.get(), data.m_size, data.m_syntheticBold, data.m_syntheticOblique, data.m_orientation, data.m_widthVariant, data.m_textRenderingMode, custom);
 }
 
 bool isSystemFont(CTFontRef font)
@@ -183,6 +237,23 @@ void FontPlatformData::updateSize(float size)
     ASSERT(m_font.get());
     m_font = adoptCF(CTFontCreateCopyWithAttributes(m_font.get(), m_size, nullptr, nullptr));
     m_ctFont = nullptr;
+}
+
+FontPlatformData::Attributes FontPlatformData::attributes() const
+{
+    Attributes result(m_size, m_orientation, m_widthVariant, m_textRenderingMode, m_syntheticBold, m_syntheticOblique);
+
+    auto fontDescriptor = adoptCF(CTFontCopyFontDescriptor(m_font.get()));
+    result.m_attributes = adoptCF(CTFontDescriptorCopyAttributes(fontDescriptor.get()));
+
+    if (!m_customPlatformData) {
+        result.m_options = CTFontDescriptorGetOptions(fontDescriptor.get());
+        auto referenceURL = adoptCF(static_cast<CFURLRef>(CTFontCopyAttribute(m_font.get(), kCTFontReferenceURLAttribute)));
+        result.m_url = CFURLGetString(referenceURL.get());
+        result.m_psName = adoptCF(CTFontCopyPostScriptName(m_font.get()));
+    }
+
+    return result;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -138,7 +138,7 @@ static bool initializeFreeTypeLibrary(FT_Library& library)
     return true;
 }
 
-std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer, const String&)
+RefPtr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer, const String&)
 {
     static FT_Library library;
     if (!library && !initializeFreeTypeLibrary(library)) {
@@ -149,7 +149,7 @@ std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffe
     FT_Face freeTypeFace;
     if (FT_New_Memory_Face(library, reinterpret_cast<const FT_Byte*>(buffer.data()), buffer.size(), 0, &freeTypeFace))
         return nullptr;
-    return makeUnique<FontCustomPlatformData>(freeTypeFace, buffer);
+    return adoptRef(new FontCustomPlatformData(freeTypeFace, buffer));
 }
 
 bool FontCustomPlatformData::supportsFormat(const String& format)

--- a/Source/WebCore/platform/graphics/mac/FontCustomPlatformDataMac.cpp
+++ b/Source/WebCore/platform/graphics/mac/FontCustomPlatformDataMac.cpp
@@ -53,13 +53,13 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
 
     auto font = preparePlatformFont(WTFMove(unrealizedFont), fontDescription, fontCreationContext);
     ASSERT(font);
-    FontPlatformData platformData(font.get(), size, bold, italic, orientation, widthVariant, fontDescription.textRenderingMode(), &creationData);
+    FontPlatformData platformData(font.get(), size, bold, italic, orientation, widthVariant, fontDescription.textRenderingMode(), this);
 
     platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust());
     return platformData;
 }
 
-std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer, const String& itemInCollection)
+RefPtr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer, const String& itemInCollection)
 {
     RetainPtr<CFDataRef> bufferData = buffer.createCFData();
 
@@ -86,7 +86,7 @@ std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffe
         fontDescriptor = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(array.get(), 0));
 
     FontPlatformData::CreationData creationData = { buffer, itemInCollection };
-    return makeUnique<FontCustomPlatformData>(fontDescriptor.get(), WTFMove(creationData));
+    return adoptRef(new FontCustomPlatformData(fontDescriptor.get(), WTFMove(creationData)));
 }
 
 bool FontCustomPlatformData::supportsFormat(const String& format)

--- a/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
@@ -67,7 +67,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
 
     cairo_font_face_t* fontFace = cairo_win32_font_face_create_for_hfont(hfont.get());
 
-    FontPlatformData fontPlatformData(WTFMove(hfont), fontFace, size, bold, italic, &creationData);
+    FontPlatformData fontPlatformData(WTFMove(hfont), fontFace, size, bold, italic, this);
 
     cairo_font_face_destroy(fontFace);
 
@@ -84,7 +84,7 @@ static String createUniqueFontName()
     return fontName;
 }
 
-std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer, const String& itemInCollection)
+RefPtr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer, const String& itemInCollection)
 {
     String fontName = createUniqueFontName();
     auto fontResource = renameAndActivateFont(buffer, fontName);
@@ -93,7 +93,7 @@ std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffe
         return nullptr;
 
     FontPlatformData::CreationData creationData = { buffer, itemInCollection, fontResource.releaseNonNull() };
-    return makeUnique<FontCustomPlatformData>(fontName, WTFMove(creationData));
+    return adoptRef(new FontCustomPlatformData(fontName, WTFMove(creationData)));
 }
 
 bool FontCustomPlatformData::supportsFormat(const String& format)

--- a/Source/WebCore/platform/graphics/win/FontPlatformDataCairoWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontPlatformDataCairoWin.cpp
@@ -60,8 +60,8 @@ void FontPlatformData::platformDataInit(HFONT font, float size, HDC hdc, WCHAR* 
         m_isSystemFont = !wcscmp(faceName, L"Lucida Grande");
 }
 
-FontPlatformData::FontPlatformData(GDIObject<HFONT> font, cairo_font_face_t* fontFace, float size, bool bold, bool oblique, const CreationData* creationData)
-    : FontPlatformData(size, bold, oblique, FontOrientation::Horizontal, FontWidthVariant::RegularWidth, TextRenderingMode::AutoTextRendering, creationData)
+FontPlatformData::FontPlatformData(GDIObject<HFONT> font, cairo_font_face_t* fontFace, float size, bool bold, bool oblique, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(size, bold, oblique, FontOrientation::Horizontal, FontWidthVariant::RegularWidth, TextRenderingMode::AutoTextRendering, customPlatformData)
 {
     m_font = SharedGDIObject<HFONT>::create(WTFMove(font));
 

--- a/Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontPlatformDataWin.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "FontPlatformData.h"
 
+#include "FontCustomPlatformData.h"
 #include "HWndDC.h"
 #include "SharedBuffer.h"
 #include <wtf/HashMap.h>
@@ -37,8 +38,8 @@ using std::min;
 
 namespace WebCore {
 
-FontPlatformData::FontPlatformData(GDIObject<HFONT> font, float size, bool bold, bool oblique, const CreationData* creationData)
-    : FontPlatformData(size, bold, oblique, FontOrientation::Horizontal, FontWidthVariant::RegularWidth, TextRenderingMode::AutoTextRendering, creationData)
+FontPlatformData::FontPlatformData(GDIObject<HFONT> font, float size, bool bold, bool oblique, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(size, bold, oblique, FontOrientation::Horizontal, FontWidthVariant::RegularWidth, TextRenderingMode::AutoTextRendering, customPlatformData)
 {
     m_font = SharedGDIObject<HFONT>::create(WTFMove(font));
 
@@ -70,6 +71,24 @@ RefPtr<SharedBuffer> FontPlatformData::platformOpenTypeTable(uint32_t table) con
 
     SelectObject(hdc, oldFont);
     return buffer;
+}
+
+FontPlatformData FontPlatformData::create(const Attributes& data, const FontCustomPlatformData* custom)
+{
+    LOGFONT logFont = data.m_font;
+    if (custom)
+        wcscpy_s(logFont.lfFaceName, LF_FACESIZE, custom->name.wideCharacters().data());
+
+    auto gdiFont = adoptGDIObject(CreateFontIndirect(&logFont));
+    return FontPlatformData(WTFMove(gdiFont), data.m_size, data.m_syntheticBold, data.m_syntheticOblique, custom);
+}
+
+FontPlatformData::Attributes FontPlatformData::attributes() const
+{
+    Attributes result(m_size, m_orientation, m_widthVariant, m_textRenderingMode, m_syntheticBold, m_syntheticOblique);
+
+    GetObject(hfont(), sizeof(LOGFONT), &result.m_font);
+    return result;
 }
 
 }

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -77,7 +77,7 @@ private:
 
     WeakPtr<ScriptExecutionContext> m_context;
     SharedBufferBuilder m_data;
-    std::unique_ptr<FontCustomPlatformData> m_fontCustomPlatformData;
+    RefPtr<FontCustomPlatformData> m_fontCustomPlatformData;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
@@ -30,6 +30,7 @@
 #include "QualifiedRenderingResourceIdentifier.h"
 #include <WebCore/DecomposedGlyphs.h>
 #include <WebCore/Font.h>
+#include <WebCore/FontCustomPlatformData.h>
 #include <WebCore/Gradient.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/NativeImage.h>
@@ -71,6 +72,11 @@ public:
         add(renderingResourceIdentifier, WTFMove(gradient), m_gradientCount);
     }
 
+    void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<WebCore::FontCustomPlatformData>&& customPlatformData)
+    {
+        add(renderingResourceIdentifier, WTFMove(customPlatformData), m_customPlatformDataCount);
+    }
+
     WebCore::ImageBuffer* getImageBuffer(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
     {
         return get<WebCore::ImageBuffer>(renderingResourceIdentifier);
@@ -110,6 +116,11 @@ public:
         return get<WebCore::Gradient>(renderingResourceIdentifier);
     }
 
+    WebCore::FontCustomPlatformData* getFontCustomPlatformData(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
+    {
+        return get<WebCore::FontCustomPlatformData>(renderingResourceIdentifier);
+    }
+
     bool removeImageBuffer(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
     {
         return remove<WebCore::ImageBuffer>(renderingResourceIdentifier, m_imageBufferCount);
@@ -135,6 +146,11 @@ public:
         return remove<WebCore::Gradient>(renderingResourceIdentifier, m_gradientCount);
     }
 
+    bool removeFontCustomPlatformData(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+    {
+        return remove<WebCore::FontCustomPlatformData>(renderingResourceIdentifier, m_customPlatformDataCount);
+    }
+
     void releaseAllResources()
     {
         checkInvariants();
@@ -146,13 +162,15 @@ public:
             return std::holds_alternative<Ref<WebCore::NativeImage>>(resource.value)
                 || std::holds_alternative<Ref<WebCore::Font>>(resource.value)
                 || std::holds_alternative<Ref<WebCore::DecomposedGlyphs>>(resource.value)
-                || std::holds_alternative<Ref<WebCore::Gradient>>(resource.value);
+                || std::holds_alternative<Ref<WebCore::Gradient>>(resource.value)
+                || std::holds_alternative<Ref<WebCore::FontCustomPlatformData>>(resource.value);
         });
 
         m_nativeImageCount = 0;
         m_fontCount = 0;
         m_decomposedGlyphsCount = 0;
         m_gradientCount = 0;
+        m_customPlatformDataCount = 0;
 
         checkInvariants();
     }
@@ -211,6 +229,7 @@ private:
         unsigned imageBufferCount = 0;
         unsigned nativeImageCount = 0;
         unsigned fontCount = 0;
+        unsigned customPlatformDataCount = 0;
         unsigned decomposedGlyphsCount = 0;
         unsigned gradientCount = 0;
         for (const auto& pair : m_resources) {
@@ -222,6 +241,8 @@ private:
                 ++nativeImageCount;
             }, [&] (const Ref<WebCore::Font>&) {
                 ++fontCount;
+            }, [&] (const Ref<WebCore::FontCustomPlatformData>&) {
+                ++customPlatformDataCount;
             }, [&] (const Ref<WebCore::DecomposedGlyphs>&) {
                 ++decomposedGlyphsCount;
             }, [&] (const Ref<WebCore::Gradient>&) {
@@ -231,9 +252,10 @@ private:
         ASSERT(imageBufferCount == m_imageBufferCount);
         ASSERT(nativeImageCount == m_nativeImageCount);
         ASSERT(fontCount == m_fontCount);
+        ASSERT(customPlatformDataCount == m_customPlatformDataCount);
         ASSERT(decomposedGlyphsCount == m_decomposedGlyphsCount);
         ASSERT(gradientCount == m_gradientCount);
-        ASSERT(m_resources.size() == m_imageBufferCount + m_nativeImageCount + m_fontCount + m_decomposedGlyphsCount + m_gradientCount);
+        ASSERT(m_resources.size() == m_imageBufferCount + m_nativeImageCount + m_fontCount + m_decomposedGlyphsCount + m_customPlatformDataCount + m_gradientCount);
 #endif
     }
 
@@ -243,7 +265,8 @@ private:
         Ref<WebCore::NativeImage>,
         Ref<WebCore::Font>,
         Ref<WebCore::DecomposedGlyphs>,
-        Ref<WebCore::Gradient>
+        Ref<WebCore::Gradient>,
+        Ref<WebCore::FontCustomPlatformData>
     >;
     HashMap<QualifiedRenderingResourceIdentifier, Resource> m_resources;
     WebCore::ProcessIdentifier m_webProcessIdentifier;
@@ -252,6 +275,7 @@ private:
     unsigned m_fontCount { 0 };
     unsigned m_decomposedGlyphsCount { 0 };
     unsigned m_gradientCount { 0 };
+    unsigned m_customPlatformDataCount { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -123,7 +123,8 @@ private:
     void cacheNativeImage(const ShareableBitmapHandle&, WebCore::RenderingResourceIdentifier);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheGradient(Ref<WebCore::Gradient>&&, WebCore::RenderingResourceIdentifier);
-    void cacheFont(Ref<WebCore::Font>&&);
+    void cacheFont(const WebCore::Font::Attributes&, WebCore::FontPlatformData::Attributes, std::optional<WebCore::RenderingResourceIdentifier>);
+    void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&);
     void releaseAllResources();
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier);
     void finalizeRenderingUpdate(RenderingUpdateID);
@@ -140,6 +141,7 @@ private:
     void cacheGradientWithQualifiedIdentifier(Ref<WebCore::Gradient>&&, QualifiedRenderingResourceIdentifier);
     void releaseRenderingResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
     void cacheFontWithQualifiedIdentifier(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
+    void cacheFontCustomPlatformDataWithQualifiedIdentifier(Ref<WebCore::FontCustomPlatformData>&&, QualifiedRenderingResourceIdentifier);
 
 #if PLATFORM(COCOA)
     void prepareLayerBuffersForDisplay(const PrepareBackingStoreBuffersInputData&, PrepareBackingStoreBuffersOutputData&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -31,7 +31,8 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     GetShareableBitmapForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, enum:bool WebCore::PreserveResolution preserveResolution) -> (WebKit::ShareableBitmapHandle handle) Synchronous NotStreamEncodableReply
     GetFilteredImageForImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer, Ref<WebCore::Filter> filter) -> (WebKit::ShareableBitmapHandle handle) Synchronous NotStreamEncodableReply
     CacheNativeImage(WebKit::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
-    CacheFont(Ref<WebCore::Font> font) NotStreamEncodable
+    CacheFont(WebCore::Font::Attributes data, WebCore::FontPlatformData::Attributes platformData, std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier) NotStreamEncodable
+    CacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData> customPlatformData) NotStreamEncodable
     CacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs> decomposedGlyphs) NotStreamEncodable
     CacheGradient(Ref<WebCore::Gradient> gradient, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     ReleaseAllResources()

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -96,6 +96,17 @@ Font* RemoteResourceCache::cachedFont(QualifiedRenderingResourceIdentifier rende
     return m_resourceHeap.getFont(renderingResourceIdentifier);
 }
 
+void RemoteResourceCache::cacheFontCustomPlatformData(Ref<FontCustomPlatformData>&& font, QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+{
+    ASSERT(renderingResourceIdentifier.object() == font->m_renderingResourceIdentifier);
+    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(font));
+}
+
+FontCustomPlatformData* RemoteResourceCache::cachedFontCustomPlatformData(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
+{
+    return m_resourceHeap.getFontCustomPlatformData(renderingResourceIdentifier);
+}
+
 DecomposedGlyphs* RemoteResourceCache::cachedDecomposedGlyphs(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getDecomposedGlyphs(renderingResourceIdentifier);
@@ -117,7 +128,8 @@ bool RemoteResourceCache::releaseRenderingResource(QualifiedRenderingResourceIde
         || m_resourceHeap.removeNativeImage(renderingResourceIdentifier)
         || m_resourceHeap.removeFont(renderingResourceIdentifier)
         || m_resourceHeap.removeDecomposedGlyphs(renderingResourceIdentifier)
-        || m_resourceHeap.removeGradient(renderingResourceIdentifier))
+        || m_resourceHeap.removeGradient(renderingResourceIdentifier)
+        || m_resourceHeap.removeFontCustomPlatformData(renderingResourceIdentifier))
         return true;
 
     // Caching the remote resource should have happened before releasing it.

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -45,6 +45,7 @@ public:
     void cacheFont(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);
     void cacheGradient(Ref<WebCore::Gradient>&&, QualifiedRenderingResourceIdentifier);
+    void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&, QualifiedRenderingResourceIdentifier);
 
     RemoteImageBuffer* cachedImageBuffer(QualifiedRenderingResourceIdentifier) const;
     RefPtr<RemoteImageBuffer> takeImageBuffer(QualifiedRenderingResourceIdentifier);
@@ -52,6 +53,7 @@ public:
     WebCore::Font* cachedFont(QualifiedRenderingResourceIdentifier) const;
     WebCore::DecomposedGlyphs* cachedDecomposedGlyphs(QualifiedRenderingResourceIdentifier) const;
     WebCore::Gradient* cachedGradient(QualifiedRenderingResourceIdentifier) const;
+    WebCore::FontCustomPlatformData* cachedFontCustomPlatformData(QualifiedRenderingResourceIdentifier) const;
 
     std::optional<WebCore::SourceImage> cachedSourceImage(QualifiedRenderingResourceIdentifier) const;
 

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -594,8 +594,7 @@ std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::Font>::decodePla
         auto fontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(baseFontDescriptor, attributes->get()));
         auto ctFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), *size, nullptr));
 
-        auto creationData = WebCore::FontPlatformData::CreationData { fontFaceData, *itemInCollection };
-        return WebCore::FontPlatformData(ctFont.get(), *size, *syntheticBold, *syntheticOblique, *orientation, *widthVariant, *textRenderingMode, &creationData);
+        return WebCore::FontPlatformData(ctFont.get(), *size, *syntheticBold, *syntheticOblique, *orientation, *widthVariant, *textRenderingMode, fontCustomPlatformData.get());
     }
 
     std::optional<CTFontDescriptorOptions> options;
@@ -620,6 +619,88 @@ std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::Font>::decodePla
     return WebCore::FontPlatformData(ctFont.get(), *size, *syntheticBold, *syntheticOblique, *orientation, *widthVariant, *textRenderingMode);
 }
 
+void ArgumentCoder<WebCore::FontCustomPlatformData>::encodePlatformData(Encoder& encoder, const WebCore::FontCustomPlatformData& customPlatformData)
+{
+    WebKit::SharedMemory::Handle handle;
+    {
+        auto sharedMemoryBuffer = WebKit::SharedMemory::copyBuffer(customPlatformData.creationData.fontFaceData);
+        if (auto memoryHandle = sharedMemoryBuffer->createHandle(WebKit::SharedMemory::Protection::ReadOnly))
+            handle = WTFMove(*memoryHandle);
+    }
+    encoder << customPlatformData.creationData.fontFaceData->size();
+    encoder << WTFMove(handle);
+    encoder << customPlatformData.creationData.itemInCollection;
+}
+
+std::optional<Ref<WebCore::FontCustomPlatformData>> ArgumentCoder<WebCore::FontCustomPlatformData>::decodePlatformData(Decoder& decoder)
+{
+    std::optional<uint64_t> bufferSize;
+    decoder >> bufferSize;
+    if (!bufferSize)
+        return std::nullopt;
+
+    std::optional<WebKit::SharedMemory::Handle> handle;
+    decoder >> handle;
+    if (!handle)
+        return std::nullopt;
+
+    auto sharedMemoryBuffer = WebKit::SharedMemory::map(*handle, WebKit::SharedMemory::Protection::ReadOnly);
+    if (!sharedMemoryBuffer)
+        return std::nullopt;
+
+    if (sharedMemoryBuffer->size() < *bufferSize)
+        return std::nullopt;
+
+    auto fontFaceData = sharedMemoryBuffer->createSharedBuffer(*bufferSize);
+
+    std::optional<String> itemInCollection;
+    decoder >> itemInCollection;
+    if (!itemInCollection)
+        return std::nullopt;
+
+    auto fontCustomPlatformData = createFontCustomPlatformData(fontFaceData, *itemInCollection);
+    if (!fontCustomPlatformData)
+        return std::nullopt;
+    return fontCustomPlatformData.releaseNonNull();
+}
+
+void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder& encoder, const WebCore::FontPlatformData::Attributes& data)
+{
+    encoder << data.m_attributes;
+    encoder << data.m_options;
+    encoder << data.m_url;
+    encoder << data.m_psName;
+}
+
+bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder& decoder, WebCore::FontPlatformData::Attributes& data)
+{
+    std::optional<RetainPtr<CFDictionaryRef>> attributes;
+    decoder >> attributes;
+    if (!attributes)
+        return false;
+
+    std::optional<CTFontDescriptorOptions> options;
+    decoder >> options;
+    if (!options)
+        return false;
+
+
+    std::optional<RetainPtr<CFStringRef>> url;
+    decoder >> url;
+    if (!url)
+        return false;
+
+    std::optional<RetainPtr<CFStringRef>> psName;
+    decoder >> psName;
+    if (!psName)
+        return false;
+
+    data.m_attributes = attributes.value();
+    data.m_options = options.value();
+    data.m_url = url.value();
+    data.m_psName = psName.value();
+    return true;
+}
 
 #if ENABLE(DATA_DETECTION)
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -158,6 +158,7 @@ struct DictionaryPopupInfo;
 struct EventTrackingRegions;
 struct ExceptionDetails;
 struct FileChooserSettings;
+struct FontCustomPlatformData;
 struct TextRecognitionDataDetector;
 struct Length;
 struct GrammarDetail;
@@ -265,6 +266,25 @@ template<> struct ArgumentCoder<WebCore::Font> {
     static std::optional<Ref<WebCore::Font>> decode(Decoder&);
     static void encodePlatformData(Encoder&, const WebCore::Font&);
     static std::optional<WebCore::FontPlatformData> decodePlatformData(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::Font::Attributes> {
+    static void encode(Encoder&, const WebCore::Font::Attributes&);
+    static std::optional<WebCore::Font::Attributes> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::FontPlatformData::Attributes> {
+    static void encode(Encoder&, const WebCore::FontPlatformData::Attributes&);
+    static std::optional<WebCore::FontPlatformData::Attributes> decode(Decoder&);
+    static void encodePlatformData(Encoder&, const WebCore::FontPlatformData::Attributes&);
+    static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::FontPlatformData::Attributes&);
+};
+
+template<> struct ArgumentCoder<WebCore::FontCustomPlatformData> {
+    static void encode(Encoder&, const WebCore::FontCustomPlatformData&);
+    static std::optional<Ref<WebCore::FontCustomPlatformData>> decode(Decoder&);
+    static void encodePlatformData(Encoder&, const WebCore::FontCustomPlatformData&);
+    static std::optional<Ref<WebCore::FontCustomPlatformData>> decodePlatformData(Decoder&);
 };
 
 template<> struct ArgumentCoder<WebCore::ResourceError> {

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
@@ -652,6 +652,12 @@ std::optional<RetainPtr<CFNumberRef>> ArgumentCoder<RetainPtr<CFNumberRef>>::dec
 template<typename Encoder>
 void ArgumentCoder<CFStringRef>::encode(Encoder& encoder, CFStringRef string)
 {
+    if (!string) {
+        encoder << true;
+        return;
+    }
+    encoder << false;
+
     CFIndex length = CFStringGetLength(string);
     CFStringEncoding encoding = CFStringGetFastestEncoding(string);
 
@@ -673,6 +679,14 @@ template void ArgumentCoder<CFStringRef>::encode<StreamConnectionEncoder>(Stream
 
 std::optional<RetainPtr<CFStringRef>> ArgumentCoder<RetainPtr<CFStringRef>>::decode(Decoder& decoder)
 {
+    std::optional<bool> isNull;
+    decoder >> isNull;
+    if (!isNull)
+        return std::nullopt;
+
+    if (*isNull)
+        return { { nullptr } };
+
     std::optional<uint32_t> encodingFromIPC;
     decoder >> encodingFromIPC;
     if (!encodingFromIPC)

--- a/Source/WebKit/Shared/playstation/WebCoreArgumentCodersPlayStation.cpp
+++ b/Source/WebKit/Shared/playstation/WebCoreArgumentCodersPlayStation.cpp
@@ -27,6 +27,7 @@
 #include "WebCoreArgumentCoders.h"
 
 #include <WebCore/Font.h>
+#include <WebCore/FontCustomPlatformData.h>
 
 namespace IPC {
 
@@ -41,6 +42,28 @@ std::optional<FontPlatformData> ArgumentCoder<Font>::decodePlatformData(Decoder&
 {
     ASSERT_NOT_REACHED();
     return std::nullopt;
+}
+
+void ArgumentCoder<WebCore::FontCustomPlatformData>::encodePlatformData(Encoder& encoder, const WebCore::FontCustomPlatformData& customPlatformData)
+{
+    ASSERT_NOT_REACHED();
+}
+
+std::optional<Ref<WebCore::FontCustomPlatformData>> ArgumentCoder<WebCore::FontCustomPlatformData>::decodePlatformData(Decoder& decoder)
+{
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+
+void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder& encoder, const WebCore::FontPlatformData::Attributes& data)
+{
+    ASSERT_NOT_REACHED();
+}
+
+bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder& decoder, WebCore::FontPlatformData::Attributes& data)
+{
+    ASSERT_NOT_REACHED();
+    return false;
 }
 
 } // namespace IPC

--- a/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
+++ b/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
@@ -34,6 +34,7 @@
 #include <WebCore/Credential.h>
 #include <WebCore/DictionaryPopupInfo.h>
 #include <WebCore/Font.h>
+#include <WebCore/FontCustomPlatformData.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ResourceResponse.h>
@@ -168,6 +169,28 @@ std::optional<FontPlatformData> ArgumentCoder<Font>::decodePlatformData(Decoder&
 {
     ASSERT_NOT_REACHED();
     return std::nullopt;
+}
+
+void ArgumentCoder<WebCore::FontCustomPlatformData>::encodePlatformData(Encoder& encoder, const WebCore::FontCustomPlatformData& customPlatformData)
+{
+    ASSERT_NOT_REACHED();
+}
+
+std::optional<Ref<WebCore::FontCustomPlatformData>> ArgumentCoder<WebCore::FontCustomPlatformData>::decodePlatformData(Decoder& decoder)
+{
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+
+void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder& encoder, const WebCore::FontPlatformData::Attributes& data)
+{
+    ASSERT_NOT_REACHED();
+}
+
+bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder& decoder, WebCore::FontPlatformData::Attributes& data)
+{
+    ASSERT_NOT_REACHED();
+    return false;
 }
 
 #if ENABLE(VIDEO)

--- a/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
+++ b/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
@@ -88,8 +88,7 @@ std::optional<FontPlatformData> ArgumentCoder<Font>::decodePlatformData(Decoder&
     if (!includesCreationData)
         return std::nullopt;
 
-    std::unique_ptr<FontCustomPlatformData> fontCustomPlatformData;
-    FontPlatformData::CreationData* creationData = nullptr;
+    RefPtr<FontCustomPlatformData> fontCustomPlatformData;
 
     if (includesCreationData.value()) {
         std::optional<Ref<SharedBuffer>> fontFaceData;
@@ -105,7 +104,6 @@ std::optional<FontPlatformData> ArgumentCoder<Font>::decodePlatformData(Decoder&
         fontCustomPlatformData = createFontCustomPlatformData(fontFaceData.value(), itemInCollection.value());
         if (!fontCustomPlatformData)
             return std::nullopt;
-        creationData = &fontCustomPlatformData->creationData;
     }
 
     std::optional<LOGFONT> logFont;
@@ -120,7 +118,48 @@ std::optional<FontPlatformData> ArgumentCoder<Font>::decodePlatformData(Decoder&
     if (!gdiFont)
         return std::nullopt;
 
-    return FontPlatformData(WTFMove(gdiFont), *size, *syntheticBold, *syntheticOblique, creationData);
+    return FontPlatformData(WTFMove(gdiFont), *size, *syntheticBold, *syntheticOblique, fontCustomPlatformData.get());
 }
+
+void ArgumentCoder<WebCore::FontCustomPlatformData>::encodePlatformData(Encoder& encoder, const WebCore::FontCustomPlatformData& customPlatformData)
+{
+    encoder << customPlatformData.creationData.fontFaceData;
+    encoder << customPlatformData.creationData.itemInCollection;
+}
+
+std::optional<Ref<WebCore::FontCustomPlatformData>> ArgumentCoder<WebCore::FontCustomPlatformData>::decodePlatformData(Decoder& decoder)
+{
+    std::optional<Ref<SharedBuffer>> fontFaceData;
+    decoder >> fontFaceData;
+    if (!fontFaceData)
+        return std::nullopt;
+
+    std::optional<String> itemInCollection;
+    decoder >> itemInCollection;
+    if (!itemInCollection)
+        return std::nullopt;
+
+    auto fontCustomPlatformData = createFontCustomPlatformData(fontFaceData.value(), itemInCollection.value());
+    if (!fontCustomPlatformData)
+        return std::nullopt;
+    return fontCustomPlatformData.releaseNonNull();
+}
+
+void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder& encoder, const WebCore::FontPlatformData::Attributes& data)
+{
+    encoder << data.m_font;
+}
+
+bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder& decoder, WebCore::FontPlatformData::Attributes& data)
+{
+    std::optional<LOGFONT> logFont;
+    decoder >> logFont;
+    if (!logFont)
+        return false;
+
+    data.m_font = *logFont;
+    return true;
+}
+
 
 } // namespace IPC

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -40,6 +40,7 @@
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
+#include <WebCore/FontCustomPlatformData.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebKit {
@@ -252,9 +253,15 @@ void RemoteRenderingBackendProxy::cacheNativeImage(const ShareableBitmapHandle& 
     send(Messages::RemoteRenderingBackend::CacheNativeImage(handle, renderingResourceIdentifier));
 }
 
-void RemoteRenderingBackendProxy::cacheFont(Ref<Font>&& font)
+void RemoteRenderingBackendProxy::cacheFont(const WebCore::Font::Attributes& fontAttributes, const WebCore::FontPlatformData::Attributes& platformData, std::optional<WebCore::RenderingResourceIdentifier> ident)
 {
-    send(Messages::RemoteRenderingBackend::CacheFont(WTFMove(font)));
+    send(Messages::RemoteRenderingBackend::CacheFont(fontAttributes, platformData, ident));
+}
+
+void RemoteRenderingBackendProxy::cacheFontCustomPlatformData(Ref<const FontCustomPlatformData>&& customPlatformData)
+{
+    Ref<FontCustomPlatformData> data = adoptRef(const_cast<FontCustomPlatformData&>(customPlatformData.leakRef()));
+    send(Messages::RemoteRenderingBackend::CacheFontCustomPlatformData(WTFMove(data)));
 }
 
 void RemoteRenderingBackendProxy::cacheDecomposedGlyphs(Ref<DecomposedGlyphs>&& decomposedGlyphs)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -96,7 +96,8 @@ public:
     RefPtr<ShareableBitmap> getShareableBitmap(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution);
     RefPtr<WebCore::Image> getFilteredImage(WebCore::RenderingResourceIdentifier, WebCore::Filter&);
     void cacheNativeImage(const ShareableBitmapHandle&, WebCore::RenderingResourceIdentifier);
-    void cacheFont(Ref<WebCore::Font>&&);
+    void cacheFont(const WebCore::Font::Attributes&, const WebCore::FontPlatformData::Attributes&, std::optional<WebCore::RenderingResourceIdentifier>);
+    void cacheFontCustomPlatformData(Ref<const WebCore::FontCustomPlatformData>&&);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheGradient(Ref<WebCore::Gradient>&&);
     void releaseAllRemoteResources();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class Font;
 class Gradient;
 class ImageBuffer;
+struct FontCustomPlatformData;
 }
 
 namespace WebKit {
@@ -60,6 +61,7 @@ public:
     void recordImageBufferUse(WebCore::ImageBuffer&);
     void recordDecomposedGlyphsUse(WebCore::DecomposedGlyphs&);
     void recordGradientUse(WebCore::Gradient&);
+    void recordFontCustomPlatformDataUse(const WebCore::FontCustomPlatformData&);
 
     void didPaintLayers();
 
@@ -92,8 +94,11 @@ private:
     FontHashMap m_fonts;
     DecomposedGlyphsHashMap m_decomposedGlyphs;
     GradientHashMap m_gradients;
+    FontHashMap m_fontCustomPlatformDatas;
 
     unsigned m_numberOfFontsUsedInCurrentRenderingUpdate { 0 };
+    unsigned m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate { 0 };
+
 
     RemoteRenderingBackendProxy& m_remoteRenderingBackendProxy;
     uint64_t m_renderingUpdateID;


### PR DESCRIPTION
#### e36b84b4cc79b4f28020cd86825a51e361e479f3
<pre>
Cherry-pick c201cea073fd. &lt;rdar://106965215&gt;

    Make RemoteRenderingData::cacheFont reconstruct a Font using Attributes, and a reference to FontCustomPlatformData.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=254490">https://bugs.webkit.org/show_bug.cgi?id=254490</a>
    &lt;rdar://106965215&gt;

    Reviewed by NOBODY (OOPS!).

    Make FontCustomPlatformData refcounted, and owned by the FontPlatformData instead of CreationData

    We currently only have the CreationData accessible from Font, but when serializing a web font,
    we need the FontCustomPlatformData in order to share the parsed font data.

    This just makes the FontCustomPlatformData the shared object on FontPlatformData, and we can
    still access the CreationData through it.

    * Source/WebCore/css/CSSFontFaceSource.h:
    * Source/WebCore/loader/cache/CachedFont.cpp:
    (WebCore::CachedFont::createCustomFontData):
    * Source/WebCore/loader/cache/CachedFont.h:
    * Source/WebCore/platform/graphics/FontCustomPlatformData.h:
    (WebCore::FontCustomPlatformData::FontCustomPlatformData):
    * Source/WebCore/platform/graphics/FontPlatformData.cpp:
    (WebCore::FontPlatformData::FontPlatformData):
    (WebCore::FontPlatformData::creationData const):
    * Source/WebCore/platform/graphics/FontPlatformData.h:
    (WebCore::FontPlatformData::customPlatformData const):
    (WebCore::FontPlatformData::creationData const): Deleted.
    * Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
    (WebCore::FontCache::systemFallbackForCharacters):
    * Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
    (WebCore::createDerivativeFont):
    (WebCore::Font::createFontWithoutSynthesizableFeatures const):
    (WebCore::Font::platformCreateScaledFont const):
    * Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
    (WebCore::FontPlatformData::FontPlatformData):
    * Source/WebCore/platform/graphics/mac/FontCustomPlatformDataMac.cpp:
    (WebCore::FontCustomPlatformData::fontPlatformData):
    (WebCore::createFontCustomPlatformData):
    (WebCore::FontCustomPlatformData::creationData const):
    * Source/WebCore/workers/WorkerFontLoadRequest.h:
    * Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
    (IPC::ArgumentCoder&lt;WebCore::Font&gt;::decodePlatformData):
    * Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
    * Source/WebKit/Shared/WebCoreArgumentCoders.h:

    Move POD serializable subset of Font into Attributes object

    In order to serialize a Font where the FontCustomPlatformData is already cached, we want to send
    the identifier of the data, plus the serialized remainder of the font.

    This creates an Attributes inner class for Font, containing the data needed to serialize the font,
    without the platform data.

    * Source/WebCore/platform/graphics/Font.cpp:
    (WebCore::Font::Font):
    (WebCore::Font::renderingResourceIdentifier const):
    * Source/WebCore/platform/graphics/Font.h:
    (WebCore::Font::isTextOrientationFallback const):
    (WebCore::Font::origin const):
    (WebCore::Font::isInterstitial const):
    (WebCore::Font::visibility const):
    (WebCore::Font::attributes const):
    * Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
    (IPC::ArgumentCoder&lt;WebCore::Font&gt;::encode):
    (IPC::ArgumentCoder&lt;Font&gt;::decode):
    (IPC::ArgumentCoder&lt;WebCore::Font::Attributes&gt;::encode):
    (IPC::ArgumentCoder&lt;Font::Attributes&gt;::decode):
    * Source/WebKit/Shared/WebCoreArgumentCoders.h:

    Add serialization and RemoteResourceCache support for FontCustomPlatformData

    This lets us cache FontCustomPlatformData objects independently of Font, so that we
    can share them between Font instances in the GPUP.

    * Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h:
    (WebKit::QualifiedResourceHeap::add):
    (WebKit::QualifiedResourceHeap::getFontCustomPlatformData const):
    (WebKit::QualifiedResourceHeap::removeFontCustomPlatformData):
    (WebKit::QualifiedResourceHeap::releaseAllResources):
    (WebKit::QualifiedResourceHeap::checkInvariants const):
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
    (WebKit::RemoteRenderingBackend::cacheFontCustomPlatformData):
    (WebKit::RemoteRenderingBackend::cacheFontCustomPlatformDataWithQualifiedIdentifier):
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
    * Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
    (WebKit::RemoteResourceCache::cacheFontCustomPlatformData):
    (WebKit::RemoteResourceCache::cachedFontCustomPlatformData const):
    (WebKit::RemoteResourceCache::releaseRenderingResource):
    * Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
    * Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
    (IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::encodePlatformData):
    (IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::decodePlatformData):
    * Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
    (IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::encode):
    (IPC::ArgumentCoder&lt;FontCustomPlatformData&gt;::decode):
    * Source/WebKit/Shared/WebCoreArgumentCoders.h:
    * Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
    (WebKit::RemoteRenderingBackendProxy::cacheFontCustomPlatformData):
    * Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
    * Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
    (WebKit::RemoteResourceCacheProxy::recordFontCustomPlatformDataUse):
    (WebKit::RemoteResourceCacheProxy::prepareForNextRenderingUpdate):
    (WebKit::RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts):
    * Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

    Add serialization and RemoteResourceCache support for FontCustomPlatformData

    This lets us cache FontCustomPlatformData objects independently of Font, so that we
    can share them between Font instances in the GPUP.

    * Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h:
    (WebKit::QualifiedResourceHeap::add):
    (WebKit::QualifiedResourceHeap::getFontCustomPlatformData const):
    (WebKit::QualifiedResourceHeap::removeFontCustomPlatformData):
    (WebKit::QualifiedResourceHeap::releaseAllResources):
    (WebKit::QualifiedResourceHeap::checkInvariants const):
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
    (WebKit::RemoteRenderingBackend::cacheFontCustomPlatformData):
    (WebKit::RemoteRenderingBackend::cacheFontCustomPlatformDataWithQualifiedIdentifier):
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
    * Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
    (WebKit::RemoteResourceCache::cacheFontCustomPlatformData):
    (WebKit::RemoteResourceCache::cachedFontCustomPlatformData const):
    (WebKit::RemoteResourceCache::releaseRenderingResource):
    * Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
    * Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
    (IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::encodePlatformData):
    (IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::decodePlatformData):
    * Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
    (IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::encode):
    (IPC::ArgumentCoder&lt;FontCustomPlatformData&gt;::decode):
    * Source/WebKit/Shared/WebCoreArgumentCoders.h:
    * Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
    (WebKit::RemoteRenderingBackendProxy::cacheFontCustomPlatformData):
    * Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
    * Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
    (WebKit::RemoteResourceCacheProxy::recordFontCustomPlatformDataUse):
    (WebKit::RemoteResourceCacheProxy::prepareForNextRenderingUpdate):
    (WebKit::RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts):
    * Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

    Add FontPlatformData::Attributes for the POD serializable subset.

    Similar to adding Font::Attributes, this adds FontPlatformData::Attributes for the serializable data,
    that can be combined with an (optional) FontCustomPlatformData in order to create a final object.

    Unfortunately this can&apos;t actually be used as the main storage within FontPlatformData, as we need
    to do some data conversion before serialization (and the equivalent conversion on deserialization
    can&apos;t be done without the FontCustomPlatformData).

    * Source/WebCore/platform/graphics/FontPlatformData.h:
    (WebCore::FontPlatformData::Attributes::Attributes):
    * Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
    (WebCore::findFontDescriptor):
    (WebCore::createCTFont):
    (WebCore::FontPlatformData::create):
    (WebCore::FontPlatformData::attributes const):
    * Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
    (IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::encodePlatformData):
    (IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::decodePlatformData):
    * Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
    (IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::encode):
    (IPC::ArgumentCoder&lt;FontPlatformData::Attributes&gt;::decode):
    * Source/WebKit/Shared/WebCoreArgumentCoders.h:
    * Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
    (IPC::ArgumentCoder&lt;CFStringRef&gt;::encode):
    (IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::decode):

    Add FontPlatformData::Attributes for the POD serializable subset.

    Similar to adding Font::Attributes, this adds FontPlatformData::Attributes for the serializable data,
    that can be combined with an (optional) FontCustomPlatformData in order to create a final object.

    Unfortunately this can&apos;t actually be used as the main storage within FontPlatformData, as we need
    to do some data conversion before serialization (and the equivalent conversion on deserialization
    can&apos;t be done without the FontCustomPlatformData).

    * Source/WebCore/platform/graphics/FontPlatformData.h:
    (WebCore::FontPlatformData::Attributes::Attributes):
    * Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
    (WebCore::findFontDescriptor):
    (WebCore::createCTFont):
    (WebCore::FontPlatformData::create):
    (WebCore::FontPlatformData::attributes const):
    * Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
    (IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::encodePlatformData):
    (IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::decodePlatformData):
    * Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
    (IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::encode):
    (IPC::ArgumentCoder&lt;FontPlatformData::Attributes&gt;::decode):
    * Source/WebKit/Shared/WebCoreArgumentCoders.h:
    * Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
    (IPC::ArgumentCoder&lt;CFStringRef&gt;::encode):
    (IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::decode):

    Make RemoteRenderingData::cacheFont reconstruct a Font using Attributes, and a reference to FontCustomPlatformData.

    Uses the new infrastructure to serialize a font using the Attributes of the Font and FontPlatformData, plus
    optionally a reference to an existing cached FontCustomPlatformData.

    We can then reconstruct a Font instance in the GPU process, using the shared FontCustomPlatformData and avoid
    re-serializing and parsing the data.

    * Source/WebCore/platform/graphics/Font.cpp:
    (WebCore::Font::description const):
    * Source/WebCore/platform/graphics/Font.h:
    * Source/WebCore/platform/graphics/FontPlatformData.h:
    * Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
    (WebKit::RemoteRenderingBackend::cacheFont):
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
    * Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
    (WebKit::RemoteRenderingBackendProxy::cacheFont):
    * Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
    * Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
    (WebKit::RemoteResourceCacheProxy::recordFontUse):
</pre>