### PR TITLE
[WGSL] Add overloads for vecN constructors

### DIFF
--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -46,9 +46,14 @@ struct TypeVariable {
 
         I32 = 1 << 3,
         U32 = 1 << 4,
-        ConcreteInteger = I32 | U32,
         AbstractInt = 1 << 5,
+        ConcreteInteger = I32 | U32,
         Integer = ConcreteInteger | AbstractInt,
+
+        Bool = 1 << 6,
+
+        Scalar = Bool | Integer | Float,
+        ConcreteScalar = Bool | ConcreteInteger | ConcreteFloat,
 
         Number = Float | Integer,
     };

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -27,6 +27,35 @@ operator :textureSample, {
     # https://bugs.webkit.org/show_bug.cgi?id=254515
 }
 
+operator :vec2, {
+    # FIXME: overload resolution should support explicitly instantiating variables
+    # [S < Scalar, T < ConcreteScalar].(Vector[S, 2]) => Vector[T, 2],
+    [S < Scalar].(Vector[S, 2]) => Vector[S, 2],
+    [T < Scalar].(T, T) => Vector[T, 2],
+}
+
+operator :vec3, {
+    # FIXME: overload resolution should support explicitly instantiating variables
+    # [S < Scalar, T < ConcreteScalar].(Vector[S, 3]) => Vector[T, 3],
+    [S < Scalar].(Vector[S, 3]) => Vector[S, 3],
+    [T < Scalar].(T, T, T) => Vector[T, 3],
+    [T < Scalar].(Vector[T, 2], T) => Vector[T, 3],
+    [T < Scalar].(T, Vector[T, 2]) => Vector[T, 3],
+}
+
+operator :vec4, {
+    # FIXME: overload resolution should support explicitly instantiating variables
+    # [S < Scalar, T < ConcreteScalar].(Vector[S, 4]) => Vector[T, 4],
+    [S < Scalar].(Vector[S, 4]) => Vector[S, 4],
+    [T < Scalar].(T, T, T, T) => Vector[T, 4],
+    [T < Scalar].(T, Vector[T, 2], T) => Vector[T, 4],
+    [T < Scalar].(T, T, Vector[T, 2]) => Vector[T, 4],
+    [T < Scalar].(Vector[T, 2], T, T) => Vector[T, 4],
+    [T < Scalar].(Vector[T, 2], Vector[T, 2]) => Vector[T, 4],
+    [T < Scalar].(Vector[T, 3], T) => Vector[T, 4],
+    [T < Scalar].(T, Vector[T, 3]) => Vector[T, 4],
+}
+
 (2..4).each do |columns|
     (2..4).each do |rows|
         operator :"mat#{columns}x#{rows}", {

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -289,8 +289,10 @@ module DSL
 
         Number = Constraint.new(:Number)
         Float = Constraint.new(:Float)
+        Scalar = Constraint.new(:Scalar)
         ConcreteInteger = Constraint.new(:ConcreteInteger)
         ConcreteFloat = Constraint.new(:ConcreteFloat)
+        ConcreteScalar = Constraint.new(:ConcreteScalar)
         EOS
     end
 

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -100,6 +100,35 @@ fn testTextureSample() {
   }
 }
 
+fn testVec2() {
+  // FIXME: overload resolution should support explicitly instantiating variables
+  // let v1 = vec2<i32>(vec2(0, 0));
+  let v2 = vec2(vec2(0, 0));
+  let v3 = vec2(0, 0);
+}
+
+fn testVec3() {
+  // FIXME: overload resolution should support explicitly instantiating variables
+  // let v1 = vec3<i32>(vec3(0, 0, 0));
+  let v2 = vec3(vec3(0, 0, 0));
+  let v3 = vec3(0, 0, 0);
+  let v4 = vec3(vec2(0, 0), 0);
+  let v5 = vec3(0, vec2(0, 0));
+}
+
+fn testVec4() {
+  // FIXME: overload resolution should support explicitly instantiating variables
+  // let v1 = vec4<i32>(vec4(0, 0, 0, 0));
+  let v2 = vec4(vec4(0, 0, 0, 0));
+  let v3 = vec4(0, 0, 0, 0);
+  let v4 = vec4(0, vec2(0, 0), 0);
+  let v5 = vec4(0, 0, vec2(0, 0));
+  let v6 = vec4(vec2(0, 0), 0, 0);
+  let v7 = vec4(vec2(0, 0), vec2(0, 0));
+  let v8 = vec4(vec3(0, 0, 0), 0);
+  let v9 = vec4(0, vec3(0, 0, 0));
+}
+
 fn testMatrixConstructor() {
   {
     // FIXME: overload resolution should support explicitly instantiating variables


### PR DESCRIPTION
#### 4b417b85f4bf9a1f51f0341bf87a5fce436907d5
<pre>
[WGSL] Add overloads for vecN constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=254586">https://bugs.webkit.org/show_bug.cgi?id=254586</a>
rdar://107315663

Reviewed by Myles C. Maxfield.

Add the declarations for all the overloads of vec2, vec3 and vec4 constructors.
This requires introducing a couple new constraints, although constraints aren&apos;t
validated yet. There&apos;s only one overload per constructor disabled with a fixme,
since they require explicitly specifying the type (e.g. vecN&lt;T&gt;(...)), but we
don&apos;t currently support that, but will be implemented next.

* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/262319@main">https://commits.webkit.org/262319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a96e3e1711483db6cb21b90519bc05c9817315c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1096 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1329 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1257 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1236 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1862 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1171 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1121 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2219 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1169 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1106 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/1140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/304 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1196 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->