### PR TITLE
Cherry-pick 252432.1013@safari-7614-branch (1d545c7ebfef). rdar://107285836

### DIFF
--- a/LayoutTests/animations/animation-set-effect-expected.txt
+++ b/LayoutTests/animations/animation-set-effect-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/animations/animation-set-effect.html
+++ b/LayoutTests/animations/animation-set-effect.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+content::part(part0),set {}
+fieldset:enabled { }
+*:defined { all;animation-name: keyframes3,keyframes0;text-underline-mode: 100%;-webkit-animation-fill-mode: forwards;user-zoom: }
+b:focus,circle { }
+#x41,select,#x43 { }
+@keyframes {}
+@keyframes keyframes3 {}
+</style>
+<script>
+var runcount = 0;
+function main() {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        window.testRunner.dumpAsText();
+    }
+    v121 = window.parent;
+    v121.onwebkitanimationend = f2;
+}
+function f1() {
+    sheet0 = document.styleSheets[0];
+    sheet0.deleteRule(94 % sheet0.cssRules.length);
+}
+function f2() {
+    runcount++; 
+    if(runcount > 1) { 
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return; 
+    }
+    var x35 = document.getElementById("x35");
+    v24 = x10.getAnimations();
+    v82 = v24[56 % v24.length];
+    x10.addEventListener("DOMCharacterDataModified",f1);
+    v100 = new KeyframeEffect(x35,{ "inset-inline-start": ["0px", ], },{ delay: 100, direction: "reverse", duration: 100, easing: "cubic-bezier(1,0.63,1,0)", endDelay: 300, fill: "both", iterationStart: 0 });
+    v82.effect = v100;
+    x34.outerText = "PASS if no crash.";
+}
+</script>
+</head>
+<body onload="main()">
+<data id="x10">
+<iframe id="x34" importance="low"></iframe>
+</data>
+</body>
+</html>

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -173,6 +173,7 @@ void CSSAnimation::setBindingsEffect(RefPtr<AnimationEffect>&& newEffect)
         m_overriddenProperties.add(Property::Direction);
         m_overriddenProperties.add(Property::Delay);
         m_overriddenProperties.add(Property::FillMode);
+        m_overriddenProperties.add(Property::Keyframes);
         m_overriddenProperties.add(Property::CompositeOperation);
     }
 }


### PR DESCRIPTION
#### f94e3bc27f8f0012c0c1ebc1054fad5edb0881c0
<pre>
Cherry-pick 252432.1013@safari-7614-branch (1d545c7ebfef). rdar://107285836

    [Web Animations] CSSAnimation::setBindingsEffect should also add KeyFrames to overriddenProperties
    rdar://102137788

    Reviewed by Jonathan Bedard and Antoine Quint.

    * LayoutTests/animations/animation-set-effect-expected.txt: Added.
    * LayoutTests/animations/animation-set-effect.html: Added.
    * Source/WebCore/animation/CSSAnimation.cpp:
    (WebCore::CSSAnimation::setBindingsEffect):

    Canonical link: <a href="https://commits.webkit.org/252432.1013@safari-7614-branch">https://commits.webkit.org/252432.1013@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262179@main">https://commits.webkit.org/262179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e21ef3d470d1e62b856afdddd771a7f7ae4e032

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1149 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/740 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/943 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/793 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1084 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/782 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/757 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1793 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/795 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/742 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/790 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/808 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/86 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->