### PR TITLE
[GPUP][MSE] incorrect handling when multiple init segments are processed during a single appendBuffer

### DIFF
--- a/LayoutTests/media/media-source/media-source-multiple-concurrent-initialization-segments-expected.txt
+++ b/LayoutTests/media/media-source/media-source-multiple-concurrent-initialization-segments-expected.txt
@@ -1,0 +1,10 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+RUN(sourceBuffer.appendBuffer(buffer))
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '21') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-multiple-concurrent-initialization-segments.html
+++ b/LayoutTests/media/media-source/media-source-multiple-concurrent-initialization-segments.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>mock-media-source</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var buffer;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+
+        buffer = concatenateSamples([
+            makeAInit(0, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)])
+            , makeASample(0,  0,  1, 1, 1, SAMPLE_FLAG.SYNC, 0)
+            , makeASample(1,  1,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(2,  2,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(3,  3,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(4,  4,  1, 1, 1, SAMPLE_FLAG.SYNC, 0)
+            , makeASample(5,  5,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(6,  6,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(7,  7,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(8,  8,  1, 1, 1, SAMPLE_FLAG.SYNC, 0)
+            , makeASample(9,  9,  1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeASample(10, 10, 1, 1, 1, SAMPLE_FLAG.NONE, 0)
+            , makeAInit(0, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)])
+            , makeASample(11,  11,  1, 1, 0, SAMPLE_FLAG.SYNC, 0)
+            , makeASample(12,  12,  1, 1, 0, SAMPLE_FLAG.NONE, 0)
+            , makeASample(13,  13,  1, 1, 0, SAMPLE_FLAG.NONE, 0)
+            , makeASample(14,  14,  1, 1, 0, SAMPLE_FLAG.NONE, 0)
+            , makeASample(15,  15,  1, 1, 0, SAMPLE_FLAG.SYNC, 0)
+            , makeASample(16,  16,  1, 1, 0, SAMPLE_FLAG.NONE, 0)
+            , makeASample(17,  17,  1, 1, 0, SAMPLE_FLAG.NONE, 0)
+            , makeASample(18,  18,  1, 1, 0, SAMPLE_FLAG.NONE, 0)
+            , makeASample(19,  19,  1, 1, 0, SAMPLE_FLAG.SYNC, 0)
+            , makeASample(20,  20,  1, 1, 0, SAMPLE_FLAG.NONE, 0)
+        ]);
+
+        run('sourceBuffer.appendBuffer(buffer)');
+        await waitFor(sourceBuffer, 'update');
+
+        testExpected("sourceBuffer.buffered.length", 1);
+        testExpected("sourceBuffer.buffered.end(0)", 21);
+
+        endTest();
+    }
+
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-stpp-crash-expected.txt
+++ b/LayoutTests/media/media-source/media-source-stpp-crash-expected.txt
@@ -6,6 +6,7 @@ RUN(sourceBuffer = source.addSourceBuffer("video/mp4"))
 RUN(sourceBuffer.appendBuffer(initSegment))
 EXPECTED (sourceBuffer.updating == 'true') OK
 EVENT(updatestart)
+EVENT(error)
 EVENT(updateend)
 EXPECTED (sourceBuffer.updating == 'false') OK
 END OF TEST

--- a/LayoutTests/media/media-source/media-source-stpp-crash.html
+++ b/LayoutTests/media/media-source/media-source-stpp-crash.html
@@ -23,6 +23,7 @@
 
         waitForEventOn(sourceBuffer, 'updatestart');
         waitForEventOn(sourceBuffer, 'update');
+        waitForEventOn(sourceBuffer, 'error');
         waitForEventOn(sourceBuffer, 'updateend', updateEnd);
 
         var request = new XMLHttpRequest();
@@ -34,7 +35,7 @@
         run('sourceBuffer.appendBuffer(initSegment)');
         testExpected('sourceBuffer.updating', true);
     }
-    
+
     function updateEnd() {
         testExpected('sourceBuffer.updating', false);
         endTest();

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -163,7 +163,6 @@ private:
     // SourceBufferPrivateClient
     void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void(ReceiveResult)>&&) final;
     void sourceBufferPrivateStreamEndedWithDecodeError() final;
-    void sourceBufferPrivateAppendError(bool decodeError) final;
     void sourceBufferPrivateAppendComplete(AppendResult) final;
     void sourceBufferPrivateBufferedChanged(const PlatformTimeRanges&, CompletionHandler<void()>&&) final;
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) final;

--- a/Source/WebCore/platform/graphics/AudioTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivate.h
@@ -87,6 +87,8 @@ public:
     const char* logClassName() const override { return "AudioTrackPrivate"; }
 #endif
 
