### PR TITLE
Use correct globals when creating readers and readable streams

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -860,7 +860,6 @@ imported/w3c/web-platform-tests/html/rendering/widgets/appearance/appearance-tra
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-element/embed-hidden-attribute.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-layout-stale-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html [ Pass Failure ]
-imported/w3c/web-platform-tests/streams/readable-streams/global.html [ Pass Failure ]
 
 # Cross-Origin-Embedder-Policy: credentialless is not supported.
 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/credentialless

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/global-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/global-expected.txt
@@ -1,12 +1,12 @@
 
 
-FAIL Stream objects created in expected globals assert_equals: reader was created in this global (.call) expected true but got false
+PASS Stream objects created in expected globals
 PASS Cancel promise is created in same global as stream
 PASS Closed Promise in correct global
-FAIL Reader objects in correct global assert_equals: Reader comes from this global expected true but got false
+PASS Reader objects in correct global
 PASS Desired size can be grafted from one prototype to another
 PASS Closing errored stream throws object in appropriate global
 PASS Can enqueue chunks from multiple globals
 PASS Correct errors and globals for closed streams
-FAIL Tee Branches in correct global assert_equals: Branch created in this global (as stream is in this global) expected true but got false
+PASS Tee Branches in correct global
 

--- a/Source/WebCore/Modules/streams/ReadableStream.js
+++ b/Source/WebCore/Modules/streams/ReadableStream.js
@@ -39,6 +39,7 @@ function initializeReadableStream(underlyingSource, strategy)
     if (strategy !== @undefined && !@isObject(strategy))
         @throwTypeError("ReadableStream constructor takes an object as second argument, if any");
 
+    @putByIdDirectPrivate(this, "globalObject", @getGlobalObject());
     @putByIdDirectPrivate(this, "state", @streamReadable);
     @putByIdDirectPrivate(this, "reader", @undefined);
     @putByIdDirectPrivate(this, "storedError", @undefined);
@@ -117,12 +118,17 @@ function getReader(options)
         throw @makeThisTypeError("ReadableStream", "getReader");
 
     const mode = @toDictionary(options, { }, "ReadableStream.getReader takes an object as first argument").mode;
-    if (mode === @undefined)
-        return new @ReadableStreamDefaultReader(this);
+    const readableStreamGlobalObject = @getByIdDirectPrivate(this, "globalObject");
+    if (mode === @undefined) {
+        const readableStreamDefaultReaderConstructor = @getByIdDirectPrivate(readableStreamGlobalObject, "ReadableStreamDefaultReader");
+        return new readableStreamDefaultReaderConstructor(this);
+    }
 
     // String conversion is required by spec, hence double equals.
-    if (mode == 'byob')
+    if (mode == 'byob') {
+        const readableStreamBYOBReaderConstructor = @getByIdDirectPrivate(readableStreamGlobalObject, "ReadableStreamBYOBReader");
         return new @ReadableStreamBYOBReader(this);
+    }
 
     @throwTypeError("Invalid mode is specified");
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamInternals.js
@@ -107,7 +107,7 @@ function readableStreamPipeTo(stream, sink)
     "use strict";
     @assert(@isReadableStream(stream));
 
-    const reader = new @ReadableStreamDefaultReader(stream);
+    const reader = @acquireReadableStreamDefaultReader(stream);
 
     @getByIdDirectPrivate(reader, "closedPromiseCapability").@promise.@then(() => { }, (e) => { sink.error(e); });
 
@@ -133,7 +133,9 @@ function readableStreamPipeTo(stream, sink)
 
 function acquireReadableStreamDefaultReader(stream)
 {
-    return new @ReadableStreamDefaultReader(stream);
+    const readableStreamGlobalObject = @getByIdDirectPrivate(stream, "globalObject");
+    const readableStreamDefaultReaderConstructor = @getByIdDirectPrivate(readableStreamGlobalObject, "ReadableStreamDefaultReader");
+    return new readableStreamDefaultReaderConstructor(stream);
 }
 
 // FIXME: Replace readableStreamPipeTo by below function.
@@ -389,7 +391,7 @@ function readableStreamTee(stream, shouldClone)
     @assert(@isReadableStream(stream));
     @assert(typeof(shouldClone) === "boolean");
 
