### PR TITLE
Cherry-pick 252432.1018@safari-7614-branch (792c09f18dc7). rdar://107315556

### DIFF
--- a/LayoutTests/streams/blob-and-then-expected.txt
+++ b/LayoutTests/streams/blob-and-then-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Ensure redefining then does not alter blob promise
+

--- a/LayoutTests/streams/blob-and-then.html
+++ b/LayoutTests/streams/blob-and-then.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+promise_test(async () => {
+    function createReadStream() {
+        const response = new Response(new Blob(['aaaaa']));
+        return response.body;
+    }
+
+    const f = document.body.appendChild(document.createElement('iframe'));
+    const response = new f.contentWindow.Response(createReadStream());
+
+    f.contentWindow.Object.prototype.__defineGetter__('then', () => {
+        delete f.contentWindow.Object.prototype.then;
+
+        f.remove();
+    });
+
+    response.blob();
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+}, "Ensure redefining then does not alter blob promise");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -279,17 +279,18 @@ void FetchBodyConsumer::resolveWithFormData(Ref<DeferredPromise>&& promise, cons
     if (!context)
         return;
 
-    m_formDataConsumer = makeUnique<FormDataConsumer>(formData, *context, [this, capturedPromise = WTFMove(promise), contentType, builder = SharedBufferBuilder { }](auto&& result) mutable {
+    m_formDataConsumer = makeUnique<FormDataConsumer>(formData, *context, [this, promise = WTFMove(promise), contentType, builder = SharedBufferBuilder { }](auto&& result) mutable {
         if (result.hasException()) {
-            auto promise = WTFMove(capturedPromise);
-            promise->reject(result.releaseException());
+            auto protectedPromise = WTFMove(promise);
+            protectedPromise->reject(result.releaseException());
             return;
         }
 
         auto& value = result.returnValue();
         if (value.empty()) {
+            auto protectedPromise = WTFMove(promise);
             auto buffer = builder.takeAsContiguous();
-            resolveWithData(WTFMove(capturedPromise), contentType, buffer->data(), buffer->size());
+            resolveWithData(WTFMove(protectedPromise), contentType, buffer->data(), buffer->size());
             return;
         }
 
@@ -309,6 +310,7 @@ void FetchBodyConsumer::consumeFormDataAsStream(const FormData& formData, FetchB
         return;
 
     m_formDataConsumer = makeUnique<FormDataConsumer>(formData, *context, [this, source = Ref { source }](auto&& result) {
+        auto protectedSource = source;
         if (result.hasException()) {
             source->error(result.releaseException());
             return;
@@ -338,16 +340,20 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
         ASSERT(!m_sink);
         m_sink = ReadableStreamToSharedBufferSink::create([promise = WTFMove(promise), data = SharedBufferBuilder(), type = m_type, contentType](auto&& result) mutable {
             if (result.hasException()) {
-                promise->reject(result.releaseException());
+                auto protectedPromise = WTFMove(promise);
+                protectedPromise->reject(result.releaseException());
                 return;
             }
 
-            if (auto* chunk = result.returnValue())
-                data.append(chunk->data(), chunk->size());
-            else {
+            auto* chunk = result.returnValue();
+            if (!chunk) {
+                auto protectedPromise = WTFMove(promise);
                 auto buffer = data.takeAsContiguous();
-                resolveWithTypeAndData(WTFMove(promise), type, contentType, buffer->data(), buffer->size());
+                resolveWithTypeAndData(WTFMove(protectedPromise), type, contentType, buffer->data(), buffer->size());
+                return;
             }
+
+            data.append(chunk->data(), chunk->size());
         });
         m_sink->pipeFrom(*stream);
         return;

--- a/Source/WebCore/Modules/streams/ReadableStreamSink.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamSink.cpp
@@ -57,14 +57,20 @@ void ReadableStreamToSharedBufferSink::enqueue(const Ref<JSC::Uint8Array>& buffe
 
 void ReadableStreamToSharedBufferSink::close()
 {
-    if (m_callback)
-        m_callback(nullptr);
+    if (!m_callback)
+        return;
+
+    auto callback = std::exchange(m_callback, { });
+    callback(nullptr);
 }
 
 void ReadableStreamToSharedBufferSink::error(String&& message)
 {
-    if (auto callback = WTFMove(m_callback))
-        callback(Exception { TypeError, WTFMove(message) });
+    if (!m_callback)
+        return;
+
+    auto callback = std::exchange(m_callback, { });
+    callback(Exception { TypeError, WTFMove(message) });
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### abafb86e06cff4ef87143bef6ce7f56e4f6f6415
<pre>
Cherry-pick 252432.1018@safari-7614-branch (792c09f18dc7). rdar://107315556

    Use-after-free in FetchBodyConsumer::resolve
    <a href="https://bugs.webkit.org/show_bug.cgi?id=249996">https://bugs.webkit.org/show_bug.cgi?id=249996</a>
    rdar://103649054

    Reviewed by Jonathan Bedard and Alex Christensen.

    Make sure in FetchBodyConsumer that refed promise/source remain protected.

    We also revert part of an unnecessary and wrong change from <a href="https://trac.webkit.org/changeset/227760.">https://trac.webkit.org/changeset/227760.</a>
    This makes sure ReadableStreamToSharedBufferSink callback remains valid until completely executed in close case, as was the case in error case.
    We use std::exchange instead of move as it is more semantically correct.

    Covered by added test.

    * LayoutTests/streams/blob-and-then-expected.txt: Added.
    * LayoutTests/streams/blob-and-then.html: Added.
    * Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
    (WebCore::FetchBodyConsumer::resolveWithFormData):
    (WebCore::FetchBodyConsumer::consumeFormDataAsStream):
    (WebCore::FetchBodyConsumer::resolve):
    * Source/WebCore/Modules/streams/ReadableStreamSink.cpp:
    (WebCore::ReadableStreamToSharedBufferSink::close):
    (WebCore::ReadableStreamToSharedBufferSink::error):

    Canonical link: <a href="https://commits.webkit.org/252432.1018@safari-7614-branch">https://commits.webkit.org/252432.1018@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262229@main">https://commits.webkit.org/262229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6691ec3c11e14910f7ba8a4aaa8b25893234d3fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1365 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/830 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1041 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1285 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/877 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/853 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1914 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/848 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/886 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/231 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/908 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->