### PR TITLE
REGRESSION(259811@main-259818@main): [ iOS Debug ] 4X TestWebKitAPI.AppPrivacyReport (API-Tests) are constant timeouts

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm
@@ -777,12 +777,14 @@ static void restoreFromSessionStateTest(IsAppInitiated isAppInitiated)
     TestWebKitAPI::Util::run(&isDone);
 }
 
-TEST(AppPrivacyReport, RestoreFromSessionStateIsAppInitiated)
+// FIXME: Re-enable this test once webkit.org/b/254289 has been resolved.
+TEST(AppPrivacyReport, DISABLED_RestoreFromSessionStateIsAppInitiated)
 {
     restoreFromSessionStateTest(IsAppInitiated::Yes);
 }
 
-TEST(AppPrivacyReport, RestoreFromSessionStateIsNonAppInitiated)
+// FIXME: Re-enable this test once webkit.org/b/254289 has been resolved.
+TEST(AppPrivacyReport, DISABLED_RestoreFromSessionStateIsNonAppInitiated)
 {
     restoreFromSessionStateTest(IsAppInitiated::No);
 }
@@ -822,12 +824,14 @@ static void restoreFromInteractionStateTest(IsAppInitiated isAppInitiated)
     TestWebKitAPI::Util::run(&isDone);
 }
 
-TEST(AppPrivacyReport, RestoreFromInteractionStateIsAppInitiated)
+// FIXME: Re-enable this test once webkit.org/b/254289 has been resolved.
+TEST(AppPrivacyReport, DISABLED_RestoreFromInteractionStateIsAppInitiated)
 {
     restoreFromInteractionStateTest(IsAppInitiated::Yes);
 }
 
-TEST(AppPrivacyReport, RestoreFromInteractionStateIsNonAppInitiated)
+// FIXME: Re-enable this test once webkit.org/b/254289 has been resolved.
+TEST(AppPrivacyReport, DISABLED_RestoreFromInteractionStateIsNonAppInitiated)
 {
     restoreFromInteractionStateTest(IsAppInitiated::No);
 }


### PR DESCRIPTION
#### 1fa0bf2759a8ebbb2918b532da63071d8b535b6e
<pre>
REGRESSION(259811@main-259818@main): [ iOS Debug ] 4X TestWebKitAPI.AppPrivacyReport (API-Tests) are constant timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=254289">https://bugs.webkit.org/show_bug.cgi?id=254289</a>
rdar://107077600

Unreviewed test gardening.

Disable the tests to speed up EWS while we investigate the root cause.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm:

Canonical link: <a href="https://commits.webkit.org/262152@main">https://commits.webkit.org/262152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74d41b4649abf229bbe208a62660e998b886b65f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/786 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/811 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/840 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/1063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/776 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/894 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/1063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/794 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/840 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1009 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/840 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/1009 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/840 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1009 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/894 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/840 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/759 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/77 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->