### PR TITLE
Remote Web Inspector: Send the `presentingApplicationPID` to the relay process for WKWebViews

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp
@@ -111,6 +111,14 @@ void RemoteInspectionTarget::unpauseForInitializedInspector()
     RemoteInspector::singleton().setupCompleted(targetIdentifier());
 }
 
+void RemoteInspectionTarget::setPresentingApplicationPID(std::optional<ProcessID>&& pid)
+{
+    m_presentingApplicationPID = pid;
+#if PLATFORM(COCOA)
+    RemoteInspector::singleton().setUsePerTargetPresentingApplicationPIDs(true);
+#endif
+}
+
 } // namespace Inspector
 
 #endif // ENABLE(REMOTE_INSPECTOR)

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h
@@ -29,6 +29,7 @@
 
 #include "JSRemoteInspector.h"
 #include "RemoteControllableTarget.h"
+#include <wtf/ProcessID.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
@@ -62,6 +63,9 @@ public:
     // RemoteControllableTarget overrides.
     bool remoteControlAllowed() const final;
 
+    std::optional<ProcessID> presentingApplicationPID() const { return m_presentingApplicationPID; }
+    void setPresentingApplicationPID(std::optional<ProcessID>&&);
+
 private:
     enum class Inspectable : uint8_t {
         Yes,
@@ -76,6 +80,8 @@ private:
 #if USE(CF)
     RetainPtr<CFRunLoopRef> m_runLoop;
 #endif
+
+    std::optional<ProcessID> m_presentingApplicationPID;
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -159,6 +159,9 @@ public:
     void setParentProcessInformation(ProcessID, RetainPtr<CFDataRef> auditData);
     void setParentProcessInfomationIsDelayed();
     std::optional<audit_token_t> parentProcessAuditToken();
+
+    void setUsePerTargetPresentingApplicationPIDs(bool usePerTargetPresentingApplicationPIDs) { m_usePerTargetPresentingApplicationPIDs = usePerTargetPresentingApplicationPIDs; }
+
     bool isSimulatingCustomerInstall() const { return m_simulateCustomerInstall; }
 #endif
 
@@ -308,6 +311,7 @@ private:
     RetainPtr<CFDataRef> m_parentProcessAuditData;
     bool m_messageDataTypeChunkSupported { false };
     bool m_simulateCustomerInstall { false };
+    bool m_usePerTargetPresentingApplicationPIDs { false };
 #endif
     bool m_shouldSendParentProcessInformation { false };
     bool m_automaticInspectionEnabled WTF_GUARDED_BY_LOCK(m_mutex) { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -580,6 +580,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 
 #if ENABLE(REMOTE_INSPECTOR)
     m_inspectorDebuggable->setInspectable(JSRemoteInspectorGetInspectionEnabledByDefault());
+    m_inspectorDebuggable->setPresentingApplicationPID(m_process->processPool().configuration().presentingApplicationPID());
     m_inspectorDebuggable->init();
 #endif
     m_inspectorController->init();


### PR DESCRIPTION
#### d5d5bd30a02deea1a39d7235f31a0bf3fee5cdd4
<pre>
Remote Web Inspector: Send the `presentingApplicationPID` to the relay process for WKWebViews
<a href="https://bugs.webkit.org/show_bug.cgi?id=254537">https://bugs.webkit.org/show_bug.cgi?id=254537</a>
rdar://105636143

Reviewed by BJ Burg.

In some cases, a process may create WKWebViews on behalf of another process to be served remotely. WKWebViews
inspectability is managed in the UI process, and those does not currently use the `presentingApplicationPID` to
associate a target with a specific parent process (a process may represent multiple parent processes at a time). We thus
need to provide target-specific PIDs for the presenting application so that WKWebViews are correctly related back to the
application that is showing the web content via the intermediate remote service that actually created the WKWebView.

* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp:
(Inspector::RemoteInspectionTarget::setPresentingApplicationPID):
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.h:
- Allow setting a per-target `presentingApplicationPID` as an alternative to having a single PID the entire process
proxies its inspectable content to.

* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::identifierForPID):
(Inspector::RemoteInspector::listingForInspectionTarget const):
- Provide a per-target presenting application PID so that individual web views can be associated the appropriate process.
Relays should use this value in place of the application-wide parent process PID when it is present. For WKWebView,
those values will be equal by default unless explicitly set.

(Inspector::RemoteInspector::receivedProxyApplicationSetupMessage):
- Proxy apps don&apos;t need to respond to the proxy setup message, since all the necessary information will be provided with
the application&apos;s listing of targets.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
- Use the `presentingApplicationPID` of the web content process pool to inform associate the inspectable page with the
correct parent application, since that is the pool that the content to be inspected will actually exist in. Unless it
has been overriden, this will be the PID of the UI process.

Canonical link: <a href="https://commits.webkit.org/262620@main">https://commits.webkit.org/262620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/396e49112d852f1de8adf3f77503daa86fb3a267

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2089 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1857 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2798 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1704 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1692 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1860 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2966 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1931 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1661 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2084 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1806 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/513 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1966 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2130 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/599 "Passed tests") | 
<!--EWS-Status-Bubble-End-->