### PR TITLE
Update WebPage::fromCorePage similarly to WebKitLegacy

### DIFF
--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
@@ -68,7 +68,7 @@ RemoteWebInspectorUI::~RemoteWebInspectorUI() = default;
 void RemoteWebInspectorUI::initialize(DebuggableInfoData&& debuggableInfo, const String& backendCommandsURL)
 {
 #if ENABLE(INSPECTOR_EXTENSIONS)
-    m_extensionController = makeUnique<WebInspectorUIExtensionController>(*this);
+    m_extensionController = makeUnique<WebInspectorUIExtensionController>(*this, m_page.identifier());
 #endif
 
     m_debuggableInfo = WTFMove(debuggableInfo);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -78,7 +78,7 @@ void WebInspectorUI::establishConnection(WebPageProxyIdentifier inspectedPageIde
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     if (!m_extensionController)
-        m_extensionController = makeUnique<WebInspectorUIExtensionController>(*this);
+        m_extensionController = makeUnique<WebInspectorUIExtensionController>(*this, m_page.identifier());
 #endif
 
     m_frontendAPIDispatcher->reset();

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -42,13 +42,11 @@
 
 namespace WebKit {
 
-WebInspectorUIExtensionController::WebInspectorUIExtensionController(WebCore::InspectorFrontendClient& inspectorFrontend)
+WebInspectorUIExtensionController::WebInspectorUIExtensionController(WebCore::InspectorFrontendClient& inspectorFrontend, WebCore::PageIdentifier pageIdentifier)
     : m_frontendClient(inspectorFrontend)
+    , m_inspectorPageIdentifier(pageIdentifier)
 {
-    auto* page = inspectorFrontend.frontendPage();
-    ASSERT(page);
-
-    m_inspectorPageIdentifier = WebPage::fromCorePage(*page).identifier();
+    ASSERT(inspectorFrontend.frontendPage() && WebPage::fromCorePage(*inspectorFrontend.frontendPage())->identifier() == pageIdentifier);
 
     WebProcess::singleton().addMessageReceiver(Messages::WebInspectorUIExtensionController::messageReceiverName(), m_inspectorPageIdentifier, *this);
 }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
@@ -57,7 +57,7 @@ class WebInspectorUIExtensionController
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(WebInspectorUIExtensionController);
 public:
-    explicit WebInspectorUIExtensionController(WebCore::InspectorFrontendClient&);
+    WebInspectorUIExtensionController(WebCore::InspectorFrontendClient&, WebCore::PageIdentifier);
     ~WebInspectorUIExtensionController();
 
     // Implemented in generated WebInspectorUIExtensionControllerMessageReceiver.cpp

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -336,7 +336,8 @@ void NetworkProcessConnection::broadcastConsoleMessage(MessageSource source, Mes
     FAST_RETURN_IF_NO_FRONTENDS(void());
 
     Page::forEachPage([&] (Page& page) {
-        WebPage::fromCorePage(page).mainWebFrame().addConsoleMessage(source, level, message);
+        if (auto* webPage = WebPage::fromCorePage(page))
+            webPage->mainWebFrame().addConsoleMessage(source, level, message);
     });
 }
 

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -402,7 +402,7 @@ void WebSWClientConnection::focusServiceWorkerClient(ScriptExecutionContextIdent
         return;
     }
 
-    WebPage::fromCorePage(*page).sendWithAsyncReply(Messages::WebPageProxy::FocusFromServiceWorker { }, [clientIdentifier, callback = WTFMove(callback)]() mutable {
+    WebPage::fromCorePage(*page)->sendWithAsyncReply(Messages::WebPageProxy::FocusFromServiceWorker { }, [clientIdentifier, callback = WTFMove(callback)]() mutable {
         auto* client = Document::allDocumentsMap().get(clientIdentifier);
         auto* frame = client ? client->frame() : nullptr;
         auto* page = frame ? frame->page() : nullptr;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp
@@ -38,14 +38,14 @@ void WebBadgeClient::setAppBadge(Page* page, const SecurityOriginData& origin, s
 {
     std::optional<WebPageProxyIdentifier> pageIdentifier;
     if (page)
-        pageIdentifier = WebPage::fromCorePage(*page).webPageProxyIdentifier();
+        pageIdentifier = WebPage::fromCorePage(*page)->webPageProxyIdentifier();
 
     WebProcess::singleton().setAppBadge(pageIdentifier, origin, badge);
 }
 
 void WebBadgeClient::setClientBadge(Page& page, const SecurityOriginData& origin, std::optional<uint64_t> badge)
 {
-    WebProcess::singleton().setClientBadge(WebPage::fromCorePage(page).webPageProxyIdentifier(), origin, badge);
+    WebProcess::singleton().setClientBadge(WebPage::fromCorePage(page)->webPageProxyIdentifier(), origin, badge);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
@@ -62,7 +62,7 @@ void WebPermissionController::query(WebCore::ClientOrigin&& origin, WebCore::Per
     std::optional<WebPageProxyIdentifier> proxyIdentifier;
     if (source == WebCore::PermissionQuerySource::Window || source == WebCore::PermissionQuerySource::DedicatedWorker) {
         ASSERT(page);
-        proxyIdentifier = WebPage::fromCorePage(*page).webPageProxyIdentifier();
+        proxyIdentifier = WebPage::fromCorePage(*page)->webPageProxyIdentifier();
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebPermissionControllerProxy::Query(origin, descriptor, proxyIdentifier, source), WTFMove(completionHandler));

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -371,7 +371,7 @@ void WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution(const 
         if (auto* opener = frame->loader().opener()) {
             if (auto* openerDocument = opener->document()) {
                 if (auto* openerPage = openerDocument->page())
-                    requestStorageAccessUnderOpener(topFrameDomain, WebPage::fromCorePage(*openerPage), *openerDocument);
+                    requestStorageAccessUnderOpener(topFrameDomain, *WebPage::fromCorePage(*openerPage), *openerDocument);
             }
         }
     }

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp
@@ -80,8 +80,7 @@ void VisitedLinkTableController::addVisitedLink(Page& page, SharedStringHash lin
     if (m_visitedLinkTable.contains(linkHash))
         return;
 
-    auto& webPage = WebPage::fromCorePage(page);
-    WebProcess::singleton().parentProcessConnection()->send(Messages::VisitedLinkStore::AddVisitedLinkHashFromPage(webPage.webPageProxyIdentifier(), linkHash), m_identifier);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::VisitedLinkStore::AddVisitedLinkHashFromPage(WebPage::fromCorePage(page)->webPageProxyIdentifier(), linkHash), m_identifier);
 }
 
 void VisitedLinkTableController::setVisitedLinkTable(const SharedMemory::Handle& handle)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -219,10 +219,8 @@ WebPage* WebFrame::page() const
     if (!m_coreFrame)
         return nullptr;
 
-    if (auto* page = m_coreFrame->page())
-        return &WebPage::fromCorePage(*page);
-
-    return nullptr;
+    auto* page = m_coreFrame->page();
+    return page ? WebPage::fromCorePage(*page) : nullptr;
 }
 
 WebFrame* WebFrame::fromCoreFrame(const Frame& frame)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2015,9 +2015,10 @@ void WebPage::tryRestoreScrollPosition()
         localMainFrame->loader().history().restoreScrollPositionAndViewState();
 }
 
-WebPage& WebPage::fromCorePage(Page& page)
+WebPage* WebPage::fromCorePage(Page& page)
 {
-    return static_cast<WebChromeClient&>(page.chrome().client()).page();
+    auto& client = page.chrome().client();
+    return client.isEmptyChromeClient() ? nullptr : &static_cast<WebChromeClient&>(client).page();
 }
 
 void WebPage::setSize(const WebCore::IntSize& viewSize)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -404,7 +404,7 @@ public:
 
     void close();
 
-    static WebPage& fromCorePage(WebCore::Page&);
+    static WebPage* fromCorePage(WebCore::Page&);
 
     WebCore::Page* corePage() const { return m_page.get(); }
     WebCore::PageIdentifier identifier() const { return m_identifier; }

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
@@ -86,12 +86,12 @@ void WebPageOverlay::clear()
 
 void WebPageOverlay::willMoveToPage(PageOverlay&, Page* page)
 {
-    m_client->willMoveToPage(*this, page ? &WebPage::fromCorePage(*page) : nullptr);
+    m_client->willMoveToPage(*this, page ? WebPage::fromCorePage(*page) : nullptr);
 }
 
 void WebPageOverlay::didMoveToPage(PageOverlay&, Page* page)
 {
-    m_client->didMoveToPage(*this, page ? &WebPage::fromCorePage(*page) : nullptr);
+    m_client->didMoveToPage(*this, page ? WebPage::fromCorePage(*page) : nullptr);
 }
 
 void WebPageOverlay::drawRect(PageOverlay&, GraphicsContext& context, const IntRect& dirtyRect)

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp
@@ -89,7 +89,8 @@ Ref<StorageNamespace> StorageNamespaceImpl::copy(Page& newPage)
     ASSERT(m_storageNamespaceID);
     ASSERT(m_storageType == StorageType::Session);
 
-    return adoptRef(*new StorageNamespaceImpl(m_storageType, WebPage::fromCorePage(newPage).identifier(), m_topLevelOrigin.get(), m_quotaInBytes, WebPage::fromCorePage(newPage).sessionStorageNamespaceIdentifier()));
+    auto* webPage = WebPage::fromCorePage(newPage);
+    return adoptRef(*new StorageNamespaceImpl(m_storageType, webPage->identifier(), m_topLevelOrigin.get(), m_quotaInBytes, webPage->sessionStorageNamespaceIdentifier()));
 }
 
 void StorageNamespaceImpl::setSessionIDForTesting(PAL::SessionID)

--- a/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp
@@ -95,15 +95,17 @@ RefPtr<WebCore::StorageNamespace> WebStorageNamespaceProvider::sessionStorageNam
 {
     ASSERT(sessionStorageQuota() != WebCore::StorageMap::noQuota);
 
-    auto& webPage = WebPage::fromCorePage(page);
+    RefPtr webPage = WebPage::fromCorePage(page);
+    if (!webPage)
+        return nullptr;
 
     // The identifier of a session storage namespace is the WebPageProxyIdentifier. It is possible we have several WebPage objects in a single process for the same
     // WebPageProxyIdentifier and these need to share the same namespace instance so we know where to route the IPC to.
-    auto namespacesIt = m_sessionStorageNamespaces.find(webPage.sessionStorageNamespaceIdentifier());
+    auto namespacesIt = m_sessionStorageNamespaces.find(webPage->sessionStorageNamespaceIdentifier());
     if (namespacesIt == m_sessionStorageNamespaces.end()) {
         if (shouldCreate == ShouldCreateNamespace::No)
             return nullptr;
-        namespacesIt = m_sessionStorageNamespaces.set(webPage.sessionStorageNamespaceIdentifier(), SessionStorageNamespaces { }).iterator;
+        namespacesIt = m_sessionStorageNamespaces.set(webPage->sessionStorageNamespaceIdentifier(), SessionStorageNamespaces { }).iterator;
     }
 
     auto& sessionStorageNamespacesMap = namespacesIt->value.map;
@@ -111,7 +113,7 @@ RefPtr<WebCore::StorageNamespace> WebStorageNamespaceProvider::sessionStorageNam
     if (it == sessionStorageNamespacesMap.end()) {
         if (shouldCreate == ShouldCreateNamespace::No)
             return nullptr;
-        auto sessionStorageNamespace = StorageNamespaceImpl::createSessionStorageNamespace(webPage.sessionStorageNamespaceIdentifier(), webPage.identifier(), topLevelOrigin, sessionStorageQuota());
+        auto sessionStorageNamespace = StorageNamespaceImpl::createSessionStorageNamespace(webPage->sessionStorageNamespaceIdentifier(), webPage->identifier(), topLevelOrigin, sessionStorageQuota());
         it = sessionStorageNamespacesMap.set(topLevelOrigin.data(), WTFMove(sessionStorageNamespace)).iterator;
     }
     return it->value;
@@ -121,8 +123,8 @@ void WebStorageNamespaceProvider::copySessionStorageNamespace(WebCore::Page& src
 {
     ASSERT(sessionStorageQuota() != WebCore::StorageMap::noQuota);
 
-    const auto& srcWebPage = WebPage::fromCorePage(srcPage);
-    const auto& dstWebPage = WebPage::fromCorePage(dstPage);
+    const auto& srcWebPage = *WebPage::fromCorePage(srcPage);
+    const auto& dstWebPage = *WebPage::fromCorePage(dstPage);
 
     auto srcNamespacesIt = m_sessionStorageNamespaces.find(srcWebPage.sessionStorageNamespaceIdentifier());
     if (srcNamespacesIt == m_sessionStorageNamespaces.end())


### PR DESCRIPTION
#### e800fd7a78333a26390f22184f7d05cdf3ff8f08
<pre>
Update WebPage::fromCorePage similarly to WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=254505">https://bugs.webkit.org/show_bug.cgi?id=254505</a>
rdar://problem/107259664

Reviewed by Alex Christensen.

Check that chorme client is not an empty client inside CorePage.
Update call sites accordingly.

* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp:
(WebKit::RemoteWebInspectorUI::initialize):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::establishConnection):
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp:
(WebKit::WebInspectorUIExtensionController::WebInspectorUIExtensionController):
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::broadcastConsoleMessage):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::tryLoadingUsingURLSchemeHandler):
(WebKit::WebLoaderStrategy::pageLoadCompleted):
(WebKit::WebLoaderStrategy::browsingContextRemoved):
(WebKit::WebLoaderStrategy::setResourceLoadSchedulingMode):
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::focusServiceWorkerClient):
* Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp:
(WebKit::WebBadgeClient::setAppBadge):
(WebKit::WebBadgeClient::setClientBadge):
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp:
(WebKit::WebPermissionController::query):
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution):
* Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp:
(WebKit::VisitedLinkTableController::addVisitedLink):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::page const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::fromCorePage):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp:
(WebKit::WebPageOverlay::willMoveToPage):
(WebKit::WebPageOverlay::didMoveToPage):
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceImpl.cpp:
(WebKit::StorageNamespaceImpl::copy):
* Source/WebKit/WebProcess/WebStorage/WebStorageNamespaceProvider.cpp:
(WebKit::WebStorageNamespaceProvider::sessionStorageNamespace):
(WebKit::WebStorageNamespaceProvider::copySessionStorageNamespace):
* Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm:
(WebKit::LaunchServicesDatabaseManager::waitForDatabaseUpdate):

Canonical link: <a href="https://commits.webkit.org/262156@main">https://commits.webkit.org/262156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba1c30269765b1e6ca5f1849a8bf4996477cb7ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/958 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/652 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/878 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/920 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/709 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/664 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1676 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/681 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/693 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/176 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/706 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->