### PR TITLE
Avoid doing event-related work for CSS animation events when no event listener is registered

### DIFF
--- a/Source/WebCore/animation/DeclarativeAnimation.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimation.cpp
@@ -294,57 +294,61 @@ void DeclarativeAnimation::invalidateDOMEvents(Seconds elapsedTime)
     bool isIdle = currentPhase == AnimationEffectPhase::Idle;
 
     if (is<CSSAnimation>(*this)) {
-        // https://drafts.csswg.org/css-animations-2/#events
-        if ((wasIdle || wasBefore) && isActive)
-            enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
-        else if ((wasIdle || wasBefore) && isAfter) {
-            enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
-            enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());
-        } else if (wasActive && isBefore)
-            enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
-        else if (wasActive && isActive && m_previousIteration != iteration) {
-            auto iterationBoundary = iteration;
-            if (m_previousIteration > iteration)
-                iterationBoundary++;
-            auto elapsedTime = animationEffect ? animationEffect->iterationDuration() * (iterationBoundary - animationEffect->iterationStart()) : 0_s;
-            enqueueDOMEvent(eventNames().animationiterationEvent, elapsedTime, effectTimeAtIteration(iteration));
-        } else if (wasActive && isAfter)
-            enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());
-        else if (wasAfter && isActive)
-            enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd, effectTimeAtStart());
-        else if (wasAfter && isBefore) {
-            enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd, effectTimeAtStart());
-            enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
-        } else if ((!wasIdle && !wasAfter) && isIdle)
-            enqueueDOMEvent(eventNames().animationcancelEvent, elapsedTime, elapsedTime);
-    } else if (is<CSSTransition>(*this) && m_owningElement->document().hasListenerType(Document::TRANSITION_ANIMATION_LISTENER)) {
-        // https://drafts.csswg.org/css-transitions-2/#transition-events
-        if (wasIdle && (isPending || isBefore))
-            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());
-        else if (wasIdle && isActive) {
-            auto scheduledEffectTime = effectTimeAtStart();
-            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, scheduledEffectTime);
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, scheduledEffectTime);
-        } else if (wasIdle && isAfter) {
-            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
-            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
-        } else if ((m_wasPending || wasBefore) && isActive)
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
-        else if ((m_wasPending || wasBefore) && isAfter) {
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
-            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
-        } else if (wasActive && isAfter)
-            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
-        else if (wasActive && isBefore)
-            enqueueDOMEvent(eventNames().transitionendEvent, intervalStart, effectTimeAtEnd());
-        else if (wasAfter && isActive)
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd, effectTimeAtStart());
-        else if (wasAfter && isBefore) {
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd, effectTimeAtStart());
-            enqueueDOMEvent(eventNames().transitionendEvent, intervalStart, effectTimeAtEnd());
-        } else if ((!wasIdle && !wasAfter) && isIdle)
-            enqueueDOMEvent(eventNames().transitioncancelEvent, elapsedTime, elapsedTime);
+        if (m_owningElement->document().hasListenerType(Document::CSS_ANIMATION_LISTENER)) {
+            // https://drafts.csswg.org/css-animations-2/#events
+            if ((wasIdle || wasBefore) && isActive)
+                enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
+            else if ((wasIdle || wasBefore) && isAfter) {
+                enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
+                enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());
+            } else if (wasActive && isBefore)
+                enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
+            else if (wasActive && isActive && m_previousIteration != iteration) {
+                auto iterationBoundary = iteration;
+                if (m_previousIteration > iteration)
+                    iterationBoundary++;
+                auto elapsedTime = animationEffect ? animationEffect->iterationDuration() * (iterationBoundary - animationEffect->iterationStart()) : 0_s;
+                enqueueDOMEvent(eventNames().animationiterationEvent, elapsedTime, effectTimeAtIteration(iteration));
+            } else if (wasActive && isAfter)
+                enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());
+            else if (wasAfter && isActive)
+                enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd, effectTimeAtStart());
+            else if (wasAfter && isBefore) {
+                enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd, effectTimeAtStart());
+                enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
+            } else if ((!wasIdle && !wasAfter) && isIdle)
+                enqueueDOMEvent(eventNames().animationcancelEvent, elapsedTime, elapsedTime);
+        }
+    } else if (is<CSSTransition>(*this)) {
+        if (m_owningElement->document().hasListenerType(Document::CSS_TRANSITION_LISTENER)) {
+            // https://drafts.csswg.org/css-transitions-2/#transition-events
+            if (wasIdle && (isPending || isBefore))
+                enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());
+            else if (wasIdle && isActive) {
+                auto scheduledEffectTime = effectTimeAtStart();
+                enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, scheduledEffectTime);
+                enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, scheduledEffectTime);
+            } else if (wasIdle && isAfter) {
+                enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());
+                enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
+                enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
+            } else if ((m_wasPending || wasBefore) && isActive)
+                enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
+            else if ((m_wasPending || wasBefore) && isAfter) {
+                enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
+                enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
+            } else if (wasActive && isAfter)
+                enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
+            else if (wasActive && isBefore)
+                enqueueDOMEvent(eventNames().transitionendEvent, intervalStart, effectTimeAtEnd());
+            else if (wasAfter && isActive)
+                enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd, effectTimeAtStart());
+            else if (wasAfter && isBefore) {
+                enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd, effectTimeAtStart());
+                enqueueDOMEvent(eventNames().transitionendEvent, intervalStart, effectTimeAtEnd());
+            } else if ((!wasIdle && !wasAfter) && isIdle)
+                enqueueDOMEvent(eventNames().transitioncancelEvent, elapsedTime, elapsedTime);
+        }
     }
 
     m_wasPending = isPending;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5473,7 +5473,9 @@ void Document::addListenerTypeIfNeeded(const AtomString& eventType)
     else if (eventType == eventNames.focusoutEvent)
         addListenerType(FOCUSOUT_LISTENER);
     else if (eventNames.isCSSTransitionEventType(eventType))