-    const reader = new @ReadableStreamDefaultReader(stream);
+    const reader = @acquireReadableStreamDefaultReader(stream);
 
     const teeState = {
         stream: stream,
@@ -413,8 +415,10 @@ function readableStreamTee(stream, shouldClone)
     @putByIdDirectPrivate(branch2Source, "pull", pullFunction);
     @putByIdDirectPrivate(branch2Source, "cancel", @readableStreamTeeBranch2CancelFunction(teeState, stream));
 
-    const branch1 = new @ReadableStream(branch1Source);
-    const branch2 = new @ReadableStream(branch2Source);
+    const readableStreamGlobalObject = @getByIdDirectPrivate(stream, "globalObject");
+    const readableStreamConstructor = @getByIdDirectPrivate(readableStreamGlobalObject, "ReadableStream");
+    const branch1 = new readableStreamConstructor(branch1Source);
+    const branch2 = new readableStreamConstructor(branch2Source);
 
     @getByIdDirectPrivate(reader, "closedPromiseCapability").@promise.@then(@undefined, function(e) {
         @readableStreamDefaultControllerError(branch1.@readableStreamController, e);

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -91,6 +91,7 @@ JSC_DECLARE_HOST_FUNCTION(makeGetterTypeErrorForBuiltins);
 JSC_DECLARE_HOST_FUNCTION(makeDOMExceptionForBuiltins);
 JSC_DECLARE_HOST_FUNCTION(isReadableByteStreamAPIEnabled);
 JSC_DECLARE_HOST_FUNCTION(createWritableStreamFromInternal);
+JSC_DECLARE_HOST_FUNCTION(getGlobalObject);
 JSC_DECLARE_HOST_FUNCTION(getInternalWritableStream);
 JSC_DECLARE_HOST_FUNCTION(addAbortAlgorithmToSignal);
 JSC_DECLARE_HOST_FUNCTION(removeAbortAlgorithmFromSignal);
@@ -192,6 +193,11 @@ JSC_DEFINE_HOST_FUNCTION(getInternalWritableStream, (JSGlobalObject*, CallFrame*
     return JSValue::encode(writableStream->wrapped().internalWritableStream());
 }
 
+JSC_DEFINE_HOST_FUNCTION(getGlobalObject, (JSGlobalObject* globalObject, CallFrame*))
+{
+    return JSValue::encode(globalObject);
+}
+
 JSC_DEFINE_HOST_FUNCTION(createWritableStreamFromInternal, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     ASSERT(callFrame);
@@ -289,6 +295,7 @@ SUPPRESS_ASAN void JSDOMGlobalObject::addBuiltinGlobals(VM& vm)
         JSDOMGlobalObject::GlobalPropertyInfo(builtinNames.readableByteStreamAPIEnabledPrivateName(), JSFunction::create(vm, this, 0, String(), isReadableByteStreamAPIEnabled, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         JSDOMGlobalObject::GlobalPropertyInfo(builtinNames.isAbortSignalPrivateName(), JSFunction::create(vm, this, 1, String(), isAbortSignal, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         JSDOMGlobalObject::GlobalPropertyInfo(builtinNames.getInternalWritableStreamPrivateName(), JSFunction::create(vm, this, 1, String(), getInternalWritableStream, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
+        JSDOMGlobalObject::GlobalPropertyInfo(builtinNames.getGlobalObjectPrivateName(), JSFunction::create(vm, this, 1, String(), getGlobalObject, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
         JSDOMGlobalObject::GlobalPropertyInfo(builtinNames.createWritableStreamFromInternalPrivateName(), JSFunction::create(vm, this, 1, String(), createWritableStreamFromInternal, ImplementationVisibility::Public), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly),
     };
     addStaticGlobals(staticGlobals, std::size(staticGlobals));

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -531,10 +531,12 @@ namespace WebCore {
     macro(flushAlgorithm) \
     macro(focus) \
     macro(frames) \
+    macro(getGlobalObject) \
     macro(getInternalWritableStream) \
     macro(getMatchedCSSRules) \
     macro(getTracks) \
     macro(getUserMedia) \
+    macro(globalObject) \
     macro(gpu) \
     macro(handleEvent) \
     macro(header) \


### PR DESCRIPTION
#### 09d5e763955353febc4df850bdfb75b5669537de
<pre>
Use correct globals when creating readers and readable streams
<a href="https://bugs.webkit.org/show_bug.cgi?id=254589">https://bugs.webkit.org/show_bug.cgi?id=254589</a>
rdar://problem/107317226

Reviewed by Alex Christensen.

Store the ReadableStream global in it.
Use it to get related constructors when needed.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/global-expected.txt:
* Source/WebCore/Modules/streams/ReadableStream.js:
(initializeReadableStream):
(getReader):
* Source/WebCore/Modules/streams/ReadableStreamInternals.js:
(readableStreamPipeTo):
(acquireReadableStreamDefaultReader):
(readableStreamTee):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):
(WebCore::JSDOMGlobalObject::addBuiltinGlobals):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/262313@main">https://commits.webkit.org/262313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9f4a000ada34640ba2c399c2c4d1da518a4072e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1039 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1283 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/874 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/851 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1908 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/892 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/846 "2 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/299 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/906 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->