### PR TITLE
HTML Comments after </body> are placed at the bottom of the <body> contents

### DIFF
--- a/LayoutTests/editing/selection/doubleclick-crash-expected.txt
+++ b/LayoutTests/editing/selection/doubleclick-crash-expected.txt
@@ -8,14 +8,13 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x587
       RenderBlock {PRE} at (0,0) size 800x75
-        RenderText {#text} at (0,0) size 40x60
+        RenderText {#text} at (0,0) size 40x75
           text run at (0,0) width 40: "Test."
           text run at (39,0) width 1: " "
           text run at (0,15) width 40: "Test."
           text run at (39,15) width 1: " "
           text run at (0,30) width 0: " "
           text run at (0,45) width 0: " "
-        RenderText {#text} at (0,60) size 0x15
           text run at (0,60) width 0: " "
 selection start: position 5 of child 0 {#text} of child 1 {PRE} of body
 selection end:   position 6 of child 0 {#text} of child 1 {PRE} of body

--- a/LayoutTests/html5lib/resources/webkit01.dat
+++ b/LayoutTests/html5lib/resources/webkit01.dat
@@ -329,6 +329,30 @@ console.log("FOO<span>BAR</span>BAZ");
 | <!--  Again  -->
 
 #data
+<html><body></body>
+   <!-- Hi there --></html>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     "
+   "
+|   <!--  Hi there  -->
+
+#data
+<html><body></body></html>
+   <!-- Hi there -->
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     "
+   "
+| <!--  Hi there  -->
+
+#data
 <html><body><ruby><div><rp>xx</rp></div></ruby></body></html>
 #errors
 (1,6): expected-doctype-but-got-start-tag

--- a/LayoutTests/platform/gtk/editing/selection/doubleclick-crash-expected.txt
+++ b/LayoutTests/platform/gtk/editing/selection/doubleclick-crash-expected.txt
@@ -8,14 +8,13 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x587
       RenderBlock {PRE} at (0,0) size 800x75
-        RenderText {#text} at (0,0) size 40x60
+        RenderText {#text} at (0,0) size 40x75
           text run at (0,0) width 40: "Test."
           text run at (40,0) width 0: " "
           text run at (0,15) width 40: "Test."
           text run at (40,15) width 0: " "
           text run at (0,30) width 0: " "
           text run at (0,45) width 0: " "
-        RenderText {#text} at (0,60) size 0x15
           text run at (0,60) width 0: " "
 selection start: position 5 of child 0 {#text} of child 1 {PRE} of body
 selection end:   position 6 of child 0 {#text} of child 1 {PRE} of body

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.h
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.h
@@ -21,7 +21,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -141,6 +141,7 @@ private:
 
     void processAnyOtherEndTagForInBody(AtomHTMLToken&&);
 
+    inline bool consumeAndInsertWhitespace(ExternalCharacterTokenBuffer&);
     void processCharacterBuffer(ExternalCharacterTokenBuffer&);
     inline void processCharacterBufferForInBody(ExternalCharacterTokenBuffer&);
 
@@ -165,7 +166,7 @@ private:
 
     bool shouldProcessTokenInForeignContent(const AtomHTMLToken&);
     void processTokenInForeignContent(AtomHTMLToken&&);
-    
+
     HTMLStackItem& adjustedCurrentStackItem();
 
     void callTheAdoptionAgency(AtomHTMLToken&);


### PR DESCRIPTION
#### 4dc62c7c9b46afea3f1ebda36f85d13dcd158ee8
<pre>
HTML Comments after &lt;/body&gt; are placed at the bottom of the &lt;body&gt; contents
<a href="https://bugs.webkit.org/show_bug.cgi?id=79273">https://bugs.webkit.org/show_bug.cgi?id=79273</a>
rdar://95557786

Reviewed by Ryosuke Niwa.

Consume whitespace in the &quot;after body&quot; and &quot;after after body&quot; modes so following comments get inserted after the body element.

Tests are from <a href="https://chromium.googlesource.com/chromium/src/+/9a75bc03766976f883731f08d52ae70204f94caa%5E%21/">https://chromium.googlesource.com/chromium/src/+/9a75bc03766976f883731f08d52ae70204f94caa%5E%21/</a> and contrary to the assertion there do not pass in WebKit today.

* LayoutTests/editing/selection/doubleclick-crash-expected.txt:
* LayoutTests/html5lib/resources/webkit01.dat:
* LayoutTests/platform/gtk/editing/selection/doubleclick-crash-expected.txt:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::consumeAndInsertWhitespace):

Abstracts a common operation.

(WebCore::HTMLTreeBuilder::processCharacterBuffer):
(WebCore::HTMLTreeBuilder::processTokenInForeignContent):
* Source/WebCore/html/parser/HTMLTreeBuilder.h:

Canonical link: <a href="https://commits.webkit.org/262222@main">https://commits.webkit.org/262222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ecfc26dcc8b1c5cbbbec530dc17dd8c97100a45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1358 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1045 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1282 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/874 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/850 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/901 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1907 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/891 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/883 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/226 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/905 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->