### PR TITLE
ReadableStreamDefaultReader.releaseLock is now rejecting pending read promises

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any-expected.txt
@@ -16,7 +16,7 @@ PASS ReadableStream with byte source: Test that closing a stream does not releas
 PASS ReadableStream with byte source: Test that closing a stream does not release a BYOB reader automatically
 PASS ReadableStream with byte source: Test that erroring a stream does not release a reader automatically
 PASS ReadableStream with byte source: Test that erroring a stream does not release a BYOB reader automatically
-FAIL ReadableStream with byte source: releaseLock() on ReadableStreamDefaultReader must reject pending read() promise_test: Unhandled rejection with value: object "TypeError: There are still pending read requests, cannot release the lock"
+PASS ReadableStream with byte source: releaseLock() on ReadableStreamDefaultReader must reject pending read()
 FAIL ReadableStream with byte source: releaseLock() on ReadableStreamBYOBReader must reject pending read() promise_test: Unhandled rejection with value: object "TypeError: There are still pending read requests, cannot release the lock"
 PASS ReadableStream with byte source: Automatic pull() after start()
 PASS ReadableStream with byte source: Automatic pull() after start() and read()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.sharedworker-expected.txt
@@ -16,7 +16,7 @@ PASS ReadableStream with byte source: Test that closing a stream does not releas
 PASS ReadableStream with byte source: Test that closing a stream does not release a BYOB reader automatically
 PASS ReadableStream with byte source: Test that erroring a stream does not release a reader automatically
 PASS ReadableStream with byte source: Test that erroring a stream does not release a BYOB reader automatically
-FAIL ReadableStream with byte source: releaseLock() on ReadableStreamDefaultReader must reject pending read() promise_test: Unhandled rejection with value: object "TypeError: There are still pending read requests, cannot release the lock"
+PASS ReadableStream with byte source: releaseLock() on ReadableStreamDefaultReader must reject pending read()
 FAIL ReadableStream with byte source: releaseLock() on ReadableStreamBYOBReader must reject pending read() promise_test: Unhandled rejection with value: object "TypeError: There are still pending read requests, cannot release the lock"
 PASS ReadableStream with byte source: Automatic pull() after start()
 PASS ReadableStream with byte source: Automatic pull() after start() and read()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any-expected.txt
@@ -27,5 +27,5 @@ PASS Reading twice on an errored stream
 PASS Reading twice on a stream that gets errored
 PASS getReader() should call ToString() on mode
 PASS controller.close() should clear the list of pending read requests
-FAIL Second reader can read chunks after first reader was released with pending read requests There are still pending read requests, cannot release the lock
+PASS Second reader can read chunks after first reader was released with pending read requests
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.serviceworker-expected.txt
@@ -27,5 +27,5 @@ PASS Reading twice on an errored stream
 PASS Reading twice on a stream that gets errored
 PASS getReader() should call ToString() on mode
 PASS controller.close() should clear the list of pending read requests
-FAIL Second reader can read chunks after first reader was released with pending read requests There are still pending read requests, cannot release the lock
+PASS Second reader can read chunks after first reader was released with pending read requests
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.sharedworker-expected.txt
@@ -27,5 +27,5 @@ PASS Reading twice on an errored stream
 PASS Reading twice on a stream that gets errored
 PASS getReader() should call ToString() on mode
 PASS controller.close() should clear the list of pending read requests
-FAIL Second reader can read chunks after first reader was released with pending read requests There are still pending read requests, cannot release the lock
+PASS Second reader can read chunks after first reader was released with pending read requests
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.worker-expected.txt
@@ -27,5 +27,5 @@ PASS Reading twice on an errored stream
 PASS Reading twice on a stream that gets errored
 PASS getReader() should call ToString() on mode
 PASS controller.close() should clear the list of pending read requests
-FAIL Second reader can read chunks after first reader was released with pending read requests There are still pending read requests, cannot release the lock
+PASS Second reader can read chunks after first reader was released with pending read requests
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any-expected.txt
@@ -9,7 +9,7 @@ PASS ReadableStream (empty) reader: read() should never settle
 PASS ReadableStream (empty) reader: two read()s should both never settle
 PASS ReadableStream (empty) reader: read() should return distinct promises each time
 PASS ReadableStream (empty) reader: getReader() again on the stream should fail
-FAIL ReadableStream (empty) reader: releasing the lock should reject all pending read requests promise_test: Unhandled rejection with value: object "TypeError: There are still pending read requests, cannot release the lock"
+PASS ReadableStream (empty) reader: releasing the lock should reject all pending read requests
 PASS ReadableStream (empty) reader: releasing the lock should cause further read() calls to reject with a TypeError
 PASS ReadableStream (empty) reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream (empty) reader: releasing the lock should cause locked to become false

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any.serviceworker-expected.txt
@@ -9,7 +9,7 @@ PASS ReadableStream (empty) reader: read() should never settle
 PASS ReadableStream (empty) reader: two read()s should both never settle
 PASS ReadableStream (empty) reader: read() should return distinct promises each time
 PASS ReadableStream (empty) reader: getReader() again on the stream should fail
-FAIL ReadableStream (empty) reader: releasing the lock should reject all pending read requests promise_test: Unhandled rejection with value: object "TypeError: There are still pending read requests, cannot release the lock"
+PASS ReadableStream (empty) reader: releasing the lock should reject all pending read requests
 PASS ReadableStream (empty) reader: releasing the lock should cause further read() calls to reject with a TypeError
 PASS ReadableStream (empty) reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream (empty) reader: releasing the lock should cause locked to become false

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any.sharedworker-expected.txt
@@ -9,7 +9,7 @@ PASS ReadableStream (empty) reader: read() should never settle
 PASS ReadableStream (empty) reader: two read()s should both never settle
 PASS ReadableStream (empty) reader: read() should return distinct promises each time
 PASS ReadableStream (empty) reader: getReader() again on the stream should fail
