### PR TITLE
Avoid some string allocations in JSStringJoiner::join()

### DIFF
--- a/Source/JavaScriptCore/runtime/JSStringJoiner.h
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.h
@@ -69,7 +69,7 @@ inline JSStringJoiner::JSStringJoiner(JSGlobalObject* globalObject, StringView s
 inline JSValue JSStringJoiner::join(JSGlobalObject* globalObject)
 {
     if (m_strings.size() == 1)
-        return jsString(globalObject->vm(), m_strings[0].view.toString());
+        return jsString(globalObject->vm(), m_strings[0].toString());
     return joinSlow(globalObject);
 }
 

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -283,10 +283,19 @@ struct StringViewWithUnderlyingString {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
     StringView view;
     String underlyingString;
+
+    String toString() const;
 };
 
 inline StringView::StringView()
 {
+}
+
+inline String StringViewWithUnderlyingString::toString() const
+{
+    if (LIKELY(view.length() == underlyingString.length()))
+        return underlyingString;
+    return view.toString();
 }
 
 #if CHECK_STRINGVIEW_LIFETIME


### PR DESCRIPTION
#### 72ed5e715480a97da6c55be10cd6c058287df888
<pre>
Avoid some string allocations in JSStringJoiner::join()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254594">https://bugs.webkit.org/show_bug.cgi?id=254594</a>

Reviewed by Yusuke Suzuki.

Avoid some string allocations in JSStringJoiner::join(), in the common case
where the StringViewWithUnderlyingString&apos;s view covers the whole underlying
string.

* Source/JavaScriptCore/runtime/JSStringJoiner.h:
(JSC::JSStringJoiner::join):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringViewWithUnderlyingString::toString const):

Canonical link: <a href="https://commits.webkit.org/262228@main">https://commits.webkit.org/262228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2fdcacfe3b742522276ff5ddd6e50097a4a958b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/833 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1051 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1289 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/879 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/833 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/909 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/1921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/924 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/897 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/967 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/891 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/229 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/911 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/970 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/188 "Passed tests") | 
<!--EWS-Status-Bubble-End-->