### PR TITLE
[popover] event.preventDefault() should not cancel popover light dismiss

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/light-dismiss-event-ordering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/light-dismiss-event-ordering-expected.txt
@@ -1,14 +1,14 @@
 target
 
 PASS Tests the interactions between popover light dismiss and pointer/mouse events. eventName: pointerdown, capture: true
-FAIL Tests the interactions between popover light dismiss and pointer/mouse events. eventName: pointerup, capture: true assert_equals: The popover should be closed via light dismiss even when preventDefault is called. expected 0 but got 1
+PASS Tests the interactions between popover light dismiss and pointer/mouse events. eventName: pointerup, capture: true
 PASS Tests the interactions between popover light dismiss and pointer/mouse events. eventName: mousedown, capture: true
 PASS Tests the interactions between popover light dismiss and pointer/mouse events. eventName: mouseup, capture: true
 PASS Tests the interactions between popover light dismiss and pointer/mouse events. eventName: click, capture: true
 PASS Tests the interactions between popover light dismiss and pointer/mouse events. eventName: pointerdown, capture: false
-FAIL Tests the interactions between popover light dismiss and pointer/mouse events. eventName: pointerup, capture: false assert_equals: The popover should be closed via light dismiss even when preventDefault is called. expected 0 but got 1
+PASS Tests the interactions between popover light dismiss and pointer/mouse events. eventName: pointerup, capture: false
 PASS Tests the interactions between popover light dismiss and pointer/mouse events. eventName: mousedown, capture: false
 PASS Tests the interactions between popover light dismiss and pointer/mouse events. eventName: mouseup, capture: false
 PASS Tests the interactions between popover light dismiss and pointer/mouse events. eventName: click, capture: false
-FAIL Tests the order of pointer/mouse events during popover light dismiss. assert_array_equals: pointer and popover events should be fired in the correct order. expected property 2 to be "beforetoggle newState: closed" but got "pointerup" (expected array ["pointerdown", "mousedown", "beforetoggle newState: closed", "pointerup", "mouseup", "click"] got ["pointerdown", "mousedown", "pointerup", "beforetoggle newState: closed", "mouseup", "click"])
+PASS Tests the order of pointer/mouse events during popover light dismiss.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,11 +1,11 @@
 Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1  Popover 3 - button 3 Popover 6  Popover8 anchor (no action)  Open convoluted popover Popover 1
 
 PASS Clicking outside a popover will dismiss the popover
-FAIL Canceling pointer events should not keep clicks from light dismissing popovers assert_false: preventDefault should not prevent light dismiss expected false got true
-FAIL Clicking inside a popover does not close that popover assert_false: expected false got true
-FAIL Popovers close on pointerup, not pointerdown assert_false: expected false got true
-FAIL Synthetic events can't close popovers assert_false: expected false got true
-FAIL Moving focus outside the popover should not dismiss the popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
+PASS Canceling pointer events should not keep clicks from light dismissing popovers
+PASS Clicking inside a popover does not close that popover
+PASS Popovers close on pointerup, not pointerdown
+PASS Synthetic events can't close popovers
+FAIL Moving focus outside the popover should not dismiss the popover assert_equals: Focus should move to a button outside the popover expected Element node <button id="after_p1">Next control after popover1</button> but got Element node <body><button id="b1t" popovertarget="p1">Popover 1</butt...
 FAIL Clicking inside a child popover shouldn't close either popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 FAIL Clicking inside a parent popover should close child popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
 PASS Clicking on invoking element, after using it for activation, shouldn't close its popover

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,13 +1,13 @@
 Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1 Popover 3 - button 3   Popover 6  Popover8 anchor (no action)  Open convoluted popover Popover 1
 
 PASS Clicking outside a popover will dismiss the popover
