### PR TITLE
Update XHR to use new XMLHttpRequestBodyInit

### DIFF
--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -160,7 +160,7 @@ void XMLHttpRequest::didCacheResponse()
 ExceptionOr<Document*> XMLHttpRequest::responseXML()
 {
     ASSERT(scriptExecutionContext()->isDocument());
-    
+
     if (responseType() != ResponseType::EmptyString && responseType() != ResponseType::Document)
         return Exception { InvalidStateError };
 
@@ -469,10 +469,9 @@ ExceptionOr<void> XMLHttpRequest::send(Document& document)
         return WTFMove(result.value());
 
     if (m_method != "GET"_s && m_method != "HEAD"_s) {
-        if (!m_requestHeaders.contains(HTTPHeaderName::ContentType)) {
-            // FIXME: this should include the charset used for encoding.
+        if (!m_requestHeaders.contains(HTTPHeaderName::ContentType))
             m_requestHeaders.set(HTTPHeaderName::ContentType, document.isHTMLDocument() ? "text/html;charset=UTF-8"_s : "application/xml;charset=UTF-8"_s);
-        } else {
+        else {
             String contentType = m_requestHeaders.get(HTTPHeaderName::ContentType);
             replaceCharsetInMediaTypeIfNeeded(contentType);
             m_requestHeaders.set(HTTPHeaderName::ContentType, contentType);
@@ -524,13 +523,13 @@ ExceptionOr<void> XMLHttpRequest::send(Blob& body)
         if (!m_url.url().protocolIsInHTTPFamily()) {
             // FIXME: We would like to support posting Blobs to non-http URLs (e.g. custom URL schemes)
             // but because of the architecture of blob-handling that will require a fair amount of work.
-            
+
             ASCIILiteral consoleMessage { "POST of a Blob to non-HTTP protocols in XMLHttpRequest.send() is currently unsupported."_s };
             scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, consoleMessage);
-            
+
             return createRequest();
         }
-        
+
         if (!m_requestHeaders.contains(HTTPHeaderName::ContentType)) {
             const String& blobType = body.type();
             if (!blobType.isEmpty() && isValidContentType(blobType))
@@ -703,7 +702,6 @@ bool XMLHttpRequest::internalAbort()
 {
     m_error = true;
 
-    // FIXME: when we add the support for multi-part XHR, we will have to think be careful with this initialization.
     m_receivedLength = 0;
 
     m_decoder = nullptr;
@@ -767,7 +765,7 @@ void XMLHttpRequest::networkError()
     dispatchErrorEvents(eventNames().errorEvent);
     internalAbort();
 }
-    
+
 void XMLHttpRequest::abortError()
 {
     ASSERT(m_wasAbortedByClient);

--- a/Source/WebCore/xml/XMLHttpRequest.idl
+++ b/Source/WebCore/xml/XMLHttpRequest.idl
@@ -26,8 +26,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// FIXME: Add ReadableStream to the union when supported.
-typedef (Blob or BufferSource or DOMFormData or USVString or URLSearchParams) BodyInit;
+typedef (Blob or BufferSource or DOMFormData or USVString or URLSearchParams) XMLHttpRequestBodyInit;
 
 enum XMLHttpRequestResponseType {
     "",
@@ -67,7 +66,7 @@ enum XMLHttpRequestResponseType {
     attribute unsigned long timeout;
     attribute boolean withCredentials;
     [SameObject] readonly attribute XMLHttpRequestUpload upload;
-    undefined send(optional (Document or BodyInit)? body = null);
+    undefined send(optional (Document or XMLHttpRequestBodyInit)? body = null);
     undefined abort();
 
     // response


### PR DESCRIPTION
#### 0528c528cf1353a5a0059cd8dde10e3eea8520bb
<pre>
Update XHR to use new XMLHttpRequestBodyInit
<a href="https://bugs.webkit.org/show_bug.cgi?id=212731">https://bugs.webkit.org/show_bug.cgi?id=212731</a>
rdar://64033262

Reviewed by Youenn Fablet.

No functional changes. This aligns the IDL with the latest standard and removes two additional FIXMEs because:

- XMLHttpRequest won&apos;t be extended with multi-part support.
- Documents are always encoded in UTF-8.

* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::send):
(WebCore::XMLHttpRequest::internalAbort):
* Source/WebCore/xml/XMLHttpRequest.idl:

Canonical link: <a href="https://commits.webkit.org/262149@main">https://commits.webkit.org/262149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a5b77d196b1b14538dcc544580a5b5cc07cb595

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/666 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/893 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/942 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/724 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/679 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/720 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1691 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/692 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/705 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/171 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/720 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->