### PR TITLE
Hulu.com video doesn't play

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1140,6 +1140,16 @@ String HTMLMediaElement::canPlayType(const String& mimeType) const
 {
     MediaEngineSupportParameters parameters;
     ContentType contentType(mimeType);
+
+#if PLATFORM(COCOA)
+    if (document().quirks().shouldAdvertiseSupportForHLSSubtitleTypes()
+        && contentType.containerType() == "application/vnd.apple.mpegurl"_s
+        && (contentType.codecs().contains("stpp.ttml.im1t"_s) || contentType.codecs().contains("wvtt"_s))) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Quirk, ", mimeType, ": probably");
+        return "probably"_s;
+    }
+#endif
+
     parameters.type = contentType;
     parameters.contentTypesRequiringHardwareSupport = mediaContentTypesRequiringHardwareSupport();
     parameters.allowedMediaContainerTypes = allowedMediaContainerTypes();

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1584,4 +1584,19 @@ bool Quirks::shouldDisableFetchMetadata() const
     return equalLettersIgnoringASCIICase(host, "victoriassecret.com"_s) || host.endsWithIgnoringASCIICase(".victoriassecret.com"_s);
 }
 
+#if PLATFORM(COCOA)
+bool Quirks::shouldAdvertiseSupportForHLSSubtitleTypes() const
+{
+    if (!needsQuirks())
+        return false;
+
+    if (!m_shouldAdvertiseSupportForHLSSubtitleTypes) {
+        auto domain = RegistrableDomain(m_document->url()).string();
+        m_shouldAdvertiseSupportForHLSSubtitleTypes = domain == "hulu.com"_s;
+    }
+
+    return *m_shouldAdvertiseSupportForHLSSubtitleTypes;
+}
+#endif
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -164,7 +164,11 @@ public:
     bool shouldDisableLazyIframeLoadingQuirk() const;
 
     bool shouldDisableFetchMetadata() const;
-    
+
+#if PLATFORM(COCOA)
+    bool shouldAdvertiseSupportForHLSSubtitleTypes() const;
+#endif
+
 private:
     bool needsQuirks() const;
 
@@ -223,6 +227,9 @@ private:
 #endif
     mutable std::optional<bool> m_shouldDisableLazyImageLoadingQuirk;
     mutable std::optional<bool> m_shouldDisableLazyIframeLoadingQuirk;
+#if PLATFORM(COCOA)
+    mutable std::optional<bool> m_shouldAdvertiseSupportForHLSSubtitleTypes;
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 621cea8475c6fd1e080e42afab04cb857c815407
<pre>
Hulu.com video doesn&apos;t play
<a href="https://bugs.webkit.org/show_bug.cgi?id=254605">https://bugs.webkit.org/show_bug.cgi?id=254605</a>
rdar://106667631

Reviewed by Eric Carlson.

Recent changes in the AVFoundation framework have caused canPlayType() queries for
`application/vnd.apple.mpegurl; codecs=&quot;stpp.ttml.im1t&quot;` and
`application/vnd.apple.mpegurl; codecs=&quot;wvtt&quot;` to fail. These were never well-formed
queries in the first place, as `application/vnd.apple.mpegurl` does not take a codecs
parameter. However, Hulu.com appears to depend upon those queries returning &quot;probably&quot;
in order to vend a working HLS stream.

Add a quirk for hulu.com only which hard codes the answer to those two canPlayType()
queries to &quot;probably&quot;.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::canPlayType const):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldAdvertiseSupportForHLSSubtitleTypes const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/262248@main">https://commits.webkit.org/262248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4396776601246693dab14d488b6577ecfe0082b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1084 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1070 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1358 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/961 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/902 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/888 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/1960 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/875 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/915 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/247 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/943 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->