### PR TITLE
Update ReadableStream constructor type checking according spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any-expected.txt
@@ -1,12 +1,10 @@
 
 PASS ReadableStream can be constructed with no errors
 PASS ReadableStream can't be constructed with garbage
-FAIL ReadableStream can't be constructed with an invalid type assert_throws_js: constructor should throw when the type is null function "() => new ReadableStream({ type: null })" threw object "RangeError: Invalid type for underlying source" ("RangeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream can't be constructed with an invalid type
 PASS ReadableStream constructor should throw for non-function start arguments
-FAIL ReadableStream constructor will not tolerate initial garbage as cancel argument assert_throws_js: constructor should throw function "() => new ReadableStream({ cancel: '2' })" did not throw
-FAIL ReadableStream constructor will not tolerate initial garbage as pull argument assert_throws_js: constructor should throw function "() => new ReadableStream({ pull: { } })" did not throw
+PASS ReadableStream constructor will not tolerate initial garbage as cancel argument
+PASS ReadableStream constructor will not tolerate initial garbage as pull argument
 PASS ReadableStream start should be called with the proper thisArg
 PASS ReadableStream start controller parameter should be extensible
 PASS default ReadableStream getReader() should only accept mode:undefined

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.serviceworker-expected.txt
@@ -1,12 +1,10 @@
 
 PASS ReadableStream can be constructed with no errors
 PASS ReadableStream can't be constructed with garbage
-FAIL ReadableStream can't be constructed with an invalid type assert_throws_js: constructor should throw when the type is null function "() => new ReadableStream({ type: null })" threw object "RangeError: Invalid type for underlying source" ("RangeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream can't be constructed with an invalid type
 PASS ReadableStream constructor should throw for non-function start arguments
-FAIL ReadableStream constructor will not tolerate initial garbage as cancel argument assert_throws_js: constructor should throw function "() => new ReadableStream({ cancel: '2' })" did not throw
-FAIL ReadableStream constructor will not tolerate initial garbage as pull argument assert_throws_js: constructor should throw function "() => new ReadableStream({ pull: { } })" did not throw
+PASS ReadableStream constructor will not tolerate initial garbage as cancel argument
+PASS ReadableStream constructor will not tolerate initial garbage as pull argument
 PASS ReadableStream start should be called with the proper thisArg
 PASS ReadableStream start controller parameter should be extensible
 PASS default ReadableStream getReader() should only accept mode:undefined

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.sharedworker-expected.txt
@@ -1,12 +1,10 @@
 
 PASS ReadableStream can be constructed with no errors
 PASS ReadableStream can't be constructed with garbage
-FAIL ReadableStream can't be constructed with an invalid type assert_throws_js: constructor should throw when the type is null function "() => new ReadableStream({ type: null })" threw object "RangeError: Invalid type for underlying source" ("RangeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream can't be constructed with an invalid type
 PASS ReadableStream constructor should throw for non-function start arguments
-FAIL ReadableStream constructor will not tolerate initial garbage as cancel argument assert_throws_js: constructor should throw function "() => new ReadableStream({ cancel: '2' })" did not throw
-FAIL ReadableStream constructor will not tolerate initial garbage as pull argument assert_throws_js: constructor should throw function "() => new ReadableStream({ pull: { } })" did not throw
+PASS ReadableStream constructor will not tolerate initial garbage as cancel argument
+PASS ReadableStream constructor will not tolerate initial garbage as pull argument
 PASS ReadableStream start should be called with the proper thisArg
 PASS ReadableStream start controller parameter should be extensible
 PASS default ReadableStream getReader() should only accept mode:undefined

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.worker-expected.txt
@@ -1,12 +1,10 @@
 
 PASS ReadableStream can be constructed with no errors
 PASS ReadableStream can't be constructed with garbage
-FAIL ReadableStream can't be constructed with an invalid type assert_throws_js: constructor should throw when the type is null function "() => new ReadableStream({ type: null })" threw object "RangeError: Invalid type for underlying source" ("RangeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream can't be constructed with an invalid type
 PASS ReadableStream constructor should throw for non-function start arguments
-FAIL ReadableStream constructor will not tolerate initial garbage as cancel argument assert_throws_js: constructor should throw function "() => new ReadableStream({ cancel: '2' })" did not throw
-FAIL ReadableStream constructor will not tolerate initial garbage as pull argument assert_throws_js: constructor should throw function "() => new ReadableStream({ pull: { } })" did not throw
+PASS ReadableStream constructor will not tolerate initial garbage as cancel argument
+PASS ReadableStream constructor will not tolerate initial garbage as pull argument
 PASS ReadableStream start should be called with the proper thisArg
 PASS ReadableStream start controller parameter should be extensible
 PASS default ReadableStream getReader() should only accept mode:undefined

--- a/Source/WebCore/Modules/streams/ReadableStream.js
+++ b/Source/WebCore/Modules/streams/ReadableStream.js
@@ -70,12 +70,28 @@ function initializeReadableStream(underlyingSource, strategy)
         let readableByteStreamControllerConstructor = @ReadableByteStreamController;
         @putByIdDirectPrivate(this, "readableStreamController", new @ReadableByteStreamController(this, underlyingSource, strategy.highWaterMark, @isReadableStream));
     } else if (type === @undefined) {
-        if (strategy.highWaterMark === @undefined)
-            strategy.highWaterMark = 1;
+        let highWaterMark = strategy.highWaterMark;
+        if (highWaterMark !== @undefined)
+            highWaterMark = @toNumber(highWaterMark);
+        else
+            highWaterMark = 1;
+        const size = strategy.size;
+        if (size !== @undefined && !@isCallable(size))
+            @throwTypeError("size parameter must be a function");
 
-        @setupReadableStreamDefaultController(this, underlyingSource, strategy.size, strategy.highWaterMark, underlyingSource.start, underlyingSource.pull, underlyingSource.cancel);
+        const cancel = underlyingSource.cancel;
+        if (cancel !== @undefined && !@isCallable(cancel))
+            @throwTypeError("underlyingSource cancel must be a function");
+        const pull = underlyingSource.pull;
+        if (pull !== @undefined && !@isCallable(pull))
+            @throwTypeError("underlyingSource pull must be a function");
+        const start = underlyingSource.start;
+        if (start !== @undefined && !@isCallable(start))
+            @throwTypeError("underlyingSource start must be a function");
+
+        @setupReadableStreamDefaultController(this, underlyingSource, size, highWaterMark, start, pull, cancel);
     } else
-        @throwRangeError("Invalid type for underlying source");
+        @throwTypeError("Invalid type for underlying source");
 
     return this;
 }


### PR DESCRIPTION
#### d3b2d6457c79fe6b7cadf30c0a58ae5ff9f15e2b
<pre>
Update ReadableStream constructor type checking according spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=254503">https://bugs.webkit.org/show_bug.cgi?id=254503</a>
rdar://problem/107257592

Reviewed by Alex Christensen.

Update implementation according WebIDL definition.

* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.worker-expected.txt:
* Source/WebCore/Modules/streams/ReadableStream.js:
(initializeReadableStream):

Canonical link: <a href="https://commits.webkit.org/262165@main">https://commits.webkit.org/262165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9df1b133ab67d7493571228da7bd049e14e1341

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/961 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/880 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/926 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/711 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/667 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1673 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/684 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/696 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/184 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/709 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->