### PR TITLE
Deduplicate headers in generated GeneratedSerializers file

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -177,6 +177,11 @@ class ConditionalHeader(object):
     def __lt__(self, other):
         return self.header < other.header
 
+    def __eq__(self, other):
+        return other and self.header == other.header and self.condition == other.condition
+
+    def __hash__(self):
+        return hash((self.header, self.condition))
 
 def sanitize_string_for_variable_name(string):
     return string.replace('()', '').replace('.', '')
@@ -891,6 +896,7 @@ def main(argv):
     serialized_enums = []
     typedefs = []
     headers = []
+    header_set = set()
     file_extension = argv[1]
     for i in range(3, len(argv)):
         with open(argv[2] + argv[i]) as file:
@@ -902,8 +908,8 @@ def main(argv):
             for typedef in new_typedefs:
                 typedefs.append(typedef)
             for header in new_headers:
-                headers.append(header)
-    headers.sort()
+                header_set.add(header)
+    headers = sorted(header_set)
 
     with open('GeneratedSerializers.h', "w+") as output:
         output.write(generate_header(serialized_types, serialized_enums))

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -35,6 +35,10 @@ template<size_t firstOffset, size_t secondOffset, size_t... remainingOffsets> st
 IGNORE_WARNINGS_BEGIN("invalid-offsetof")
 #endif
 #if ENABLE(TEST_FEATURE)
+#include "CommonHeader.h"
+#endif
+#include "CommonHeader.h"
+#if ENABLE(TEST_FEATURE)
 #include "FirstMemberType.h"
 #endif
 #include "HeaderWithoutCondition"
@@ -638,6 +642,78 @@ std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunctio
 
     ASSERT_NOT_REACHED();
     return std::nullopt;
+}
+
+#if ENABLE(TEST_FEATURE)
+
+void ArgumentCoder<Namespace::ConditionalCommonClass>::encode(Encoder& encoder, const Namespace::ConditionalCommonClass& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, int>);
+    static_assert(MembersInCorrectOrder<0
+        , offsetof(Namespace::ConditionalCommonClass, value)
+    >::value);
+    encoder << instance.value;
+}
+
+std::optional<Namespace::ConditionalCommonClass> ArgumentCoder<Namespace::ConditionalCommonClass>::decode(Decoder& decoder)
+{
+    auto value = decoder.decode<int>();
+    if (!value)
+        return std::nullopt;
+
+    return {
+        Namespace::ConditionalCommonClass {
+            WTFMove(*value)
+        }
+    };
+}
+
+#endif
+
+
+void ArgumentCoder<Namesapce::CommonClass>::encode(Encoder& encoder, const Namesapce::CommonClass& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, int>);
+    static_assert(MembersInCorrectOrder<0
+        , offsetof(Namesapce::CommonClass, value)
+    >::value);
+    encoder << instance.value;
+}
+
+std::optional<Namesapce::CommonClass> ArgumentCoder<Namesapce::CommonClass>::decode(Decoder& decoder)
+{
+    auto value = decoder.decode<int>();
+    if (!value)
+        return std::nullopt;
+
+    return {
+        Namesapce::CommonClass {
+            WTFMove(*value)
+        }
+    };
+}
+
+
+void ArgumentCoder<Namesapce::AnotherCommonClass>::encode(Encoder& encoder, const Namesapce::AnotherCommonClass& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, int>);
+    static_assert(MembersInCorrectOrder<0
+        , offsetof(Namesapce::AnotherCommonClass, value)
+    >::value);
+    encoder << instance.value;
+}
+
+std::optional<Namesapce::AnotherCommonClass> ArgumentCoder<Namesapce::AnotherCommonClass>::decode(Decoder& decoder)
+{
+    auto value = decoder.decode<int>();
+    if (!value)
+        return std::nullopt;
+
+    return {
+        Namesapce::AnotherCommonClass {
+            WTFMove(*value)
+        }
+    };
 }
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -56,6 +56,11 @@ using FloatBoxExtent = ScrollSnapOffsetsInfo<float, double>;
 }
 struct NullableSoftLinkedMember;
 namespace WebCore { class TimingFunction; }
