### PR TITLE
REGRESSION(261943@main) [iOS] media/video-object-fit.html failing

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
@@ -203,8 +203,13 @@ void PlatformCALayerRemote::recursiveBuildTransaction(RemoteLayerTreeContext& co
                 m_properties.children[i] = m_children[i]->layerID();
         }
 
-        if (type() == PlatformCALayer::Type::RemoteCustom) {
+        // FIXME: the below is only necessary when blockMediaLayerRehostingInWebContentProcess() is disabled.
+        // Once that setting is made unnecessary, remove this entire conditional as well.
+        if (type() == PlatformCALayer::Type::RemoteCustom
+            && !downcast<PlatformCALayerRemoteCustom>(*this).hasVideo()) {
             RemoteLayerTreePropertyApplier::applyPropertiesToLayer(platformLayer(), nullptr, nullptr, m_properties, RemoteLayerBackingStoreProperties::LayerContentsType::CAMachPort);
+            didCommit();
+            return;
         }
 
         transaction.layerPropertiesChanged(*this);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
@@ -49,6 +49,8 @@ public:
     void setNeedsDisplayInRect(const WebCore::FloatRect& dirtyRect) override;
     void setNeedsDisplay() override;
 
+    bool hasVideo() const { return m_hasVideo; }
+
 private:
     PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, PlatformLayer *, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
     PlatformCALayerRemoteCustom(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
@@ -62,6 +64,7 @@ private:
     CFTypeRef contents() const override;
     void setContents(CFTypeRef) override;
 
+    bool m_hasVideo { false };
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     RetainPtr<PlatformLayer> m_platformLayer;
 };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
@@ -65,6 +65,7 @@ PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(HTMLVideoElement& video
     : PlatformCALayerRemote(LayerTypeAVPlayerLayer, owner, context)
 {
     m_layerHostingContext = LayerHostingContext::createTransportLayerForRemoteHosting(videoElement.layerHostingContextID());
+    m_hasVideo = true;
 }
 
 PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(LayerType layerType, PlatformLayer * customLayer, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)


### PR DESCRIPTION
#### 7df0acc2c3c3436563b3e80fa6e102be458927fc
<pre>
REGRESSION(261943@main) [iOS] media/video-object-fit.html failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=254560">https://bugs.webkit.org/show_bug.cgi?id=254560</a>
rdar://107290418

Reviewed by Eric Carlson.

Revert more parts of 260575@main. In 260575@main, a call to didCommit() in
PlatformCALayerRemote::recursiveBuildTransaction() was removed to force the compositor to
send the new properties up to the UIProcess (rather than just apply them locally). And this
worked as intended so long as &quot;no remote hosting from the WebContent process&quot; was enabled.
However, as soon as an off-by-default runtime check was added in 261943@main, the removal
of didCommit() caused all layer properties to be applied _both_ in the UIProcess _and_ the
WebContent process, which for videos whose contents&apos; aspect ratio did not match their own,
caused them to be pushed partially or completely out of frame.

It also broke the media/video-object-fit.html test.

Add a parallel runtime check that only calls didCommit() when we are on the legacy
path for video content.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp:
(WebKit::PlatformCALayerRemote::recursiveBuildTransaction):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom):

Canonical link: <a href="https://commits.webkit.org/262215@main">https://commits.webkit.org/262215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5f791d76174b8f5f615bb67fd39e89850ecebf4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/779 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/991 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/991 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1188 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/824 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/798 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1846 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/795 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/222 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/852 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->