### PR TITLE
Make more use of UniqueRef in WebCore::Page

### DIFF
--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -80,6 +80,7 @@ public:
     virtual ~Chrome();
 
     ChromeClient& client() { return m_client; }
+    const ChromeClient& client() const { return m_client; }
 
     // HostWindow methods.
     void invalidateRootView(const IntRect&) override;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -278,24 +278,24 @@ static Ref<Frame> createMainFrame(Page& page, std::variant<UniqueRef<FrameLoader
 }
 
 Page::Page(PageConfiguration&& pageConfiguration)
-    : m_chrome(makeUnique<Chrome>(*this, WTFMove(pageConfiguration.chromeClient)))
-    , m_dragCaretController(makeUnique<DragCaretController>())
+    : m_chrome(makeUniqueRef<Chrome>(*this, WTFMove(pageConfiguration.chromeClient)))
+    , m_dragCaretController(makeUniqueRef<DragCaretController>())
 #if ENABLE(DRAG_SUPPORT)
-    , m_dragController(makeUnique<DragController>(*this, WTFMove(pageConfiguration.dragClient)))
+    , m_dragController(makeUniqueRef<DragController>(*this, WTFMove(pageConfiguration.dragClient)))
 #endif
     , m_focusController(makeUnique<FocusController>(*this, pageInitialActivityState()))
 #if ENABLE(CONTEXT_MENUS)
-    , m_contextMenuController(makeUnique<ContextMenuController>(*this, WTFMove(pageConfiguration.contextMenuClient)))
+    , m_contextMenuController(makeUniqueRef<ContextMenuController>(*this, WTFMove(pageConfiguration.contextMenuClient)))
 #endif
-    , m_userInputBridge(makeUnique<UserInputBridge>(*this))
-    , m_inspectorController(makeUnique<InspectorController>(*this, WTFMove(pageConfiguration.inspectorClient)))
-    , m_pointerCaptureController(makeUnique<PointerCaptureController>(*this))
+    , m_userInputBridge(makeUniqueRef<UserInputBridge>(*this))
+    , m_inspectorController(makeUniqueRef<InspectorController>(*this, WTFMove(pageConfiguration.inspectorClient)))
+    , m_pointerCaptureController(makeUniqueRef<PointerCaptureController>(*this))
 #if ENABLE(POINTER_LOCK)
-    , m_pointerLockController(makeUnique<PointerLockController>(*this))
+    , m_pointerLockController(makeUniqueRef<PointerLockController>(*this))
 #endif
     , m_settings(Settings::create(this))
-    , m_progress(makeUnique<ProgressTracker>(*this, WTFMove(pageConfiguration.progressTrackerClient)))
-    , m_backForwardController(makeUnique<BackForwardController>(*this, WTFMove(pageConfiguration.backForwardClient)))
+    , m_progress(makeUniqueRef<ProgressTracker>(*this, WTFMove(pageConfiguration.progressTrackerClient)))
+    , m_backForwardController(makeUniqueRef<BackForwardController>(*this, WTFMove(pageConfiguration.backForwardClient)))
     , m_mainFrame(createMainFrame(*this, WTFMove(pageConfiguration.clientForMainFrame), pageConfiguration.mainFrameIdentifier))
     , m_editorClient(WTFMove(pageConfiguration.editorClient))
     , m_validationMessageClient(WTFMove(pageConfiguration.validationMessageClient))
@@ -314,9 +314,9 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_domTimerAlignmentIntervalIncreaseTimer(*this, &Page::domTimerAlignmentIntervalIncreaseTimerFired)
     , m_activityState(pageInitialActivityState())
     , m_alternativeTextClient(WTFMove(pageConfiguration.alternativeTextClient))
-    , m_consoleClient(makeUnique<PageConsoleClient>(*this))
+    , m_consoleClient(makeUniqueRef<PageConsoleClient>(*this))
 #if ENABLE(REMOTE_INSPECTOR)
-    , m_inspectorDebuggable(makeUnique<PageDebuggable>(*this))
+    , m_inspectorDebuggable(makeUniqueRef<PageDebuggable>(*this))
 #endif
     , m_socketProvider(WTFMove(pageConfiguration.socketProvider))
     , m_cookieJar(WTFMove(pageConfiguration.cookieJar))
@@ -2897,7 +2897,7 @@ void Page::setRemoteInspectionNameOverride(const String& name)
     m_inspectorDebuggable->setNameOverride(name);
 }
 
