### PR TITLE
Text tracks are not visible in fullscreen

### DIFF
--- a/LayoutTests/platform/ios-simulator-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-simulator-wk2/TestExpectations
@@ -164,3 +164,5 @@ webkit.org/b/236926 webrtc/vp9-profile2.html [ Timeout Pass ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/adopt-from-image-document.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/242748 [ Release arm64 ] css3/color-filters/svg/color-filter-inline-svg.html [ ImageOnlyFailure ]
+
+webkit.org/b/254872 webrtc/video-rotation.html [ Pass Timeout ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -780,8 +780,7 @@ BlockMediaLayerRehostingInWebContentProcess:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(MAC)": true
-      default: false
+      default: true
     WebCore:
       default: false
 

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -298,7 +298,7 @@ void MediaControlTextTrackContainerElement::updateTextTrackRepresentationIfNeede
     if (!m_textTrackRepresentation) {
         ALWAYS_LOG(LOGIDENTIFIER);
 
-        m_textTrackRepresentation = TextTrackRepresentation::create(*this);
+        m_textTrackRepresentation = TextTrackRepresentation::create(*this, *m_mediaElement);
         if (document().page())
             m_textTrackRepresentation->setContentScale(document().page()->deviceScaleFactor());
         m_mediaElement->setTextTrackRepresentation(m_textTrackRepresentation.get());

--- a/Source/WebCore/platform/graphics/TextTrackRepresentation.cpp
+++ b/Source/WebCore/platform/graphics/TextTrackRepresentation.cpp
@@ -44,7 +44,7 @@ public:
 
 #if !(PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)))
 
-std::unique_ptr<TextTrackRepresentation> TextTrackRepresentation::create(TextTrackRepresentationClient&)
+std::unique_ptr<TextTrackRepresentation> TextTrackRepresentation::create(TextTrackRepresentationClient&, HTMLMediaElement&)
 {
     return makeUnique<NullTextTrackRepresentation>();
 }

--- a/Source/WebCore/platform/graphics/TextTrackRepresentation.h
+++ b/Source/WebCore/platform/graphics/TextTrackRepresentation.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class HTMLMediaElement;
 class Image;
 class IntRect;
 
@@ -46,7 +47,7 @@ public:
 class TextTrackRepresentation {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<TextTrackRepresentation> create(TextTrackRepresentationClient&);
+    static std::unique_ptr<TextTrackRepresentation> create(TextTrackRepresentationClient&, HTMLMediaElement&);
 
     virtual ~TextTrackRepresentation() = default;
 

--- a/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef TextTrackRepresentationCocoa_h
-#define TextTrackRepresentationCocoa_h
+#pragma once
 
 #if (PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))) && ENABLE(VIDEO)
 
@@ -37,24 +36,33 @@
 
 namespace WebCore {
 
-class TextTrackRepresentationCocoa final : public TextTrackRepresentation, public CanMakeWeakPtr<TextTrackRepresentationCocoa, WeakPtrFactoryInitialization::Eager> {
+class HTMLMediaElement;
+
+class TextTrackRepresentationCocoa : public TextTrackRepresentation, public CanMakeWeakPtr<TextTrackRepresentationCocoa, WeakPtrFactoryInitialization::Eager> {
 public:
-    explicit TextTrackRepresentationCocoa(TextTrackRepresentationClient&);
-    virtual ~TextTrackRepresentationCocoa();
+    WEBCORE_EXPORT explicit TextTrackRepresentationCocoa(TextTrackRepresentationClient&);
+    WEBCORE_EXPORT virtual ~TextTrackRepresentationCocoa();
 
     TextTrackRepresentationClient& client() const { return m_client; }
 
     PlatformLayer* platformLayer() final { return m_layer.get(); }
 
-    IntRect bounds() const final;
+    WEBCORE_EXPORT IntRect bounds() const override;
     void boundsChanged();
 
-private:
-    void update() final;
-    void setContentScale(float) final;
-    void setHidden(bool) const final;
+    using TextTrackRepresentationFactory = WTF::Function<std::unique_ptr<TextTrackRepresentation>(TextTrackRepresentationClient&, HTMLMediaElement&)>;
+
+    WEBCORE_EXPORT static TextTrackRepresentationFactory& representationFactory();
+
+protected:
+    // TextTrackRepresentation
+    WEBCORE_EXPORT void update() override;
+    WEBCORE_EXPORT void setContentScale(float) override;
+    WEBCORE_EXPORT void setHidden(bool) const override;
 
     TextTrackRepresentationClient& m_client;
+
+private:
     RetainPtr<CALayer> m_layer;
     RetainPtr<WebCoreTextTrackRepresentationCocoaHelper> m_delegate;
 };
@@ -62,5 +70,3 @@ private:
 }
 
 #endif // (PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))) && ENABLE(VIDEO)
-
-#endif // TextTrackRepresentationCocoa_h

--- a/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm
@@ -107,9 +107,17 @@
 
 namespace WebCore {
 
-std::unique_ptr<TextTrackRepresentation> TextTrackRepresentation::create(TextTrackRepresentationClient& client)
+std::unique_ptr<TextTrackRepresentation> TextTrackRepresentation::create(TextTrackRepresentationClient& client, HTMLMediaElement& mediaElement)
 {
+    if (TextTrackRepresentationCocoa::representationFactory())
+        return TextTrackRepresentationCocoa::representationFactory()(client, mediaElement);
     return makeUnique<TextTrackRepresentationCocoa>(client);
+}
+
+TextTrackRepresentationCocoa::TextTrackRepresentationFactory& TextTrackRepresentationCocoa::representationFactory()
+{
+    static NeverDestroyed<TextTrackRepresentationFactory> factory;
+    return factory.get();
 }
 
 TextTrackRepresentationCocoa::TextTrackRepresentationCocoa(TextTrackRepresentationClient& client)

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
@@ -31,6 +31,7 @@
 #include "EventListener.h"
 #include "HTMLMediaElementEnums.h"
 #include "MediaPlayerIdentifier.h"
+#include "PlatformImage.h"
 #include "PlatformLayer.h"
 #include "PlaybackSessionInterfaceAVKit.h"
 #include "VideoFullscreenModel.h"
@@ -162,6 +163,15 @@ public:
     WEBCORE_EXPORT AVPlayerViewController *avPlayerViewController() const;
     WebAVPlayerController *playerController() const;
 
+    WEBCORE_EXPORT void textTrackRepresentationUpdate(PlatformImagePtr textTrack);
+    WEBCORE_EXPORT void textTrackRepresentationSetContentsScale(float scale);
+    WEBCORE_EXPORT void textTrackRepresentationSetHidden(bool hidden);
+
+    WEBCORE_EXPORT CALayer* captionsLayer();
+    WEBCORE_EXPORT void setCaptionsFrame(const CGRect&);
+    WEBCORE_EXPORT void setupCaptionsLayer(CALayer* parent, const WebCore::FloatSize&);
+    WEBCORE_EXPORT void removeCaptionsLayer();
+
 private:
     WEBCORE_EXPORT VideoFullscreenInterfaceAVKit(PlaybackSessionInterfaceAVKit&);
 
@@ -236,6 +246,8 @@ private:
     bool m_shouldIgnoreAVKitCallbackAboutExitFullscreenReason { false };
     bool m_enteringPictureInPicture { false };
     bool m_exitingPictureInPicture { false };
+
+    RetainPtr<CALayer> m_captionsLayer;
 };
 
 }

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -1533,6 +1533,52 @@ bool VideoFullscreenInterfaceAVKit::isPlayingVideoInEnhancedFullscreen() const
     return hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) && [playerController() isPlaying];
 }
 
+void VideoFullscreenInterfaceAVKit::textTrackRepresentationUpdate(PlatformImagePtr textTrack)
+{
+    [m_captionsLayer setContents:(__bridge id)textTrack.get()];
+}
+
+void VideoFullscreenInterfaceAVKit::textTrackRepresentationSetContentsScale(float scale)
+{
+    [m_captionsLayer setContentsScale:scale];
+}
+
+void VideoFullscreenInterfaceAVKit::textTrackRepresentationSetHidden(bool hidden)
+{
+    [m_captionsLayer setHidden:hidden];
+}
+
+CALayer *VideoFullscreenInterfaceAVKit::captionsLayer()
+{
+    if (!m_captionsLayer)
+        m_captionsLayer = adoptNS([[CALayer alloc] init]);
+    return m_captionsLayer.get();
+}
+
+void VideoFullscreenInterfaceAVKit::setCaptionsFrame(const CGRect& frame)
+{
+    [captionsLayer() setFrame:frame];
+}
+
+void VideoFullscreenInterfaceAVKit::setupCaptionsLayer(CALayer* parent, const WebCore::FloatSize& initialSize)
+{
+    [captionsLayer() removeFromSuperlayer];
+    [parent addSublayer:captionsLayer()];
+
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    captionsLayer().zPosition = FLT_MAX;
+    [captionsLayer() setAnchorPoint:CGPointZero];
+    [captionsLayer() setBounds:CGRectMake(0, 0, initialSize.width(), initialSize.height())];
+    [CATransaction commit];
+}
+
+void VideoFullscreenInterfaceAVKit::removeCaptionsLayer()
+{
+    [m_captionsLayer removeFromSuperlayer];
+    m_captionsLayer = nullptr;
+}
+
 static std::optional<bool> isPictureInPictureSupported;
 
 void WebCore::setSupportsPictureInPicture(bool isSupported)

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
@@ -213,6 +213,9 @@ private:
     void preparedToExitFullscreen(PlaybackSessionContextIdentifier);
     void exitFullscreenWithoutAnimationToMode(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
     void setPlayerIdentifier(PlaybackSessionContextIdentifier, std::optional<WebCore::MediaPlayerIdentifier>);
+    void textTrackRepresentationUpdate(PlaybackSessionContextIdentifier, const ShareableBitmapHandle& textTrack);
+    void textTrackRepresentationSetContentsScale(PlaybackSessionContextIdentifier, float scale);
+    void textTrackRepresentationSetHidden(PlaybackSessionContextIdentifier, bool hidden);
 
     // Messages to VideoFullscreenManager
     void requestFullscreenMode(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false);

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.messages.in
@@ -36,5 +36,9 @@ messages -> VideoFullscreenManagerProxy {
     PreparedToReturnToInline(WebKit::PlaybackSessionContextIdentifier contextId, bool visible, WebCore::FloatRect inlineRect)
     PreparedToExitFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
     ExitFullscreenWithoutAnimationToMode(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode)
+
+    TextTrackRepresentationUpdate(WebKit::PlaybackSessionContextIdentifier contextId, WebKit::ShareableBitmapHandle textTrack)
+    TextTrackRepresentationSetContentsScale(WebKit::PlaybackSessionContextIdentifier contextId, float scale)
+    TextTrackRepresentationSetHidden(WebKit::PlaybackSessionContextIdentifier contextId, bool hidden)
 }
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -598,6 +598,11 @@ RetainPtr<WKLayerHostView> VideoFullscreenManagerProxy::createLayerHostViewWithI
     }
     [view layer].frame = CGRectMake(0, 0, initialSize.width(), initialSize.height());
     [view setContextID:videoLayerID];
+
+#if PLATFORM(IOS_FAMILY)
+    interface->setupCaptionsLayer([view layer], initialSize);
+#endif
+
     return view;
 }
 
@@ -855,6 +860,32 @@ void VideoFullscreenManagerProxy::preparedToExitFullscreen(PlaybackSessionContex
     ensureInterface(contextId).preparedToExitFullscreen();
 }
 
+void VideoFullscreenManagerProxy::textTrackRepresentationUpdate(PlaybackSessionContextIdentifier contextId, const ShareableBitmapHandle& textTrack)
+{
+#if PLATFORM(IOS_FAMILY)
+    auto bitmap = ShareableBitmap::create(textTrack);
+    if (!bitmap)
+        return;
+    
+    auto platformImage = bitmap->createPlatformImage();
+    ensureInterface(contextId).textTrackRepresentationUpdate(platformImage);
+#endif
+}
+
+void VideoFullscreenManagerProxy::textTrackRepresentationSetContentsScale(PlaybackSessionContextIdentifier contextId, float scale)
+{
+#if PLATFORM(IOS_FAMILY)
+    ensureInterface(contextId).textTrackRepresentationSetContentsScale(scale);
+#endif
+}
+
+void VideoFullscreenManagerProxy::textTrackRepresentationSetHidden(PlaybackSessionContextIdentifier contextId, bool hidden)
+{
+#if PLATFORM(IOS_FAMILY)
+    ensureInterface(contextId).textTrackRepresentationSetHidden(hidden);
+#endif
+}
+
 #pragma mark Messages to VideoFullscreenManager
 
 void VideoFullscreenManagerProxy::callCloseCompletionHandlers()
@@ -966,6 +997,9 @@ void VideoFullscreenManagerProxy::didCleanupFullscreen(PlaybackSessionContextIde
     auto& [model, interface] = ensureModelAndInterface(contextId);
 
     [model->layerHostView() removeFromSuperview];
+#if PLATFORM(IOS_FAMILY)
+    interface->removeCaptionsLayer();
+#endif
     if (auto playerLayer = model->playerLayer()) {
         // Return the video layer to the player layer
         auto videoView = model->layerHostView();
@@ -986,7 +1020,9 @@ void VideoFullscreenManagerProxy::didCleanupFullscreen(PlaybackSessionContextIde
 void VideoFullscreenManagerProxy::setVideoLayerFrame(PlaybackSessionContextIdentifier contextId, WebCore::FloatRect frame)
 {
 #if PLATFORM(IOS_FAMILY)
+    auto& [model, interface] = ensureModelAndInterface(contextId);
     auto fenceSendRight = MachSendRight::adopt([UIWindow _synchronizeDrawingAcrossProcesses]);
+    interface->setCaptionsFrame(CGRectMake(0, 0, frame.width(), frame.height()));
 #else
     MachSendRight fenceSendRight;
     if (DrawingAreaProxy* drawingArea = m_page->drawingArea())

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2113,6 +2113,7 @@
 		E1E552C516AE065F004ED653 /* SandboxInitializationParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = E1E552C316AE065E004ED653 /* SandboxInitializationParameters.h */; };
 		E1EE53E311F8CFC000CCBEE4 /* InjectedBundlePageEditorClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E1EE53DC11F8CF9F00CCBEE4 /* InjectedBundlePageEditorClient.h */; };
 		E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */; };
+		E36A00E329CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */; };
 		E36FF00327F36FBD004BE21A /* SandboxStateVariables.h in Headers */ = {isa = PBXBuildFile; fileRef = E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */; };
 		E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3816B3B27E24639005EAFC0 /* WebMockContentFilterManager.cpp */; };
 		E3816B3E27E2463A005EAFC0 /* WebMockContentFilterManager.h in Headers */ = {isa = PBXBuildFile; fileRef = E3816B3C27E24639005EAFC0 /* WebMockContentFilterManager.h */; };
