### PR TITLE
REGRESSION (262146@main): TestWGSL.WGSLASTDumperTests.dumpTriangleVert is failing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp
@@ -64,10 +64,10 @@ TEST(WGSLASTDumperTests, dumpTriangleVert)
         "@vertex\n"
         "fn main(\n"
         "    @builtin(vertex_index) VertexIndex: u32\n"
-        ") -> @builtin(position) Vec4<f32>\n"
+        ") -> @builtin(position) vec4<f32>\n"
         "{\n"
-        "    var pos = array<Vec2<f32>, 3>(Vec2<f32>(0.000000, 0.500000), Vec2<f32>(-0.500000, -0.500000), Vec2<f32>(0.500000, -0.500000));\n"
-        "    return Vec4<f32>(pos[VertexIndex], 0.000000, 1.000000);\n"
+        "    var pos = array<vec2<f32>, 3>(vec2<f32>(0.000000, 0.500000), vec2<f32>(-0.500000, -0.500000), vec2<f32>(0.500000, -0.500000));\n"
+        "    return vec4<f32>(pos[VertexIndex], 0.000000, 1.000000);\n"
         "}\n\n\n"_str);
 }
 


### PR DESCRIPTION
#### d9f105bb73af2ccf3a0a3d5325913aba08347cbd
<pre>
REGRESSION (262146@main): TestWGSL.WGSLASTDumperTests.dumpTriangleVert is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=254596">https://bugs.webkit.org/show_bug.cgi?id=254596</a>
rdar://107320480

Unreviewed, simple test fix.

The test relies on the serialization of the AST, and I changed the serialization of
vector types from `VecN` to `vecN`. Just update the test to reflect the change.

* Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262226@main">https://commits.webkit.org/262226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20158a3cc4ff4c50679626da7bcb20add6e95bc4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1011 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/1387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1059 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/1387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/1303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/919 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/97 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->