### PR TITLE
[git-webkit] Add clone command

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.11.0',
+    version='0.12.0',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 11, 0)
+version = Version(0, 12, 0)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/__init__.py
@@ -21,6 +21,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from .bugzilla import Bugzilla
-from .data import ISSUES, USERS, PROJECTS
+from .data import ISSUES, USERS, PROJECTS, MILESTONES
 from .github import GitHub
 from .radar import Radar, NoRadar

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
@@ -132,3 +132,18 @@ PROJECTS = dict(
         ),
     ),
 )
+
+MILESTONES = [
+    dict(
+        name='October',
+        isProtected=True,
+        protectedAccessGroup='Managers,Integrators',
+        categories=['Test Development', 'Tentpole Feature Work', 'Escape / Regression in the Build'],
+        events=['Week 1', 'Week 2', 'Week 3', 'Week 4', 'Convergence'],
+        tentpoles=['Scrolling', 'SVG'],
+        isCategoryRequired=True,
+    ), dict(
+        name='Future',
+        categories=['Test Development', 'Tentpole TBD', 'Escape / Regression in the Build'],
+    ),
+]

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -402,3 +402,22 @@ What version of 'WebKit Text' should the bug be associated with?:
         with mocks.Radar(issues=mocks.ISSUES):
             tracker = radar.Tracker()
             self.assertEqual(tracker.issue(1).classification, 'Other Bug')
