### PR TITLE
[WGSL] Add overload resolution tests

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1,0 +1,45 @@
+fn testAdd() {
+  {
+    let x1 = 1 + 2;
+    let x2 = 1i + 1;
+    let x3 = 1 + 1i;
+    let x4 = 1u + 1;
+    let x5 = 1 + 1u;
+    let x6 = 1.0 + 2;
+    let x7 = 1 + 2.0;
+    let x8 = 1.0 + 2.0;
+  }
+
+
+  {
+    let v1 = vec2<f32>(0, 0) + 1;
+    let v2 = vec3<f32>(0, 0, 0) + 1;
+    let v3 = vec4<f32>(0, 0, 0, 0) + 1;
+  }
+
+  {
+    let v1 = 1 + vec2<f32>(0, 0);
+    let v2 = 1 + vec3<f32>(0, 0, 0);
+    let v3 = 1 + vec4<f32>(0, 0, 0, 0);
+  }
+
+  {
+    let v1 = vec2<f32>(0, 0) + vec2<f32>(1, 1);
+    let v2 = vec3<f32>(0, 0, 0) + vec3<f32>(1, 1, 1);
+    let v3 = vec4<f32>(0, 0, 0, 0) + vec4<f32>(1, 1, 1, 1);
+  }
+
+  {
+    let m1 = mat2x2<f32>(0, 0, 0, 0) + mat2x2<f32>(1, 1, 1, 1);
+    let m2 = mat2x3<f32>(0, 0, 0, 0, 0, 0) + mat2x3<f32>(1, 1, 1, 1, 1, 1);
+    let m3 = mat2x4<f32>(0, 0, 0, 0, 0, 0, 0, 0) + mat2x4<f32>(1, 1, 1, 1, 1, 1, 1, 1);
+  }
+}
+
+fn testMultiply() {
+  let v2 = vec2<f32>(0, 0);
+  let v4 = vec4<f32>(0, 0, 0, 0);
+  let m = mat2x4<f32>(0, 0, 0, 0);
+  let r1 = m * v2;
+  let r2 = v4 * m;
+}


### PR DESCRIPTION
#### 1c684c63e7ce6c72bf6edc54f24c50ef6085d355
<pre>
[WGSL] Add overload resolution tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=254530">https://bugs.webkit.org/show_bug.cgi?id=254530</a>
rdar://107270787

Reviewed by Myles C. Maxfield.

Add tests to verify that we correctly handle the few overload declarations we
currently have. NOTE: this depends on PR #11995 in order for us to run the
test, and (for now) the tests must be run manually.

* Source/WebGPU/WGSL/tests/valid/overload.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/262198@main">https://commits.webkit.org/262198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04142f9862a6e0146cb4a4fc235d7857ba758de9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/705 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/927 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1024 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/756 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/720 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1746 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/729 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/751 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/204 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/768 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->