### PR TITLE
[iOS] screen.colorDepth reports incorrect value

### DIFF
--- a/LayoutTests/platform/ios-device/TestExpectations
+++ b/LayoutTests/platform/ios-device/TestExpectations
@@ -58,7 +58,6 @@ http/tests/preload/onerror_event.html [ Skip ]
 http/tests/preload/onload_event.html [ Skip ]
 http/tests/websocket/tests/hybi/multiple-connections.html [ Skip ]
 
-imported/w3c/web-platform-tests/cssom-view/Screen-pixelDepth-Screen-colorDepth001.html [ Failure ]
 imported/w3c/web-platform-tests/cssom-view/scrolling-quirks-vs-nonquirks.html [ Failure ]
 imported/w3c/web-platform-tests/dom/events/EventTarget-dispatchEvent.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/toDataURL.png.complexcolours.html [ Failure ]

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/cssom-view/Screen-pixelDepth-Screen-colorDepth001-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/cssom-view/Screen-pixelDepth-Screen-colorDepth001-expected.txt
@@ -1,8 +1,0 @@
-This case tests the Screen pixelDepth and colorDepth
-
-The test passes if the value is 24
-
-
-FAIL testColorDepth assert_equals: Expected value for colorDepth is 24 expected 24 but got 32
-FAIL testPixelDepth assert_equals: Expected value for pixelDepth is 24 expected 24 but got 32
-

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -48,14 +48,13 @@ namespace WebCore {
 
 int screenDepth(Widget*)
 {
-    // Assume 32 bits per pixel. See <rdar://problem/9378829>.
-    return 32;
+    // See <rdar://problem/9378829> for why this is a constant.
+    return 24;
 }
 
 int screenDepthPerComponent(Widget*)
 {
-    // Assume the screen depth is evenly divided into four color components. See <rdar://problem/9378829>.
-    return screenDepth(nullptr) / 4;
+    return screenDepth(nullptr) / 3;
 }
 
 bool screenIsMonochrome(Widget*)
@@ -67,7 +66,7 @@ bool screenHasInvertedColors()
 {
     if (auto data = screenData(primaryScreenDisplayID()))
         return data->screenHasInvertedColors;
-    
+
     return PAL::softLinkUIKitUIAccessibilityIsInvertColorsEnabled();
 }
 
@@ -146,7 +145,7 @@ float screenPPIFactor()
         float mainScreenPPI = (pitch && scale) ? pitch / scale : originalIPhonePPI;
         ppiFactor = mainScreenPPI / originalIPhonePPI;
     });
-    
+
     return ppiFactor;
 }
 
@@ -202,7 +201,7 @@ ScreenProperties collectScreenProperties()
         auto screenAvailableRect = FloatRect { screen.bounds };
         screenAvailableRect.setY(NSMaxY(screen.bounds) - (screenAvailableRect.y() + screenAvailableRect.height())); // flip
         screenData.screenAvailableRect = screenAvailableRect;
-        
+
         screenData.screenRect = screen._referenceBounds;
         screenData.colorSpace = { screenColorSpace(nullptr) };
         screenData.screenDepth = WebCore::screenDepth(nullptr);
@@ -213,11 +212,11 @@ ScreenProperties collectScreenProperties()
         screenData.scaleFactor = WebCore::screenPPIFactor();
 
         screenProperties.screenDataMap.set(++displayID, WTFMove(screenData));
-        
+
         if (screen == [PAL::getUIScreenClass() mainScreen])
             screenProperties.primaryDisplayID = displayID;
     }
-    
+
     return screenProperties;
 }
 


### PR DESCRIPTION
#### c073b6cbaccdcb73c1b5a70f95e87c9f02043681
<pre>
[iOS] screen.colorDepth reports incorrect value
<a href="https://bugs.webkit.org/show_bug.cgi?id=244845">https://bugs.webkit.org/show_bug.cgi?id=244845</a>
rdar://99871925

Reviewed by Jer Noble.

24 is the CSSOM View value for 8 bits per color channel. The alpha channel is to be excluded.

* LayoutTests/platform/ios-device/TestExpectations:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/cssom-view/Screen-pixelDepth-Screen-colorDepth001-expected.txt: Removed.
* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::screenDepth):
(WebCore::screenDepthPerComponent):
(WebCore::screenHasInvertedColors):
(WebCore::screenPPIFactor):
(WebCore::collectScreenProperties):

Canonical link: <a href="https://commits.webkit.org/262386@main">https://commits.webkit.org/262386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b02eec292a7152dff8a073592f9f208ae2d06d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/849 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1060 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1318 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/895 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/873 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1939 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/867 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/905 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/348 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/928 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->