+    Type type() const final { return Type::Audio; }
+
 protected:
     AudioTrackPrivate() = default;
 
@@ -98,6 +100,10 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AudioTrackPrivate)
+static bool isType(const WebCore::TrackPrivateBase& track) { return track.type() == WebCore::TrackPrivateBase::Type::Audio; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 namespace WTF {
 

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
@@ -95,6 +95,8 @@ public:
     const char* logClassName() const override { return "InbandTextTrackPrivate"; }
 #endif
 
+    Type type() const final { return Type::Text; };
+
 protected:
     InbandTextTrackPrivate(CueFormat format)
         : m_format(format)
@@ -108,6 +110,10 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::InbandTextTrackPrivate)
+static bool isType(const WebCore::TrackPrivateBase& track) { return track.type() == WebCore::TrackPrivateBase::Type::Text; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 namespace WTF {
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -76,7 +76,6 @@ public:
     };
     virtual void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void(ReceiveResult)>&&) = 0;
     virtual void sourceBufferPrivateStreamEndedWithDecodeError() = 0;
-    virtual void sourceBufferPrivateAppendError(bool decodeError) = 0;
     enum class AppendResult : uint8_t {
         Succeeded,
         ReadStreamFailed,
@@ -90,6 +89,7 @@ public:
     virtual void sourceBufferPrivateDidDropSample() = 0;
     virtual void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) = 0;
     virtual void sourceBufferPrivateReportExtraMemoryCost(uint64_t) = 0;
+    virtual bool isAsync() const { return false; }
 };
 
 String convertEnumerationToString(SourceBufferPrivateClient::ReceiveResult);

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -68,6 +68,9 @@ public:
     
     virtual bool operator==(const TrackPrivateBase&) const;
 
+    enum class Type { Video, Audio, Text };
+    virtual Type type() const = 0;
+
 #if !RELEASE_LOG_DISABLED
     virtual void setLogger(const Logger&, const void*);
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }

--- a/Source/WebCore/platform/graphics/VideoTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivate.h
@@ -79,6 +79,8 @@ public:
             && kind() == track.kind();
     }
 
+    Type type() const final { return Type::Video; }
+
 protected:
     VideoTrackPrivate() = default;
 
@@ -91,6 +93,10 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::VideoTrackPrivate)
+static bool isType(const WebCore::TrackPrivateBase& track) { return track.type() == WebCore::TrackPrivateBase::Type::Video; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 namespace WTF {
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -135,7 +135,7 @@ public:
     void setDecompressionSession(WebCoreDecompressionSession*);
 
     void bufferWasConsumed();
-    
+
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     SharedBuffer* initData() { return m_initData.get(); }
 #endif
@@ -156,9 +156,9 @@ private:
     void didParseInitializationData(InitializationSegment&&);
     void didEncounterErrorDuringParsing(int32_t);
     void didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&&, uint64_t trackId, const String& mediaType);
+    bool isMediaSampleAllowed(const MediaSample&) const final;
 
     // SourceBufferPrivate overrides
-    void didReceiveSampleForTrackId(uint64_t, Ref<MediaSample>&&) final;
     void append(Ref<SharedBuffer>&&) final;
     void abort() final;
     void resetParserState() final;
@@ -200,6 +200,8 @@ private:
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
     void keyStatusesChanged();
 #endif
+
+    void setTrackChangeCallbacks(const Vector<Ref<TrackPrivateBase>>& tracks, bool initialized);
 
     HashMap<AtomString, RefPtr<VideoTrackPrivate>> m_videoTracks;
     HashMap<AtomString, RefPtr<AudioTrackPrivate>> m_audioTracks;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -72,7 +72,7 @@ public:
     void setActive(bool) final;
     bool isActive() const final;
 
-    void didReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&&, CompletionHandler<void(SourceBufferPrivateClient::ReceiveResult)>&&);
+    void didReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void(ReceiveResult)>&&);
     void didReceiveSample(Ref<MediaSample>&&);
     void didReceiveAllPendingSamples();
     void appendParsingFailed();

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -187,7 +187,10 @@ void MockSourceBufferPrivate::didReceiveInitializationSegment(const MockInitiali
         }
     }
 
