### PR TITLE
Cherry-pick 259548.8@safari-7615-branch (5a0f792b008f). rdar://107333395

### DIFF
--- a/LayoutTests/fast/backgrounds/background-color-lch-crash-expected.txt
+++ b/LayoutTests/fast/backgrounds/background-color-lch-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash

--- a/LayoutTests/fast/backgrounds/background-color-lch-crash.html
+++ b/LayoutTests/fast/backgrounds/background-color-lch-crash.html
@@ -1,0 +1,14 @@
+<style>
+    html, body {
+      background-color: lch(0 0 0 / 0.001);
+    }
+  </style>
+  <script>
+    internals.settings.setCaretBrowsingEnabled(true);
+    onload = () => {
+      document.execCommand('SelectAll');
+    };
+    if (window.testRunner)
+        testRunner.dumpAsText();
+  </script>
+  <span>This test passes if it does not crash</span>

--- a/Source/WebCore/platform/graphics/ColorBlending.cpp
+++ b/Source/WebCore/platform/graphics/ColorBlending.cpp
@@ -43,6 +43,12 @@ Color blendSourceOver(const Color& backdrop, const Color& source)
     auto [backdropR, backdropG, backdropB, backdropA] = backdrop.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
     auto [sourceR, sourceG, sourceB, sourceA] = source.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
 
+    if (!backdropA || sourceA == 255)
+        return source;
+
+    if (!sourceA)
+        return backdrop;
+
     int d = 0xFF * (backdropA + sourceA) - backdropA * sourceA;
     int a = d / 0xFF;
     int r = (backdropR * backdropA * (0xFF - sourceA) + 0xFF * sourceA * sourceR) / d;


### PR DESCRIPTION
#### 1bb6a599c3aef0843ff171cb156f008ae1c634a0
<pre>
Cherry-pick 259548.8@safari-7615-branch (5a0f792b008f). rdar://107333395

    Check color opacity after lossy conversion when blending
    <a href="https://bugs.webkit.org/show_bug.cgi?id=251158">https://bugs.webkit.org/show_bug.cgi?id=251158</a>
    rdar://104553839

    Reviewed by Dean Jackson.

    We check opacity to determine if we should forgo blending,
    however after performing a lossy conversion we can end
    up with alpha values that result in a division by zero.
    Add an additional check after conversion to prevent this
    case.

    * LayoutTests/fast/backgrounds/background-color-lch-crash-expected.txt: Added.
    * LayoutTests/fast/backgrounds/background-color-lch-crash.html: Added.
    * Source/WebCore/platform/graphics/ColorBlending.cpp:
    (WebCore::blendSourceOver):

    Canonical link: <a href="https://commits.webkit.org/259548.8@safari-7615-branch">https://commits.webkit.org/259548.8@safari-7615-branch</a>

Canonical link: <a href="https://commits.webkit.org/262245@main">https://commits.webkit.org/262245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/def0c60eec23af073ac1e266ebc2b07255d2416c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1104 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1002 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1403 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/922 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/907 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/950 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/1964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/950 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/931 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/245 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/965 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->