### PR TITLE
Two media/track/track-webvtt-snap-to-lines tests sometimes fail

### DIFF
--- a/LayoutTests/media/track/track-webvtt-snap-to-lines-inline-style.html
+++ b/LayoutTests/media/track/track-webvtt-snap-to-lines-inline-style.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>track-webvtt-snap-to-lines-inline-style</title>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-9" />
     <style>
         html { overflow:hidden }
         body { margin:0 }

--- a/LayoutTests/media/track/track-webvtt-snap-to-lines-left-right.html
+++ b/LayoutTests/media/track/track-webvtt-snap-to-lines-left-right.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>track-webvtt-snap-to-lines-left-right</title>
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10" />
     <style>
         html { overflow:hidden }
         body { margin:0 }


### PR DESCRIPTION
#### 35a071cc970e256250103ce8d2381f19cc651635
<pre>
Two media/track/track-webvtt-snap-to-lines tests sometimes fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=254538">https://bugs.webkit.org/show_bug.cgi?id=254538</a>
rdar://106031213

Reviewed by Jer Noble.

Allow minor pixel differences.

* LayoutTests/media/track/track-webvtt-snap-to-lines-inline-style.html:
* LayoutTests/media/track/track-webvtt-snap-to-lines-left-right.html:

Canonical link: <a href="https://commits.webkit.org/262182@main">https://commits.webkit.org/262182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e87e3d458cd8883acb1b75f606182e98e814d4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/724 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/943 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1054 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/773 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/791 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1767 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/746 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/776 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/196 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/788 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->