+
+    def test_clone(self):
+        with wkmocks.Environment(RADAR_USERNAME='tcontributor'), mocks.Radar(issues=mocks.ISSUES, projects=mocks.PROJECTS):
+            tracker = radar.Tracker()
+            original = tracker.issue(1)
+            cloned = tracker.clone(original, reason='Cloning for merge-back')
+
+            self.assertEqual(original.title, cloned.title)
+            self.assertEqual(original.classification, cloned.classification)
+            self.assertEqual(original.project, cloned.project)
+            self.assertEqual(original.component, cloned.component)
+            self.assertEqual(original.version, cloned.version)
+            self.assertEqual(
+                cloned.description,
+                'Reason for clone:\n'
+                'Cloning for merge-back\n\n'
+                '<original text - begin>\n\n'
+                'An example issue for testing',
+            )

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.5.0',
+    version='6.6.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 5, 0)
+version = Version(6, 6, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -30,6 +30,7 @@ from .branch import Branch
 from .canonicalize import Canonicalize
 from .cherry_pick import CherryPick
 from .clean import Clean, DeletePRBranches
+from .clone import Clone
 from .command import Command
 from .commit import Commit
 from .squash import Squash
@@ -91,7 +92,7 @@ def main(
 
     programs = [
         Blame, Branch, Canonicalize, Checkout,
-        Clean, Find, Info, Land, Log, Pull,
+        Clean, Clone, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
         Pickable, CherryPick, Trace, Track, Show, Publish,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py
@@ -1,0 +1,271 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+from .command import Command
+from .trace import Trace, Relationship
+from webkitbugspy import Tracker, radar
+from webkitcorepy import arguments, Terminal
+from webkitscmpy import log
+
+
+class Clone(Command):
+    name = 'clone'
+    help = 'Clone the radar a bugzilla or commit refers to'
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            'argument', nargs=1,
+            type=str, default=None,
+            help='String representation of a commit to be cherry-picked',
+        )
+        parser.add_argument(
+            '--milestone', '-m',
+            dest='milestone', default=None,
+            help='Milestone to move cloned radar into',
+            type=str,
+        )
+        parser.add_argument(
+            '--why', '-w', '--reason', '-r',
+            dest='reason', default=None,
+            help='Reason why issue is being cloned',
+            type=str,
+        )
+        parser.add_argument(
+            '--prompt', '--no-prompt',
+            dest='prompt', default=Terminal.isatty(sys.stdout),
+            help='Enable (or disable) prompts to populate cloned radar',
+            action=arguments.NoAction,
+        )
+        parser.add_argument(
+            '--dry-run', '-d',
+            dest='dry_run', default=False,
+            help='Gather milestone, category, tentpole and event for clone, but do not preform clone',
+            action='store_true',
+        )
+        parser.add_argument(
+            '--merge-back',
+            dest='merge_back', default=False,
+            help='Annotate the cloned issue for merge-back',
+            action='store_true',
+        )
+
+    @classmethod
+    def main(cls, args, repository, merge_back=False, **kwargs):
+        rdar = None
+        merge_back = merge_back or args.merge_back
+        prefix = '[merge-back]' if merge_back else ''
+
+        for tracker in Tracker._trackers:
+            if isinstance(tracker, radar.Tracker):
+                rdar = tracker
+                break
+        if not rdar or not rdar.radarclient():
+            sys.stderr.write("'cloning' is a concept which belongs solely to radar\n")
+            if not rdar:
+                sys.stderr.write('This repository does not declare radar as an issue tracker\n')
+            else:
+                sys.stderr.write('Radar is not available on this machine\n')
+            return 255
+
+        if not args.reason and args.milestone:
+            args.reason = "Cloning for inclusion in '{}'".format(args.milestone)
+        if not args.reason:
+            sys.stderr.write('No reason for cloning issue has been provided\n')
+            return 255
+
+        # First, check if we were provided a bug URL
+        issue = Tracker.from_string(args.argument[0])
+        if not issue:
+            if not repository:
+                sys.stderr.write("Failed to resolve '{}' to a radar\n".format(args.argument[0]))
+                sys.stderr.write('No repository to search for commits in\n')
+                return 255
+            commit = repository.find(args.argument[0], include_identifier=False)
+            if not commit:
+                sys.stderr.write("Failed to resolve '{}' to a radar\n".format(args.argument[0]))
+                sys.stderr.write("No commit found matching '{}'\n".format(args.argument[0]))
+                return 255
+            for relation in (Trace.relationships(commit, repository) or []):
+                if relation.type in Relationship.IDENTITY:
+                    commit = relation.commit
+                    break
+            if not commit.issues:
+                sys.stderr.write("Failed to resolve '{}' to a radar\n".format(args.argument[0]))
+                sys.stderr.write("Found {}, but it doesn't reference any issues\n".format(commit))
+                return 255
+            for candidate in commit.issues:
+                if isinstance(candidate.tracker, radar.Tracker):
+                    issue = candidate
+                    break
+            if not issue:
+                issue = commit.issues[0]
+            log.info('{} references {}'.format(commit, issue))
+
+        if not isinstance(issue.tracker, radar.Tracker):
+            for candidate in issue.references:
+                if isinstance(candidate.tracker, radar.Tracker):
+                    issue = candidate
+                    break
+        if not isinstance(issue.tracker, radar.Tracker):
+            sys.stderr.write("'{}' is not a radar, therefore cannot be cloned\n".format(issue))
+            return 255
+
+        milestone = None
+        raw_issue = rdar.client.radar_for_id(issue.id)
+        milestones = {
+            milestone.name: milestone
+            for milestone in rdar.client.milestones_for_component(raw_issue.component, include_access_groups=True)
+        }
+        if args.milestone:
+            milestone = milestones.get(args.milestone, None)
+        if args.milestone and not milestone:
+            sys.stderr.write("Specified milestone '{}' not found in component '{}'\n".format(args.milestone, raw_issue.component))
+        while True:
+            if not milestone and not args.prompt:
+                break
+            if not milestone:
+                milestone = milestones.get(Terminal.choose(
+                    prompt='Pick a milestone for your clone',
+                    options=list(milestones.keys()),
+                    numbered=True,
+                ), None)
+                if not milestone:
+                    continue
+            if milestone.isClosed:
+                sys.stderr.write("'{}' is closed, pick another\n".format(milestone.name))
+                milestone = None
+                continue
+            if milestone.isRestricted:
+                for group in milestone.restrictedAccessGroup.split(','):
+                    if rdar.me().username in rdar.library.AppleDirectoryQuery.member_dsid_list_for_group_name(group):
+                        break
+                else:
+                    sys.stderr.write("You do not have read access to '{}', pick another\n".format(milestone.name))
+                    milestone = None
+                    continue
+            if milestone.isProtected:
+                for group in milestone.protectedAccessGroup.split(','):
+                    if rdar.me().username in rdar.library.AppleDirectoryQuery.member_dsid_list_for_group_name(group):
+                        break
+                else:
+                    sys.stderr.write("You do not have write access to '{}', pick another\n".format(milestone.name))
+                    milestone = None
+                    continue
+            break
+
+        if not milestone:
+            sys.stderr.write("Failed to find milestone matching '{}'\n".format(args.milestone))
+            return 255
+
+        milestone_association = raw_issue.milestone_associations(milestone)
+
+        def pick_attr(name, plural, default=None):
+            mapping = {candidate.name: candidate for candidate in getattr(milestone_association, plural, [])}
+            attr = getattr(raw_issue, name, None)
+            if default or attr:
+                value = mapping.get(default or attr.name, None)
+                if value:
+                    return value
+                sys.stderr.write("{} '{}' does not exist in '{}'\n".format(name.capitalize(), default or attr.name, milestone.name))
+            if not getattr(milestone_association, 'is{}Required'.format(name.capitalize()), None):
+                return None
+            value = mapping.get(Terminal.choose(
+                prompt='Pick a {} for your clone'.format(name),
+                options=sorted(mapping.keys()),
+                numbered=True,
+            ), None) if args.prompt else None
+            if not value:
+                sys.stderr.write("{} required for '{}', but not provided\n".format(name.capitalize(), milestone.name))
+                return False
+            return value
+
+        category = pick_attr('category', 'categories', 'Escape / Regression in the Build' if merge_back else None)
+        event = pick_attr('event', 'events')
+        tentpole = pick_attr('tentpole', 'tentpoles')
+
+        if False in (category, event, tentpole):
+            sys.stderr.write('Too few attributes specified to clone {}\n'.format(issue))
+            return 255
+
+        if args.dry_run:
+            print("Cloning into '{}'".format(milestone.name))
+            print("    Reason: {}".format(args.reason))
+            if prefix:
+                print("    with tile '{} {}'".format(prefix, issue.title))
+            if category:
+                print("    with category '{}'".format(category.name))
+            if event:
+                print("    with event '{}'".format(event.name))
+            if tentpole:
+                print("    with tentpole '{}'".format(tentpole.name))
+            return 255
+
+        cloned = rdar.clone(issue, reason=args.reason)
+        if not cloned:
+            sys.stderr.write("Failed to clone '{}'\n".format(issue))
+            return 255
+        print("Created '{}{}'".format('{} '.format(prefix) if merge_back else '', cloned))
+
+        raw_clone = rdar.client.radar_for_id(cloned.id)
+
+        try:
+            if prefix:
+                raw_clone.title = '{} {}'.format(prefix, raw_issue.title)
+            raw_clone.priority = raw_issue.priority
+            raw_clone.resolution = raw_issue.resolution
+            raw_clone.commit_changes()
+        except rdar.radarclient().exceptions.UnsuccessfulResponseException:
+            sys.stderr.write('Completed clone, but failed to set priority and resolution\n')
+            return 1
+
+        try:
+            raw_clone.milestone = milestone
+            raw_clone.category = category
+            raw_clone.event = event
+            raw_clone.tentpole = tentpole
+            raw_clone.commit_changes()
+        except rdar.radarclient().exceptions.UnsuccessfulResponseException:
+            sys.stderr.write('Completed clone, but failed to set milestone, category, event and tentpole\n')
+            return 1
+
+        try:
+            raw_clone.state = 'Analyze'
+            if raw_clone.resolution:
+                raw_clone.substate = 'Prepare'
+            else:
+                raw_clone.substate = 'Investigate'
+                sys.stderr.write('{} does not have a resolution\n'.format(issue.link))
+                sys.stderr.write('Placing {} in {}\n'.format(cloned.link, raw_clone.substate))
+            raw_clone.commit_changes()
+        except rdar.radarclient().exceptions.UnsuccessfulResponseException:
+            sys.stderr.write("Completed clone and set milestone, but failed to move to 'Integrate'\n")
+            return 1
+
+        print('Moved clone to {} and into {}{}'.format(
+            raw_clone.milestone.name,
+            raw_clone.state,
+            ': {}'.format(raw_clone.substate) if raw_clone.state == 'Analyze' else '',
+        ))
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
@@ -1,0 +1,167 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+
+from mock import patch
+from webkitcorepy import OutputCapture, testing
+from webkitcorepy.mocks import Terminal as MockTerminal, Environment
+from webkitbugspy import Tracker, radar, mocks as bmocks
+from webkitscmpy import program, mocks
+
+
+class TestClone(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super(TestClone, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_no_radar(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn(), bmocks.NoRadar(), patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+            self.assertEqual(255, program.main(
+                args=('clone', 'HEAD'),
+                path=self.path,
+            ))
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "'cloning' is a concept which belongs solely to radar\nRadar is not available on this machine\n",
+        )
+
+    def test_no_reason(self):
+        with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
+            issues=bmocks.ISSUES,
+            projects=bmocks.PROJECTS,
+            milestones=bmocks.MILESTONES,
+        ), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+
+            self.assertEqual(255, program.main(
+                args=('clone', 'rdar://1'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'No reason for cloning issue has been provided\n',
+        )
+
+    def test_basic(self):
+        with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
+            issues=bmocks.ISSUES,
+            projects=bmocks.PROJECTS,
+            milestones=bmocks.MILESTONES,
+        ), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+
+            self.assertEqual(0, program.main(
+                args=('clone', 'rdar://1', '--reason', 'Cloning for a future branch', '--milestone', 'Future'),
+                path=self.path,
+            ))
+            tracker = radar.Tracker()
+            raw_issue = tracker.client.radar_for_id(4)
+
+            self.assertEqual(raw_issue.milestone.name, 'Future')
+            self.assertIsNone(raw_issue.category)
+            self.assertIsNone(raw_issue.event)
+            self.assertIsNone(raw_issue.tentpole)
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created 'rdar://4 Example issue 1'\n"
+            'Moved clone to Future and into Analyze: Prepare\n',
+        )
+
+    def test_no_prompt(self):
+        with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
+            issues=bmocks.ISSUES,
+            projects=bmocks.PROJECTS,
+            milestones=bmocks.MILESTONES,
+        ), MockTerminal.input('1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+
+            self.assertEqual(255, program.main(
+                args=('clone', 'rdar://1', '--reason', 'Cloning for an October branch', '--milestone', 'October', '--no-prompt'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            "Category required for 'October', but not provided\n"
+            'Too few attributes specified to clone rdar://1 Example issue 1\n',
+        )
+        self.assertEqual(captured.stdout.getvalue(), '')
+
+    def test_prompt(self):
+        with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
+            issues=bmocks.ISSUES,
+            projects=bmocks.PROJECTS,
+            milestones=bmocks.MILESTONES,
+        ), MockTerminal.input('3'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+
+            self.assertEqual(0, program.main(
+                args=('clone', 'rdar://1', '--reason', 'Cloning for an October branch', '--milestone', 'October', '--prompt'),
+                path=self.path,
+            ))
+            tracker = radar.Tracker()
+            raw_issue = tracker.client.radar_for_id(4)
+
+            self.assertEqual(raw_issue.milestone.name, 'October')
+            self.assertEqual(raw_issue.category.name, 'Test Development')
+            self.assertIsNone(raw_issue.event)
+            self.assertIsNone(raw_issue.tentpole)
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Pick a category for your clone:\n'
+            '    1) Escape / Regression in the Build\n'
+            '    2) Tentpole Feature Work\n'
+            '    3) Test Development\n: \n'
+            "Created 'rdar://4 Example issue 1'\n"
+            'Moved clone to October and into Analyze: Prepare\n',
+        )
+
+    def test_merge_back(self):
+        with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
+            issues=bmocks.ISSUES,
+            projects=bmocks.PROJECTS,
+            milestones=bmocks.MILESTONES,
+        ), MockTerminal.input('1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+
+            self.assertEqual(0, program.main(
+                args=('clone', 'rdar://1', '--reason', 'Cloning for an October branch', '--milestone', 'October', '--merge-back'),
+                path=self.path,
+            ))
+            tracker = radar.Tracker()
+            raw_issue = tracker.client.radar_for_id(4)
+
+            self.assertEqual(raw_issue.milestone.name, 'October')
+            self.assertEqual(raw_issue.category.name, 'Escape / Regression in the Build')
+            self.assertIsNone(raw_issue.event)
+            self.assertIsNone(raw_issue.tentpole)
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created '[merge-back] rdar://4 Example issue 1'\n"
+            'Moved clone to October and into Analyze: Prepare\n',
+        )


### PR DESCRIPTION
#### 1463644b7ce9725be5e1ec33d0870244409f02cb
<pre>
[git-webkit] Add clone command
<a href="https://bugs.webkit.org/show_bug.cgi?id=254599">https://bugs.webkit.org/show_bug.cgi?id=254599</a>
rdar://107320897

Reviewed by Dewei Zhu.

Add a command to quickly clone a radar from a commit or Bugzilla.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/__init__.py: Import mock milestones.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py: Add mock milestones.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(AppleDirectoryQuery.member_dsid_list_for_group_name): Add.
(RadarModel.Milestone): Add mock Milestone object.
(RadarModel.Category): Add mock Category object.
(RadarModel.Event): Add mock Event object.
(RadarModel.Tentpole): Add mock Tentpole object.
(RadarModel.MilestoneAssociations): Add mock MilestoneAssociations object.
(RadarModel.commit_changes): Commit milestone, category, event and tentpole.
(RadarModel.milestone_associations): List MilestoneAssociations object from Milestone object.
(RadarClient.milestones_for_component): List all mock milestones.
(RadarClient.clone_radar): Mock implementation of Radarclient&apos;s clone_radar.
(Radar.__init__):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.create): Handle empty project.
(Tracker.clone): Clone radar with specified reason.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py: Added.
(Clone.parser): User must specify problem, reason and optionally milestone
to clone radar into.
(Clone.main): Resolve the provided argument to a radar and then clone the
specified radar. Attempt to copy as much of the original radar as possible
after moving the cloned radar into the specified milestone.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py: Added.
(TestClone):

Canonical link: <a href="https://commits.webkit.org/265475@main">https://commits.webkit.org/265475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b80f88966e8dd7df881f2029efbcf1bd62bb630b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11524 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/12639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/11007 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13581 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/11186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/11151 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/12045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/13044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/11094 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/9338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/13044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/10409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/13044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/11186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/10893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/13965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1232 "Failed to push commit to Webkit repository") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/10378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->