### PR TITLE
@counter-style: extends system should always extend first symbol for fixed system

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-extends-fixed-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-extends-fixed-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Test: system extends fixed</title>
+<link rel="stylesheet" href="support/test-common.css">
+<style type="text/css">
+  @counter-style a {
+      system: fixed 3;
+      symbols: "Y" "E" "S";
+  }
+</style>
+<ol style="list-style-type: a">
+  <li><li><li><li><li><li>
+</ol>
+<br>
+<ol style="list-style-type: a">
+  <li><li><li><li><li><li>
+</ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-extends-fixed-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-extends-fixed-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Test: system extends fixed</title>
+<link rel="stylesheet" href="support/test-common.css">
+<style type="text/css">
+  @counter-style a {
+      system: fixed 3;
+      symbols: "Y" "E" "S";
+  }
+</style>
+<ol style="list-style-type: a">
+  <li><li><li><li><li><li>
+</ol>
+<br>
+<ol style="list-style-type: a">
+  <li><li><li><li><li><li>
+</ol>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-extends-fixed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-extends-fixed.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Test: system extends fixed</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles-3/#extends-system">
+<link rel="match" href="system-extends-fixed-ref.html">
+<link rel="stylesheet" href="support/test-common.css">
+<style type="text/css">
+  @counter-style a {
+      system: fixed 3;
+      symbols: "Y" "E" "S";
+  }
+  @counter-style b {
+      system: extends a;
+  }
+</style>
+<ol style="list-style-type: a">
+  <li><li><li><li><li><li>
+</ol>
+<br>
+<ol style="list-style-type: b">
+  <li><li><li><li><li><li>
+</ol>

--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -292,6 +292,7 @@ void CSSCounterStyle::extendAndResolve(const CSSCounterStyle& extendedCounterSty
     m_isExtendedUnresolved = false;
 
     setSystem(extendedCounterStyle.system());
+    setFirstSymbolValueForFixedSystem(extendedCounterStyle.firstSymbolValueForFixedSystem());
 
     if (!explicitlySetDescriptors().contains(CSSCounterStyleDescriptors::ExplicitlySetDescriptors::Negative))
         setNegative(extendedCounterStyle.negative());

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -70,6 +70,7 @@ public:
     void setSymbols(const Vector<CSSCounterStyleDescriptors::Symbol>& symbols) { m_descriptors.m_symbols = symbols; }
     void setAdditiveSymbols(const CSSCounterStyleDescriptors::AdditiveSymbols& additiveSymbols) { m_descriptors.m_additiveSymbols = additiveSymbols; }
     void setSpeakAs(CSSCounterStyleDescriptors::SpeakAs speakAs) { m_descriptors.m_speakAs = speakAs; }
+    void setFirstSymbolValueForFixedSystem(int firstSymbolValue) { m_descriptors.m_fixedSystemFirstSymbolValue = firstSymbolValue; }
 
     void setFallbackReference(RefPtr<CSSCounterStyle>&&);
     bool isFallbackUnresolved() { return !m_fallbackReference; }


### PR DESCRIPTION
#### 2eff4ba097378064ae626ddfb29d7ad931eb1931
<pre>
@counter-style: extends system should always extend first symbol for fixed system
<a href="https://bugs.webkit.org/show_bug.cgi?id=254597">https://bugs.webkit.org/show_bug.cgi?id=254597</a>
rdar://107320608

Reviewed by Tim Nguyen.

When extending a system: fixed, the first symbol for the fixed system
should always be extended (copied from the counter being extended), since it is impossible to explicitly define
a first symbol when the counter style&apos;s system is extends.

* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-extends-fixed-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-extends-fixed-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-extends-fixed.html: Added.
* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::CSSCounterStyle::extendAndResolve):
* Source/WebCore/css/CSSCounterStyle.h:
(WebCore::CSSCounterStyle::setFirstSymbolValueForFixedSystem):

Canonical link: <a href="https://commits.webkit.org/262264@main">https://commits.webkit.org/262264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f333aa0f92244cbe53e3c014349adcb3110c8378

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1647 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/925 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1158 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1056 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1538 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1020 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/955 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2027 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1000 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/986 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/260 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1017 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->