-        addListenerType(TRANSITION_ANIMATION_LISTENER);
+        addListenerType(CSS_TRANSITION_LISTENER);
+    else if (eventNames.isCSSAnimationEventType(eventType))
+        addListenerType(CSS_ANIMATION_LISTENER);
 }
 
 HTMLFrameOwnerElement* Document::ownerElement() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -958,7 +958,8 @@ public:
         FORCEUP_LISTENER                     = 1 << 12,
         FOCUSIN_LISTENER                     = 1 << 13,
         FOCUSOUT_LISTENER                    = 1 << 14,
-        TRANSITION_ANIMATION_LISTENER        = 1 << 15
+        CSS_TRANSITION_LISTENER              = 1 << 15,
+        CSS_ANIMATION_LISTENER               = 1 << 16
     };
 
     bool hasListenerType(ListenerType listenerType) const { return (m_listenerTypes & listenerType); }

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -380,6 +380,7 @@ public:
     bool isMouseClickRelatedEventType(const AtomString& eventType) const;
     bool isMouseMoveRelatedEventType(const AtomString& eventType) const;
     bool isCSSTransitionEventType(const AtomString& eventType) const;
+    bool isCSSAnimationEventType(const AtomString& eventType) const;
 #if ENABLE(GAMEPAD)
     bool isGamepadEventType(const AtomString& eventType) const;
 #endif
@@ -465,6 +466,17 @@ inline bool EventNames::isCSSTransitionEventType(const AtomString& eventType) co
         || eventType == transitionrunEvent
         || eventType == transitionstartEvent
         || eventType == webkitTransitionEndEvent;
+}
+
+inline bool EventNames::isCSSAnimationEventType(const AtomString& eventType) const
+{
+    return eventType == animationcancelEvent
+        || eventType == animationendEvent
+        || eventType == animationiterationEvent
+        || eventType == animationstartEvent
+        || eventType == webkitAnimationEndEvent
+        || eventType == webkitAnimationIterationEvent
+        || eventType == webkitAnimationStartEvent;
 }
 
 inline std::array<std::reference_wrapper<const AtomString>, 13> EventNames::touchRelatedEventNames() const


### PR DESCRIPTION
#### f3a4982bb1a712a260572205d199b16147ce6797
<pre>
Avoid doing event-related work for CSS animation events when no event listener is registered
<a href="https://bugs.webkit.org/show_bug.cgi?id=254546">https://bugs.webkit.org/show_bug.cgi?id=254546</a>

Reviewed by Antoine Quint.

* Source/WebCore/animation/DeclarativeAnimation.cpp:
(WebCore::DeclarativeAnimation::invalidateDOMEvents):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::addListenerTypeIfNeeded):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EventNames.h:
(WebCore::EventNames::isCSSAnimationEventType const):

Canonical link: <a href="https://commits.webkit.org/262231@main">https://commits.webkit.org/262231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25d060cbdb94f81e3a018a03200bbbeac2c64fa6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/831 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1042 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/884 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/854 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1922 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/849 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/233 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/909 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->