### PR TITLE
[popover] Implement "check and possibly close popover stack" algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled-expected.txt
@@ -2,11 +2,11 @@ form
 helloother button
 
 PASS Disabled popover*target buttons should not affect the popover heirarchy.
-FAIL Disabling popover*target buttons when popovers are open should still cause all popovers to be closed when the formerly outer popover is closed. assert_false: The inner popover should be closed when the hierarchy is broken. expected false got true
-FAIL Disabling popover*target buttons when popovers are open should still cause all popovers to be closed when the formerly inner popover is closed. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
-FAIL Setting the form attribute on popover*target buttons when popovers are open should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
-FAIL Changing the input type on a popover*target button when popovers are open should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
-FAIL Disconnecting popover*target buttons when popovers are open should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
-FAIL Changing the popovertarget attribute to break the chain should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
+PASS Disabling popover*target buttons when popovers are open should still cause all popovers to be closed when the formerly outer popover is closed.
+PASS Disabling popover*target buttons when popovers are open should still cause all popovers to be closed when the formerly inner popover is closed.
+PASS Setting the form attribute on popover*target buttons when popovers are open should close all popovers.
+PASS Changing the input type on a popover*target button when popovers are open should close all popovers.
+PASS Disconnecting popover*target buttons when popovers are open should close all popovers.
+PASS Changing the popovertarget attribute to break the chain should close all popovers.
 PASS Modifying popovertarget on a button which doesn't break the chain shouldn't close any popovers.
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1284,6 +1284,23 @@ static HTMLElement* topmostPopoverAncestor(Element& newPopover)
     return topmostAncestor.get();
 }
 
+void HTMLElement::checkAndPossiblyClosePopoverStackInternal()
+{
+    Vector<RefPtr<Element>> autoPopoverList;
+    for (auto& element : document().topLayerElements()) {
+        if (!is<HTMLElement>(element) || downcast<HTMLElement>(element.get()).popoverState() != PopoverState::Auto)
+            continue;
+        autoPopoverList.append(element.ptr());
+    }
+
+    for (size_t i = autoPopoverList.size(); i-- > 1;) {
+        if (topmostPopoverAncestor(*autoPopoverList[i]) != autoPopoverList[i - 1]) {
+            document().hideAllPopoversUntil(nullptr, FocusPreviousElement::No, FireEvents::No);
+            return;
+        }
+    }
+}
+
 // https://html.spec.whatwg.org/#popover-focusing-steps
 static void runPopoverFocusingSteps(HTMLElement& popover)
 {

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "ColorTypes.h"
+#include "Document.h"
 #include "HTMLNames.h"
 #include "InputMode.h"
 #include "StyledElement.h"
@@ -191,6 +192,13 @@ protected:
     void childrenChanged(const ChildChange&) override;
     void updateEffectiveDirectionalityOfDirAuto();
 
+    void checkAndPossiblyClosePopoverStack()
+    {
+        if (!document().settings().popoverAttributeEnabled() || !document().hasTopLayerElement())
+            return;
+        checkAndPossiblyClosePopoverStackInternal();
+    }
+
     using EventHandlerNameMap = HashMap<AtomStringImpl*, AtomString>;
     static const AtomString& eventNameForEventHandlerAttribute(const QualifiedName& attributeName, const EventHandlerNameMap&);
 
@@ -214,6 +222,7 @@ private:
     enum class UseCSSPXAsUnitType : bool { No, Yes };
     enum class IsMultiLength : bool { No, Yes };
     void addHTMLLengthToStyle(MutableStyleProperties&, CSSPropertyID, StringView value, AllowPercentage, UseCSSPXAsUnitType, IsMultiLength, AllowZeroValue = AllowZeroValue::Yes);
+    void checkAndPossiblyClosePopoverStackInternal();
 };
 
 inline HTMLElement::HTMLElement(const QualifiedName& tagName, Document& document, ConstructionType type = CreateHTMLElement)

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -141,6 +141,7 @@ void HTMLFormControlElement::removedFromAncestor(RemovalType removalType, Contai
 {
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
     ValidatedFormListedElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    checkAndPossiblyClosePopoverStack();
 }
 
 void HTMLFormControlElement::parseAttribute(const QualifiedName& name, const AtomString& value)
@@ -152,7 +153,9 @@ void HTMLFormControlElement::parseAttribute(const QualifiedName& name, const Ato
             m_isRequired = newRequired;
             requiredStateChanged();
         }
-    } else {
+    } else if (name == popovertargetAttr)
+        checkAndPossiblyClosePopoverStack();
+    else {
         HTMLElement::parseAttribute(name, value);
         ValidatedFormListedElement::parseAttribute(name, value);
     }
@@ -170,6 +173,7 @@ void HTMLFormControlElement::disabledStateChanged()
     ValidatedFormListedElement::disabledStateChanged();
     if (renderer() && renderer()->style().hasEffectiveAppearance())
         renderer()->theme().stateChanged(*renderer(), ControlStates::States::Enabled);
+    checkAndPossiblyClosePopoverStack();
 }
 
 void HTMLFormControlElement::readOnlyStateChanged()
@@ -407,4 +411,10 @@ bool HTMLFormControlElement::needsMouseFocusableQuirk() const
     return document().quirks().needsFormControlToBeMouseFocusable();
 }
 
-} // namespace WebCore
+void HTMLFormControlElement::didChangeForm()
+{
+    ValidatedFormListedElement::didChangeForm();
+    checkAndPossiblyClosePopoverStack();
+}
+
+} // namespace Webcore

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -127,6 +127,8 @@ protected:
 
     void handlePopoverTargetAction() const;
 
+    void didChangeForm() override;
+
 private:
     void refFormAssociatedElement() const final { ref(); }
     void derefFormAssociatedElement() const final { deref(); }

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -586,6 +586,8 @@ void HTMLInputElement::updateType()
     }
 
     updateValidity();
+
+    checkAndPossiblyClosePopoverStack();
 }
 
 inline void HTMLInputElement::runPostTypeUpdateTasks()


### PR DESCRIPTION
#### f4a34ff850554d9c85d9114b14a3a12bb01f1ccf
<pre>
[popover] Implement &quot;check and possibly close popover stack&quot; algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=254382">https://bugs.webkit.org/show_bug.cgi?id=254382</a>

Reviewed by Tim Nguyen.

Implement &quot;check and possibly close popover stack&quot; algorithm as specified here:
<a href="https://github.com/whatwg/html/pull/9048">https://github.com/whatwg/html/pull/9048</a>

This patch also imports the latest version of popover-target-element-disabled.html.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled.html:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::checkAndPossiblyClosePopoverStackInternal):
* Source/WebCore/html/HTMLElement.h:
(WebCore::HTMLElement::checkAndPossiblyClosePopoverStack):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::removedFromAncestor):
(WebCore::HTMLFormControlElement::parseAttribute):
(WebCore::HTMLFormControlElement::disabledStateChanged):
(WebCore::HTMLFormControlElement::didChangeForm):
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):

Canonical link: <a href="https://commits.webkit.org/262440@main">https://commits.webkit.org/262440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b11dc7261bda540218c91b468345320105c9efa2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2444 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1614 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1538 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2282 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1364 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1389 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1403 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1370 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/381 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1487 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->