### PR TITLE
[Wasm-GC] Avoid stack consistency checking in LLIntGenerator::addStructNew()

### DIFF
--- a/JSTests/wasm/gc/bug254226.js
+++ b/JSTests/wasm/gc/bug254226.js
@@ -1,0 +1,85 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function testNestedStruct() {
+   let m = instantiate(`(module
+    (type $inner (struct (field i32) (field i32)))
+    (type $outer (struct (field (ref $inner)) (field (ref $inner))))
+
+    (func $new (export "new") (result (ref $outer))
+       (struct.new_canon $outer (struct.new_canon $inner (i32.const 41) (i32.const 42))
+                                (struct.new_canon $inner (i32.const 43) (i32.const 45))))
+
+    (func (export "get_field0_0") (result i32)
+       (call $new)
+       (struct.get $inner 0 (struct.get $outer 0)))
+
+    (func (export "get_field0_1") (result i32)
+       (call $new)
+       (struct.get $inner 1 (struct.get $outer 0)))
+
+    (func (export "get_field1_0") (result i32)
+       (call $new)
+       (struct.get $inner 0 (struct.get $outer 1)))
+
+    (func (export "get_field1_1") (result i32)
+       (call $new)
+       (struct.get $inner 1 (struct.get $outer 1))))`);
+
+    assert.eq(m.exports.get_field0_0(), 41);
+    assert.eq(m.exports.get_field0_1(), 42);
+    assert.eq(m.exports.get_field1_0(), 43);
+    assert.eq(m.exports.get_field1_1(), 45);
+}
+
+function testNestedStructWithLocal() {
+   let m = instantiate(`(module
+  (type $bvec (array i8))
+  (type $inner (struct (field i32) (field (ref $bvec))))
+  (type $outer (struct (field (ref $inner)) (field (ref $inner))))
+
+  (func $new (export "new") (result (ref $outer))
+    (local i32)
+    (local.set 0 (i32.const 42))
+    (struct.new_canon $outer (struct.new_canon $inner (i32.const 3) (array.new_canon_default $bvec (i32.const 1)))
+                             (struct.new_canon $inner (local.get 0) (array.new_canon_default $bvec (i32.const 6)))))
+
+  (func (export "get_field0_0") (result i32)
+    (call $new)
+    (struct.get $inner 0 (struct.get $outer 0)))
+
+  (func (export "get_field0_len1") (result i32)
+    (call $new)
+    (array.len (struct.get $inner 1 (struct.get $outer 0))))
+
+
+  (func (export "get_field1_0") (result i32)
+    (call $new)
+    (struct.get $inner 0 (struct.get $outer 1)))
+
+  (func (export "get_field1_len1") (result i32)
+    (call $new)
+    (array.len (struct.get $inner 1 (struct.get $outer 1))))
+
+)`);
+
+    assert.eq(m.exports.get_field0_0(), 3);
+    assert.eq(m.exports.get_field0_len1(), 1);
+
+    assert.eq(m.exports.get_field1_0(), 42);
+    assert.eq(m.exports.get_field1_len1(), 6);
+}
+
+testNestedStruct();
+testNestedStructWithLocal();

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -2050,35 +2050,33 @@ auto LLIntGenerator::addArrayLen(ExpressionType arrayref, ExpressionType& result
 
 auto LLIntGenerator::addStructNew(uint32_t index, Vector<ExpressionType>& args, ExpressionType& result) -> PartialResult
 {
-    // Allocate space for the return value
-    result = push();
-
     // Special-case the 0-arguments case since the logic below only makes sense with at least one argument
     if (!args.size()) {
+        result = push();
         WasmStructNew::emit(this, result, index, static_cast<bool>(UseDefaultValue::No), VirtualRegister());
         return { };
     }
 
-    // "Pop" the stack in order to use the same slot for the result and the first arg
-    m_stackSize--;
+    // Allocate stack slots for walkExpressionStack() to use
+    m_stackSize += args.size();
 
-    // By similar reasoning to the `addThrow` operation:
-    // We have to materialize the arguments here since it might include constants or
-    // delayed moves, but the wasm_struct_new opcode expects all the arguments to be contiguous
-    // in the stack.
-    for (unsigned i = 0; i < args.size(); ++i) {
-        auto& arg = args[i];
-        ExpressionType argLoc = push();
-        WasmMov::emit(this, argLoc, arg);
-        arg = argLoc;
-    }
+    // The logic here is similar to addThrow(); see comments there.
+    // It's important to use walkExpressionStack() here and not call push() explicitly,
+    // because the stack consistency checking that push() does will fail if there's
+    // more than one struct field. The parser pops the arguments off the stack before
+    // calling into this method, and by pushing arguments, we get out of sync
+    // with the parser's expression stack.
+    walkExpressionStack(args, [&](VirtualRegister& arg, VirtualRegister slot) {
+        if (arg == slot)
+            return;
+        WasmMov::emit(this, slot, arg);
+        arg = slot;
+    });
 
-    // Arguments are passed in reverse order (the last arg will be at the highest virtual register index, which
-    // will have the lowest address.)
-    // The implementation of struct_new has to iterate over its arguments in reverse order.
+    result = args[0];
     WasmStructNew::emit(this, result, index, static_cast<bool>(UseDefaultValue::No), args.last());
 
-    // Subtract 1 from the arg length to account for leaving the return value on the stack
+    // "Pop" arguments off, minus one slot for the return value
     m_stackSize -= args.size() - 1;
 
     return { };


### PR DESCRIPTION
#### 927cb4227a3673e681c36659637e1f5a78cd8f56
<pre>
[Wasm-GC] Avoid stack consistency checking in LLIntGenerator::addStructNew()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254226">https://bugs.webkit.org/show_bug.cgi?id=254226</a>

Reviewed by Justin Michaud.

`addStructNew()` was failing in debug mode if called with a non-empty parser
stack, because pushing the arguments results in LLInt&apos;s view of the stack
getting out of sync with the parser&apos;s stack. Changed it to use
`walkExpressionStack()`, similarly to `addThrow()`.

* JSTests/wasm/gc/bug254226.js: Added.
(module):
(testNestedStruct):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::addStructNew):

Canonical link: <a href="https://commits.webkit.org/262236@main">https://commits.webkit.org/262236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ef1686a76be25a64b1846d82ebfc9e5f3ef4291

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/738 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1109 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/843 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/796 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/734 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/754 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1840 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/821 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/759 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/859 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/788 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/176 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/237 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/805 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/862 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/171 "Passed tests") | 
<!--EWS-Status-Bubble-End-->