### PR TITLE
[GTK] Add WebKitClipboardPermissionRequest to handle DOM paste access requests

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -118,6 +118,7 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitAutomationSession.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitBackForwardList.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitBackForwardListItem.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitClipboardPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitCredential.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitContextMenu.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitContextMenuActions.h.in

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -132,6 +132,7 @@ UIProcess/API/glib/WebKitAuthenticationRequest.cpp @no-unify
 UIProcess/API/glib/WebKitAutomationSession.cpp @no-unify
 UIProcess/API/glib/WebKitBackForwardList.cpp @no-unify
 UIProcess/API/glib/WebKitBackForwardListItem.cpp @no-unify
+UIProcess/API/glib/WebKitClipboardPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitContextMenuClient.cpp @no-unify
 UIProcess/API/glib/WebKitCookieManager.cpp @no-unify
 UIProcess/API/glib/WebKitCredential.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/WebKitClipboardPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitClipboardPermissionRequest.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitClipboardPermissionRequest.h"
+
+#include "WebKitClipboardPermissionRequestPrivate.h"
+#include "WebKitPermissionRequest.h"
+#include <wtf/glib/WTFGType.h>
+
+#if !ENABLE(2022_GLIB_API)
+typedef WebKitPermissionRequestIface WebKitPermissionRequestInterface;
+#endif
+
+/**
+ * WebKitClipboardPermissionRequest:
+ * @See_also: #WebKitPermissionRequest, #WebKitWebView
+ *
+ * A permission request for reading clipboard contents.
+ *
+ * WebKitClipboardPermissionRequest represents a request for
+ * permission to decide whether WebKit can access the clibpard to read
+ * its contents through the Async Clipboard API.
+ *
+ * When a WebKitClipboardPermissionRequest is not handled by the user,
+ * it is denied by default.
+ *
+ * Since: 2.42
+ */
+
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface*);
+
+struct _WebKitClipboardPermissionRequestPrivate {
+    CompletionHandler<void(WebCore::DOMPasteAccessResponse)> completionHandler;
+};
+
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitClipboardPermissionRequest, webkit_clipboard_permission_request, G_TYPE_OBJECT, GObject,
+    G_IMPLEMENT_INTERFACE(WEBKIT_TYPE_PERMISSION_REQUEST, webkit_permission_request_interface_init))
+
+static void webkitClipboardPermissionRequestAllow(WebKitPermissionRequest* request)
+{
+    ASSERT(WEBKIT_IS_CLIPBOARD_PERMISSION_REQUEST(request));
+
+    WebKitClipboardPermissionRequestPrivate* priv = WEBKIT_CLIPBOARD_PERMISSION_REQUEST(request)->priv;
+
+    if (priv->completionHandler)
+        priv->completionHandler(WebCore::DOMPasteAccessResponse::GrantedForGesture);
+}
+
+static void webkitClipboardPermissionRequestDeny(WebKitPermissionRequest* request)
+{
+    ASSERT(WEBKIT_IS_CLIPBOARD_PERMISSION_REQUEST(request));
+
+    WebKitClipboardPermissionRequestPrivate* priv = WEBKIT_CLIPBOARD_PERMISSION_REQUEST(request)->priv;
+
+    if (priv->completionHandler)
+        priv->completionHandler(WebCore::DOMPasteAccessResponse::DeniedForGesture);
+}
+
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface* iface)
+{
+    iface->allow = webkitClipboardPermissionRequestAllow;
+    iface->deny = webkitClipboardPermissionRequestDeny;
+}
+
+static void webkitClipboardPermissionRequestDispose(GObject* object)
+{
+    // Default behaviour when no decision has been made is denying the request.
+    webkitClipboardPermissionRequestDeny(WEBKIT_PERMISSION_REQUEST(object));
+    G_OBJECT_CLASS(webkit_clipboard_permission_request_parent_class)->dispose(object);
+}
+
+static void webkit_clipboard_permission_request_class_init(WebKitClipboardPermissionRequestClass* klass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(klass);
+    objectClass->dispose = webkitClipboardPermissionRequestDispose;
+}
+
+WebKitClipboardPermissionRequest* webkitClipboardPermissionRequestCreate(CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&& completionHandler)
+{
+    WebKitClipboardPermissionRequest* clipboardPermissionRequest = WEBKIT_CLIPBOARD_PERMISSION_REQUEST(g_object_new(WEBKIT_TYPE_CLIPBOARD_PERMISSION_REQUEST, nullptr));
+    clipboardPermissionRequest->priv->completionHandler = WTFMove(completionHandler);
+    return clipboardPermissionRequest;
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitClipboardPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitClipboardPermissionRequest.h.in
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+@API_SINGLE_HEADER_CHECK@
+
+#ifndef WebKitClipboardPermissionRequest_h
+#define WebKitClipboardPermissionRequest_h
+
+#include <glib-object.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_CLIPBOARD_PERMISSION_REQUEST            (webkit_clipboard_permission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
+#define WEBKIT_CLIPBOARD_PERMISSION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_CLIPBOARD_PERMISSION_REQUEST, WebKitClipboardPermissionRequest))
+#define WEBKIT_CLIPBOARD_PERMISSION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_CLIPBOARD_PERMISSION_REQUEST, WebKitClipboardPermissionRequestClass))
+#define WEBKIT_IS_CLIPBOARD_PERMISSION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_CLIPBOARD_PERMISSION_REQUEST))
+#define WEBKIT_IS_CLIPBOARD_PERMISSION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_CLIPBOARD_PERMISSION_REQUEST))
+#define WEBKIT_CLIPBOARD_PERMISSION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_CLIPBOARD_PERMISSION_REQUEST, WebKitClipboardPermissionRequestClass))
+
+struct _WebKitClipboardPermissionRequestClass {
+    GObjectClass parent_class;
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitClipboardPermissionRequest, webkit_clipboard_permission_request, WEBKIT, CLIPBOARD_PERMISSION_REQUEST, GObject)
+
+G_END_DECLS
+
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitClipboardPermissionRequestPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitClipboardPermissionRequestPrivate.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "WebKitClipboardPermissionRequest.h"
+#include <WebCore/DOMPasteAccess.h>
+#include <wtf/CompletionHandler.h>
+
+WebKitClipboardPermissionRequest* webkitClipboardPermissionRequestCreate(CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&&);

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -46,6 +46,7 @@
 #include <@API_INCLUDE_PREFIX@/WebKitBackForwardList.h>
 #include <@API_INCLUDE_PREFIX@/WebKitBackForwardListItem.h>
 #if PLATFORM(GTK)
+#include <@API_INCLUDE_PREFIX@/WebKitClipboardPermissionRequest.h>
 #include <@API_INCLUDE_PREFIX@/WebKitColorChooserRequest.h>
 #endif
 #include <@API_INCLUDE_PREFIX@/WebKitContextMenu.h>

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -38,6 +38,7 @@
 #include "WebContextMenuProxyGtk.h"
 #include "WebDataListSuggestionsDropdownGtk.h"
 #include "WebEventFactory.h"
+#include "WebKitClipboardPermissionRequestPrivate.h"
 #include "WebKitColorChooser.h"
 #include "WebKitPopupMenu.h"
 #include "WebKitWebViewBaseInternal.h"
@@ -56,6 +57,7 @@
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/ValidationBubble.h>
 #include <wtf/Compiler.h>
+#include <wtf/glib/GWeakPtr.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 #include <wtf/unix/UnixFileDescriptor.h>
@@ -552,13 +554,19 @@ void PageClientImpl::derefView()
 void PageClientImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, const IntRect&, const String& originIdentifier, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&& completionHandler)
 {
     auto& clipboard = Clipboard::get("CLIPBOARD"_s);
-    clipboard.readBuffer(PasteboardCustomData::gtkType().characters(), [originIdentifier, completionHandler = WTFMove(completionHandler)](Ref<SharedBuffer>&& buffer) mutable {
+    clipboard.readBuffer(PasteboardCustomData::gtkType().characters(), [weakWebView = GWeakPtr<GtkWidget>(m_viewWidget), originIdentifier, completionHandler = WTFMove(completionHandler)](Ref<SharedBuffer>&& buffer) mutable {
         if (PasteboardCustomData::fromSharedBuffer(buffer.get()).origin() == originIdentifier) {
             completionHandler(DOMPasteAccessResponse::GrantedForGesture);
             return;
         }
 
-        completionHandler(DOMPasteAccessResponse::DeniedForGesture);
+        if (!WEBKIT_IS_WEB_VIEW(weakWebView.get())) {
+            completionHandler(DOMPasteAccessResponse::DeniedForGesture);
+            return;
+        }
+
+        GRefPtr<WebKitClipboardPermissionRequest> request = adoptGRef(webkitClipboardPermissionRequestCreate(WTFMove(completionHandler)));
+        webkitWebViewMakePermissionRequest(WEBKIT_WEB_VIEW(weakWebView.get()), WEBKIT_PERMISSION_REQUEST(request.get()));
     });
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebViewEditor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebViewEditor.cpp
@@ -90,6 +90,15 @@ public:
         return m_text.get();
     }
 
+    void writeText(const char* text)
+    {
+#if USE(GTK4)
+        gdk_clipboard_set_text(m_clipboard, text);
+#else
+        gtk_clipboard_set_text(m_clipboard, text, -1);
+#endif
+    }
+
 private:
     GMainLoop* m_mainLoop { nullptr };
 #if USE(GTK4)
@@ -105,6 +114,14 @@ class EditorTest: public WebViewTest {
 public:
     MAKE_GLIB_TEST_FIXTURE(EditorTest);
 
+    enum class ClipboardPermissionRequestResponse {
+        Allow,
+        Deny,
+        AllowAsync,
+        DenyAsync,
+        Unhandled
+    };
+
     EditorTest()
         : m_clipboard(m_mainLoop)
     {
@@ -112,11 +129,48 @@ public:
         m_clipboard.clear();
         loadURI("about:blank");
         waitUntilLoadFinished();
+
+        g_signal_connect(m_webView, "permission-request", G_CALLBACK(+[](WebKitWebView*, WebKitPermissionRequest* request, gpointer userData) {
+            if (!WEBKIT_IS_CLIPBOARD_PERMISSION_REQUEST(request))
+                return FALSE;
+
+            auto& test = *static_cast<EditorTest*>(userData);
+            return test.clipboardPermissionRequested(request);
+        }), this);
     }
 
     ~EditorTest()
     {
         m_clipboard.clear();
+        g_signal_handlers_disconnect_by_data(m_webView, this);
+    }
+
+    gboolean clipboardPermissionRequested(WebKitPermissionRequest* request)
+    {
+        switch (m_permissionRequestResponse) {
+        case ClipboardPermissionRequestResponse::Allow:
+            webkit_permission_request_allow(request);
+            return TRUE;
+        case ClipboardPermissionRequestResponse::Deny:
+            webkit_permission_request_deny(request);
+            return TRUE;
+        case ClipboardPermissionRequestResponse::AllowAsync:
+            g_idle_add_full(G_PRIORITY_DEFAULT_IDLE, [](gpointer userData) -> gboolean {
+                webkit_permission_request_allow(WEBKIT_PERMISSION_REQUEST(userData));
+                return FALSE;
+            }, g_object_ref(request), reinterpret_cast<GDestroyNotify>(g_object_unref));
+            return TRUE;
+        case ClipboardPermissionRequestResponse::DenyAsync:
+            g_idle_add_full(G_PRIORITY_DEFAULT_IDLE, [](gpointer userData) -> gboolean {
+                webkit_permission_request_deny(WEBKIT_PERMISSION_REQUEST(userData));
+                return FALSE;
+            }, g_object_ref(request), reinterpret_cast<GDestroyNotify>(g_object_unref));
+            return TRUE;
+        case ClipboardPermissionRequestResponse::Unhandled:
+            break;
+        }
+
+        return FALSE;
     }
 
     static gboolean webViewDrawCallback(GMainLoop* mainLoop)
@@ -220,6 +274,7 @@ public:
     Clipboard m_clipboard;
     bool m_canExecuteEditingCommand { false };
     WebKitEditorState* m_editorState { nullptr };
+    ClipboardPermissionRequestResponse m_permissionRequestResponse { ClipboardPermissionRequestResponse::Deny };
 };
 
 static const char* selectedSpanHTMLFormat =
@@ -551,6 +606,44 @@ static void testWebViewEditorCreateLink(EditorTest* test, gconstpointer)
     g_assert_cmpstr(resultString.get(), ==, webkitGTKURL);
 }
 
+static void testWebViewClipboardPermissionRequest(EditorTest* test, gconstpointer)
+{
+    test->m_clipboard.writeText("system clipboard contents");
+    test->loadHtml("<html><body></body></html>", "file://");
+    test->waitUntilLoadFinished();
+
+    test->m_permissionRequestResponse = EditorTest::ClipboardPermissionRequestResponse::Deny;
+    GUniqueOutPtr<GError> error;
+    JSCValue* value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return navigator.clipboard.readText();", nullptr, nullptr, &error.outPtr());
+    g_assert_null(value);
+    g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
+    g_assert_true(g_str_has_prefix(error->message, "NotAllowedError:"));
+
+    test->m_permissionRequestResponse = EditorTest::ClipboardPermissionRequestResponse::Allow;
+    value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return navigator.clipboard.readText();", nullptr, nullptr, &error.outPtr());
+    g_assert_true(JSC_IS_VALUE(value));
+    GUniquePtr<char> valueString(WebViewTest::javascriptResultToCString(value));
+    g_assert_cmpstr(valueString.get(), ==, "system clipboard contents");
+
+    test->m_permissionRequestResponse = EditorTest::ClipboardPermissionRequestResponse::DenyAsync;
+    value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return navigator.clipboard.readText();", nullptr, nullptr, &error.outPtr());
+    g_assert_null(value);
+    g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
+    g_assert_true(g_str_has_prefix(error->message, "NotAllowedError:"));
+
+    test->m_permissionRequestResponse = EditorTest::ClipboardPermissionRequestResponse::AllowAsync;
+    value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return navigator.clipboard.readText();", nullptr, nullptr, &error.outPtr());
+    g_assert_true(JSC_IS_VALUE(value));
+    valueString.reset(WebViewTest::javascriptResultToCString(value));
+    g_assert_cmpstr(valueString.get(), ==, "system clipboard contents");
+
+    test->m_permissionRequestResponse = EditorTest::ClipboardPermissionRequestResponse::Unhandled;
+    value = test->runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished("return navigator.clipboard.readText();", nullptr, nullptr, &error.outPtr());
+    g_assert_null(value);
+    g_assert_error(error.get(), WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_SCRIPT_FAILED);
+    g_assert_true(g_str_has_prefix(error->message, "NotAllowedError:"));
+}
+
 void beforeAll()
 {
     EditorTest::add("WebKitWebView", "editable/editable", testWebViewEditorEditable);
@@ -561,6 +654,7 @@ void beforeAll()
     EditorTest::add("WebKitWebView", "editor-state/typing-attributes", testWebViewEditorEditorStateTypingAttributes);
     EditorTest::add("WebKitWebView", "insert/image", testWebViewEditorInsertImage);
     EditorTest::add("WebKitWebView", "insert/link", testWebViewEditorCreateLink);
+    EditorTest::add("WebKitWebView", "clipboard/permission-request", testWebViewClipboardPermissionRequest);
 }
 
 void afterAll()


### PR DESCRIPTION
#### 2ec3bfdc8377ed6d94254d62ccd5f53f33e47d58
<pre>
[GTK] Add WebKitClipboardPermissionRequest to handle DOM paste access requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=254510">https://bugs.webkit.org/show_bug.cgi?id=254510</a>

Reviewed by Michael Catanzaro and Adrian Perez de Castro.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/UIProcess/API/glib/WebKitClipboardPermissionRequest.cpp: Added.
(webkitClipboardPermissionRequestAllow):
(webkitClipboardPermissionRequestDeny):
(webkit_permission_request_interface_init):
(webkitClipboardPermissionRequestDispose):
(webkit_clipboard_permission_request_class_init):
(webkitClipboardPermissionRequestCreate):
* Source/WebKit/UIProcess/API/glib/WebKitClipboardPermissionRequest.h.in: Added.
* Source/WebKit/UIProcess/API/glib/WebKitClipboardPermissionRequestPrivate.h: Added.
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::requestDOMPasteAccess):
* Tools/MiniBrowser/gtk/BrowserTab.c:
(permissionRequestDialogResponse):
(decidePermissionRequest):
(browser_tab_class_init):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebViewEditor.cpp:
(Clipboard::writeText):
(testWebViewClipboardPermissionRequest):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/262202@main">https://commits.webkit.org/262202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e66b13784c020d9c7003d98b37d2197fac8e1a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1307 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1015 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1009 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1232 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/843 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/821 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/873 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1872 "267 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/862 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/857 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/876 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/93 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->