### PR TITLE
RenderLayer::hasVisibleContent() incorrect when layer removed

### DIFF
--- a/LayoutTests/compositing/visibility/visibility-remove-layer-expected.html
+++ b/LayoutTests/compositing/visibility/visibility-remove-layer-expected.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .set {
+      position: absolute;
+      top: 8px;
+    }
+    .box {
+      height: 100px;
+      width: 100px;
+      background-color: blue;
+    }
+    
+    .hidden {
+      visibility: hidden;
+    }
+    .container.hidden {
+      outline: 4px solid red;
+    }
+    .visible {
+      visibility: visible;
+    }
+    .should-be-hidden {
+      background-color: red !important;
+    }
+    .should-be-visible {
+      background-color: green !important;
+    }
+    
+    .visible-indicator {
+      background-color: green;
+    }
+    .hidden-indicator {
+      background-color: red;
+    }
+  </style>
+</head>
+<body>
+  <div class="set">
+    <div class="hidden-indicator box"></div>
+  </div>
+  <div class="set">
+    <div class="hidden container">
+      <div id="target" class="hidden">
+        <div class="visible box should-be-visible"></div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/LayoutTests/compositing/visibility/visibility-remove-layer.html
+++ b/LayoutTests/compositing/visibility/visibility-remove-layer.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .set {
+      position: absolute;
+      top: 8px;
+    }
+    .box {
+      height: 100px;
+      width: 100px;
+      background-color: blue;
+    }
+    
+    .hidden {
+      visibility: hidden;
+    }
+    .container.hidden {
+      outline: 4px solid red;
+    }
+    .visible {
+      visibility: visible;
+    }
+    .should-be-hidden {
+      background-color: red !important;
+    }
+    .should-be-visible {
+      background-color: green !important;
+    }
+    .composited {
+      -webkit-transform: translateZ(1px);
+    }
+    
+    .visible-indicator {
+      background-color: green;
+    }
+    .hidden-indicator {
+      background-color: red;
+    }
+  </style>
+  <script>
+    if (window.testRunner)
+      testRunner.waitUntilDone();
+    requestAnimationFrame(function() {
+      requestAnimationFrame(function() {
+        document.getElementById('target').classList.remove('composited');
+        setTimeout(function() {
+          if (window.testRunner)
+            testRunner.notifyDone();
+        });
+      });
+    });
+  </script>
+</head>
+<body>
+  <div class="set">
+    <div class="hidden-indicator box"></div>
+  </div>
+  <div class="set">
+    <div class="hidden container composited">
+      <div id="target" class="hidden composited">
+        <div class="visible box should-be-visible"></div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  * Copyright (C) 2019 Adobe. All rights reserved.
  * Copyright (c) 2020, 2021, 2022 Igalia S.L.
  *
@@ -475,6 +476,8 @@ void RenderLayer::removeChild(RenderLayer& oldChild)
     if (oldChild.hasBlendMode() || (oldChild.hasNotIsolatedBlendingDescendants() && !oldChild.isolatesBlending()))
         dirtyAncestorChainHasBlendingDescendants();
 #endif
+    if (renderer().style().visibility() != Visibility::Visible)
+        dirtyVisibleContentStatus();
 }
 
 void RenderLayer::dirtyPaintOrderListsOnChildChange(RenderLayer& child)


### PR DESCRIPTION
#### 059e2bb75dc33571362fae9152d36631b1df91ba
<pre>
RenderLayer::hasVisibleContent() incorrect when layer removed

<a href="https://bugs.webkit.org/show_bug.cgi?id=253706">https://bugs.webkit.org/show_bug.cgi?id=253706</a>
rdar://problem/106860749

Reviewed by Simon Fraser.

This patch is to align WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/c5587982b1ed1ec62452f5d2c93c0f385a3941a1">https://chromium.googlesource.com/chromium/blink/+/c5587982b1ed1ec62452f5d2c93c0f385a3941a1</a>

Prior to this change, we were incorrectly dirtying
RenderLayer::hasVisibleContent() when removing a RenderLayer from the layer
tree. This caused us to incorrectly believe that the parent layer lacked
visible content.

* Source/WebCore/rendering/RenderLayer.cpp:
(RenderLayer::removeChild):
* LayoutTests/compositing/visibility/visibility-remove-layer.html: Add Test Case
* LayoutTests/compositing/visibility/visibility-remove-layer-expected.html: Add Test Case

Canonical link: <a href="https://commits.webkit.org/262284@main">https://commits.webkit.org/262284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06575224f4c7f5db84ff38a914b915148dcc0e9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/914 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/988 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/744 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/704 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1780 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/719 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/736 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/275 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/746 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->