@@ -2125,6 +2126,7 @@
 		E38A1FC023A551BF00D2374F /* UserInterfaceIdiom.mm in Sources */ = {isa = PBXBuildFile; fileRef = E38A1FBF23A551BF00D2374F /* UserInterfaceIdiom.mm */; };
 		E39628DD23960CC600658ECD /* WebDeviceOrientationUpdateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = E39628DB23960CC500658ECD /* WebDeviceOrientationUpdateProvider.h */; };
 		E39628DE23960CC600658ECD /* WebDeviceOrientationUpdateProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E39628DC23960CC600658ECD /* WebDeviceOrientationUpdateProvider.cpp */; };
+		E3C6727329D4A3AD00AD4452 /* TextTrackRepresentationCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = E36A00E129CF4EBA00AC4E8A /* TextTrackRepresentationCocoa.h */; };
 		E3CAAA442413279900CED2E2 /* AccessibilitySupportSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E3CAAA432413278A00CED2E2 /* AccessibilitySupportSPI.h */; };
 		E413F59D1AC1ADC400345360 /* NetworkCacheEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = E413F59B1AC1ADB600345360 /* NetworkCacheEntry.h */; };
 		E42E06101AA7523B00B11699 /* NetworkCacheIOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = E42E060B1AA7440D00B11699 /* NetworkCacheIOChannel.h */; };