-void Page::remoteInspectorInformationDidChange() const
+void Page::remoteInspectorInformationDidChange()
 {
     m_inspectorDebuggable->update();
 }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -348,23 +348,27 @@ public:
     WEBCORE_EXPORT void setInspectable(bool);
     WEBCORE_EXPORT String remoteInspectionNameOverride() const;
     WEBCORE_EXPORT void setRemoteInspectionNameOverride(const String&);
-    void remoteInspectorInformationDidChange() const;
+    void remoteInspectorInformationDidChange();
 #endif
 
-    Chrome& chrome() const { return *m_chrome; }
-    DragCaretController& dragCaretController() const { return *m_dragCaretController; }
+    Chrome& chrome() { return m_chrome.get(); }
+    const Chrome& chrome() const { return m_chrome.get(); }
+    DragCaretController& dragCaretController() { return m_dragCaretController.get(); }
+    const DragCaretController& dragCaretController() const { return m_dragCaretController.get(); }
 #if ENABLE(DRAG_SUPPORT)
-    DragController& dragController() const { return *m_dragController; }
+    DragController& dragController() { return m_dragController.get(); }
+    const DragController& dragController() const { return m_dragController.get(); }
 #endif
     FocusController& focusController() const { return *m_focusController; }
 #if ENABLE(CONTEXT_MENUS)
-    ContextMenuController& contextMenuController() const { return *m_contextMenuController; }
+    ContextMenuController& contextMenuController() { return m_contextMenuController.get(); }
+    const ContextMenuController& contextMenuController() const { return m_contextMenuController.get(); }
 #endif
-    UserInputBridge& userInputBridge() const { return *m_userInputBridge; }
-    InspectorController& inspectorController() const { return *m_inspectorController; }
-    PointerCaptureController& pointerCaptureController() const { return *m_pointerCaptureController; }
+    UserInputBridge& userInputBridge() { return m_userInputBridge.get(); }
+    InspectorController& inspectorController() { return m_inspectorController.get(); }
+    PointerCaptureController& pointerCaptureController() { return m_pointerCaptureController.get(); }
 #if ENABLE(POINTER_LOCK)
-    PointerLockController& pointerLockController() const { return *m_pointerLockController; }
+    PointerLockController& pointerLockController() { return m_pointerLockController.get(); }
 #endif
     WebRTCProvider& webRTCProvider() { return m_webRTCProvider.get(); }
     RTCController& rtcController() { return m_rtcController; }
@@ -392,10 +396,11 @@ public:
     WEBCORE_EXPORT void settingsDidChange();
 
     Settings& settings() const { return *m_settings; }
-    ProgressTracker& progress() const { return *m_progress; }
+    ProgressTracker& progress() { return m_progress.get(); }
+    const ProgressTracker& progress() const { return m_progress.get(); }
     void progressEstimateChanged(LocalFrame&) const;
     void progressFinished(LocalFrame&) const;
-    BackForwardController& backForward() const { return *m_backForwardController; }
+    BackForwardController& backForward() { return m_backForwardController.get(); }
 
     Seconds domTimerAlignmentInterval() const { return m_domTimerAlignmentInterval; }
 
@@ -771,10 +776,12 @@ public:
     void sawMediaEngine(const String& engineName);
     void resetSeenMediaEngines();
 
-    PageConsoleClient& console() { return *m_consoleClient; }
+    PageConsoleClient& console() { return m_consoleClient.get(); }
+    const PageConsoleClient& console() const { return m_consoleClient.get(); }
 
 #if ENABLE(REMOTE_INSPECTOR)
-    PageDebuggable& inspectorDebuggable() const { return *m_inspectorDebuggable.get(); }
+    PageDebuggable& inspectorDebuggable() { return m_inspectorDebuggable.get(); }
+    const PageDebuggable& inspectorDebuggable() const { return m_inspectorDebuggable.get(); }
 #endif
 
     void hiddenPageCSSAnimationSuspensionStateChanged();
@@ -1079,28 +1086,28 @@ private:
     void updateElementsWithTextRecognitionResults();
 #endif
 
-    const std::unique_ptr<Chrome> m_chrome;
-    const std::unique_ptr<DragCaretController> m_dragCaretController;
+    UniqueRef<Chrome> m_chrome;
+    UniqueRef<DragCaretController> m_dragCaretController;
 
 #if ENABLE(DRAG_SUPPORT)
-    const std::unique_ptr<DragController> m_dragController;
+    UniqueRef<DragController> m_dragController;
 #endif
-    const std::unique_ptr<FocusController> m_focusController;
+    std::unique_ptr<FocusController> m_focusController;
 #if ENABLE(CONTEXT_MENUS)
-    const std::unique_ptr<ContextMenuController> m_contextMenuController;
+    UniqueRef<ContextMenuController> m_contextMenuController;
 #endif
