### PR TITLE
ReadableStreamError should reject closed promise before erroring read promises

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any-expected.txt
@@ -14,7 +14,7 @@ PASS ReadableStream should be able to call start method within prototype chain o
 PASS ReadableStream start should be able to return a promise
 PASS ReadableStream start should be able to return a promise and reject it
 PASS ReadableStream should be able to enqueue different objects.
-FAIL ReadableStream: if pull rejects, it should error the stream assert_true: expected true got false
+PASS ReadableStream: if pull rejects, it should error the stream
 PASS ReadableStream: should only call pull once upon starting the stream
 PASS ReadableStream: should call pull when trying to read from a started, empty stream
 PASS ReadableStream: should only call pull once on a non-empty stream read from before start fulfills

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.serviceworker-expected.txt
@@ -14,7 +14,7 @@ PASS ReadableStream should be able to call start method within prototype chain o
 PASS ReadableStream start should be able to return a promise
 PASS ReadableStream start should be able to return a promise and reject it
 PASS ReadableStream should be able to enqueue different objects.
-FAIL ReadableStream: if pull rejects, it should error the stream assert_true: expected true got false
+PASS ReadableStream: if pull rejects, it should error the stream
 PASS ReadableStream: should only call pull once upon starting the stream
 PASS ReadableStream: should call pull when trying to read from a started, empty stream
 PASS ReadableStream: should only call pull once on a non-empty stream read from before start fulfills

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.sharedworker-expected.txt
@@ -14,7 +14,7 @@ PASS ReadableStream should be able to call start method within prototype chain o
 PASS ReadableStream start should be able to return a promise
 PASS ReadableStream start should be able to return a promise and reject it
 PASS ReadableStream should be able to enqueue different objects.
-FAIL ReadableStream: if pull rejects, it should error the stream assert_true: expected true got false
+PASS ReadableStream: if pull rejects, it should error the stream
 PASS ReadableStream: should only call pull once upon starting the stream
 PASS ReadableStream: should call pull when trying to read from a started, empty stream
 PASS ReadableStream: should only call pull once on a non-empty stream read from before start fulfills

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.worker-expected.txt
@@ -14,7 +14,7 @@ PASS ReadableStream should be able to call start method within prototype chain o
 PASS ReadableStream start should be able to return a promise
 PASS ReadableStream start should be able to return a promise and reject it
 PASS ReadableStream should be able to enqueue different objects.
-FAIL ReadableStream: if pull rejects, it should error the stream assert_true: expected true got false
+PASS ReadableStream: if pull rejects, it should error the stream
 PASS ReadableStream: should only call pull once upon starting the stream
 PASS ReadableStream: should call pull when trying to read from a started, empty stream
 PASS ReadableStream: should only call pull once on a non-empty stream read from before start fulfills

--- a/LayoutTests/streams/readable-stream-default-reader-read.html
+++ b/LayoutTests/streams/readable-stream-default-reader-read.html
@@ -117,20 +117,20 @@ test4.step(function() {
         assert_unreached('read() should reject on an errored stream');
     }), test4.step_func(function(err) {
         assert_equals(myError, err);
-        assert_equals(++counter, 1);
+        assert_equals(++counter, 2);
     }));
     reader.read().then(test4.step_func(function() {
         assert_unreached('read() should reject on an errored stream');
     }), test4.step_func(function(err) {
         assert_equals(myError, err);
-        assert_equals(++counter, 2);
+        assert_equals(++counter, 3);
+        test4.done();
     }));
     reader.closed.then(test4.step_func(function() {
         assert_unreached('read() should reject on an errored stream');
     }), test4.step_func(function(err) {
         assert_equals(myError, err);
-        assert_equals(++counter, 3);
-        test4.done();
+        assert_equals(++counter, 1);
     }));
 
     var myError = { potato: 'mashed' };

--- a/Source/WebCore/Modules/streams/ReadableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamInternals.js
@@ -535,6 +535,10 @@ function readableStreamError(stream, error)
 
     const reader = @getByIdDirectPrivate(stream, "reader");
 
+    @getByIdDirectPrivate(reader, "closedPromiseCapability").@reject.@call(@undefined, error);
+    const promise = @getByIdDirectPrivate(reader, "closedPromiseCapability").@promise;
+    @markPromiseAsHandled(promise);
+
     if (@isReadableStreamDefaultReader(reader)) {
         const requests = @getByIdDirectPrivate(reader, "readRequests");
         @putByIdDirectPrivate(reader, "readRequests", []);
@@ -547,10 +551,6 @@ function readableStreamError(stream, error)
         for (let index = 0, length = requests.length; index < length; ++index)
             @rejectPromise(requests[index], error);
     }
-
-    @getByIdDirectPrivate(reader, "closedPromiseCapability").@reject.@call(@undefined, error);
-    const promise = @getByIdDirectPrivate(reader, "closedPromiseCapability").@promise;
-    @markPromiseAsHandled(promise);
 }
 
 function readableStreamDefaultControllerShouldCallPull(controller)


### PR DESCRIPTION
#### 1f74c15de9b455d6662f228abda98a7cde9d9e2c
<pre>
ReadableStreamError should reject closed promise before erroring read promises
<a href="https://bugs.webkit.org/show_bug.cgi?id=254509">https://bugs.webkit.org/show_bug.cgi?id=254509</a>
rdar://problem/107262301

Reviewed by Alex Christensen.

Update implementation as per latest version of <a href="https://streams.spec.whatwg.org/#readable-stream-error.">https://streams.spec.whatwg.org/#readable-stream-error.</a>

* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.worker-expected.txt:
* LayoutTests/streams/readable-stream-default-reader-read.html:
* Source/WebCore/Modules/streams/ReadableStreamInternals.js:
(readableStreamError):

Canonical link: <a href="https://commits.webkit.org/262164@main">https://commits.webkit.org/262164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceeb586b73301e3db170b70c5a9af8afc64fa192

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/963 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/737 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/693 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1711 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/705 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/723 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/183 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/735 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->