### PR TITLE
Disconnect WKView from its WebViewImpl

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKView.h
@@ -39,6 +39,10 @@
 @class WKProcessGroup;
 @class WKViewData;
 
+// FIXME: Remove this file once rdar://105559864 and rdar://105560420 and rdar://105560497 are complete.
+// Note: rdar://105011969 tracks additional use of this file, but those are unused test utilities that are never built.
+// Also, this stub needs to be kept as long as Ventura-based macOS versions are used for performance testing.
+
 WK_CLASS_DEPRECATED_WITH_REPLACEMENT("WKWebView", macos(10.10, 10.14.4), ios(8.0, 12.2))
 @interface WKView : NSView <NSTextInputClient> {
 @private

--- a/Source/WebKit/UIProcess/API/mac/WKView.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKView.mm
@@ -52,11 +52,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/NakedRef.h>
 
-@interface WKViewData : NSObject {
-@public
-    std::unique_ptr<WebKit::WebViewImpl> _impl;
-}
-
+@interface WKViewData : NSObject
 @end
 
 @implementation WKViewData
@@ -88,86 +84,72 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (id)initWithFrame:(NSRect)frame processGroup:(WKProcessGroup *)processGroup browsingContextGroup:(WKBrowsingContextGroup *)browsingContextGroup
 {
-    return [self initWithFrame:frame contextRef:processGroup._contextRef pageGroupRef:browsingContextGroup._pageGroupRef relatedToPage:nil];
+    return nil;
 }
 
 - (id)initWithFrame:(NSRect)frame processGroup:(WKProcessGroup *)processGroup browsingContextGroup:(WKBrowsingContextGroup *)browsingContextGroup relatedToView:(WKView *)relatedView
 {
-    return [self initWithFrame:frame contextRef:processGroup._contextRef pageGroupRef:browsingContextGroup._pageGroupRef relatedToPage:relatedView ? relatedView.pageRef : nil];
+    return nil;
 }
 
 - (void)dealloc
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKView.class, self))
-        return;
-
-    _data->_impl->page().setIconLoadingClient(nullptr);
-    _data->_impl = nullptr;
-
-    [_data release];
-    _data = nil;
-
     [super dealloc];
 }
 
 - (WKBrowsingContextController *)browsingContextController
 {
-    return _data->_impl->browsingContextController();
+    return nil;
 }
 
 - (void)setDrawsBackground:(BOOL)drawsBackground
 {
-    _data->_impl->setDrawsBackground(drawsBackground);
 }
 
 - (BOOL)drawsBackground
 {
-    return _data->_impl->drawsBackground();
+    return NO;
 }
 
 - (NSColor *)_backgroundColor
 {
-    return _data->_impl->backgroundColor();
+    return nil;
 }
 
 - (void)_setBackgroundColor:(NSColor *)backgroundColor
 {
-    _data->_impl->setBackgroundColor(backgroundColor);
 }
 
 - (void)setDrawsTransparentBackground:(BOOL)drawsTransparentBackground
 {
-    _data->_impl->setDrawsBackground(!drawsTransparentBackground);
 }
 
 - (BOOL)drawsTransparentBackground
 {
-    return !_data->_impl->drawsBackground();
+    return NO;
 }
 
 - (BOOL)acceptsFirstResponder
 {
-    return _data->_impl->acceptsFirstResponder();
+    return NO;
 }
 
 - (BOOL)becomeFirstResponder
 {
-    return _data->_impl->becomeFirstResponder();
+    return NO;
 }
 
 - (BOOL)resignFirstResponder
 {
-    return _data->_impl->resignFirstResponder();
+    return NO;
 }
 
 - (void)viewWillStartLiveResize
 {
-    _data->_impl->viewWillStartLiveResize();
 }
 
 - (void)viewDidEndLiveResize
 {
-    _data->_impl->viewDidEndLiveResize();
 }
 
 - (BOOL)isFlipped
@@ -177,33 +159,21 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (NSSize)intrinsicContentSize
 {
-    return NSSizeFromCGSize(_data->_impl->intrinsicContentSize());
+    return { };
 }
 
 - (void)prepareContentInRect:(NSRect)rect
 {
-    _data->_impl->prepareContentInRect(NSRectToCGRect(rect));
 }
 
 - (void)setFrameSize:(NSSize)size
 {
-    [super setFrameSize:size];
-    _data->_impl->setFrameSize(NSSizeToCGSize(size));
 }
 
 #if USE(NSVIEW_SEMANTICCONTEXT)
 
 - (void)_setSemanticContext:(NSViewSemanticContext)semanticContext
 {
-    auto wasUsingFormSemanticContext = _data->_impl ? _data->_impl->useFormSemanticContext() : false;
-
-    [super _setSemanticContext:semanticContext];
-
-    if (!_data->_impl)
-        return;
-
-    if (wasUsingFormSemanticContext != _data->_impl->useFormSemanticContext())
-        _data->_impl->semanticContextDidChange();
 }
 
 #endif
@@ -212,11 +182,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)renewGState
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    _data->_impl->renewGState();
-    [super renewGState];
 }
 
-#define WEBCORE_COMMAND(command) - (void)command:(id)sender { _data->_impl->executeEditCommandForSelector(_cmd); }
+#define WEBCORE_COMMAND(command) - (void)command:(id)sender { }
 
 WEBCORE_COMMAND(alignCenter)
 WEBCORE_COMMAND(alignJustified)
