### PR TITLE
[GStreamer][WebCodec] Gardening after 262208@main

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1145,12 +1145,6 @@ imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?vp8 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?vp9 [ Failure ]
 
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?vp9_p2 [ Failure ]
-importee/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp9_p2 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.html?vp9_p2 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker.html?vp9_p2 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.html  [ Failure ]
-
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of GStreamer-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Encoding and decoding cycle assert_not_equals: colorSpace.primaries got disallowed value null
+FAIL Encoding and decoding cycle w/ stripped color space assert_not_equals: colorSpace.primaries got disallowed value null
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Encoding and decoding cycle assert_not_equals: colorSpace.primaries got disallowed value null
+FAIL Encoding and decoding cycle w/ stripped color space assert_not_equals: colorSpace.primaries got disallowed value null
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Reconfiguring encoder
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Reconfiguring encoder
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
@@ -1,0 +1,34 @@
+
+PASS Test we can construct a VideoFrame.
+FAIL Test closed VideoFrame. assert_equals: timestamp expected 10 but got 0
+PASS Test we can construct a VideoFrame with a negative timestamp.
+PASS Test that timestamp is required when constructing VideoFrame from ImageBitmap
+PASS Test that timestamp is required when constructing VideoFrame from OffscreenCanvas
+PASS Test that timestamp is NOT required when constructing VideoFrame from another VideoFrame
+PASS Test we can construct an odd-sized VideoFrame.
+PASS Test constructing w/ unusable image argument throws: HAVE_NOTHING <video>.
+PASS Test we can construct a VideoFrame from a <video>.
+PASS Test constructing w/ unusable image argument throws: emtpy Canvas.
+PASS Test constructing w/ unusable image argument throws: closed ImageBitmap.
+PASS Test constructing w/ unusable image argument throws: closed VideoFrame.
+PASS Test invalid CanvasImageSource constructed VideoFrames
+PASS Test visibleRect metadata override where source display size = visible size
+PASS Test visibleRect metadata override where source display width = 2 * visible width (anamorphic)
+PASS Test visibleRect metadata override where source display size = 2 * visible size for both width and height
+PASS Test visibleRect + display size metadata override
+PASS Test display size metadata override
+PASS Test invalid buffer constructed VideoFrames
+PASS Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame
+PASS Test ArrayBuffer constructed I420 VideoFrame
+PASS Test planar constructed I420 VideoFrame with colorSpace
+FAIL Test planar constructed I420 VideoFrame with null colorSpace values Type error
+FAIL Test buffer constructed I420+Alpha VideoFrame VideoPixelFormat is not supported
+PASS Test buffer constructed NV12 VideoFrame
+PASS Test buffer constructed RGB VideoFrames
+PASS Test VideoFrame constructed VideoFrame
+PASS Test we can construct a VideoFrame from an offscreen canvas.
+PASS Test I420 VideoFrame with odd visible size
+FAIL Test I420A VideoFrame and alpha={keep,discard} VideoPixelFormat is not supported
+PASS Test RGBA, BGRA VideoFrames with alpha={keep,discard}
+PASS Test a VideoFrame constructed from canvas can drop the alpha channel.
+


### PR DESCRIPTION
#### 53f231e103d66aac687d2e8831c1e1a288f72970
<pre>
[GStreamer][WebCodec] Gardening after 262208@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=254593">https://bugs.webkit.org/show_bug.cgi?id=254593</a>

Unreviewed.

full-cycle tests fail slightly differently than on the Apple ports. reconfiguring-encoder pass on
GStreamer but not on Apple ports. videoFrame-construction still fails, but doesn&apos;t time out as on
Apple ports.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p2-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/262221@main">https://commits.webkit.org/262221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5052f29525c3bb3ea4c3985df204512f6b55a54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1004 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1373 "Failed to checkout and rebase branch from PR 12057") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1052 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/1373 "Failed to checkout and rebase branch from PR 12057") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/949 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1290 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/857 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/1915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/96 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->