@@ -7028,6 +7030,8 @@
 		E350A7C52934F1C100A06C29 /* common.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = common.sb; sourceTree = "<group>"; };
 		E350A7C82934F75F00A06C29 /* common.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = common.sb; sourceTree = "<group>"; };
 		E350A7DF29364D3800A06C29 /* util.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = util.sb; sourceTree = "<group>"; };
+		E36A00E129CF4EBA00AC4E8A /* TextTrackRepresentationCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextTrackRepresentationCocoa.h; sourceTree = "<group>"; };
+		E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextTrackRepresentationCocoa.mm; sourceTree = "<group>"; };
 		E36D701A27B709ED006531B7 /* WebAttachmentElementClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebAttachmentElementClient.h; sourceTree = "<group>"; };
 		E36D701D27B718EF006531B7 /* WebAttachmentElementClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebAttachmentElementClient.cpp; sourceTree = "<group>"; };
 		E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SandboxStateVariables.h; sourceTree = "<group>"; };
@@ -11376,6 +11380,8 @@
 				416008B125DA86B900E892FE /* RemoteRealtimeMediaSourceProxy.h */,
 				418FCBE3271049DB00F96ECA /* RemoteRealtimeVideoSource.cpp */,
 				418FCBE4271049DC00F96ECA /* RemoteRealtimeVideoSource.h */,
