### PR TITLE
[JSC] Make HasOwnPropertyCache::hash better

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5504,6 +5504,9 @@ void SpeculativeJIT::compile(Node* node)
         load32(Address(implGPR, UniquedStringImpl::flagsOffset()), hashGPR);
         urshift32(TrustedImm32(StringImpl::s_flagCount), hashGPR);
         load32(Address(objectGPR, JSCell::structureIDOffset()), structureIDGPR);
+        move(structureIDGPR, tempGPR);
+        urshift32(TrustedImm32(HasOwnPropertyCache::structureIDHashShift), structureIDGPR);
+        xor32(tempGPR, structureIDGPR);
         add32(structureIDGPR, hashGPR);
         and32(TrustedImm32(HasOwnPropertyCache::mask), hashGPR);
         if (hasOneBitSet(sizeof(HasOwnPropertyCache::Entry))) // is a power of 2

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -13699,7 +13699,7 @@ IGNORE_CLANG_WARNINGS_END
         LValue hash = m_out.lShr(m_out.load32(uniquedStringImpl, m_heaps.StringImpl_hashAndFlags), m_out.constInt32(StringImpl::s_flagCount));
 
         LValue structureID = m_out.load32(object, m_heaps.JSCell_structureID);
-        LValue index = m_out.add(hash, structureID);
+        LValue index = m_out.add(hash, m_out.bitXor(m_out.lShr(structureID, m_out.constInt32(HasOwnPropertyCache::structureIDHashShift)), structureID));
         index = m_out.zeroExtPtr(m_out.bitAnd(index, m_out.constInt32(HasOwnPropertyCache::mask)));
         ASSERT(vm().hasOwnPropertyCache());
         LValue cache = m_out.constIntPtr(vm().hasOwnPropertyCache());

--- a/Source/JavaScriptCore/runtime/HasOwnPropertyCache.h
+++ b/Source/JavaScriptCore/runtime/HasOwnPropertyCache.h
@@ -65,9 +65,14 @@ public:
         return result;
     }
 
+    // Due to sizeof(Structure), lower several bits are always zero.
+    // sizeof(Structure) <= 128. And 128 / 16 = 8 (0b1000). So, 3 + log2(size)
+    static constexpr unsigned structureIDHashShift = 3 + 11;
     ALWAYS_INLINE static uint32_t hash(StructureID structureID, UniquedStringImpl* impl)
     {
-        return bitwise_cast<uint32_t>(structureID) + impl->hash();
+        uint32_t value = structureID.bits();
+        uint32_t hash = (value >> structureIDHashShift) ^ value;
+        return hash + impl->hash();
     }
 
     ALWAYS_INLINE std::optional<bool> get(Structure* structure, PropertyName propName)


### PR DESCRIPTION
#### e6d06056ffddd0d4bf6259c0e52900ca8c7990d0
<pre>
[JSC] Make HasOwnPropertyCache::hash better
<a href="https://bugs.webkit.org/show_bug.cgi?id=254554">https://bugs.webkit.org/show_bug.cgi?id=254554</a>
rdar://107289916

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/HasOwnPropertyCache.h:
(JSC::HasOwnPropertyCache::hash):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6d06056ffddd0d4bf6259c0e52900ca8c7990d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/750 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/967 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1116 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/794 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/798 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/746 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/768 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1811 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/834 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/769 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/874 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/802 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/183 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/819 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/877 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/178 "Passed tests") | 
<!--EWS-Status-Bubble-End-->