@@ -325,29 +293,27 @@ WEBCORE_COMMAND(yankAndSelect)
 
 - (BOOL)writeSelectionToPasteboard:(NSPasteboard *)pasteboard types:(NSArray *)types
 {
-    return _data->_impl->writeSelectionToPasteboard(pasteboard, types);
+    return NO;
 }
 
 - (void)centerSelectionInVisibleArea:(id)sender 
 { 
-    _data->_impl->centerSelectionInVisibleArea();
 }
 
 - (id)validRequestorForSendType:(NSString *)sendType returnType:(NSString *)returnType
 {
-    return _data->_impl->validRequestorForSendAndReturnTypes(sendType, returnType);
+    return nil;
 }
 
 - (BOOL)readSelectionFromPasteboard:(NSPasteboard *)pasteboard 
 {
-    return _data->_impl->readSelectionFromPasteboard(pasteboard);
+    return NO;
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)changeFont:(id)sender
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    _data->_impl->changeFontFromFontManager();
 }
 
 /*
@@ -381,332 +347,284 @@ Some other editing-related methods still unimplemented:
 
 - (BOOL)validateUserInterfaceItem:(id <NSValidatedUserInterfaceItem>)item
 {
-    return _data->_impl->validateUserInterfaceItem(item);
+    return NO;
 }
 
 - (IBAction)startSpeaking:(id)sender
 {
-    _data->_impl->startSpeaking();
 }
 
 - (IBAction)stopSpeaking:(id)sender
 {
-    _data->_impl->stopSpeaking(sender);
 }
 
 - (IBAction)showGuessPanel:(id)sender
 {
-    _data->_impl->showGuessPanel(sender);
 }
 
 - (IBAction)checkSpelling:(id)sender
 {
-    _data->_impl->checkSpelling();
 }
 
 - (void)changeSpelling:(id)sender
 {
-    _data->_impl->changeSpelling(sender);
 }
 
 - (IBAction)toggleContinuousSpellChecking:(id)sender
 {
-    _data->_impl->toggleContinuousSpellChecking();
 }
 
 - (BOOL)isGrammarCheckingEnabled
 {
-    return _data->_impl->isGrammarCheckingEnabled();
+    return NO;
 }
 
 - (void)setGrammarCheckingEnabled:(BOOL)flag
 {
-    _data->_impl->setGrammarCheckingEnabled(flag);
 }
 
 - (IBAction)toggleGrammarChecking:(id)sender
 {
-    _data->_impl->toggleGrammarChecking();
 }
 
 - (IBAction)toggleAutomaticSpellingCorrection:(id)sender
 {
-    _data->_impl->toggleAutomaticSpellingCorrection();
 }
 
 - (void)orderFrontSubstitutionsPanel:(id)sender
 {
-    _data->_impl->orderFrontSubstitutionsPanel(sender);
 }
 
 - (IBAction)toggleSmartInsertDelete:(id)sender
 {
-    _data->_impl->toggleSmartInsertDelete();
 }
 
 - (BOOL)isAutomaticQuoteSubstitutionEnabled
 {
-    return _data->_impl->isAutomaticQuoteSubstitutionEnabled();
+    return NO;
 }
 
 - (void)setAutomaticQuoteSubstitutionEnabled:(BOOL)flag
 {
-    _data->_impl->setAutomaticQuoteSubstitutionEnabled(flag);
 }
 
 - (void)toggleAutomaticQuoteSubstitution:(id)sender
 {
-    _data->_impl->toggleAutomaticQuoteSubstitution();
 }
 
 - (BOOL)isAutomaticDashSubstitutionEnabled
 {
-    return _data->_impl->isAutomaticDashSubstitutionEnabled();
+    return NO;
 }
 
 - (void)setAutomaticDashSubstitutionEnabled:(BOOL)flag
 {
-    _data->_impl->setAutomaticDashSubstitutionEnabled(flag);
 }
 
 - (void)toggleAutomaticDashSubstitution:(id)sender
 {
-    _data->_impl->toggleAutomaticDashSubstitution();
 }
 
 - (BOOL)isAutomaticLinkDetectionEnabled
 {
-    return _data->_impl->isAutomaticLinkDetectionEnabled();
+    return NO;
 }
 
 - (void)setAutomaticLinkDetectionEnabled:(BOOL)flag
 {
-    _data->_impl->setAutomaticLinkDetectionEnabled(flag);
 }
 
 - (void)toggleAutomaticLinkDetection:(id)sender
 {
-    _data->_impl->toggleAutomaticLinkDetection();
 }
 
 - (BOOL)isAutomaticTextReplacementEnabled
 {
-    return _data->_impl->isAutomaticTextReplacementEnabled();
+    return NO;
 }
 
 - (void)setAutomaticTextReplacementEnabled:(BOOL)flag
 {
-    _data->_impl->setAutomaticTextReplacementEnabled(flag);
 }
 
 - (void)toggleAutomaticTextReplacement:(id)sender
 {
-    _data->_impl->toggleAutomaticTextReplacement();
 }
 
 - (void)uppercaseWord:(id)sender
 {
-    _data->_impl->uppercaseWord();
 }
 
 - (void)lowercaseWord:(id)sender
 {
-    _data->_impl->lowercaseWord();
 }
 
 - (void)capitalizeWord:(id)sender
 {
-    _data->_impl->capitalizeWord();
 }
 
 - (BOOL)_wantsKeyDownForEvent:(NSEvent *)event
 {
-    return _data->_impl->wantsKeyDownForEvent(event);
+    return NO;
 }
 
 - (void)scrollWheel:(NSEvent *)event
 {
-    _data->_impl->scrollWheel(event);
 }
 
 - (void)swipeWithEvent:(NSEvent *)event
 {
-    _data->_impl->swipeWithEvent(event);
 }
 
 - (void)mouseDown:(NSEvent *)event
 {
-    _data->_impl->mouseDown(event);
 }
 
 - (void)mouseUp:(NSEvent *)event
 {
-    _data->_impl->mouseUp(event);
 }
 
 - (void)mouseDragged:(NSEvent *)event
 {
-    _data->_impl->mouseDragged(event);
 }
 
 - (void)otherMouseDown:(NSEvent *)event
 {
-    _data->_impl->otherMouseDown(event);
 }
 
 - (void)otherMouseDragged:(NSEvent *)event
 {
-    _data->_impl->otherMouseDragged(event);
 }
 
 - (void)otherMouseUp:(NSEvent *)event
 {
-    _data->_impl->otherMouseUp(event);
 }
 
 - (void)rightMouseDown:(NSEvent *)event
 {
-    _data->_impl->rightMouseDown(event);
 }
 
 - (void)rightMouseDragged:(NSEvent *)event
 {
-    _data->_impl->rightMouseDragged(event);
 }
 
 - (void)rightMouseUp:(NSEvent *)event
 {
-    _data->_impl->rightMouseUp(event);
 }
 
 - (void)pressureChangeWithEvent:(NSEvent *)event
 {
-    _data->_impl->pressureChangeWithEvent(event);
 }
 
 - (BOOL)acceptsFirstMouse:(NSEvent *)event
 {
-    return _data->_impl->acceptsFirstMouse(event);
+    return NO;
 }
 
 - (BOOL)shouldDelayWindowOrderingForEvent:(NSEvent *)event
 {
-    return _data->_impl->shouldDelayWindowOrderingForEvent(event);
+    return NO;
 }
 
 - (void)doCommandBySelector:(SEL)selector
 {
-    _data->_impl->doCommandBySelector(selector);
 }
 
 - (void)insertText:(id)string
 {
-    _data->_impl->insertText(string);
 }
 
 - (void)insertText:(id)string replacementRange:(NSRange)replacementRange
 {
-    _data->_impl->insertText(string, replacementRange);
 }
 
 - (NSTextInputContext *)inputContext
 {
-    return _data->_impl->inputContext();
+    return nil;
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent *)event
 {
-    return _data->_impl->performKeyEquivalent(event);
+    return NO;
 }
 
 - (void)keyUp:(NSEvent *)theEvent
 {
-    _data->_impl->keyUp(theEvent);
 }
 
 - (void)keyDown:(NSEvent *)theEvent
 {
-    _data->_impl->keyDown(theEvent);
 }
 
 - (void)flagsChanged:(NSEvent *)theEvent
 {
-    _data->_impl->flagsChanged(theEvent);
 }
 
 - (void)setMarkedText:(id)string selectedRange:(NSRange)newSelectedRange replacementRange:(NSRange)replacementRange
 {
-    _data->_impl->setMarkedText(string, newSelectedRange, replacementRange);
 }
 
 - (void)unmarkText
 {
-    _data->_impl->unmarkText();
 }
 
 - (NSRange)selectedRange
 {
-    return _data->_impl->selectedRange();
+    return { };
 }
 
 - (BOOL)hasMarkedText
 {
-    return _data->_impl->hasMarkedText();
+    return NO;
 }
 
 - (NSRange)markedRange
 {
-    return _data->_impl->markedRange();
+    return { };
 }
 
 - (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)nsRange actualRange:(NSRangePointer)actualRange
 {
-    return _data->_impl->attributedSubstringForProposedRange(nsRange, actualRange);
+    return nil;
 }
 
 - (NSUInteger)characterIndexForPoint:(NSPoint)thePoint
 {
-    return _data->_impl->characterIndexForPoint(thePoint);
+    return 0;
 }
 
 - (NSRect)firstRectForCharacterRange:(NSRange)theRange actualRange:(NSRangePointer)actualRange
 {
-    return _data->_impl->firstRectForCharacterRange(theRange, actualRange);
+    return { };
 }
 
 - (void)selectedRangeWithCompletionHandler:(void(^)(NSRange selectedRange))completionHandlerPtr
 {
-    _data->_impl->selectedRangeWithCompletionHandler(completionHandlerPtr);
 }
 
 - (void)markedRangeWithCompletionHandler:(void(^)(NSRange markedRange))completionHandlerPtr
 {
-    _data->_impl->markedRangeWithCompletionHandler(completionHandlerPtr);
 }
 
 - (void)hasMarkedTextWithCompletionHandler:(void(^)(BOOL hasMarkedText))completionHandlerPtr
 {
-    _data->_impl->hasMarkedTextWithCompletionHandler(completionHandlerPtr);
 }
 
 - (void)attributedSubstringForProposedRange:(NSRange)nsRange completionHandler:(void(^)(NSAttributedString *attrString, NSRange actualRange))completionHandlerPtr
 {
-    _data->_impl->attributedSubstringForProposedRange(nsRange, completionHandlerPtr);
 }
 
 - (void)firstRectForCharacterRange:(NSRange)theRange completionHandler:(void(^)(NSRect firstRect, NSRange actualRange))completionHandlerPtr
 {
-    _data->_impl->firstRectForCharacterRange(theRange, completionHandlerPtr);
 }
 
 - (void)characterIndexForPoint:(NSPoint)thePoint completionHandler:(void(^)(NSUInteger))completionHandlerPtr
 {
-    _data->_impl->characterIndexForPoint(thePoint, completionHandlerPtr);
 }
 
 - (NSArray *)validAttributesForMarkedText
 {
-    return _data->_impl->validAttributesForMarkedText();
+    return nil;
 }
 
 #if ENABLE(DRAG_SUPPORT)
@@ -714,382 +632,287 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)draggedImage:(NSImage *)image endedAt:(NSPoint)endPoint operation:(NSDragOperation)operation
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    _data->_impl->draggedImage(image, NSPointToCGPoint(endPoint), operation);
 }
 
 - (NSDragOperation)draggingEntered:(id <NSDraggingInfo>)draggingInfo
 {
-    return _data->_impl->draggingEntered(draggingInfo);
+    return 0;
 }
 
 - (NSDragOperation)draggingUpdated:(id <NSDraggingInfo>)draggingInfo
 {
-    return _data->_impl->draggingUpdated(draggingInfo);
+    return 0;
 }
 
 - (void)draggingExited:(id <NSDraggingInfo>)draggingInfo
 {
-    _data->_impl->draggingExited(draggingInfo);
 }
 
 - (BOOL)prepareForDragOperation:(id <NSDraggingInfo>)draggingInfo
 {
-    return _data->_impl->prepareForDragOperation(draggingInfo);
+    return NO;
 }
 
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)draggingInfo
 {
-    return _data->_impl->performDragOperation(draggingInfo);
+    return NO;
 }
 
 - (NSView *)_hitTest:(NSPoint *)point dragTypes:(NSSet *)types
 {
-    return _data->_impl->hitTestForDragTypes(NSPointToCGPoint(*point), types);
+    return nil;
 }
 #endif // ENABLE(DRAG_SUPPORT)
 
 - (BOOL)_windowResizeMouseLocationIsInVisibleScrollerThumb:(NSPoint)point
 {
-    return _data->_impl->windowResizeMouseLocationIsInVisibleScrollerThumb(NSPointToCGPoint(point));
+    return NO;
 }
 
 - (void)viewWillMoveToWindow:(NSWindow *)window
 {
-    _data->_impl->viewWillMoveToWindow(window);
 }
 
 - (void)viewDidMoveToWindow
 {
-    _data->_impl->viewDidMoveToWindow();
 }
 
 - (void)drawRect:(NSRect)rect
 {
-    _data->_impl->drawRect(NSRectToCGRect(rect));
 }
 
 - (BOOL)isOpaque
 {
-    return _data->_impl->isOpaque();
+    return NO;
 }
 
 - (BOOL)mouseDownCanMoveWindow
 {
-    return WebKit::WebViewImpl::mouseDownCanMoveWindow();
+    return NO;
 }
 
 - (void)viewDidHide
 {
-    _data->_impl->viewDidHide();
 }
 
 - (void)viewDidUnhide
 {
-    _data->_impl->viewDidUnhide();
 }
 
 - (void)viewDidChangeBackingProperties
 {
-    _data->_impl->viewDidChangeBackingProperties();
 }
 
 - (void)_activeSpaceDidChange:(NSNotification *)notification
 {
-    _data->_impl->activeSpaceDidChange();
 }
 
 - (id)accessibilityFocusedUIElement
 {
-    return _data->_impl->accessibilityFocusedUIElement();
+    return nil;
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (BOOL)accessibilityIsIgnored
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    return _data->_impl->accessibilityIsIgnored();
+    return NO;
 }
 
 - (id)accessibilityHitTest:(NSPoint)point
 {
-    return _data->_impl->accessibilityHitTest(NSPointToCGPoint(point));
+    return nil;
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (id)accessibilityAttributeValue:(NSString *)attribute
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    return _data->_impl->accessibilityAttributeValue(attribute);
+    return nil;
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (id)accessibilityAttributeValue:(NSString *)attribute forParameter:(id)parameter
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    return _data->_impl->accessibilityAttributeValue(attribute, parameter);
+    return nil;
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (NSArray<NSString *> *)accessibilityParameterizedAttributeNames
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    NSArray<NSString *> *names = [super accessibilityParameterizedAttributeNames];
-    return [names arrayByAddingObject:@"AXConvertRelativeFrame"];
+    return nil;
 }
 
 - (NSView *)hitTest:(NSPoint)point
 {
-    if (!_data)
-        return [super hitTest:point];
-    return _data->_impl->hitTest(NSPointToCGPoint(point));
+    return nil;
 }
 
 - (NSInteger)conversationIdentifier
 {
-    return (NSInteger)self;
+    return 0;
 }
 
 - (void)quickLookWithEvent:(NSEvent *)event
 {
-    _data->_impl->quickLookWithEvent(event);
 }
 
 - (NSTrackingRectTag)addTrackingRect:(NSRect)rect owner:(id)owner userData:(void *)data assumeInside:(BOOL)assumeInside
 {
-    return _data->_impl->addTrackingRect(NSRectToCGRect(rect), owner, data, assumeInside);
+    return { };
 }
 
 - (NSTrackingRectTag)_addTrackingRect:(NSRect)rect owner:(id)owner userData:(void *)data assumeInside:(BOOL)assumeInside useTrackingNum:(int)tag
 {
-    return _data->_impl->addTrackingRectWithTrackingNum(NSRectToCGRect(rect), owner, data, assumeInside, tag);
+    return { };
 }
 
 - (void)_addTrackingRects:(NSRect *)rects owner:(id)owner userDataList:(void **)userDataList assumeInsideList:(BOOL *)assumeInsideList trackingNums:(NSTrackingRectTag *)trackingNums count:(int)count
 {
-    CGRect *cgRects = (CGRect *)calloc(1, sizeof(CGRect));
-    for (int i = 0; i < count; i++)
-        cgRects[i] = NSRectToCGRect(rects[i]);
-    _data->_impl->addTrackingRectsWithTrackingNums(cgRects, owner, userDataList, assumeInsideList, trackingNums, count);
-    free(cgRects);
 }
 
 - (void)removeTrackingRect:(NSTrackingRectTag)tag
 {
-    if (!_data)
-        return;
-    _data->_impl->removeTrackingRect(tag);
 }
 
 - (void)_removeTrackingRects:(NSTrackingRectTag *)tags count:(int)count
 {
-    if (!_data)
-        return;
-    _data->_impl->removeTrackingRects(tags, count);
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (NSString *)view:(NSView *)view stringForToolTip:(NSToolTipTag)tag point:(NSPoint)point userData:(void *)data
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    return _data->_impl->stringForToolTip(tag);
+    return nil;
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)pasteboardChangedOwner:(NSPasteboard *)pasteboard
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    _data->_impl->pasteboardChangedOwner(pasteboard);
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)pasteboard:(NSPasteboard *)pasteboard provideDataForType:(NSString *)type
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    _data->_impl->provideDataForPasteboard(pasteboard, type);
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (NSArray *)namesOfPromisedFilesDroppedAtDestination:(NSURL *)dropDestination
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    return _data->_impl->namesOfPromisedFilesDroppedAtDestination(dropDestination);
+    return nil;
 }
 
 - (void)maybeInstallIconLoadingClient
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    class IconLoadingClient : public API::IconLoadingClient {
-        WTF_MAKE_FAST_ALLOCATED;
-    public:
-        explicit IconLoadingClient(WKView *wkView)
-            : m_wkView(wkView)
-        {
-        }
-
-        static SEL delegateSelector()
-        {
-            return @selector(_shouldLoadIconWithParameters:completionHandler:);
-        }
-
-    private:
-        typedef void (^IconLoadCompletionHandler)(NSData*);
-
-        void getLoadDecisionForIcon(const WebCore::LinkIcon& linkIcon, CompletionHandler<void(CompletionHandler<void(API::Data*)>&&)>&& completionHandler) override
-        {
-            RetainPtr<_WKLinkIconParameters> parameters = adoptNS([[_WKLinkIconParameters alloc] _initWithLinkIcon:linkIcon]);
-
-            [m_wkView _shouldLoadIconWithParameters:parameters.get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](IconLoadCompletionHandler loadCompletionHandler) mutable {
-                ASSERT(RunLoop::isMain());
-                if (loadCompletionHandler) {
-                    completionHandler([loadCompletionHandler = makeBlockPtr(loadCompletionHandler)](API::Data* data) {
-                        loadCompletionHandler(wrapper(data));
-                    });
-                } else
-                    completionHandler(nullptr);
-            }).get()];
-        }
-
-        WKView *m_wkView;
-    };
-    ALLOW_DEPRECATED_DECLARATIONS_END
-
-    if ([self respondsToSelector:IconLoadingClient::delegateSelector()])
-        _data->_impl->page().setIconLoadingClient(makeUnique<IconLoadingClient>(self));
 }
 
 - (instancetype)initWithFrame:(NSRect)frame processPool:(NakedRef<WebKit::WebProcessPool>)processPool configuration:(Ref<API::PageConfiguration>&&)configuration
 {
-    self = [super initWithFrame:frame];
-    if (!self)
-        return nil;
-
-    WebKit::InitializeWebKit2();
-
-    _data = [[WKViewData alloc] init];
-    _data->_impl = makeUnique<WebKit::WebViewImpl>(self, nullptr, processPool.get(), WTFMove(configuration));
-
-    [self maybeInstallIconLoadingClient];
-    [WebViewVisualIdentificationOverlay installForWebViewIfNeeded:self kind:@"WKView" deprecated:YES];
-
-    return self;
+    return nil;
 }
 
 - (void)_setThumbnailView:(_WKThumbnailView *)thumbnailView
 {
-    _data->_impl->setThumbnailView(thumbnailView);
 }
 
 - (_WKThumbnailView *)_thumbnailView
 {
-    if (!_data->_impl)
-        return nil;
-    return _data->_impl->thumbnailView();
+    return nil;
 }
 
 - (NSTextInputContext *)_web_superInputContext
 {
-    return [super inputContext];
+    return nil;
 }
 
 - (void)_web_superQuickLookWithEvent:(NSEvent *)event
 {
-    [super quickLookWithEvent:event];
 }
 
 - (void)_web_superSwipeWithEvent:(NSEvent *)event
 {
-    [super swipeWithEvent:event];
 }
 
 - (void)_web_superMagnifyWithEvent:(NSEvent *)event
 {
-    [super magnifyWithEvent:event];
 }
 
 - (void)_web_superSmartMagnifyWithEvent:(NSEvent *)event
 {
-    [super smartMagnifyWithEvent:event];
 }
 
 - (void)_web_superRemoveTrackingRect:(NSTrackingRectTag)tag
 {
-    [super removeTrackingRect:tag];
 }
 
 - (id)_web_superAccessibilityAttributeValue:(NSString *)attribute
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return [super accessibilityAttributeValue:attribute];
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    return nil;
 }
 
 - (void)_web_superDoCommandBySelector:(SEL)selector
 {
-    [super doCommandBySelector:selector];
 }
 
 - (BOOL)_web_superPerformKeyEquivalent:(NSEvent *)event
 {
-    return [super performKeyEquivalent:event];
+    return NO;
 }
 
 - (void)_web_superKeyDown:(NSEvent *)event
 {
-    [super keyDown:event];
 }
 
 - (NSView *)_web_superHitTest:(NSPoint)point
 {
-    return [super hitTest:point];
+    return nil;
 }
 
 - (id)_web_immediateActionAnimationControllerForHitTestResultInternal:(API::HitTestResult*)hitTestResult withType:(uint32_t)type userData:(API::Object*)userData
 {
-    return [self _immediateActionAnimationControllerForHitTestResult:WebKit::toAPI(hitTestResult) withType:type userData:WebKit::toAPI(userData)];
+    return nil;
 }
 
 - (void)_web_prepareForImmediateActionAnimation
 {
-    [self _prepareForImmediateActionAnimation];
 }
 
 - (void)_web_cancelImmediateActionAnimation
 {
-    [self _cancelImmediateActionAnimation];
 }
 
 - (void)_web_completeImmediateActionAnimation
 {
-    [self _completeImmediateActionAnimation];
 }
 
 - (void)_web_didChangeContentSize:(NSSize)newSize
 {
-    [self _didChangeContentSize:newSize];
 }
 
 #if ENABLE(DRAG_SUPPORT)
 
 - (void)_web_didPerformDragOperation:(BOOL)handled
 {
-    UNUSED_PARAM(handled);
 }
 
 - (WKDragDestinationAction)_web_dragDestinationActionForDraggingInfo:(id <NSDraggingInfo>)draggingInfo
 {
-    return WKDragDestinationActionAny;
+    return 0;
 }
 
 #endif
 
 - (void)_web_dismissContentRelativeChildWindows
 {
-    [self _dismissContentRelativeChildWindows];
 }
 
 - (void)_web_dismissContentRelativeChildWindowsWithAnimation:(BOOL)withAnimation
 {
-    [self _dismissContentRelativeChildWindowsWithAnimation:withAnimation];
 }
 
 - (void)_web_editorStateDidChange
@@ -1098,7 +921,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_web_gestureEventWasNotHandledByWebCore:(NSEvent *)event
 {
-    [self _gestureEventWasNotHandledByWebCore:event];
 }
 
 - (void)_didHandleAcceptedCandidate
@@ -1115,22 +937,20 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (NSTouchBar *)makeTouchBar
 {
-    return _data->_impl->makeTouchBar();
+    return nil;
 }
 
 - (NSCandidateListTouchBarItem *)candidateListTouchBarItem
 {
-    return _data->_impl->candidateListTouchBarItem();
+    return nil;
 }
 
 - (void)_web_didAddMediaControlsManager:(id)controlsManager
 {
-    [self _addMediaPlaybackControlsView:controlsManager];
 }
 
 - (void)_web_didRemoveMediaControlsManager
 {
-    [self _removeMediaPlaybackControlsView];
 }
 
 #endif // HAVE(TOUCH_BAR)
@@ -1139,16 +959,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (NSRect)scrollViewFrame
 {
-    if (!_data->_impl)
-        return NSZeroRect;
-    return _data->_impl->scrollViewFrame();
+    return { };
 }
 
 - (BOOL)hasScrolledContentsUnderTitlebar
 {
-    if (!_data->_impl)
-        return NO;
-    return _data->_impl->hasScrolledContentsUnderTitlebar();
+    return NO;
 }
 
 #endif // HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)
@@ -1157,22 +973,20 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (NSString *)filePromiseProvider:(NSFilePromiseProvider *)filePromiseProvider fileNameForType:(NSString *)fileType
 {
-    return _data->_impl->fileNameForFilePromiseProvider(filePromiseProvider, fileType);
+    return nil;
 }
 
 - (void)filePromiseProvider:(NSFilePromiseProvider *)filePromiseProvider writePromiseToURL:(NSURL *)url completionHandler:(void (^)(NSError *error))completionHandler
 {
-    _data->_impl->writeToURLForFilePromiseProvider(filePromiseProvider, url, completionHandler);
 }
 
 - (NSDragOperation)draggingSession:(NSDraggingSession *)session sourceOperationMaskForDraggingContext:(NSDraggingContext)context
 {
-    return _data->_impl->dragSourceOperationMask(session, context);
+    return 0;
 }
 
 - (void)draggingSession:(NSDraggingSession *)session endedAtPoint:(NSPoint)screenPoint operation:(NSDragOperation)operation
 {
-    _data->_impl->draggingSessionEnded(session, screenPoint, operation);
 }
 
 #endif // ENABLE(DRAG_SUPPORT)
@@ -1186,412 +1000,340 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)saveBackForwardSnapshotForCurrentItem
 {
-    _data->_impl->saveBackForwardSnapshotForCurrentItem();
 }
 
 - (void)saveBackForwardSnapshotForItem:(WKBackForwardListItemRef)item
 {
-    _data->_impl->saveBackForwardSnapshotForItem(*WebKit::toImpl(item));
 }
 
 - (id)initWithFrame:(NSRect)frame contextRef:(WKContextRef)contextRef pageGroupRef:(WKPageGroupRef)pageGroupRef
 {
-    return [self initWithFrame:frame contextRef:contextRef pageGroupRef:pageGroupRef relatedToPage:nil];
+    return nil;
 }
-
-#if PLATFORM(MAC)
-static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(NSUserInterfaceLayoutDirection direction)
-{
-    switch (direction) {
-    case NSUserInterfaceLayoutDirectionLeftToRight:
-        return WebCore::UserInterfaceLayoutDirection::LTR;
-    case NSUserInterfaceLayoutDirectionRightToLeft:
-        return WebCore::UserInterfaceLayoutDirection::RTL;
-    }
-    return WebCore::UserInterfaceLayoutDirection::LTR;
-}
-#endif
 
 - (id)initWithFrame:(NSRect)frame contextRef:(WKContextRef)contextRef pageGroupRef:(WKPageGroupRef)pageGroupRef relatedToPage:(WKPageRef)relatedPage
 {
-    auto configuration = API::PageConfiguration::create();
-    configuration->setProcessPool(WebKit::toImpl(contextRef));
-    configuration->setPageGroup(WebKit::toImpl(pageGroupRef));
-    configuration->setRelatedPage(WebKit::toImpl(relatedPage));
-#if PLATFORM(MAC)
-    configuration->setPreferences(&configuration->pageGroup()->preferences());
-    configuration->preferences()->setSystemLayoutDirection(static_cast<uint32_t>(toUserInterfaceLayoutDirection(self.userInterfaceLayoutDirection)));
-#endif
-
-    return [self initWithFrame:frame processPool:*WebKit::toImpl(contextRef) configuration:WTFMove(configuration)];
+    return nil;
 }
 
 - (id)initWithFrame:(NSRect)frame configurationRef:(WKPageConfigurationRef)configurationRef
 {
-    Ref<API::PageConfiguration> configuration = WebKit::toImpl(configurationRef)->copy();
-    auto& processPool = *configuration->processPool();
-
-    return [self initWithFrame:frame processPool:processPool configuration:WTFMove(configuration)];
+    return nil;
 }
 
 - (BOOL)wantsUpdateLayer
 {
-    return WebKit::WebViewImpl::wantsUpdateLayer();
+    return NO;
 }
 
 - (void)updateLayer
 {
-    _data->_impl->updateLayer();
 }
 
 - (WKPageRef)pageRef
 {
-    return WebKit::toAPI(&_data->_impl->page());
+    return nullptr;
 }
 
 - (BOOL)canChangeFrameLayout:(WKFrameRef)frameRef
 {
-    return _data->_impl->canChangeFrameLayout(*WebKit::toImpl(frameRef));
+    return NO;
 }
 
 - (NSPrintOperation *)printOperationWithPrintInfo:(NSPrintInfo *)printInfo forFrame:(WKFrameRef)frameRef
 {
-    return _data->_impl->printOperationWithPrintInfo(printInfo, *WebKit::toImpl(frameRef));
+    return nil;
 }
 
 - (void)setFrame:(NSRect)rect andScrollBy:(NSSize)offset
 {
-    _data->_impl->setFrameAndScrollBy(NSRectToCGRect(rect), NSSizeToCGSize(offset));
 }
 
 - (void)disableFrameSizeUpdates
 {
-    _data->_impl->disableFrameSizeUpdates();
 }
 
 - (void)enableFrameSizeUpdates
 {
-    _data->_impl->enableFrameSizeUpdates();
 }
 
 - (BOOL)frameSizeUpdatesDisabled
 {
-    return _data->_impl->frameSizeUpdatesDisabled();
+    return NO;
 }
 
 + (void)hideWordDefinitionWindow
 {
-    WebKit::WebViewImpl::hideWordDefinitionWindow();
 }
 
 - (NSSize)minimumSizeForAutoLayout
 {
-    return NSSizeFromCGSize(_data->_impl->minimumSizeForAutoLayout());
+    return { };
 }
 
 - (void)setMinimumSizeForAutoLayout:(NSSize)minimumSizeForAutoLayout
 {
-    _data->_impl->setMinimumSizeForAutoLayout(NSSizeToCGSize(minimumSizeForAutoLayout));
 }
 
 - (NSSize)sizeToContentAutoSizeMaximumSize
 {
-    return NSSizeFromCGSize(_data->_impl->sizeToContentAutoSizeMaximumSize());
+    return { };
 }
 
 - (void)setSizeToContentAutoSizeMaximumSize:(NSSize)sizeToContentAutoSizeMaximumSize
 {
-    _data->_impl->setSizeToContentAutoSizeMaximumSize(NSSizeToCGSize(sizeToContentAutoSizeMaximumSize));
 }
 
 - (BOOL)shouldExpandToViewHeightForAutoLayout
 {
-    return _data->_impl->shouldExpandToViewHeightForAutoLayout();
+    return NO;
 }
 
 - (void)setShouldExpandToViewHeightForAutoLayout:(BOOL)shouldExpand
 {
-    return _data->_impl->setShouldExpandToViewHeightForAutoLayout(shouldExpand);
 }
 
 - (BOOL)shouldClipToVisibleRect
 {
-    return _data->_impl->clipsToVisibleRect();
+    return NO;
 }
 
 - (void)setShouldClipToVisibleRect:(BOOL)clipsToVisibleRect
 {
-    _data->_impl->setClipsToVisibleRect(clipsToVisibleRect);
 }
 
 - (NSColor *)underlayColor
 {
-    return _data->_impl->underlayColor().autorelease();
+    return nil;
 }
 
 - (void)setUnderlayColor:(NSColor *)underlayColor
 {
-    _data->_impl->setUnderlayColor(underlayColor);
 }
 
 - (NSView *)_inspectorAttachmentView
 {
-    return _data->_impl->inspectorAttachmentView();
+    return nil;
 }
 
 - (void)_setInspectorAttachmentView:(NSView *)newView
 {
-    _data->_impl->setInspectorAttachmentView(newView);
 }
 
 - (NSView *)fullScreenPlaceholderView
 {
-    return _data->_impl->fullScreenPlaceholderView();
+    return nil;
 }
 
 // FIXME: This returns an autoreleased object. Should it really be prefixed 'create'?
 - (NSWindow *)createFullScreenWindow
 {
-    return _data->_impl->fullScreenWindow();
+    return nil;
 }
 
 - (void)beginDeferringViewInWindowChanges
 {
-    _data->_impl->beginDeferringViewInWindowChanges();
 }
 
 - (void)endDeferringViewInWindowChanges
 {
-    _data->_impl->endDeferringViewInWindowChanges();
 }
 
 - (void)endDeferringViewInWindowChangesSync
 {
-    _data->_impl->endDeferringViewInWindowChangesSync();
 }
 
 - (void)_prepareForMoveToWindow:(NSWindow *)targetWindow withCompletionHandler:(void(^)(void))completionHandler
 {
-    auto completionHandlerCopy = makeBlockPtr(completionHandler);
-    _data->_impl->prepareForMoveToWindow(targetWindow, [completionHandlerCopy] {
-        completionHandlerCopy();
-    });
 }
 
 - (BOOL)isDeferringViewInWindowChanges
 {
-    return _data->_impl->isDeferringViewInWindowChanges();
+    return NO;
 }
 
 - (BOOL)windowOcclusionDetectionEnabled
 {
-    return _data->_impl->windowOcclusionDetectionEnabled();
+    return NO;
 }
 
 - (void)setWindowOcclusionDetectionEnabled:(BOOL)enabled
 {
-    _data->_impl->setWindowOcclusionDetectionEnabled(enabled);
 }
 
 - (void)setAllowsBackForwardNavigationGestures:(BOOL)allowsBackForwardNavigationGestures
 {
-    _data->_impl->setAllowsBackForwardNavigationGestures(allowsBackForwardNavigationGestures);
 }
 
 - (BOOL)allowsBackForwardNavigationGestures
 {
-    return _data->_impl->allowsBackForwardNavigationGestures();
+    return NO;
 }
 
 - (BOOL)allowsLinkPreview
 {
-    return _data->_impl->allowsLinkPreview();
+    return NO;
 }
 
 - (void)setAllowsLinkPreview:(BOOL)allowsLinkPreview
 {
-    _data->_impl->setAllowsLinkPreview(allowsLinkPreview);
 }
 
 - (void)_setIgnoresAllEvents:(BOOL)ignoresAllEvents
 {
-    _data->_impl->setIgnoresAllEvents(ignoresAllEvents);
 }
 
 // Forward _setIgnoresNonWheelMouseEvents to _setIgnoresNonWheelEvents to avoid breaking existing clients.
 - (void)_setIgnoresNonWheelMouseEvents:(BOOL)ignoresNonWheelMouseEvents
 {
-    _data->_impl->setIgnoresNonWheelEvents(ignoresNonWheelMouseEvents);
 }
 
 - (void)_setIgnoresNonWheelEvents:(BOOL)ignoresNonWheelEvents
 {
-    _data->_impl->setIgnoresNonWheelEvents(ignoresNonWheelEvents);
 }
 
 - (BOOL)_ignoresNonWheelEvents
 {
-    return _data->_impl->ignoresNonWheelEvents();
+    return NO;
 }
 
 - (BOOL)_ignoresAllEvents
 {
-    return _data->_impl->ignoresAllEvents();
+    return NO;
 }
 
 - (void)_setOverrideDeviceScaleFactor:(CGFloat)deviceScaleFactor
 {
-    _data->_impl->page().setCustomDeviceScaleFactor(deviceScaleFactor);
 }
 
 - (CGFloat)_overrideDeviceScaleFactor
 {
-    return _data->_impl->page().customDeviceScaleFactor().value_or(0);
+    return { };
 }
 
 - (WKLayoutMode)_layoutMode
 {
-    return _data->_impl->layoutMode();
+    return 0;
 }
 
 - (void)_setLayoutMode:(WKLayoutMode)layoutMode
 {
-    _data->_impl->setLayoutMode(layoutMode);
 }
 
 - (CGSize)_fixedLayoutSize
 {
-    return _data->_impl->fixedLayoutSize();
+    return { };
 }
 
 - (void)_setFixedLayoutSize:(CGSize)fixedLayoutSize
 {
-    _data->_impl->setFixedLayoutSize(fixedLayoutSize);
 }
 
 - (CGFloat)_viewScale
 {
-    return _data->_impl->viewScale();
+    return 0;
 }
 
 - (void)_setViewScale:(CGFloat)viewScale
 {
-    if (viewScale <= 0 || isnan(viewScale) || isinf(viewScale))
-        [NSException raise:NSInvalidArgumentException format:@"View scale should be a positive number"];
-
-    _data->_impl->setViewScale(viewScale);
 }
 
 - (void)_setTopContentInset:(CGFloat)contentInset
 {
-    return _data->_impl->setTopContentInset(contentInset);
 }
 
 - (CGFloat)_topContentInset
 {
-    return _data->_impl->topContentInset();
+    return 0;
 }
 
 - (void)_setTotalHeightOfBanners:(CGFloat)totalHeightOfBanners
 {
-    _data->_impl->setTotalHeightOfBanners(totalHeightOfBanners);
 }
 
 - (CGFloat)_totalHeightOfBanners
 {
-    return _data->_impl->totalHeightOfBanners();
+    return 0;
 }
 
 - (void)_setOverlayScrollbarStyle:(_WKOverlayScrollbarStyle)scrollbarStyle
 {
-    _data->_impl->setOverlayScrollbarStyle(toCoreScrollbarStyle(scrollbarStyle));
 }
 
 - (_WKOverlayScrollbarStyle)_overlayScrollbarStyle
 {
-    return toAPIScrollbarStyle(_data->_impl->overlayScrollbarStyle());
+    return _WKOverlayScrollbarStyleDefault;
 }
 
 - (NSColor *)_pageExtendedBackgroundColor
 {
-    return _data->_impl->pageExtendedBackgroundColor().autorelease();
+    return nil;
 }
 
 - (BOOL)isUsingUISideCompositing
 {
-    return _data->_impl->isUsingUISideCompositing();
+    return NO;
 }
 
 - (void)setAllowsMagnification:(BOOL)allowsMagnification
 {
-    _data->_impl->setAllowsMagnification(allowsMagnification);
 }
 
 - (BOOL)allowsMagnification
 {
-    return _data->_impl->allowsMagnification();
+    return NO;
 }
 
 - (void)magnifyWithEvent:(NSEvent *)event
 {
-    _data->_impl->magnifyWithEvent(event);
 }
 
 #if ENABLE(MAC_GESTURE_EVENTS)
 - (void)rotateWithEvent:(NSEvent *)event
 {
-    _data->_impl->rotateWithEvent(event);
 }
 #endif
 
 - (void)_gestureEventWasNotHandledByWebCore:(NSEvent *)event
 {
-    _data->_impl->gestureEventWasNotHandledByWebCoreFromViewOnly(event);
 }
 
 - (void)_simulateMouseMove:(NSEvent *)event
 {
-    _data->_impl->mouseMoved(event);
 }
 
 - (void)smartMagnifyWithEvent:(NSEvent *)event
 {
-    _data->_impl->smartMagnifyWithEvent(event);
 }
 
 - (void)setMagnification:(double)magnification centeredAtPoint:(NSPoint)point
 {
-    _data->_impl->setMagnification(magnification, NSPointToCGPoint(point));
 }
 
 - (void)setMagnification:(double)magnification
 {
-    _data->_impl->setMagnification(magnification);
 }
 
 - (double)magnification
 {
-    return _data->_impl->magnification();
+    return 0;
 }
 
 - (void)_setCustomSwipeViews:(NSArray *)customSwipeViews
 {
-    _data->_impl->setCustomSwipeViews(customSwipeViews);
 }
 
 - (void)_setCustomSwipeViewsTopContentInset:(float)topContentInset
 {
-    _data->_impl->setCustomSwipeViewsTopContentInset(topContentInset);
 }
 
 - (BOOL)_tryToSwipeWithEvent:(NSEvent *)event ignoringPinnedState:(BOOL)ignoringPinnedState
 {
-    return _data->_impl->tryToSwipeWithEvent(event, ignoringPinnedState);
+    return NO;
 }
 
 - (void)_setDidMoveSwipeSnapshotCallback:(void(^)(CGRect))callback
 {
-    _data->_impl->setDidMoveSwipeSnapshotCallback(callback);
 }
 
 - (id)_immediateActionAnimationControllerForHitTestResult:(WKHitTestResultRef)hitTestResult withType:(uint32_t)type userData:(WKTypeRef)userData
@@ -1617,54 +1359,37 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(NSUs
 
 - (void)_dismissContentRelativeChildWindows
 {
-    _data->_impl->dismissContentRelativeChildWindowsFromViewOnly();
 }
 
 - (void)_dismissContentRelativeChildWindowsWithAnimation:(BOOL)withAnimation
 {
-    _data->_impl->dismissContentRelativeChildWindowsWithAnimationFromViewOnly(withAnimation);
 }
 
 - (void)_setAutomaticallyAdjustsContentInsets:(BOOL)automaticallyAdjustsContentInsets
 {
-    _data->_impl->setAutomaticallyAdjustsContentInsets(automaticallyAdjustsContentInsets);
 }
 
 - (BOOL)_automaticallyAdjustsContentInsets
 {
-    return _data->_impl->automaticallyAdjustsContentInsets();
+    return NO;
 }
 
 - (void)setUserInterfaceLayoutDirection:(NSUserInterfaceLayoutDirection)userInterfaceLayoutDirection
 {
-    [super setUserInterfaceLayoutDirection:userInterfaceLayoutDirection];
-
-    _data->_impl->setUserInterfaceLayoutDirection(userInterfaceLayoutDirection);
 }
 
 - (BOOL)_wantsMediaPlaybackControlsView
 {
-#if HAVE(TOUCH_BAR)
-    return _data->_impl->clientWantsMediaPlaybackControlsView();
-#else
     return NO;
-#endif
 }
 
 - (void)_setWantsMediaPlaybackControlsView:(BOOL)wantsMediaPlaybackControlsView
 {
-#if HAVE(TOUCH_BAR)
-    _data->_impl->setClientWantsMediaPlaybackControlsView(wantsMediaPlaybackControlsView);
-#endif
 }
 
 - (id)_mediaPlaybackControlsView
 {
-#if HAVE(TOUCH_BAR) && ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
-    return _data->_impl->clientWantsMediaPlaybackControlsView() ? _data->_impl->mediaPlaybackControlsView() : nil;
-#else
     return nil;
-#endif
 }
 
 // This method is for subclasses to override.
@@ -1679,51 +1404,36 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(NSUs
 
 - (void)_doAfterNextPresentationUpdate:(void (^)(void))updateBlock
 {
-    auto updateBlockCopy = makeBlockPtr(updateBlock);
-    _data->_impl->page().callAfterNextPresentationUpdate([updateBlockCopy] {
-        if (updateBlockCopy)
-            updateBlockCopy();
-    });
 }
 
 - (void)_setShouldSuppressFirstResponderChanges:(BOOL)shouldSuppress
 {
-    _data->_impl->setShouldSuppressFirstResponderChanges(shouldSuppress);
 }
 
 - (void)viewDidChangeEffectiveAppearance
 {
-    // This can be called during [super initWithCoder:] and [super initWithFrame:].
-    // That is before _data or _impl is ready to be used, so check. <rdar://problem/39611236>
-    if (!_data || !_data->_impl)
-        return;
-
-    _data->_impl->effectiveAppearanceDidChange();
 }
 
 - (void)_setUseSystemAppearance:(BOOL)useSystemAppearance
 {
-    _data->_impl->setUseSystemAppearance(useSystemAppearance);
 }
 
 - (BOOL)_useSystemAppearance
 {
-    return _data->_impl->useSystemAppearance();
+    return NO;
 }
 
 - (BOOL)acceptsPreviewPanelControl:(QLPreviewPanel *)panel
 {
-    return _data->_impl->acceptsPreviewPanelControl(panel);
+    return NO;
 }
 
 - (void)beginPreviewPanelControl:(QLPreviewPanel *)panel
 {
-    _data->_impl->beginPreviewPanelControl(panel);
 }
 
 - (void)endPreviewPanelControl:(QLPreviewPanel *)panel
 {
-    _data->_impl->endPreviewPanelControl(panel);
 }
 
 @end


### PR DESCRIPTION
#### 613982b34447b24cb85747efbf2427a320838f12
<pre>
Disconnect WKView from its WebViewImpl
<a href="https://bugs.webkit.org/show_bug.cgi?id=254570">https://bugs.webkit.org/show_bug.cgi?id=254570</a>
rdar://107299990

Reviewed by Tim Horton.

WKView.h is proving difficult to remove.
It&apos;s included by several internal projects that don&apos;t use it any more.
The ObjC class&apos;s existence is necessary for performance testing on Ventura.
We don&apos;t need to completely remove it.  Just disconnect it from its
WebViewImpl as a first step, while keeping all the ObjC selectors existing
right where they are.  Nothing uses it any more, and this should minimize
other breakage.

* Source/WebKit/UIProcess/API/Cocoa/WKView.h:
* Source/WebKit/UIProcess/API/mac/WKView.mm:
(-[WKView initWithFrame:processGroup:browsingContextGroup:]):
(-[WKView initWithFrame:processGroup:browsingContextGroup:relatedToView:]):
(-[WKView dealloc]):
(-[WKView browsingContextController]):
(-[WKView setDrawsBackground:]):
(-[WKView drawsBackground]):
(-[WKView _backgroundColor]):
(-[WKView _setBackgroundColor:]):
(-[WKView setDrawsTransparentBackground:]):
(-[WKView drawsTransparentBackground]):
(-[WKView acceptsFirstResponder]):
(-[WKView becomeFirstResponder]):
(-[WKView resignFirstResponder]):
(-[WKView viewWillStartLiveResize]):
(-[WKView viewDidEndLiveResize]):
(-[WKView intrinsicContentSize]):
(-[WKView prepareContentInRect:]):
(-[WKView setFrameSize:]):
(-[WKView _setSemanticContext:]):
(-[WKView ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
(-[WKView writeSelectionToPasteboard:types:]):
(-[WKView centerSelectionInVisibleArea:]):
(-[WKView validRequestorForSendType:returnType:]):
(-[WKView readSelectionFromPasteboard:]):
(-[WKView changeFont:]):
(-[WKView validateUserInterfaceItem:]):
(-[WKView startSpeaking:]):
(-[WKView stopSpeaking:]):
(-[WKView showGuessPanel:]):
(-[WKView checkSpelling:]):
(-[WKView changeSpelling:]):
(-[WKView toggleContinuousSpellChecking:]):
(-[WKView isGrammarCheckingEnabled]):
(-[WKView setGrammarCheckingEnabled:]):
(-[WKView toggleGrammarChecking:]):
(-[WKView toggleAutomaticSpellingCorrection:]):
(-[WKView orderFrontSubstitutionsPanel:]):
(-[WKView toggleSmartInsertDelete:]):
(-[WKView isAutomaticQuoteSubstitutionEnabled]):
(-[WKView setAutomaticQuoteSubstitutionEnabled:]):
(-[WKView toggleAutomaticQuoteSubstitution:]):
(-[WKView isAutomaticDashSubstitutionEnabled]):
(-[WKView setAutomaticDashSubstitutionEnabled:]):
(-[WKView toggleAutomaticDashSubstitution:]):
(-[WKView isAutomaticLinkDetectionEnabled]):
(-[WKView setAutomaticLinkDetectionEnabled:]):
(-[WKView toggleAutomaticLinkDetection:]):
(-[WKView isAutomaticTextReplacementEnabled]):
(-[WKView setAutomaticTextReplacementEnabled:]):
(-[WKView toggleAutomaticTextReplacement:]):
(-[WKView uppercaseWord:]):
(-[WKView lowercaseWord:]):
(-[WKView capitalizeWord:]):
(-[WKView _wantsKeyDownForEvent:]):
(-[WKView scrollWheel:]):
(-[WKView swipeWithEvent:]):
(-[WKView mouseDown:]):
(-[WKView mouseUp:]):
(-[WKView mouseDragged:]):
(-[WKView otherMouseDown:]):
(-[WKView otherMouseDragged:]):
(-[WKView otherMouseUp:]):
(-[WKView rightMouseDown:]):
(-[WKView rightMouseDragged:]):
(-[WKView rightMouseUp:]):
(-[WKView pressureChangeWithEvent:]):
(-[WKView acceptsFirstMouse:]):
(-[WKView shouldDelayWindowOrderingForEvent:]):
(-[WKView doCommandBySelector:]):
(-[WKView insertText:]):
(-[WKView insertText:replacementRange:]):
(-[WKView inputContext]):
(-[WKView performKeyEquivalent:]):
(-[WKView keyUp:]):
(-[WKView keyDown:]):
(-[WKView flagsChanged:]):
(-[WKView setMarkedText:selectedRange:replacementRange:]):
(-[WKView unmarkText]):
(-[WKView selectedRange]):
(-[WKView hasMarkedText]):
(-[WKView markedRange]):
(-[WKView attributedSubstringForProposedRange:actualRange:]):
(-[WKView characterIndexForPoint:]):
(-[WKView firstRectForCharacterRange:actualRange:]):
(-[WKView selectedRangeWithCompletionHandler:]):
(-[WKView markedRangeWithCompletionHandler:]):
(-[WKView hasMarkedTextWithCompletionHandler:]):
(-[WKView attributedSubstringForProposedRange:completionHandler:]):
(-[WKView firstRectForCharacterRange:completionHandler:]):
(-[WKView characterIndexForPoint:completionHandler:]):
(-[WKView validAttributesForMarkedText]):
(-[WKView draggedImage:endedAt:operation:]):
(-[WKView draggingEntered:]):
(-[WKView draggingUpdated:]):
(-[WKView draggingExited:]):
(-[WKView prepareForDragOperation:]):
(-[WKView performDragOperation:]):
(-[WKView _hitTest:dragTypes:]):
(-[WKView _windowResizeMouseLocationIsInVisibleScrollerThumb:]):
(-[WKView viewWillMoveToWindow:]):
(-[WKView viewDidMoveToWindow]):
(-[WKView drawRect:]):
(-[WKView isOpaque]):
(-[WKView mouseDownCanMoveWindow]):
(-[WKView viewDidHide]):
(-[WKView viewDidUnhide]):
(-[WKView viewDidChangeBackingProperties]):
(-[WKView _activeSpaceDidChange:]):
(-[WKView accessibilityFocusedUIElement]):
(-[WKView accessibilityHitTest:]):
(-[WKView accessibilityAttributeValue:]):
(-[WKView accessibilityAttributeValue:forParameter:]):
(-[WKView hitTest:]):
(-[WKView conversationIdentifier]):
(-[WKView quickLookWithEvent:]):
(-[WKView addTrackingRect:owner:userData:assumeInside:]):
(-[WKView _addTrackingRect:owner:userData:assumeInside:useTrackingNum:]):
(-[WKView _addTrackingRects:owner:userDataList:assumeInsideList:trackingNums:count:]):
(-[WKView removeTrackingRect:]):
(-[WKView _removeTrackingRects:count:]):
(-[WKView view:stringForToolTip:point:userData:]):
(-[WKView pasteboardChangedOwner:]):
(-[WKView pasteboard:provideDataForType:]):
(-[WKView namesOfPromisedFilesDroppedAtDestination:]):
(-[WKView maybeInstallIconLoadingClient]):
(-[WKView initWithFrame:processPool:configuration:]):
(-[WKView _setThumbnailView:]):
(-[WKView _thumbnailView]):
(-[WKView _web_superInputContext]):
(-[WKView _web_superQuickLookWithEvent:]):
(-[WKView _web_superSwipeWithEvent:]):
(-[WKView _web_superMagnifyWithEvent:]):
(-[WKView _web_superSmartMagnifyWithEvent:]):
(-[WKView _web_superRemoveTrackingRect:]):
(-[WKView _web_superAccessibilityAttributeValue:]):
(-[WKView _web_superDoCommandBySelector:]):
(-[WKView _web_superPerformKeyEquivalent:]):
(-[WKView _web_superKeyDown:]):
(-[WKView _web_superHitTest:]):
(-[WKView _web_immediateActionAnimationControllerForHitTestResultInternal:withType:userData:]):
(-[WKView _web_prepareForImmediateActionAnimation]):
(-[WKView _web_cancelImmediateActionAnimation]):
(-[WKView _web_completeImmediateActionAnimation]):
(-[WKView _web_didChangeContentSize:]):
(-[WKView _web_didPerformDragOperation:]):
(-[WKView _web_dragDestinationActionForDraggingInfo:]):
(-[WKView _web_dismissContentRelativeChildWindows]):
(-[WKView _web_dismissContentRelativeChildWindowsWithAnimation:]):
(-[WKView _web_gestureEventWasNotHandledByWebCore:]):
(-[WKView makeTouchBar]):
(-[WKView candidateListTouchBarItem]):
(-[WKView _web_didAddMediaControlsManager:]):
(-[WKView _web_didRemoveMediaControlsManager]):
(-[WKView scrollViewFrame]):
(-[WKView hasScrolledContentsUnderTitlebar]):
(-[WKView filePromiseProvider:fileNameForType:]):
(-[WKView filePromiseProvider:writePromiseToURL:completionHandler:]):
(-[WKView draggingSession:sourceOperationMaskForDraggingContext:]):
(-[WKView draggingSession:endedAtPoint:operation:]):
(-[WKView saveBackForwardSnapshotForCurrentItem]):
(-[WKView saveBackForwardSnapshotForItem:]):
(-[WKView initWithFrame:contextRef:pageGroupRef:]):
(-[WKView initWithFrame:contextRef:pageGroupRef:relatedToPage:]):
(-[WKView initWithFrame:configurationRef:]):
(-[WKView wantsUpdateLayer]):
(-[WKView updateLayer]):
(-[WKView pageRef]):
(-[WKView canChangeFrameLayout:]):
(-[WKView printOperationWithPrintInfo:forFrame:]):
(-[WKView setFrame:andScrollBy:]):
(-[WKView disableFrameSizeUpdates]):
(-[WKView enableFrameSizeUpdates]):
(-[WKView frameSizeUpdatesDisabled]):
(+[WKView hideWordDefinitionWindow]):
(-[WKView minimumSizeForAutoLayout]):
(-[WKView setMinimumSizeForAutoLayout:]):
(-[WKView sizeToContentAutoSizeMaximumSize]):
(-[WKView setSizeToContentAutoSizeMaximumSize:]):
(-[WKView shouldExpandToViewHeightForAutoLayout]):
(-[WKView setShouldExpandToViewHeightForAutoLayout:]):
(-[WKView shouldClipToVisibleRect]):
(-[WKView setShouldClipToVisibleRect:]):
(-[WKView underlayColor]):
(-[WKView setUnderlayColor:]):
(-[WKView _inspectorAttachmentView]):
(-[WKView _setInspectorAttachmentView:]):
(-[WKView fullScreenPlaceholderView]):
(-[WKView createFullScreenWindow]):
(-[WKView beginDeferringViewInWindowChanges]):
(-[WKView endDeferringViewInWindowChanges]):
(-[WKView endDeferringViewInWindowChangesSync]):
(-[WKView _prepareForMoveToWindow:withCompletionHandler:]):
(-[WKView isDeferringViewInWindowChanges]):
(-[WKView windowOcclusionDetectionEnabled]):
(-[WKView setWindowOcclusionDetectionEnabled:]):
(-[WKView setAllowsBackForwardNavigationGestures:]):
(-[WKView allowsBackForwardNavigationGestures]):
(-[WKView allowsLinkPreview]):
(-[WKView setAllowsLinkPreview:]):
(-[WKView _setIgnoresAllEvents:]):
(-[WKView _setIgnoresNonWheelMouseEvents:]):
(-[WKView _setIgnoresNonWheelEvents:]):
(-[WKView _ignoresNonWheelEvents]):
(-[WKView _ignoresAllEvents]):
(-[WKView _setOverrideDeviceScaleFactor:]):
(-[WKView _overrideDeviceScaleFactor]):
(-[WKView _layoutMode]):
(-[WKView _setLayoutMode:]):
(-[WKView _fixedLayoutSize]):
(-[WKView _setFixedLayoutSize:]):
(-[WKView _viewScale]):
(-[WKView _setViewScale:]):
(-[WKView _setTopContentInset:]):
(-[WKView _topContentInset]):
(-[WKView _setTotalHeightOfBanners:]):
(-[WKView _totalHeightOfBanners]):
(-[WKView _setOverlayScrollbarStyle:]):
(-[WKView _overlayScrollbarStyle]):
(-[WKView _pageExtendedBackgroundColor]):
(-[WKView isUsingUISideCompositing]):
(-[WKView setAllowsMagnification:]):
(-[WKView allowsMagnification]):
(-[WKView magnifyWithEvent:]):
(-[WKView rotateWithEvent:]):
(-[WKView _gestureEventWasNotHandledByWebCore:]):
(-[WKView _simulateMouseMove:]):
(-[WKView smartMagnifyWithEvent:]):
(-[WKView setMagnification:centeredAtPoint:]):
(-[WKView setMagnification:]):
(-[WKView magnification]):
(-[WKView _setCustomSwipeViews:]):
(-[WKView _setCustomSwipeViewsTopContentInset:]):
(-[WKView _tryToSwipeWithEvent:ignoringPinnedState:]):
(-[WKView _setDidMoveSwipeSnapshotCallback:]):
(-[WKView _dismissContentRelativeChildWindows]):
(-[WKView _dismissContentRelativeChildWindowsWithAnimation:]):
(-[WKView _setAutomaticallyAdjustsContentInsets:]):
(-[WKView _automaticallyAdjustsContentInsets]):
(-[WKView setUserInterfaceLayoutDirection:]):
(-[WKView _wantsMediaPlaybackControlsView]):
(-[WKView _setWantsMediaPlaybackControlsView:]):
(-[WKView _mediaPlaybackControlsView]):
(-[WKView _doAfterNextPresentationUpdate:]):
(-[WKView _setShouldSuppressFirstResponderChanges:]):
(-[WKView viewDidChangeEffectiveAppearance]):
(-[WKView _setUseSystemAppearance:]):
(-[WKView _useSystemAppearance]):
(-[WKView acceptsPreviewPanelControl:]):
(-[WKView beginPreviewPanelControl:]):
(-[WKView endPreviewPanelControl:]):
(toUserInterfaceLayoutDirection): Deleted.

Canonical link: <a href="https://commits.webkit.org/262256@main">https://commits.webkit.org/262256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f421ce72c01368d7cad76b9a5c07099e625f00f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1247 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/778 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/988 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1185 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/823 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/797 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/849 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1845 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/794 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/834 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/851 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/105 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->