+				E36A00E129CF4EBA00AC4E8A /* TextTrackRepresentationCocoa.h */,
+				E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */,
 				CD491B051E70D05F00009066 /* UserMediaCaptureManager.cpp */,
 				CD491B061E70D05F00009066 /* UserMediaCaptureManager.h */,
 				CD491B0A1E732D1200009066 /* UserMediaCaptureManager.messages.in */,
@@ -14632,6 +14638,7 @@
 				53CFBBC82224D1B500266546 /* TextCheckerCompletion.h in Headers */,
 				1A5E4DA412D3BD3D0099A2BB /* TextCheckerState.h in Headers */,
 				CE1A0BD71A48E6C60054EF74 /* TextInputSPI.h in Headers */,
+				E3C6727329D4A3AD00AD4452 /* TextTrackRepresentationCocoa.h in Headers */,
 				1AAF263914687C39004A1E8A /* TiledCoreAnimationDrawingArea.h in Headers */,
 				1AF05D8714688348008B1E81 /* TiledCoreAnimationDrawingAreaProxy.h in Headers */,
 				F48570A32644BEC500C05F71 /* Timeout.h in Headers */,
@@ -16981,6 +16988,7 @@
 				93D6B782254CCCF40058DD3A /* SpeechRecognitionServerMessageReceiver.cpp in Sources */,
 				1A334DED16DE8F88006A8E38 /* StorageAreaMapMessageReceiver.cpp in Sources */,
 				5CAAA85029BFBE99003340AE /* TCCSoftLink.mm in Sources */,