-    SourceBufferPrivate::didReceiveInitializationSegment(WTFMove(segment), [](SourceBufferPrivateClient::ReceiveResult) { });
+    SourceBufferPrivate::didReceiveInitializationSegment(
+        WTFMove(segment),
+        [] (auto&) { return true; },
+        [] (auto) { });
 }
 
 void MockSourceBufferPrivate::didReceiveSample(const MockSampleBox& sampleBox)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -58,13 +58,12 @@ RemoteSourceBufferProxy::RemoteSourceBufferProxy(GPUConnectionToWebProcess& conn
     , m_remoteMediaPlayerProxy(remoteMediaPlayerProxy)
 {
     m_connectionToWebProcess->messageReceiverMap().addMessageReceiver(Messages::RemoteSourceBufferProxy::messageReceiverName(), m_identifier.toUInt64(), *this);
-    m_sourceBufferPrivate->setClient(this);
-    m_sourceBufferPrivate->setIsAttached(true);
+    m_sourceBufferPrivate->setClient(*this);
 }
 
 RemoteSourceBufferProxy::~RemoteSourceBufferProxy()
 {
-    m_sourceBufferPrivate->setIsAttached(false);
+    m_sourceBufferPrivate->detach();
     m_connectionToWebProcess->messageReceiverMap().removeMessageReceiver(Messages::RemoteSourceBufferProxy::messageReceiverName(), m_identifier.toUInt64());
 }
 
@@ -119,14 +118,6 @@ void RemoteSourceBufferProxy::sourceBufferPrivateStreamEndedWithDecodeError()
         return;
 
     m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemote::SourceBufferPrivateStreamEndedWithDecodeError(), m_identifier);
-}
-
-void RemoteSourceBufferProxy::sourceBufferPrivateAppendError(bool decodeError)
-{
-    if (!m_connectionToWebProcess)
-        return;
-
-    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemote::SourceBufferPrivateAppendError(decodeError), m_identifier);
 }
 
 void RemoteSourceBufferProxy::sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime& timestamp)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -71,7 +71,6 @@ private:
     // SourceBufferPrivateClient
     void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&, CompletionHandler<void(ReceiveResult)>&&) final;
     void sourceBufferPrivateStreamEndedWithDecodeError() final;
-    void sourceBufferPrivateAppendError(bool decodeError) final;
     void sourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult) final;
     void sourceBufferPrivateBufferedChanged(const WebCore::PlatformTimeRanges&, CompletionHandler<void()>&&) final;
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) final;
@@ -80,6 +79,7 @@ private:
     void sourceBufferPrivateDidDropSample() final;
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) final;
     void sourceBufferPrivateReportExtraMemoryCost(uint64_t extraMemory) final;
+    bool isAsync() const { return true; }
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -414,12 +414,6 @@ void SourceBufferPrivateRemote::sourceBufferPrivateStreamEndedWithDecodeError()
         m_client->sourceBufferPrivateStreamEndedWithDecodeError();
 }
 
-void SourceBufferPrivateRemote::sourceBufferPrivateAppendError(bool decodeError)
-{
-    if (m_client)
-        m_client->sourceBufferPrivateAppendError(decodeError);
-}
-
 void SourceBufferPrivateRemote::sourceBufferPrivateAppendComplete(SourceBufferPrivateClient::AppendResult appendResult, uint64_t totalTrackBufferSizeInBytes, const MediaTime& timestampOffset)
 {
     m_totalTrackBufferSizeInBytes = totalTrackBufferSizeInBytes;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -112,7 +112,6 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&&, CompletionHandler<void(WebCore::SourceBufferPrivateClient::ReceiveResult)>&&);
     void sourceBufferPrivateStreamEndedWithDecodeError();