+#if ENABLE(TEST_FEATURE)
+namespace Namespace { class ConditionalCommonClass; }
+#endif
+namespace Namesapce { class CommonClass; }
+namespace Namesapce { class AnotherCommonClass; }
 
 namespace IPC {
 
@@ -130,6 +135,23 @@ template<> struct ArgumentCoder<NullableSoftLinkedMember> {
 template<> struct ArgumentCoder<WebCore::TimingFunction> {
     static void encode(Encoder&, const WebCore::TimingFunction&);
     static std::optional<Ref<WebCore::TimingFunction>> decode(Decoder&);
+};
+
+#if ENABLE(TEST_FEATURE)
+template<> struct ArgumentCoder<Namespace::ConditionalCommonClass> {
+    static void encode(Encoder&, const Namespace::ConditionalCommonClass&);
+    static std::optional<Namespace::ConditionalCommonClass> decode(Decoder&);
+};
+#endif
+
+template<> struct ArgumentCoder<Namesapce::CommonClass> {
+    static void encode(Encoder&, const Namesapce::CommonClass&);
+    static std::optional<Namesapce::CommonClass> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<Namesapce::AnotherCommonClass> {
+    static void encode(Encoder&, const Namesapce::AnotherCommonClass&);
+    static std::optional<Namesapce::AnotherCommonClass> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -26,6 +26,10 @@
 #include "SerializedTypeInfo.h"
 
 #if ENABLE(TEST_FEATURE)
+#include "CommonHeader.h"
+#endif
+#include "CommonHeader.h"
+#if ENABLE(TEST_FEATURE)
 #include "FirstMemberType.h"
 #endif
 #include "HeaderWithoutCondition"
@@ -174,6 +178,24 @@ Vector<SerializedTypeInfo> allSerializedTypes()
         } },
         { "WebCore::TimingFunction"_s, {
             { "std::variant<WebCore::LinearTimingFunction, WebCore::CubicBezierTimingFunction, WebCore::StepsTimingFunction, WebCore::SpringTimingFunction>"_s, "subclasses"_s }
+        } },
+        { "Namespace::ConditionalCommonClass"_s, {
+            {
+                "int"_s,
+                "value"_s
+            }
+        } },
+        { "Namesapce::CommonClass"_s, {
+            {
+                "int"_s,
+                "value"_s
+            }
+        } },
+        { "Namesapce::AnotherCommonClass"_s, {
+            {
+                "int"_s,
+                "value"_s
+            }
         } },
         { "WebCore::SharedStringHash"_s, {
             { "uint32_t"_s, "alias"_s }

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -4,7 +4,7 @@ headers: "HeaderWithoutCondition"
 
 #if ENABLE(TEST_FEATURE)
 headers: "StructHeader.h" "FirstMemberType.h" "SecondMemberType.h"
-[AdditionalEncoder=OtherEncoder, CustomHeader=True] struct Namespace::Subnamespace::StructName {
+[AdditionalEncoder=OtherEncoder, CustomHeader] struct Namespace::Subnamespace::StructName {
     FirstMemberType firstMemberName
     #if ENABLE(SECOND_MEMBER)
     SecondMemberType secondMemberName;
@@ -103,10 +103,10 @@ struct NullableSoftLinkedMember {
 }
 
 [RefCounted] class WebCore::TimingFunction subclasses {
-  WebCore::LinearTimingFunction,
-  WebCore::CubicBezierTimingFunction,
-  WebCore::StepsTimingFunction,
-  WebCore::SpringTimingFunction
+    WebCore::LinearTimingFunction,
+    WebCore::CubicBezierTimingFunction,
+    WebCore::StepsTimingFunction,
+    WebCore::SpringTimingFunction
 }
 
 [OptionSet] enum class OptionSetEnumFirstCondition : uint32_t {
@@ -139,3 +139,19 @@ struct NullableSoftLinkedMember {
 
 using WebCore::SharedStringHash = uint32_t
 
+#if ENABLE(TEST_FEATURE)
+headers: "CommonHeader.h"
+[CustomHeader] class Namespace::ConditionalCommonClass {
+    int value;
+}
+#endif
+
+headers: "CommonHeader.h"
+[CustomHeader] class Namesapce::CommonClass {
+    int value;
+}
+
+headers: "CommonHeader.h"
+[CustomHeader] class Namesapce::AnotherCommonClass {
+    int value;
+}


### PR DESCRIPTION
#### 40ad311960214102f5e5b80de441cfa280598b76
<pre>
Deduplicate headers in generated GeneratedSerializers file
<a href="https://bugs.webkit.org/show_bug.cgi?id=254547">https://bugs.webkit.org/show_bug.cgi?id=254547</a>
rdar://107283996

Reviewed by Alex Christensen.

Use dictionary and set to avoid including a header multiple times in generated file.

* Source/WebKit/Scripts/generate-serializers.py:
(ConditionalHeader.__eq__):
(ConditionalHeader):
(ConditionalHeader.__hash__):
(main):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::ConditionalCommonClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::ConditionalCommonClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namesapce::CommonClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namesapce::CommonClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namesapce::AnotherCommonClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namesapce::AnotherCommonClass&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:

Canonical link: <a href="https://commits.webkit.org/262625@main">https://commits.webkit.org/262625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/539f888a5eac588f945c69595a340582e75dc67d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2069 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2132 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1887 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2845 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/2101 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1738 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1907 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3009 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1903 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1840 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2009 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/228 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->