### PR TITLE
Use DOMCacheEngine::CrossThreadRecord in CacheStorageConnection

### DIFF
--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -44,9 +44,9 @@ public:
     virtual void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) = 0;
     virtual void retrieveCaches(const ClientOrigin&, uint64_t updateCounter, DOMCacheEngine::CacheInfosCallback&&) = 0;
 
-    virtual void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::RecordsCallback&&) = 0;
+    virtual void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::CrossThreadRecordsCallback&&) = 0;
     virtual void batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) = 0;
-    virtual void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::Record>&&, DOMCacheEngine::RecordIdentifiersCallback&&) = 0;
+    virtual void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&, DOMCacheEngine::RecordIdentifiersCallback&&) = 0;
 
     virtual void reference(DOMCacheIdentifier /* cacheIdentifier */) = 0;
     virtual void dereference(DOMCacheIdentifier /* cacheIdentifier */) = 0;

--- a/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
@@ -185,6 +185,22 @@ Record fromCrossThreadRecord(CrossThreadRecord&& record)
     };
 }
 
+CrossThreadRecord CrossThreadRecord::isolatedCopy() &&
+{
+    return CrossThreadRecord {
+        identifier,
+        updateResponseCounter,
+        requestHeadersGuard,
+        WTFMove(request).isolatedCopy(),
+        WTFMove(options).isolatedCopy(),
+        WTFMove(referrer).isolatedCopy(),
+        responseHeadersGuard,
+        WTFMove(response).isolatedCopy(),
+        isolatedResponseBody(responseBody),
+        responseBodySize
+    };
+}
+
 } // namespace DOMCacheEngine
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cache/DOMCacheEngine.h
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.h
@@ -100,6 +100,7 @@ struct CrossThreadRecord {
         , responseBodySize(responseBodySize)
     {
     }
+    CrossThreadRecord isolatedCopy() &&;
 
     uint64_t identifier;
     uint64_t updateResponseCounter;

--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
@@ -50,9 +50,9 @@ private:
     void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) final;
     void retrieveCaches(const ClientOrigin&, uint64_t updateCounter, DOMCacheEngine::CacheInfosCallback&&) final;
 
-    void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::RecordsCallback&&) final;
+    void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::CrossThreadRecordsCallback&&) final;
     void batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) final;
-    void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::Record>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final;
+    void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final;
 
     void reference(DOMCacheIdentifier) final;
     void dereference(DOMCacheIdentifier) final;
@@ -60,7 +60,7 @@ private:
     void openCompleted(uint64_t requestIdentifier, const DOMCacheEngine::CacheIdentifierOrError&);
     void removeCompleted(uint64_t requestIdentifier, const DOMCacheEngine::RemoveCacheIdentifierOrError&);
     void retrieveCachesCompleted(uint64_t requestIdentifier, DOMCacheEngine::CacheInfosOrError&&);
-    void retrieveRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::RecordsOrError&&);
+    void retrieveRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::CrossThreadRecordsOrError&&);
     void deleteRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::RecordIdentifiersOrError&&);
     void putRecordsCompleted(uint64_t requestIdentifier, DOMCacheEngine::RecordIdentifiersOrError&&);
 
@@ -71,7 +71,7 @@ private:
     HashMap<uint64_t, DOMCacheEngine::CacheIdentifierCallback> m_openCachePendingRequests;
     HashMap<uint64_t, DOMCacheEngine::RemoveCacheIdentifierCallback> m_removeCachePendingRequests;
     HashMap<uint64_t, DOMCacheEngine::CacheInfosCallback> m_retrieveCachesPendingRequests;
-    HashMap<uint64_t, DOMCacheEngine::RecordsCallback> m_retrieveRecordsPendingRequests;
+    HashMap<uint64_t, DOMCacheEngine::CrossThreadRecordsCallback> m_retrieveRecordsPendingRequests;
     HashMap<uint64_t, DOMCacheEngine::RecordIdentifiersCallback> m_batchDeleteAndPutPendingRequests;
 
     uint64_t m_lastRequestIdentifier { 0 };

--- a/Source/WebCore/page/CacheStorageProvider.h
+++ b/Source/WebCore/page/CacheStorageProvider.h
@@ -44,9 +44,9 @@ public:
         void open(const ClientOrigin&, const String&, DOMCacheEngine::CacheIdentifierCallback&&) final { }
         void remove(DOMCacheIdentifier, DOMCacheEngine::RemoveCacheIdentifierCallback&&) final { }
         void retrieveCaches(const ClientOrigin&, uint64_t, DOMCacheEngine::CacheInfosCallback&&) final { }
-        void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::RecordsCallback&&) final { }
+        void retrieveRecords(DOMCacheIdentifier, RetrieveRecordsOptions&&, DOMCacheEngine::CrossThreadRecordsCallback&&) final { }
         void batchDeleteOperation(DOMCacheIdentifier, const ResourceRequest&, CacheQueryOptions&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }
-        void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::Record>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }
+        void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }
         void reference(DOMCacheIdentifier) final { }
         void dereference(DOMCacheIdentifier) final { }
     };

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
@@ -57,9 +57,9 @@ private:
     void remove(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&) final;
     void retrieveCaches(const WebCore::ClientOrigin&, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&) final;
 
-    void retrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::RecordsCallback&&) final;
+    void retrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&) final;
     void batchDeleteOperation(WebCore::DOMCacheIdentifier, const WebCore::ResourceRequest&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&) final;
-    void batchPutOperation(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::Record>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&) final;
+    void batchPutOperation(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&) final;
 
     void reference(WebCore::DOMCacheIdentifier) final;
     void dereference(WebCore::DOMCacheIdentifier) final;


### PR DESCRIPTION
#### 4a4f090090cbb3536a67f10cdbcf0851e64f276a
<pre>
Use DOMCacheEngine::CrossThreadRecord in CacheStorageConnection
<a href="https://bugs.webkit.org/show_bug.cgi?id=254430">https://bugs.webkit.org/show_bug.cgi?id=254430</a>
rdar://107290770

Reviewed by Youenn Fablet.

This would simplify the code a bit.

* Source/WebCore/Modules/cache/CacheStorageConnection.h:
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::queryCache):
(WebCore::DOMCache::batchPutOperation):
* Source/WebCore/Modules/cache/DOMCacheEngine.cpp:
(WebCore::DOMCacheEngine::CrossThreadRecord::isolatedCopy):
* Source/WebCore/Modules/cache/DOMCacheEngine.h:
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp:
(WebCore::isolatedCopyCrossThreadRecordsOrError):
(WebCore::WorkerCacheStorageConnection::retrieveRecords):
(WebCore::WorkerCacheStorageConnection::retrieveRecordsCompleted):
(WebCore::WorkerCacheStorageConnection::batchPutOperation):
(WebCore::toCrossThreadRecordData): Deleted.
(WebCore::fromCrossThreadRecordData): Deleted.
(WebCore::recordsDataFromRecords): Deleted.
(WebCore::recordsDataOrErrorFromRecords): Deleted.
(WebCore::recordsFromRecordsData): Deleted.
(WebCore::recordsOrErrorFromRecordsData): Deleted.
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h:
* Source/WebCore/page/CacheStorageProvider.h:
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::retrieveRecords):
(WebKit::WebCacheStorageConnection::batchPutOperation):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h:

Canonical link: <a href="https://commits.webkit.org/262219@main">https://commits.webkit.org/262219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac4bd6ef6bdd84b1ec81f4bc72b7171628a5ea86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/854 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1193 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/971 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/804 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/772 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1816 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/773 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/811 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/227 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/824 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->