-FAIL Canceling pointer events should not keep clicks from light dismissing popovers assert_false: preventDefault should not prevent light dismiss expected false got true
-FAIL Clicking inside a popover does not close that popover assert_false: expected false got true
-FAIL Popovers close on pointerup, not pointerdown assert_false: expected false got true
-FAIL Synthetic events can't close popovers assert_false: expected false got true
-FAIL Moving focus outside the popover should not dismiss the popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking inside a child popover shouldn't close either popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking inside a parent popover should close child popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
+PASS Canceling pointer events should not keep clicks from light dismissing popovers
+PASS Clicking inside a popover does not close that popover
+PASS Popovers close on pointerup, not pointerdown
+PASS Synthetic events can't close popovers
+PASS Moving focus outside the popover should not dismiss the popover
+PASS Clicking inside a child popover shouldn't close either popover
+PASS Clicking inside a parent popover should close child popover
 PASS Clicking on invoking element, after using it for activation, shouldn't close its popover
 PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case)
 PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8983,7 +8983,7 @@ void Document::hideAllPopoversUntil(Element* endpoint, FocusPreviousElement focu
 }
 
 // https://html.spec.whatwg.org/#popover-light-dismiss
-void Document::handlePopoverLightDismiss(PointerEvent& event)
+void Document::handlePopoverLightDismiss(const PointerEvent& event, Node& target)
 {
     ASSERT(event.isTrusted());
 
@@ -8992,7 +8992,6 @@ void Document::handlePopoverLightDismiss(PointerEvent& event)
         return;
 
     RefPtr popoverToAvoidHiding = [&]() -> HTMLElement* {
-        auto& target = downcast<Node>(*event.target());
         auto* startElement = is<Element>(target) ? &downcast<Element>(target) : target.parentElement();
         auto [clickedPopover, invokerPopover] = [&]() {
             RefPtr<HTMLElement> clickedPopover;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1633,7 +1633,7 @@ public:
     HTMLElement* topmostAutoPopover() const;
 
     void hideAllPopoversUntil(Element*, FocusPreviousElement, FireEvents);
-    void handlePopoverLightDismiss(PointerEvent&);
+    void handlePopoverLightDismiss(const PointerEvent&, Node&);
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     void registerAttachmentIdentifier(const String&, const HTMLImageElement&);

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2498,9 +2498,6 @@ void Node::defaultEventHandler(Event& event)
             }
         }
 #endif
-    } else if (eventType == eventNames.pointerdownEvent || eventType == eventNames.pointerupEvent) {
-        if (is<PointerEvent>(event))
-            document().handlePopoverLightDismiss(downcast<PointerEvent>(event));
     } else if (eventNames.isWheelEventType(eventType) && is<WheelEvent>(event)) {
         // If we don't have a renderer, send the wheel event to the first node we find with a renderer.
         // This is needed for <option> and <optgroup> elements so that <select>s get a wheel scroll.


### PR DESCRIPTION
#### afc536e4bc276f974e802f28e5440b316ce2736f
<pre>
[popover] event.preventDefault() should not cancel popover light dismiss
<a href="https://bugs.webkit.org/show_bug.cgi?id=254384">https://bugs.webkit.org/show_bug.cgi?id=254384</a>

Reviewed by Tim Nguyen.

Move light dismiss logic to PointerCaptureController::dispatchEvent so the event can&apos;t
be cancelled, also see:
<a href="https://github.com/whatwg/dom/pull/1117#issuecomment-1311928234">https://github.com/whatwg/dom/pull/1117#issuecomment-1311928234</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/light-dismiss-event-ordering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::handlePopoverLightDismiss):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::defaultEventHandler):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::pointerEventWillBeDispatched):

Canonical link: <a href="https://commits.webkit.org/262283@main">https://commits.webkit.org/262283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f15dc8f83a3f9d69ede0ad87c8b2d8b34a2ed59d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1680 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1141 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1074 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/998 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1562 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/980 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/973 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2056 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/953 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1003 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/274 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1035 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->