### PR TITLE
CSS Nesting: serialization support for CSSOM

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL Simple CSSOM manipulation of subrules ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('& .b { color: green; }')', 'ss.cssRules[0].insertRule' is undefined)
-FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('& .broken {}', 3); }" threw object "TypeError: ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('& .broken {}', 3)', 'ss.cssRules[0].insertRule' is undefined)" that is not a DOMException IndexSizeError: property "code" is equal to undefined, expected 1
-FAIL Simple CSSOM manipulation of subrules 2 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('& .broken {}', -1); }" threw object "TypeError: ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('& .broken {}', -1)', 'ss.cssRules[0].insertRule' is undefined)" that is not a DOMException IndexSizeError: property "code" is equal to undefined, expected 1
-FAIL Simple CSSOM manipulation of subrules 3 assert_throws_dom: function "() => { ss.cssRules[0].deleteRule(5); }" threw object "TypeError: ss.cssRules[0].deleteRule is not a function. (In 'ss.cssRules[0].deleteRule(5)', 'ss.cssRules[0].deleteRule' is undefined)" that is not a DOMException IndexSizeError: property "code" is equal to undefined, expected 1
-FAIL Simple CSSOM manipulation of subrules 4 undefined is not an object (evaluating 'ss.cssRules[0].cssRules[2]')
-FAIL Simple CSSOM manipulation of subrules 5 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('% {}'); }" threw object "TypeError: ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('% {}')', 'ss.cssRules[0].insertRule' is undefined)" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
-FAIL Simple CSSOM manipulation of subrules 6 undefined is not an object (evaluating 'ss.cssRules[0].cssRules[1]')
-FAIL Simple CSSOM manipulation of subrules 7 ss.cssRules[0].insertRule is not a function. (In 'ss.cssRules[0].insertRule('@supports selector(&) { & div { font-size: 10px; }}', 1)', 'ss.cssRules[0].insertRule' is undefined)
-FAIL Simple CSSOM manipulation of subrules 8 assert_equals: color is changed, new rule is ignored expected ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  & .c { color: blue; }\n}" but got ".a {\n  color: olivedrab;& .b { color: green; }\n}& .c { color: blue; }\n}"
-FAIL Simple CSSOM manipulation of subrules 9 undefined is not an object (evaluating 'ss.cssRules[0].cssRules[0]')
+FAIL Simple CSSOM manipulation of subrules The operation is not supported.
+FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('& .broken {}', 3); }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException IndexSizeError: property "code" is equal to 9, expected 1
+FAIL Simple CSSOM manipulation of subrules 2 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('& .broken {}', -1); }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException IndexSizeError: property "code" is equal to 9, expected 1
+FAIL Simple CSSOM manipulation of subrules 3 assert_throws_dom: function "() => { ss.cssRules[0].deleteRule(5); }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException IndexSizeError: property "code" is equal to 9, expected 1
+PASS Simple CSSOM manipulation of subrules 4
+FAIL Simple CSSOM manipulation of subrules 5 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('% {}'); }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
+PASS Simple CSSOM manipulation of subrules 6
+FAIL Simple CSSOM manipulation of subrules 7 The operation is not supported.
+PASS Simple CSSOM manipulation of subrules 8
+FAIL Simple CSSOM manipulation of subrules 9 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('div & {}'); }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
 FAIL Simple CSSOM manipulation of subrules 10 assert_equals: invalid rule containing ampersand is kept in serialization expected ".a {\n  :is(!& .foo, .b) { color: green; }\n}" but got ".a {\n  :is(.b) { color: green; }\n}"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Simple CSSOM manipulation of subrules
-FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].cssRules[0].insertRule('@font-face {}', 0); }" threw object "TypeError: undefined is not an object (evaluating 'ss.cssRules[0].cssRules[0]')" that is not a DOMException HierarchyRequestError: property "code" is equal to undefined, expected 3
+FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].cssRules[0].insertRule('@font-face {}', 0); }" did not throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL .foo { & { color: green; } } assert_equals: expected ".foo { color: green; }" but got ".foo {\n  & { color: green; }\n}"
+PASS .foo { & { color: green; } }
 PASS .foo { //color: red; color: green; }
 PASS .foo {
   &.bar { color: green; }
@@ -43,14 +43,14 @@ PASS .foo, .bar {
 PASS .foo {
   & .bar & .baz & .qux { color: green; }
 }
-FAIL .foo {
+PASS .foo {
   @media (min-width: 50px) {
   & { color: green; }
 }
-} assert_equals: expected ".foo {\n  @media (min-width: 50px) { color: green; }\n}" but got ".foo {\n  @media (min-width: 50px) {\n  & { color: green; }\n}\n}"
-FAIL .foo {
+}
+PASS .foo {
   @media (min-width: 50px) { color: green; }
-} assert_equals: expected ".foo {\n  @media (min-width: 50px) { color: green; }\n}" but got ".foo {\n  @media (min-width: 50px) {\n  & { color: green; }\n}\n}"
+}
 PASS main {
   & > section, & > article {
   & > header { color: green; }
@@ -67,9 +67,9 @@ PASS .foo {
 PASS .foo {
  color: red; ident { color: green; }
 }
-FAIL .foo {
+PASS .foo {
  //color: comment; & { color: green; }
-} assert_equals: expected ".foo { color: green; }" but got ".foo {\n  & { color: green; }\n}"
+}
 PASS .foo {
  .bar {
   functionalnotation(div) { color: green; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Serialization of declarations in group rules assert_equals: expected "div {\n  @media screen { color: red; background-color: green; }\n}" but got "div {\n  @media screen {\n  & { color: red; background-color: green; }\n}\n}"
-FAIL Serialization of declarations in group rules 1 assert_equals: expected "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n  &:hover { color: navy; }\n}\n}" but got "div {\n  @supports selector(&) {\n  & { color: red; background-color: green; }\n  &:hover { color: navy; }\n}\n}"
-FAIL Serialization of declarations in group rules 2 assert_equals: expected "div {\n  @media screen { color: red; }\n}" but got "div {\n  @media screen {\n  & { color: red; }\n}\n}"
-FAIL Serialization of declarations in group rules 3 assert_equals: expected "div { color: red; }" but got "div {\n  & { color: red; }\n}"
+PASS Serialization of declarations in group rules
+FAIL Serialization of declarations in group rules 1 assert_equals: expected "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n  &:hover { color: navy; }\n}\n}" but got "div {\n  @supports selector(&) {\ncolor: red; background-color: green;\n  &:hover { color: navy; }\n}\n}"
+FAIL Serialization of declarations in group rules 2 assert_equals: expected "div {\n  @media screen {\n  &.cls { color: red; }\n  & { color: red; }\n}\n}" but got "div {\n  @media screen {\ncolor: red;\n  &.cls { color: red; }\n}\n}"
+PASS Serialization of declarations in group rules 3
 PASS Serialization of declarations in group rules 4
 

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -193,4 +193,22 @@ bool CSSSelectorList::hasExplicitNestingParent() const
 
     return forEachSelector(functor, this);
 }
+
+bool CSSSelectorList::hasOnlyNestingSelector() const
+{
+    if (componentCount() != 1)
+        return false;
+
+    auto singleSelector = first();
+
+    if (!singleSelector)
+        return false;
+    
+    // Selector should be a single selector
+    if (singleSelector->tagHistory())
+        return false;
+
+    return singleSelector->match() == CSSSelector::Match::PseudoClass && singleSelector->pseudoClassType() == CSSSelector::PseudoClassType::PseudoClassNestingParent;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -60,6 +60,7 @@ public:
     bool selectorsNeedNamespaceResolution();
     bool hasInvalidSelector() const;
     bool hasExplicitNestingParent() const;
+    bool hasOnlyNestingSelector() const;
 
     String selectorsText() const;
     void buildSelectorsText(StringBuilder&) const;

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -49,7 +49,9 @@ public:
     // FIXME: Not CSSOM. Remove.
     StyleRule& styleRule() const { return m_styleRule.get(); }
 
-    CSSRuleList& cssRules() const;
+    WEBCORE_EXPORT CSSRuleList& cssRules() const;
+    WEBCORE_EXPORT ExceptionOr<unsigned> insertRule(const String& rule, unsigned index);
+    WEBCORE_EXPORT ExceptionOr<void> deleteRule(unsigned index);
     unsigned length() const;
     CSSRule* item(unsigned index) const;
 
@@ -65,6 +67,7 @@ private:
 
     String generateSelectorText() const;
     Vector<Ref<StyleRuleBase>> nestedRules() const;
+    void cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& rules) const;
 
     Ref<StyleRule> m_styleRule;
     Ref<DeclaredStylePropertyMap> m_styleMap;

--- a/Source/WebCore/css/CSSStyleRule.idl
+++ b/Source/WebCore/css/CSSStyleRule.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -18,6 +18,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+typedef USVString CSSOMString;
+
 [
     Exposed=Window
 ] interface CSSStyleRule : CSSRule {
@@ -26,4 +28,8 @@
 
     // https://drafts.css-houdini.org/css-typed-om/#declared-stylepropertymap-objects
     [SameObject, EnabledBySetting=CSSTypedOMEnabled] readonly attribute StylePropertyMap styleMap;
+
+    [EnabledBySetting=CSSNestingEnabled, SameObject] readonly attribute CSSRuleList cssRules;
+    [EnabledBySetting=CSSNestingEnabled] unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
+    [EnabledBySetting=CSSNestingEnabled] undefined deleteRule(unsigned long index);
 };


### PR DESCRIPTION
#### f4dfe341bdcccb74b460130f620df70c8c9b561c
<pre>
CSS Nesting: serialization support for CSSOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=254432">https://bugs.webkit.org/show_bug.cgi?id=254432</a>
rdar://107190613

Reviewed by Antti Koivisto.

This implement the CSSStyleRule serialization (the read-only part of CSSOM).

<a href="https://w3c.github.io/csswg-drafts/cssom-1/#serialize-a-css-rule">https://w3c.github.io/csswg-drafts/cssom-1/#serialize-a-css-rule</a>

It also implements the lifting-up (in the parent rule) of properties when the style rule contains only &quot;&amp;&quot;
as selector list.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::deleteRule):
(WebCore::CSSGroupingRule::cssTextForDeclsAndRules const):
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::hasOnlyNestingSelector const):
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::cssText const):
(WebCore::CSSStyleRule::cssTextForDeclsAndRules const):
(WebCore::CSSStyleRule::reattach):
(WebCore::CSSStyleRule::insertRule):
(WebCore::CSSStyleRule::deleteRule):
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleRule.idl:

Canonical link: <a href="https://commits.webkit.org/262177@main">https://commits.webkit.org/262177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d23411fff548803273b7dd8d0b1601da709ee05a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1133 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/937 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/838 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1071 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/778 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/801 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/1792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/789 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/786 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/191 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/802 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->