### PR TITLE
Remove unused BlobRegistryImpl::writeBlobToFilePath

### DIFF
--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -370,22 +370,6 @@ void BlobRegistryImpl::writeBlobsToTemporaryFilesForIndexedDB(const Vector<Strin
     });
 }
 
-void BlobRegistryImpl::writeBlobToFilePath(const URL& blobURL, const String& path, Function<void(bool success)>&& completionHandler)
-{
-    Vector<BlobForFileWriting> blobsForWriting;
-    if (!populateBlobsForFileWriting({ blobURL.string() }, blobsForWriting) || blobsForWriting.size() != 1) {
-        completionHandler(false);
-        return;
-    }
-
-    blobUtilityQueue().dispatch([path, blobsForWriting = WTFMove(blobsForWriting), completionHandler = WTFMove(completionHandler)]() mutable {
-        bool success = writeFilePathsOrDataBuffersToFile(blobsForWriting.first().filePathsOrDataBuffers, FileSystem::openFile(path, FileSystem::FileOpenMode::Truncate), path);
-        callOnMainThread([success, completionHandler = WTFMove(completionHandler)]() {
-            completionHandler(success);
-        });
-    });
-}
-
 Vector<RefPtr<BlobDataFileReference>> BlobRegistryImpl::filesInBlob(const URL& url) const
 {
     auto* blobData = getBlobDataFromURL(url);

--- a/Source/WebCore/platform/network/BlobRegistryImpl.h
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.h
@@ -56,7 +56,6 @@ public:
     BlobData* getBlobDataFromURL(const URL&) const;
 
     Ref<ResourceHandle> createResourceHandle(const ResourceRequest&, ResourceHandleClient*);
-    void writeBlobToFilePath(const URL& blobURL, const String& path, Function<void(bool success)>&& completionHandler);
 
     void appendStorageItems(BlobData*, const BlobDataItemList&, long long offset, long long length);
 


### PR DESCRIPTION
#### 9fc9ff9d807016df0327358abc680bfdcf93666d
<pre>
Remove unused BlobRegistryImpl::writeBlobToFilePath
<a href="https://bugs.webkit.org/show_bug.cgi?id=254563">https://bugs.webkit.org/show_bug.cgi?id=254563</a>
rdar://107295924

Reviewed by Wenson Hsieh.

This functions apparently became unused after 208482@main, where the
NetworkProcess and UI process use case was deleted.

* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::BlobRegistryImpl::writeBlobToFilePath): Deleted.
* Source/WebCore/platform/network/BlobRegistryImpl.h:

Canonical link: <a href="https://commits.webkit.org/262322@main">https://commits.webkit.org/262322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e04c3efb377b9c311e86d1e387dddc8204c7512d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1230 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/768 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/980 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1169 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/814 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/813 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/786 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/840 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1834 "267 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/786 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/310 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/840 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->