### PR TITLE
[UI-side compositing] RenderListBox scrollbars do not show

### DIFF
--- a/LayoutTests/fast/forms/select/mac-wk2/listbox-scrollbar-painting-expected-mismatch.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/listbox-scrollbar-painting-expected-mismatch.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false ] -->
+<html>
+<head>
+<style>
+select {
+    font-size: 18px;
+}
+</style>
+</head>
+<body>
+    <select size="5">
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+    </select>
+</body>
+</html>

--- a/LayoutTests/fast/forms/select/mac-wk2/listbox-scrollbar-painting.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/listbox-scrollbar-painting.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false ] -->
+<html>
+<head>
+<style>
+select {
+    font-size: 18px;
+}
+</style>
+</head>
+<body>
+    <select size="5">
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+        <option>item</option>
+    </select>
+</body>
+</html>

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -27,6 +27,7 @@
 #include "Scrollbar.h"
 
 #include "DeprecatedGlobalSettings.h"
+#include "DisplayView.h"
 #include "GraphicsContext.h"
 #include "LocalFrameView.h"
 #include "PlatformMouseEvent.h"
@@ -504,6 +505,13 @@ NativeScrollbarVisibility Scrollbar::nativeScrollbarVisibility(const Scrollbar* 
     if (DeprecatedGlobalSettings::mockScrollbarsEnabled() || (scrollbar && scrollbar->isCustomScrollbar()))
         return NativeScrollbarVisibility::ReplacedByCustomScrollbar;
     return NativeScrollbarVisibility::Visible;
+}
+
+float Scrollbar::deviceScaleFactor() const
+{
+    if (RefPtr root = this->root())
+        return root->displayView().deviceScaleFactor();
+    return 1;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -135,6 +135,8 @@ public:
     bool supportsUpdateOnSecondaryThread() const;
     static NativeScrollbarVisibility nativeScrollbarVisibility(const Scrollbar*);
 
+    float deviceScaleFactor() const;
+
 protected:
     Scrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarControlSize, ScrollbarTheme* = nullptr, bool isCustomScrollbar = false);
 


### PR DESCRIPTION
#### 563327c0f1c402dee399680de8da20c23de89356
<pre>
[UI-side compositing] RenderListBox scrollbars do not show
<a href="https://bugs.webkit.org/show_bug.cgi?id=253750">https://bugs.webkit.org/show_bug.cgi?id=253750</a>
rdar://106382552

Reviewed by Aditya Keerthi.

With UI-side compositing on the painting context does not have a platform CG context so painting the
scrollbars does not work. To get around this, draw the scrollbars into a local buffer then draw that
buffer into the painting context.

Based on a patch by Nikos Mouchtaris.

* LayoutTests/fast/forms/select/mac-wk2/listbox-scrollbar-painting-expected-mismatch.html: Added.
* LayoutTests/fast/forms/select/mac-wk2/listbox-scrollbar-painting.html: Added.

Add a regression test to verify that system scrollbars show up in list boxes, with always-on
scrollbars enabled.

* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::deviceScaleFactor const):
* Source/WebCore/platform/Scrollbar.h:
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::paint):
(WebCore::scrollerImpPaint): Deleted.

Canonical link: <a href="https://commits.webkit.org/262243@main">https://commits.webkit.org/262243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15459b4d3d2ea5e9ff42a1598f865320fa508636

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1500 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1092 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1083 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/988 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1386 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/917 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/945 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/1965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/936 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/926 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/243 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/951 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->