+				E36A00E329CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm in Sources */,
 				2D11B7512126A282006F8878 /* UnifiedSource1-mm.mm in Sources */,
 				7B9FC5F028ABB557007570E7 /* UnifiedSource1.cpp in Sources */,
 				2D11B7532126A282006F8878 /* UnifiedSource2-mm.mm in Sources */,

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/TextTrackRepresentationCocoa.h>
+
+namespace WebCore {
+class HTMLMediaElement;
+class WeakPtrImplWithEventTargetData;
+}
+
+namespace WebKit {
+
+class WebPage;
+
+class WebTextTrackRepresentationCocoa final : public WebCore::TextTrackRepresentationCocoa {
+public:
+    explicit WebTextTrackRepresentationCocoa(WebCore::TextTrackRepresentationClient&, WebCore::HTMLMediaElement&);
+    virtual ~WebTextTrackRepresentationCocoa() { }
+
+private:
+    void update() final;
+    void setContentScale(float) final;
+    void setHidden(bool) const final;
+
+    WeakPtr<WebPage> m_page;
+    WeakPtr<WebCore::HTMLMediaElement, WebCore::WeakPtrImplWithEventTargetData> m_mediaElement;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+#import "TextTrackRepresentationCocoa.h"
+
+#import "VideoFullscreenManager.h"
+#import "VideoFullscreenManagerProxyMessages.h"
+#import "WebPage.h"
+
+#import <WebCore/GraphicsContext.h>
+#import <WebCore/HTMLVideoElement.h>
+
+namespace WebKit {
+
+WebTextTrackRepresentationCocoa::WebTextTrackRepresentationCocoa(WebCore::TextTrackRepresentationClient& client, WebCore::HTMLMediaElement& mediaElement)
+    : WebCore::TextTrackRepresentationCocoa(client)
+    , m_mediaElement(WeakPtr { mediaElement })
+{
+    auto* page = mediaElement.document().page();
+    if (page)
+        m_page = WeakPtr { WebPage::fromCorePage(*page) };
+}
+
+void WebTextTrackRepresentationCocoa::update()
+{
+    if (!m_page)
+        return;
+    auto& fullscreenManager = m_page->videoFullscreenManager();
+    if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
+        return;
+    
+    auto representation = m_client.createTextTrackRepresentationImage();
+    if (!representation)
+        return;
+    auto image = representation->nativeImage();
+    if (!image)
+        return;
+    auto imageSize = image->size();
+    auto bitmap = ShareableBitmap::create(image->size(), { image->colorSpace() });
+    if (!bitmap)
+        return;
+    auto context = bitmap->createGraphicsContext();
+    if (!context)
+        return;
+    context->drawNativeImage(*image, imageSize, WebCore::FloatRect({ }, imageSize), WebCore::FloatRect({ }, imageSize), { WebCore::CompositeOperator::Copy });
+    auto handle = bitmap->createHandle();
+    if (!handle)
+        return;
+    fullscreenManager.updateTextTrackRepresentationForVideoElement(downcast<WebCore::HTMLVideoElement>(*m_mediaElement), *handle);
+}
+
+void WebTextTrackRepresentationCocoa::setContentScale(float scale)
+{
+    WebCore::TextTrackRepresentationCocoa::setContentScale(scale);
+    if (!m_page)
+        return;
+    auto& fullscreenManager = m_page->videoFullscreenManager();
+    if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
+        return;
+    fullscreenManager.setTextTrackRepresentationContentScaleForVideoElement(downcast<WebCore::HTMLVideoElement>(*m_mediaElement), scale);
+}
+
+void WebTextTrackRepresentationCocoa::setHidden(bool hidden) const
+{
+    WebCore::TextTrackRepresentationCocoa::setHidden(hidden);
+    if (!m_page)
+        return;
+    auto& fullscreenManager = m_page->videoFullscreenManager();
+    if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
+        return;
+    fullscreenManager.setTextTrackRepresentationIsHiddenForVideoElement(downcast<WebCore::HTMLVideoElement>(*m_mediaElement), hidden);
+}
+
+} // namespace WebKit
+
+#endif
+

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
@@ -60,6 +60,7 @@ class LayerHostingContext;
 class WebPage;
 class PlaybackSessionInterfaceContext;
 class PlaybackSessionManager;
+class ShareableBitmapHandle;
 class VideoFullscreenManager;
 
 class VideoFullscreenInterfaceContext
@@ -93,6 +94,9 @@ public:
     bool isFullscreen() const { return m_isFullscreen; }
     void setIsFullscreen(bool flag) { m_isFullscreen = flag; }
 
+    RetainPtr<CALayer> rootLayer() const { return m_rootLayer; }
+    void setRootLayer(RetainPtr<CALayer> layer) { m_rootLayer = layer; }
+
 private:
     // VideoFullscreenModelClient
     void hasVideoChanged(bool) override;
@@ -109,6 +113,7 @@ private:
     WebCore::HTMLMediaElementEnums::VideoFullscreenMode m_fullscreenMode { WebCore::HTMLMediaElementEnums::VideoFullscreenModeNone };
     bool m_fullscreenStandby { false };
     bool m_isFullscreen { false };
+    RetainPtr<CALayer> m_rootLayer;
 };
 
 class VideoFullscreenManager : public RefCounted<VideoFullscreenManager>, private IPC::MessageReceiver {
@@ -133,14 +138,18 @@ public:
     void exitVideoFullscreenForVideoElement(WebCore::HTMLVideoElement&, WTF::CompletionHandler<void(bool)>&& = [](bool) { });
     void exitVideoFullscreenToModeWithoutAnimation(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
 
+    void updateTextTrackRepresentationForVideoElement(WebCore::HTMLVideoElement&, const ShareableBitmapHandle&);
+    void setTextTrackRepresentationContentScaleForVideoElement(WebCore::HTMLVideoElement&, float scale);
+    void setTextTrackRepresentationIsHiddenForVideoElement(WebCore::HTMLVideoElement&, bool hidden);
+
 protected:
     friend class VideoFullscreenInterfaceContext;
 
     explicit VideoFullscreenManager(WebPage&, PlaybackSessionManager&);
 
     typedef std::tuple<RefPtr<WebCore::VideoFullscreenModelVideoElement>, RefPtr<VideoFullscreenInterfaceContext>> ModelInterfaceTuple;
-    ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier);
-    ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier);
+    ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier, bool createLayerHostingContext);
+    ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier, bool createLayerHostingContext = true);
     WebCore::VideoFullscreenModelVideoElement& ensureModel(PlaybackSessionContextIdentifier);
     VideoFullscreenInterfaceContext& ensureInterface(PlaybackSessionContextIdentifier);
     void removeContext(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -31,6 +31,7 @@
 #import "LayerHostingContext.h"
 #import "Logging.h"
 #import "PlaybackSessionManager.h"
+#import "TextTrackRepresentationCocoa.h"
 #import "VideoFullscreenManagerMessages.h"
 #import "VideoFullscreenManagerProxyMessages.h"
 #import "WebCoreArgumentCoders.h"
@@ -158,23 +159,25 @@ bool VideoFullscreenManager::hasVideoPlayingInPictureInPicture() const
     return !!m_videoElementInPictureInPicture;
 }
 