-    const std::unique_ptr<UserInputBridge> m_userInputBridge;
-    const std::unique_ptr<InspectorController> m_inspectorController;
-    const std::unique_ptr<PointerCaptureController> m_pointerCaptureController;
+    UniqueRef<UserInputBridge> m_userInputBridge;
+    UniqueRef<InspectorController> m_inspectorController;
+    UniqueRef<PointerCaptureController> m_pointerCaptureController;
 #if ENABLE(POINTER_LOCK)
-    const std::unique_ptr<PointerLockController> m_pointerLockController;
+    UniqueRef<PointerLockController> m_pointerLockController;
 #endif
     RefPtr<ScrollingCoordinator> m_scrollingCoordinator;
 
     const RefPtr<Settings> m_settings;
-    const std::unique_ptr<ProgressTracker> m_progress;
+    UniqueRef<ProgressTracker> m_progress;
 
-    const std::unique_ptr<BackForwardController> m_backForwardController;
+    UniqueRef<BackForwardController> m_backForwardController;
     WeakHashSet<LocalFrame> m_rootFrames;
     Ref<Frame> m_mainFrame;
 
@@ -1223,10 +1230,10 @@ private:
     std::unique_ptr<AlternativeTextClient> m_alternativeTextClient;
 
     bool m_scriptedAnimationsSuspended { false };
-    const std::unique_ptr<PageConsoleClient> m_consoleClient;
+    UniqueRef<PageConsoleClient> m_consoleClient;
 
 #if ENABLE(REMOTE_INSPECTOR)
-    const std::unique_ptr<PageDebuggable> m_inspectorDebuggable;
+    UniqueRef<PageDebuggable> m_inspectorDebuggable;
 #endif
 
     RefPtr<IDBClient::IDBConnectionToServer> m_idbConnectionToServer;

--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -134,7 +134,7 @@ static ContentExtensions::ContentExtensionsBackend::RuleListFilter ruleListFilte
     return { };
 }
 
-static void sanitizeLookalikeCharactersIfNeeded(ContentRuleListResults& results, const Page& page, const URL& url, const DocumentLoader& initiatingDocumentLoader)
+static void sanitizeLookalikeCharactersIfNeeded(ContentRuleListResults& results, Page& page, const URL& url, const DocumentLoader& initiatingDocumentLoader)
 {
     if (RefPtr frame = initiatingDocumentLoader.frame(); !frame || !frame->isMainFrame())
         return;


### PR DESCRIPTION
#### 969004bb4fc5be727a58339a770c363c2173d57c
<pre>
Make more use of UniqueRef in WebCore::Page
<a href="https://bugs.webkit.org/show_bug.cgi?id=254513">https://bugs.webkit.org/show_bug.cgi?id=254513</a>
rdar://problem/107265298

Reviewed by Alex Christensen.

Replace some const unique_ptr by UniqueRef in Page class, to ease reading of getters.

* Source/WebCore/page/Chrome.h:
(WebCore::Chrome::client const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::Page):
(WebCore::Page::remoteInspectorInformationDidChange):
(WebCore::Page::remoteInspectorInformationDidChange const): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::chrome):
(WebCore::Page::chrome const):
(WebCore::Page::dragCaretController):
(WebCore::Page::dragCaretController const):
(WebCore::Page::dragController):
(WebCore::Page::dragController const):
(WebCore::Page::contextMenuController):
(WebCore::Page::contextMenuController const):
(WebCore::Page::userInputBridge):
(WebCore::Page::inspectorController):
(WebCore::Page::pointerCaptureController):
(WebCore::Page::pointerLockController):
(WebCore::Page::progress):
(WebCore::Page::progress const):
(WebCore::Page::backForward):
(WebCore::Page::console):
(WebCore::Page::console const):
(WebCore::Page::inspectorDebuggable):
(WebCore::Page::inspectorDebuggable const):
(WebCore::Page::userInputBridge const): Deleted.
(WebCore::Page::inspectorController const): Deleted.
(WebCore::Page::pointerCaptureController const): Deleted.
(WebCore::Page::pointerLockController const): Deleted.
(WebCore::Page::backForward const): Deleted.
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::sanitizeLookalikeCharactersIfNeeded):

Canonical link: <a href="https://commits.webkit.org/262262@main">https://commits.webkit.org/262262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f969cd191da346e83f7c80d34e5ac4c598e7dadc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1274 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/794 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/998 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1216 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/839 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/813 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/862 "8 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1868 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/854 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/807 "4 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/847 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/256 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/868 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->