### PR TITLE
Fallback to elogind when systemd is unavailable at build time

### DIFF
--- a/Source/cmake/FindJournald.cmake
+++ b/Source/cmake/FindJournald.cmake
@@ -55,6 +55,10 @@ find_package(PkgConfig QUIET)
 
 # libelogind provides compatible pc and header files
 pkg_check_modules(PC_SYSTEMD QUIET libsystemd)
+if (NOT PC_SYSTEMD_FOUND)
+    pkg_check_modules(PC_SYSTEMD QUIET libelogind)
+endif ()
+
 set(Journald_COMPILE_OPTIONS ${PC_SYSTEMD_CFLAGS_OTHER})
 set(Journald_VERSION ${PC_SYSTEMD_VERSION})
 


### PR DESCRIPTION
#### f2566d6ee88085254aa9cfbfeb4f334aea422f3e
<pre>
Fallback to elogind when systemd is unavailable at build time
<a href="https://bugs.webkit.org/show_bug.cgi?id=254475">https://bugs.webkit.org/show_bug.cgi?id=254475</a>

Reviewed by Michael Catanzaro.

The build system supports elogind, but it only considers the
&apos;libsystemd&apos; library name for the pkg-config lookup and not
&apos;libelogind&apos;.  This change makes the build system fallback to search
for libelogind when libsystemd was not found.

* Source/cmake/FindJournald.cmake [!PC_SYSTEMD_FOUND]: Search for libelogind.

Canonical link: <a href="https://commits.webkit.org/262163@main">https://commits.webkit.org/262163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d46803c09edc2b6d4e35c778a3d2f90e5baad0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/620 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/853 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/879 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/684 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/619 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/633 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/681 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/694 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/665 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/655 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/725 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/666 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/153 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/182 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/675 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/726 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/147 "Passed tests") | 
<!--EWS-Status-Bubble-End-->