-VideoFullscreenManager::ModelInterfaceTuple VideoFullscreenManager::createModelAndInterface(PlaybackSessionContextIdentifier contextId)
+VideoFullscreenManager::ModelInterfaceTuple VideoFullscreenManager::createModelAndInterface(PlaybackSessionContextIdentifier contextId, bool createlayerHostingContext)
 {
     auto model = VideoFullscreenModelVideoElement::create();
     auto interface = VideoFullscreenInterfaceContext::create(*this, contextId);
     m_playbackSessionManager->addClientForContext(contextId);
 
-    interface->setLayerHostingContext(LayerHostingContext::createForExternalHostingProcess());
+    if (createlayerHostingContext)
+        interface->setLayerHostingContext(LayerHostingContext::createForExternalHostingProcess());
+
     model->addClient(interface.get());
 
     return std::make_tuple(WTFMove(model), WTFMove(interface));
 }
 
-VideoFullscreenManager::ModelInterfaceTuple& VideoFullscreenManager::ensureModelAndInterface(PlaybackSessionContextIdentifier contextId)
+VideoFullscreenManager::ModelInterfaceTuple& VideoFullscreenManager::ensureModelAndInterface(PlaybackSessionContextIdentifier contextId, bool createlayerHostingContext)
 {
     auto addResult = m_contextMap.add(contextId, ModelInterfaceTuple());
     if (addResult.isNewEntry)
-        addResult.iterator->value = createModelAndInterface(contextId);
+        addResult.iterator->value = createModelAndInterface(contextId, createlayerHostingContext);
     return addResult.iterator->value;
 }
 
