### PR TITLE
Cherry-pick 252432.1019@safari-7614-branch (1988807a5229). rdar://107319167

### DIFF
--- a/LayoutTests/editing/async-clipboard/clipboard-clear-expected.txt
+++ b/LayoutTests/editing/async-clipboard/clipboard-clear-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/editing/async-clipboard/clipboard-clear.html
+++ b/LayoutTests/editing/async-clipboard/clipboard-clear.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+function runTest() {
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        window.testRunner.dumpAsText();
+    }
+
+    var clipboard = window.clientInformation.clipboard;
+    var textBlob = new Blob([ (new TextEncoder()).encode("a") ], { type : "text/plain" });
+    if (typeof ClipBoardItem !== "undefined") {
+        var cbi = new ClipboardItem({ "text/plain" : textBlob });
+        clipboard.write([cbi]);
+        clipboard.write([cbi]);
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</head>
+<body onload=runTest()>
+<p>PASS if no crash.</p>
+</body>
+</html>

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -125,9 +125,17 @@ void ClipboardItemBindingsDataSource::getType(const String& type, Ref<DeferredPr
     });
 }
 
+void ClipboardItemBindingsDataSource::clearItemTypeLoaders()
+{
+    for (auto& itemTypeLoader : m_itemTypeLoaders)
+        itemTypeLoader->invokeCompletionHandler();
+
+    m_itemTypeLoaders.clear();
+}
+
 void ClipboardItemBindingsDataSource::collectDataForWriting(Clipboard& destination, CompletionHandler<void(std::optional<PasteboardCustomData>)>&& completion)
 {
-    m_itemTypeLoaders.clear();
+    clearItemTypeLoaders();
     ASSERT(!m_completionHandler);
     m_completionHandler = WTFMove(completion);
     m_writingDestination = destination;
@@ -241,8 +249,8 @@ ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::~ClipboardItemTypeLoad
 {
     if (m_blobLoader)
         m_blobLoader->cancel();
-
-    invokeCompletionHandler();
+    
+    ASSERT(!m_completionHandler);
 }
 
 void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didFinishLoading()

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
@@ -52,6 +52,7 @@ private:
     void getType(const String&, Ref<DeferredPromise>&&) final;
     void collectDataForWriting(Clipboard& destination, CompletionHandler<void(std::optional<PasteboardCustomData>)>&&) final;
 
+    void clearItemTypeLoaders();
     void invokeCompletionHandler();
 
     using BufferOrString = std::variant<String, Ref<SharedBuffer>>;
@@ -68,6 +69,8 @@ private:
         void didFailToResolve();
         void didResolveToBlob(ScriptExecutionContext&, Ref<Blob>&&);
 
+        void invokeCompletionHandler();
+
         const String& type() { return m_type; }
         const BufferOrString& data() { return m_data; }
 
@@ -75,7 +78,6 @@ private:
         ClipboardItemTypeLoader(Clipboard&, const String& type, CompletionHandler<void()>&&);
 
         void sanitizeDataIfNeeded();
-        void invokeCompletionHandler();
 
         String dataAsString() const;
 


### PR DESCRIPTION
#### 4943210909a2aeabf7c1e4c8be389b48761078c9
<pre>
Cherry-pick 252432.1019@safari-7614-branch (1988807a5229). rdar://107319167

    [Clipboard] Explicitly call completion on clearing ClipboardItemTypeLoader
    rdar://103307563

    Reviewed by Jonathan Bedard and Wenson Hsieh.

    In m_itemTypeLoaders.clear(), ClipboardItemBindingsDataSource::invokeCompletionHandler() is called after all m_itemTypeLoaders released
    and traverses the itemTypeLoaders after itemTypeLoaders is clear but before the size is updated, causing nullptr accessment.
    So we should explicitly call completion before itemTypeLoader is released.

    * LayoutTests/editing/async-clipboard/clipboard-clear-expected.txt: Added.
    * LayoutTests/editing/async-clipboard/clipboard-clear.html: Added.
    * Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
    (WebCore::ClipboardItemBindingsDataSource::clearItemTypeLoaders):
    (WebCore::ClipboardItemBindingsDataSource::collectDataForWriting):
    (WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::~ClipboardItemTypeLoader):
    * Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h:

    Canonical link: <a href="https://commits.webkit.org/252432.1019@safari-7614-branch">https://commits.webkit.org/252432.1019@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262227@main">https://commits.webkit.org/262227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb6538210f60b81de7a314dc7c72fe3614e410ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1371 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1043 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1288 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/879 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/876 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/855 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1912 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/896 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/232 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/910 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->