### PR TITLE
[GTK] Add support for swrast without using wpe renderer

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
@@ -22,5 +22,6 @@
 
 messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
     Configure(UnixFileDescriptor backFD, UnixFileDescriptor frontFD, WebCore::IntSize size, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier)
+    ConfigureSHM(WebKit::ShareableBitmapHandle backBufferHandle, WebKit::ShareableBitmapHandle frontBufferHandle)
     Frame() -> ()
 }


### PR DESCRIPTION
#### accb7777eb688ee23fb99f18b5470e05ffb60abe
<pre>
[GTK] Add support for swrast without using wpe renderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=254587">https://bugs.webkit.org/show_bug.cgi?id=254587</a>

Reviewed by Žan Doberšek.

In case of software rasterization we fallback to wpe renderer because
image_dma_buf_import extension is not available. We could use the new
DMABuf approach but using shareable bitmaps instead of DMABuf buffers.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::checkRequirements):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::Surface):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::map const):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::swap):
(WebKit::AcceleratedBackingStoreDMABuf::configure):
(WebKit::AcceleratedBackingStoreDMABuf::configureSHM):
(WebKit::AcceleratedBackingStoreDMABuf::createSource):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::realize):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::RenderTarget):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::~RenderTarget):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::willRenderFrame const):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::~RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::willRenderFrame const):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::swap):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::create):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::RenderTargetSHMImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::didRenderFrame const):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::swap):
(WebKit::AcceleratedSurfaceDMABuf::didCreateGLContext):
(WebKit::AcceleratedSurfaceDMABuf::willDestroyGLContext):
(WebKit::AcceleratedSurfaceDMABuf::surfaceID const):
(WebKit::AcceleratedSurfaceDMABuf::clientResize):
(WebKit::AcceleratedSurfaceDMABuf::willRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/262865@main">https://commits.webkit.org/262865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ad694a5b4db1eae456c073fb269266474f724aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4119 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3080 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2386 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3887 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2409 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2270 "21 flakes 148 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2428 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3644 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2793 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2241 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2412 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2453 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/332 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->