@@ -271,7 +274,18 @@ void VideoFullscreenManager::setupRemoteLayerHosting(HTMLVideoElement& videoElem
     UNUSED_PARAM(addResult);
     ASSERT(addResult.iterator->value == contextId);
 
-    auto [model, interface] = ensureModelAndInterface(contextId);
+    bool blockMediaLayerRehosting = videoElement.document().settings().blockMediaLayerRehostingInWebContentProcess();
+    RELEASE_LOG(Fullscreen, "Block Media layer rehosting = %d", blockMediaLayerRehosting);
+
+    if (blockMediaLayerRehosting) {
+        auto representationFactory = [] (TextTrackRepresentationClient& client, HTMLMediaElement& mediaElement) {
+            auto textTrackRepresentation = makeUnique<WebKit::WebTextTrackRepresentationCocoa>(client, mediaElement);
+            return textTrackRepresentation;
+        };
+        WebCore::TextTrackRepresentationCocoa::representationFactory() = WTFMove(representationFactory);
+    }
+
+    auto [model, interface] = ensureModelAndInterface(contextId, !blockMediaLayerRehosting);
     model->setVideoElement(&videoElement);
 
     addClientForContext(contextId);
@@ -335,23 +349,26 @@ void VideoFullscreenManager::enterVideoFullscreenForVideoElement(HTMLVideoElemen
     interface->setAnimationState(VideoFullscreenInterfaceContext::AnimationType::IntoFullscreen);
 
     bool allowsPictureInPicture = videoElement.webkitSupportsPresentationMode(HTMLVideoElement::VideoPresentationMode::PictureInPicture);
-    
-    if (videoElement.document().settings().blockMediaLayerRehostingInWebContentProcess())
-        m_page->send(Messages::VideoFullscreenManagerProxy::SetupFullscreenWithID(contextId, videoElement.layerHostingContextID(), videoRect, FloatSize(videoElement.videoWidth(), videoElement.videoHeight()), m_page->deviceScaleFactor(), interface->fullscreenMode(), allowsPictureInPicture, standby, videoElement.document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk()));
-    else {
-        if (!interface->layerHostingContext()->rootLayer()) {
-            auto videoLayer = model->createVideoFullscreenLayer();
-            [videoLayer setDelegate:[WebActionDisablingCALayerDelegate shared]];
-            [videoLayer setName:@"Web Video Fullscreen Layer"];
-            [videoLayer setAnchorPoint:CGPointMake(0, 0)];
-            [videoLayer setPosition:CGPointMake(0, 0)];
-            [videoLayer setBackgroundColor:cachedCGColor(WebCore::Color::transparentBlack).get()];
 
+    if (!interface->rootLayer()) {
+        auto videoLayer = model->createVideoFullscreenLayer();
+        [videoLayer setDelegate:[WebActionDisablingCALayerDelegate shared]];
+        [videoLayer setName:@"Web Video Fullscreen Layer"];
+        [videoLayer setAnchorPoint:CGPointMake(0, 0)];
+        [videoLayer setPosition:CGPointMake(0, 0)];
+        [videoLayer setBackgroundColor:cachedCGColor(WebCore::Color::transparentBlack).get()];
+        interface->setRootLayer(videoLayer.get());
+        if (interface->layerHostingContext())
             interface->layerHostingContext()->setRootLayer(videoLayer.get());
-        }
-
-        m_page->send(Messages::VideoFullscreenManagerProxy::SetupFullscreenWithID(contextId, interface->layerHostingContext()->contextID(), videoRect, FloatSize(videoElement.videoWidth(), videoElement.videoHeight()), m_page->deviceScaleFactor(), interface->fullscreenMode(), allowsPictureInPicture, standby, videoElement.document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk()));
     }
+
+    LayerHostingContextID contextID = 0;
+    if (videoElement.document().settings().blockMediaLayerRehostingInWebContentProcess())
+        contextID = videoElement.layerHostingContextID();
+    else
+        contextID = interface->layerHostingContext()->contextID();
+
+    m_page->send(Messages::VideoFullscreenManagerProxy::SetupFullscreenWithID(contextId, contextID, videoRect, FloatSize(videoElement.videoWidth(), videoElement.videoHeight()), m_page->deviceScaleFactor(), interface->fullscreenMode(), allowsPictureInPicture, standby, videoElement.document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk()));
 
     if (auto player = videoElement.player()) {
         if (auto identifier = player->identifier())
@@ -466,9 +483,9 @@ void VideoFullscreenManager::requestVideoContentLayer(PlaybackSessionContextIden
 {
     auto [model, interface] = ensureModelAndInterface(contextId);
 
-    CALayer* videoLayer = interface->layerHostingContext()->rootLayer();
+    auto videoLayer = interface->rootLayer();
 
-    model->setVideoFullscreenLayer(videoLayer, [protectedThis = Ref { *this }, this, contextId] () mutable {
+    model->setVideoFullscreenLayer(videoLayer.get(), [protectedThis = Ref { *this }, this, contextId] () mutable {
         RunLoop::main().dispatch([protectedThis = WTFMove(protectedThis), this, contextId] {
             if (protectedThis->m_page)
                 m_page->send(Messages::VideoFullscreenManagerProxy::SetHasVideoContentLayer(contextId, true));
@@ -607,7 +624,7 @@ void VideoFullscreenManager::didCleanupFullscreen(PlaybackSessionContextIdentifi
 
     auto [model, interface] = ensureModelAndInterface(contextId);
 
-    if (interface->layerHostingContext()->rootLayer()) {
+    if (interface->layerHostingContext() && interface->layerHostingContext()->rootLayer()) {
         interface->layerHostingContext()->setRootLayer(nullptr);
         interface->setLayerHostingContext(nullptr);
     }
@@ -677,11 +694,37 @@ void VideoFullscreenManager::setVideoLayerFrameFenced(PlaybackSessionContextIden
         bounds = FloatRect(0, 0, videoRect.width(), videoRect.height());
     }
 
-    if (interface->layerHostingContext()->rootLayer()) {
+    if (interface->layerHostingContext() && interface->layerHostingContext()->rootLayer()) {
         interface->layerHostingContext()->setFencePort(machSendRight.sendRight());
         model->setVideoLayerFrame(bounds);
     } else
         model->setVideoInlineSizeFenced(bounds.size(), machSendRight);
+}
+
+void VideoFullscreenManager::updateTextTrackRepresentationForVideoElement(WebCore::HTMLVideoElement& videoElement, const ShareableBitmapHandle& textTrack)
+{
+    if (!m_page)
+        return;
+    auto contextId = m_videoElements.get(&videoElement);
+    m_page->send(Messages::VideoFullscreenManagerProxy::TextTrackRepresentationUpdate(contextId, textTrack));
+}
+
+void VideoFullscreenManager::setTextTrackRepresentationContentScaleForVideoElement(WebCore::HTMLVideoElement& videoElement, float scale)
+{
+    if (!m_page)
+        return;
+    auto contextId = m_videoElements.get(&videoElement);
+    m_page->send(Messages::VideoFullscreenManagerProxy::TextTrackRepresentationSetContentsScale(contextId, scale));
+
+}
+
+void VideoFullscreenManager::setTextTrackRepresentationIsHiddenForVideoElement(WebCore::HTMLVideoElement& videoElement, bool hidden)
+{
+    if (!m_page)
+        return;
+    auto contextId = m_videoElements.get(&videoElement);
+    m_page->send(Messages::VideoFullscreenManagerProxy::TextTrackRepresentationSetHidden(contextId, hidden));
+
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### f40d4830b8c1a420d53cc9aabd15c35d4414e711
<pre>
Text tracks are not visible in fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=254473">https://bugs.webkit.org/show_bug.cgi?id=254473</a>
rdar://107230116

Reviewed by Jer Noble.

When the setting &quot;GPU Process: Block Media Layer Re-hosting&quot; is enabled, text tracks are not visible
in fullscreen, since this depends on the ability to create a CA remote layer hosting context in the
WebProcess. This patch works around the requirement to create a CA context in the WebContent process
by sending the caption bitmaps to the UI process, where they are rendered into a CA layer, which is
inserted into the fullscreen CA layer tree. The CA layer tree in the WebContent process is still
being created, since there is some amount of caption code that depends on this in order to get the
caption bounds correct. This patch also sets the flag &quot;GPU Process: Block Media Layer Re-hosting&quot; to
true, which is required to be able to block CARenderServer in the WebContent process&apos; sandbox.
Layout test runs on iOS simulator on the bots showed some flaky timeouts of the test
webrtc/video-rotation.html. Looking at test history, this test has already been flaky on simulator.
This patch is about captions in fullscreen, so I don&apos;t think it will affect this test, although it
cannot be ruled out. I marked the test as flaky. This is being tracked in webkit.org/b/254872.

* LayoutTests/platform/ios-simulator-wk2/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateTextTrackRepresentationIfNeeded):
* Source/WebCore/platform/graphics/TextTrackRepresentation.cpp:
(WebCore::TextTrackRepresentation::create):
* Source/WebCore/platform/graphics/TextTrackRepresentation.h:
* Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.h:
* Source/WebCore/platform/graphics/cocoa/TextTrackRepresentationCocoa.mm:
(WebCore::TextTrackRepresentation::create):
(WebCore::TextTrackRepresentationCocoa::representationFactory):
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(VideoFullscreenInterfaceAVKit::textTrackRepresentationUpdate):
(VideoFullscreenInterfaceAVKit::textTrackRepresentationSetContentsScale):
(VideoFullscreenInterfaceAVKit::textTrackRepresentationSetHidden):
(VideoFullscreenInterfaceAVKit::captionsLayer):
(VideoFullscreenInterfaceAVKit::setCaptionsFrame):
(VideoFullscreenInterfaceAVKit::setupCaptionsLayer):
(VideoFullscreenInterfaceAVKit::removeCaptionsLayer):
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenManagerProxy::createLayerHostViewWithID):
(WebKit::VideoFullscreenManagerProxy::textTrackRepresentationUpdate):
(WebKit::VideoFullscreenManagerProxy::textTrackRepresentationSetContentsScale):
(WebKit::VideoFullscreenManagerProxy::textTrackRepresentationSetHidden):
(WebKit::VideoFullscreenManagerProxy::didCleanupFullscreen):
(WebKit::VideoFullscreenManagerProxy::setVideoLayerFrame):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h:
(WebKit::VideoFullscreenInterfaceContext::rootLayer const):
(WebKit::VideoFullscreenInterfaceContext::setRootLayer):
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::createModelAndInterface):
(WebKit::VideoFullscreenManager::ensureModelAndInterface):
(WebKit::VideoFullscreenManager::setupRemoteLayerHosting):
(WebKit::VideoFullscreenManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::requestVideoContentLayer):
(WebKit::VideoFullscreenManager::didCleanupFullscreen):
(WebKit::VideoFullscreenManager::setVideoLayerFrameFenced):
(WebKit::VideoFullscreenManager::updateTextTrackRepresentationForVideoElement):
(WebKit::VideoFullscreenManager::setTextTrackRepresentationContentScaleForVideoElement):
(WebKit::VideoFullscreenManager::setTextTrackRepresentationIsHiddenForVideoElement):

Canonical link: <a href="https://commits.webkit.org/262487@main">https://commits.webkit.org/262487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0408a58257d81066f999355ffa2d8cfd36246cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1770 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1548 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2406 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1486 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1470 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1389 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/1397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1507 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1512 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2567 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1580 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1372 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1704 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1477 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/383 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/411 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1605 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1746 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/499 "Passed tests") | 
<!--EWS-Status-Bubble-End-->