-    void sourceBufferPrivateAppendError(bool decodeError);
     void sourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult, uint64_t totalTrackBufferSizeInBytes, const MediaTime& timestampOffset);
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&);
     void sourceBufferPrivateBufferedChanged(WebCore::PlatformTimeRanges&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
@@ -28,7 +28,6 @@
 messages -> SourceBufferPrivateRemote NotRefCounted {
     SourceBufferPrivateDidReceiveInitializationSegment(struct WebKit::InitializationSegmentInfo segmentConfiguration) -> (WebCore::SourceBufferPrivateClient::ReceiveResult result)
     SourceBufferPrivateStreamEndedWithDecodeError()
-    SourceBufferPrivateAppendError(bool decodeError)
     SourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult appendResult, uint64_t totalTrackBufferSizeInBytes, MediaTime timeStampOffset)
     SourceBufferPrivateHighestPresentationTimestampChanged(MediaTime timestamp)
     SourceBufferPrivateBufferedChanged(WebCore::PlatformTimeRanges buffered) -> ()


### PR DESCRIPTION
#### f820f4ae85677af2baa1fc8f50d354c3bfc56fc0
<pre>
[GPUP][MSE] incorrect handling when multiple init segments are processed during a single appendBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=254079">https://bugs.webkit.org/show_bug.cgi?id=254079</a>
rdar://106859839

Reviewed by Youenn Fablet.

It is necessary to tie the Media Segment being parsed to the right Init Segment.
To do so, we queue all samples and init segments found in the input buffer
until they have all been parsed by the SourceBufferPrivate.
We processed then the next init segment if any, initialize it and await
for the initialization to complete.
Once done, we will process all Media Segment tie to this Init Segment.
Once done, we repeat these steps with the next Init Segment in the Input
Buffer if any.

Tests:
* LayoutTests/media/media-source/media-source-multiple-concurrent-initialization-segments-expected.txt: Added.
* LayoutTests/media/media-source/media-source-multiple-concurrent-initialization-segments.html: Added.

* LayoutTests/media/media-source/media-source-stpp-crash-expected.txt:
* LayoutTests/media/media-source/media-source-stpp-crash.html: Amend test to explicitly show that error event should be fired.
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::m_logIdentifier):
(WebCore::SourceBuffer::~SourceBuffer):
(WebCore::SourceBuffer::removedFromMediaSource):
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment): Streamline handling of errors,
having it all managed by sourceBufferPrivateAppendComplete. It also prevents the MediaSource to be deleted and
the SourceBuffer be detached from the SourceBufferPrivate while the method is running should there be an error.
(WebCore::SourceBuffer::sourceBufferPrivateAppendError): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/platform/graphics/AudioTrackPrivate.h:
(isType):
* Source/WebCore/platform/graphics/InbandTextTrackPrivate.h:
(isType):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::~SourceBufferPrivate):
(WebCore::SourceBufferPrivate::updateHighestPresentationTimestamp):
(WebCore::SourceBufferPrivate::setBufferedRanges):
(WebCore::SourceBufferPrivate::updateBufferedFromTrackBuffers):
(WebCore::SourceBufferPrivate::appendCompleted):
(WebCore::SourceBufferPrivate::reenqueSamples):
(WebCore::SourceBufferPrivate::clearTrackBuffers):
(WebCore::SourceBufferPrivate::fastSeekTimeForMediaTime):
(WebCore::SourceBufferPrivate::provideMediaData):
(WebCore::SourceBufferPrivate::removeCodedFrames):
(WebCore::SourceBufferPrivate::evictCodedFrames):
(WebCore::SourceBufferPrivate::setClient): Simplify detection that we&apos;ve been detached
(WebCore::SourceBufferPrivate::detach): removing redundant member variable.
(WebCore::SourceBufferPrivate::isAttached const): Rely on m_client value to check if we&apos;re still attached to SourceBuffer.
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::didReceiveSample):
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::processPendingOperations):
(WebCore::SourceBufferPrivate::abortPendingOperations):
(WebCore::SourceBufferPrivate::processInitSegment):
(WebCore::SourceBufferPrivate::processMediaSample):
(WebCore::SourceBufferPrivate::processMediaSamples):
(WebCore::SourceBufferPrivate::resetParserState):
(WebCore::SourceBufferPrivate::didReceiveSampleForTrackId): Deleted.
(WebCore::SourceBufferPrivate::processPendingSamples): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::isMediaSampleAllowed const):
(WebCore::SourceBufferPrivate::setIsAttached): Deleted.
(WebCore::SourceBufferPrivate::processingInitializationSegment const): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
(WebCore::SourceBufferPrivateClient::isAsync const):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebCore/platform/graphics/TrackPrivateBase.h: Allow dynamic casting for Tracks objects.
* Source/WebCore/platform/graphics/VideoTrackPrivate.h:
(isType):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::setTrackChangeCallbacks):
(WebCore::SourceBufferPrivateAVFObjC::didParseInitializationData):
(WebCore::SourceBufferPrivateAVFObjC::didProvideMediaDataForTrackId):
(WebCore::SourceBufferPrivateAVFObjC::isMediaSampleAllowed const):
(WebCore::SourceBufferPrivateAVFObjC::didProvideContentKeyRequestInitializationDataForTrackID):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::processPendingTrackChangeTasks): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::didReceiveSampleForTrackId): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::didReceiveInitializationSegment):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::didReceiveInitializationSegment):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::RemoteSourceBufferProxy):
(WebKit::RemoteSourceBufferProxy::~RemoteSourceBufferProxy):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateAppendError): Deleted.
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateAppendError): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in: Remove unnecessary method.

Canonical link: <a href="https://commits.webkit.org/262300@main">https://commits.webkit.org/262300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bb70664b3b40fe9fb894ff55244b3eb5f626f94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/960 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1157 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1093 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1008 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/996 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1038 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2086 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/969 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1018 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/290 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1053 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->