### PR TITLE
[WGSL] Overload resolution shouldn't assume we can materialize all variables

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -28,15 +28,13 @@ operator :textureSample, {
 }
 
 operator :vec2, {
-    # FIXME: overload resolution should support explicitly instantiating variables
-    # [S < Scalar, T < ConcreteScalar].(Vector[S, 2]) => Vector[T, 2],
+    [S < Scalar, T < ConcreteScalar].(Vector[S, 2]) => Vector[T, 2],
     [S < Scalar].(Vector[S, 2]) => Vector[S, 2],
     [T < Scalar].(T, T) => Vector[T, 2],
 }
 
 operator :vec3, {
-    # FIXME: overload resolution should support explicitly instantiating variables
-    # [S < Scalar, T < ConcreteScalar].(Vector[S, 3]) => Vector[T, 3],
+    [S < Scalar, T < ConcreteScalar].(Vector[S, 3]) => Vector[T, 3],
     [S < Scalar].(Vector[S, 3]) => Vector[S, 3],
     [T < Scalar].(T, T, T) => Vector[T, 3],
     [T < Scalar].(Vector[T, 2], T) => Vector[T, 3],
@@ -44,8 +42,7 @@ operator :vec3, {
 }
 
 operator :vec4, {
-    # FIXME: overload resolution should support explicitly instantiating variables
-    # [S < Scalar, T < ConcreteScalar].(Vector[S, 4]) => Vector[T, 4],
+    [S < Scalar, T < ConcreteScalar].(Vector[S, 4]) => Vector[T, 4],
     [S < Scalar].(Vector[S, 4]) => Vector[S, 4],
     [T < Scalar].(T, T, T, T) => Vector[T, 4],
     [T < Scalar].(T, Vector[T, 2], T) => Vector[T, 4],


### PR DESCRIPTION
#### 9668cecef5520dd5a177d2fa0ad7af2a396f0010
<pre>
[WGSL] Overload resolution shouldn&apos;t assume we can materialize all variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=254588">https://bugs.webkit.org/show_bug.cgi?id=254588</a>
rdar://problem/107316646

Reviewed by Myles C. Maxfield.

Some overload candidates require explicitly instantiating type variables, and
if no explicit instantiation is given we&apos;ll fail to materialize the variable.
In this case, we should reject the overload candidate instead of failing an
assertion and crashing.

* Source/WebGPU/WGSL/Overload.cpp:
(WGSL:: const):
(WGSL::OverloadResolver::considerCandidate):
* Source/WebGPU/WGSL/TypeDeclarations.rb:

Canonical link: <a href="https://commits.webkit.org/262323@main">https://commits.webkit.org/262323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68d69936128de5c6fcfbf908cdbb9a88bd347495

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1101 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1334 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1262 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1241 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1870 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1141 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1115 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1126 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2225 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1175 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1151 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/307 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1201 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->