### PR TITLE
Web Inspector: Web inspector become unresponsive after opening online photos

### DIFF
--- a/LayoutTests/http/tests/inspector/network/resource-mime-type-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/resource-mime-type-expected.txt
@@ -124,13 +124,13 @@ PASS: Resource syntheticMIMEType should be 'text/css'.
 
 -- Running test case: Resource.MIMEType.Document.png
 PASS: Frame MainResource should be created.
-PASS: Resource Type should be 'resource-type-document'.
+PASS: Resource Type should be 'resource-type-image'.
 PASS: Resource mimeType should be 'image/png'.
 PASS: Resource syntheticMIMEType should be 'image/png'.
 
--- Running test case: Resource.MIMEType.Document.txt
+-- Running test case: Resource.MIMEType.Document.jpg
 PASS: Frame MainResource should be created.
-PASS: Resource Type should be 'resource-type-document'.
+PASS: Resource Type should be 'resource-type-image'.
 PASS: Resource mimeType should be 'image/jpeg'.
 PASS: Resource syntheticMIMEType should be 'image/jpeg'.
 

--- a/LayoutTests/http/tests/inspector/network/resource-mime-type.html
+++ b/LayoutTests/http/tests/inspector/network/resource-mime-type.html
@@ -265,15 +265,15 @@ function test()
     addDocumentResourceTestCase({
         name: "Resource.MIMEType.Document.png",
         expression: `loadDocumentWithURL("/resources/square100.png")`,
-        type: WI.Resource.Type.Document,
+        type: WI.Resource.Type.Image,
         mimeType: mimeTypeForExtension.png,
         synthetic: mimeTypeForExtension.png,
     });
 
     addDocumentResourceTestCase({
-        name: "Resource.MIMEType.Document.txt",
+        name: "Resource.MIMEType.Document.jpg",
         expression: `loadDocumentWithURL("/resources/square20.jpg")`,
-        type: WI.Resource.Type.Document,
+        type: WI.Resource.Type.Image,
         mimeType: mimeTypeForExtension.jpg,
         synthetic: mimeTypeForExtension.jpg,
     });

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -284,6 +284,9 @@ InspectorPageAgent::ResourceType InspectorPageAgent::inspectorResourceType(Cache
 
 InspectorPageAgent::ResourceType InspectorPageAgent::inspectorResourceType(const CachedResource& cachedResource)
 {
+    if (cachedResource.type() == CachedResource::Type::MainResource && MIMETypeRegistry::isSupportedImageMIMEType(cachedResource.mimeType()))
+        return InspectorPageAgent::ImageResource;
+
     if (cachedResource.type() == CachedResource::Type::RawResource) {
         switch (cachedResource.resourceRequest().requester()) {
         case ResourceRequestRequester::Fetch:

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceClusterContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceClusterContentView.js
@@ -152,11 +152,16 @@ WI.ResourceClusterContentView = class ResourceClusterContentView extends WI.Clus
         if (this._responseContentView)
             return this._responseContentView;
 
+        let typeFromMIMEType = WI.Resource.typeFromMIMEType(this._resource.mimeType);
+
+        // COMPATIBILITY (macOS 13.3, iOS 16.3): Images inspected as the main resource used to have a resource type of Document.
+        if (typeFromMIMEType === WI.Resource.Type.Image && this._resource.type === WI.Resource.Type.Document)
+            return this._contentViewForResourceType(WI.Resource.Type.Image);
+
         this._responseContentView = this._contentViewForResourceType(this._resource.type);
         if (this._responseContentView)
             return this._responseContentView;
 
-        let typeFromMIMEType = WI.Resource.typeFromMIMEType(this._resource.mimeType);
         this._responseContentView = this._contentViewForResourceType(typeFromMIMEType);
         if (this._responseContentView)
             return this._responseContentView;


### PR DESCRIPTION
#### 9b097d0ecda363b302393bf22b53c771d197995e
<pre>
Web Inspector: Web inspector become unresponsive after opening online photos
<a href="https://bugs.webkit.org/show_bug.cgi?id=254602">https://bugs.webkit.org/show_bug.cgi?id=254602</a>

Reviewed by Patrick Angle and Devin Rousso.

When the inspected main resource is an image, it is treated as a document regardless of its MIME type.

Its resource type is incorrectly assigned on the backend as `InspectorPageAgent::Document`.

See: `InspectorPageAgent::inspectorResourceType(CachedResource::Type type)`
See: `CachedResourceLoader::requestMainResource(CachedResourceRequest&amp;&amp; request)`

The Sources panel on the frontend represents resources of the type
`WI.Resource.Type.Document` with a `WI.TextResourceContentView`.

The payload of the image resource response is a blob of base64 text.

When inspecting standalone images, Web Inspector passes this giant single-line blob of text
to a `WI.SourceCodeTextEditor` where it runs expensive operations on the main thread
and blocks it for long periods of time it if there&apos;s a lot of content.

This patch modifies `InspectorPageAgent` on the backend to return
the appropriate resource type for images, `InspectorPageAgent::ImageResource`,
even when they are the main resource.

This way, the frontend can represent images with the appropriate view: `WI.ImageResourceContentView`.

* LayoutTests/http/tests/inspector/network/resource-mime-type-expected.txt:
* LayoutTests/http/tests/inspector/network/resource-mime-type.html:

Update test for resource type expectations when the document is an image.

* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::inspectorResourceType):

Canonical link: <a href="https://commits.webkit.org/262409@main">https://commits.webkit.org/262409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22114d71cdca5adb38cf4054cd1623a9fb984d25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2376 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1407 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1330 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1317 "Failed to checkout and rebase branch from PR 12063") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2226 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1263 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2410 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1378 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1226 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1307 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/368 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1420 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->