### PR TITLE
[UI-side compositing] Add helper function to ui-helper.js to get scrollbar state

### DIFF
--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -860,6 +860,35 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static scrollbarState(scroller, isVertical)
+    {
+        if (!this.isWebKit2() || this.isIOSFamily())
+            return Promise.resolve();
+        if (internals.isUsingUISideCompositing()) {
+            return new Promise(resolve => {
+                testRunner.runUIScript(`(function() {
+                    uiController.doAfterNextStablePresentationUpdate(function() {
+                        uiController.uiScriptComplete(uiController.scrollbarStateForScrollingNodeID(${internals.scrollingNodeIDForNode(scroller)}, ${isVertical}));
+                    });
+                })()`, state => {
+                    resolve(state);
+                });
+            });    
+        } else {
+            return isVertical ? Promise.resolve(internals.verticalScrollbarState(scroller)) : Promise.resolve(internals.horizontalScrollbarState(scroller));
+        }
+    }
+
+    static verticalScrollbarState(scroller)
+    {
+        return UIHelper.scrollbarState(scroller, true);
+    }
+
+    static horizontalScrollbarState(scroller)
+    {
+        return UIHelper.scrollbarState(scroller, false);
+    }
+
     static getUICaretViewRect()
     {
         if (!this.isWebKit2() || !this.isIOSFamily())


### PR DESCRIPTION
#### 9ca2fd55c2269f40ef8d1f2b37c8b15cf1cdd434
<pre>
[UI-side compositing] Add helper function to ui-helper.js to get scrollbar state
<a href="https://bugs.webkit.org/show_bug.cgi?id=254615">https://bugs.webkit.org/show_bug.cgi?id=254615</a>
rdar://107332737

Reviewed by Wenson Hsieh and Simon Fraser.

Add helper function to ui-helper.js to get scrollbar state.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.scrollbarState.return.new.Promise.):
(window.UIHelper.scrollbarState.return.new.Promise):
(window.UIHelper.scrollbarState):
(window.UIHelper.verticalScrollbarState):
(window.UIHelper.horizontalScrollbarState):

Canonical link: <a href="https://commits.webkit.org/262246@main">https://commits.webkit.org/262246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bd6436c99d9d2245cbd66422bc3478c9348a45d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1070 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/1534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1115 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/1534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1014 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/936 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/1435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/964 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/960 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/945 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/975 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/102 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->