-FAIL ReadableStream (empty) reader: releasing the lock should reject all pending read requests promise_test: Unhandled rejection with value: object "TypeError: There are still pending read requests, cannot release the lock"
+PASS ReadableStream (empty) reader: releasing the lock should reject all pending read requests
 PASS ReadableStream (empty) reader: releasing the lock should cause further read() calls to reject with a TypeError
 PASS ReadableStream (empty) reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream (empty) reader: releasing the lock should cause locked to become false

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any.worker-expected.txt
@@ -9,7 +9,7 @@ PASS ReadableStream (empty) reader: read() should never settle
 PASS ReadableStream (empty) reader: two read()s should both never settle
 PASS ReadableStream (empty) reader: read() should return distinct promises each time
 PASS ReadableStream (empty) reader: getReader() again on the stream should fail
-FAIL ReadableStream (empty) reader: releasing the lock should reject all pending read requests promise_test: Unhandled rejection with value: object "TypeError: There are still pending read requests, cannot release the lock"
+PASS ReadableStream (empty) reader: releasing the lock should reject all pending read requests
 PASS ReadableStream (empty) reader: releasing the lock should cause further read() calls to reject with a TypeError
 PASS ReadableStream (empty) reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream (empty) reader: releasing the lock should cause locked to become false

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js
@@ -74,10 +74,7 @@ function releaseLock()
     if (!@getByIdDirectPrivate(this, "ownerReadableStream"))
         return;
 
-    if (@getByIdDirectPrivate(this, "readRequests").length)
-        @throwTypeError("There are still pending read requests, cannot release the lock");
-
-    @readableStreamReaderGenericRelease(this);
+    @readableStreamDefaultReaderRelease(this);
 }
 
 @getter

--- a/Source/WebCore/Modules/streams/ReadableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamInternals.js
@@ -539,12 +539,9 @@ function readableStreamError(stream, error)
     const promise = @getByIdDirectPrivate(reader, "closedPromiseCapability").@promise;
     @markPromiseAsHandled(promise);
 
-    if (@isReadableStreamDefaultReader(reader)) {
-        const requests = @getByIdDirectPrivate(reader, "readRequests");
-        @putByIdDirectPrivate(reader, "readRequests", []);
-        for (let index = 0, length = requests.length; index < length; ++index)
-            @rejectPromise(requests[index], error);
-    } else {
+    if (@isReadableStreamDefaultReader(reader))
+        @readableStreamDefaultReaderErrorReadRequests(reader, error);
+    else {
         @assert(@isReadableStreamBYOBReader(reader));
         const requests = @getByIdDirectPrivate(reader, "readIntoRequests");
         @putByIdDirectPrivate(reader, "readIntoRequests", []);
@@ -778,6 +775,12 @@ function isReadableStreamDisturbed(stream)
     return @getByIdDirectPrivate(stream, "disturbed");
 }
 
+function readableStreamDefaultReaderRelease(reader)
+{
+    @readableStreamReaderGenericRelease(reader);
+    @readableStreamDefaultReaderErrorReadRequests(reader, @makeTypeError("releasing lock of reader"));
+}
+
 function readableStreamReaderGenericRelease(reader)
 {
     "use strict";
@@ -794,6 +797,14 @@ function readableStreamReaderGenericRelease(reader)
     @markPromiseAsHandled(promise);
     @putByIdDirectPrivate(@getByIdDirectPrivate(reader, "ownerReadableStream"), "reader", @undefined);
     @putByIdDirectPrivate(reader, "ownerReadableStream", @undefined);
+}
+
+function readableStreamDefaultReaderErrorReadRequests(reader, error)
+{
+    const requests = @getByIdDirectPrivate(reader, "readRequests");
+    @putByIdDirectPrivate(reader, "readRequests", []);
+    for (let index = 0, length = requests.length; index < length; ++index)
+        @rejectPromise(requests[index], error);
 }
 
 function readableStreamDefaultControllerCanCloseOrEnqueue(controller)


### PR DESCRIPTION
#### f8ae40c2a74e011f18e55e4164be9fa90949d4aa
<pre>
ReadableStreamDefaultReader.releaseLock is now rejecting pending read promises
<a href="https://bugs.webkit.org/show_bug.cgi?id=254511">https://bugs.webkit.org/show_bug.cgi?id=254511</a>
rdar://problem/107263837

Reviewed by Alex Christensen.

Update ReadableStreamDefaultReader.releaseLock accoding latest specification,
<a href="https://streams.spec.whatwg.org/#default-reader-release-lock.">https://streams.spec.whatwg.org/#default-reader-release-lock.</a>

* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/templated.any.worker-expected.txt:
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js:
(releaseLock):
* Source/WebCore/Modules/streams/ReadableStreamInternals.js:
(readableStreamError):
(readableStreamDefaultReaderRelease):
(readableStreamReaderGenericRelease):
(readableStreamDefaultReaderErrorReadRequests):

Canonical link: <a href="https://commits.webkit.org/262207@main">https://commits.webkit.org/262207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a7b7bc51d9058e2d87c1ce0828ce3cac3e83768

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/796 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1002 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1212 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/834 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/837 "143 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/815 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1866 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/856 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/845 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/213 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/870 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->