### PR TITLE
Cherry-pick 252432.1030@safari-7614-branch (433db4f29219). rdar://problem/107335960

### DIFF
--- a/Source/WebCore/bindings/js/JSErrorHandler.cpp
+++ b/Source/WebCore/bindings/js/JSErrorHandler.cpp
@@ -72,7 +72,11 @@ void JSErrorHandler::handleEvent(ScriptExecutionContext& scriptExecutionContext,
     if (!jsFunction)
         return;
 
-    auto* globalObject = toJSDOMGlobalObject(scriptExecutionContext, isolatedWorld());
+    auto* isolatedWorld = this->isolatedWorld();
+    if (UNLIKELY(!isolatedWorld))
+        return;
+
+    auto* globalObject = toJSDOMGlobalObject(scriptExecutionContext, *isolatedWorld);
     if (!globalObject)
         return;
 

--- a/Source/WebCore/bindings/js/JSEventListener.h
+++ b/Source/WebCore/bindings/js/JSEventListener.h
@@ -24,6 +24,7 @@
 #include "EventNames.h"
 #include "HTMLElement.h"
 #include "LocalDOMWindow.h"
+#include "WebCoreJSClientData.h"
 #include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakInlines.h>
@@ -34,7 +35,7 @@
 
 namespace WebCore {
 
-class JSEventListener : public EventListener {
+class JSEventListener : public EventListener, public JSVMClientData::Client {
 public:
     WEBCORE_EXPORT static Ref<JSEventListener> create(JSC::JSObject& listener, JSC::JSObject& wrapper, bool isAttribute, DOMWrapperWorld&);
 
@@ -48,8 +49,7 @@ public:
     bool wasCreatedFromMarkup() const { return m_wasCreatedFromMarkup; }
 
     JSC::JSObject* ensureJSFunction(ScriptExecutionContext&) const;
-    DOMWrapperWorld& isolatedWorld() const { return m_isolatedWorld; }
-
+    DOMWrapperWorld* isolatedWorld() const { return m_isolatedWorld.get(); }
 
     JSC::JSObject* jsFunction() const final { return m_jsFunction.get(); }
     JSC::JSObject* wrapper() const final { return m_wrapper.get(); }
@@ -73,6 +73,9 @@ private:
     void visitJSFunction(JSC::SlotVisitor&) final;
     virtual String code() const { return String(); }
 
+    // JSVMClientData::Client
+    void willDestroyVM() final;
+
 protected:
     enum class CreatedFromMarkup : bool { No, Yes };
 
@@ -88,7 +91,7 @@ private:
     mutable JSC::Weak<JSC::JSObject> m_jsFunction;
     mutable JSC::Weak<JSC::JSObject> m_wrapper;
 
-    Ref<DOMWrapperWorld> m_isolatedWorld;
+    RefPtr<DOMWrapperWorld> m_isolatedWorld;
 };
 
 // For "onxxx" attributes that automatically set up JavaScript event listeners.
@@ -130,6 +133,9 @@ inline JSC::JSObject* JSEventListener::ensureJSFunction(ScriptExecutionContext& 
 {
     // initializeJSFunction can trigger code that deletes this event listener
     // before we're done. It should always return null in this case.
+    if (UNLIKELY(!m_isolatedWorld))
+        return nullptr;
+
     JSC::VM& vm = m_isolatedWorld->vm();
     Ref protect = const_cast<JSEventListener&>(*this);
     JSC::EnsureStillAliveScope protectedWrapper(m_wrapper.get());

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -138,7 +138,12 @@ JSObject* JSLazyEventListener::initializeJSFunction(ScriptExecutionContext& exec
 
     if (!executionContextDocument.frame())
         return nullptr;
-    auto* globalObject = toJSLocalDOMWindow(*executionContextDocument.frame(), isolatedWorld());
+
+    auto* isolatedWorld = this->isolatedWorld();
+    if (UNLIKELY(!isolatedWorld))
+        return nullptr;
+
+    auto* globalObject = toJSLocalDOMWindow(*executionContextDocument.frame(), *isolatedWorld);
     if (!globalObject)
         return nullptr;
 

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
@@ -139,6 +139,10 @@ JSVMClientData::JSVMClientData(VM& vm)
 
 JSVMClientData::~JSVMClientData()
 {
+    m_clients.forEach([](auto& client) {
+        client.willDestroyVM();
+    });
+
     ASSERT(m_worldSet.contains(m_normalWorld.get()));
     ASSERT(m_worldSet.size() == 1);
     ASSERT(m_normalWorld->hasOneRef());

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -29,6 +29,8 @@
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/WeakHashSet.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -150,6 +152,13 @@ public:
 
     ExtendedDOMClientIsoSubspaces& clientSubspaces() { return *m_clientSubspaces.get(); }
 
+    class Client : public CanMakeWeakPtr<Client> {
+    public:
+        virtual ~Client() = default;
+        virtual void willDestroyVM() = 0;
+    };
+    void addClient(Client& client) { m_clients.add(client); }
+
 private:
     HashSet<DOMWrapperWorld*> m_worldSet;
     RefPtr<DOMWrapperWorld> m_normalWorld;
@@ -170,6 +179,8 @@ private:
     JSC::GCClient::IsoSubspace m_idbSerializationSpace;
 
     std::unique_ptr<ExtendedDOMClientIsoSubspaces> m_clientSubspaces;
+
+    WeakHashSet<Client> m_clients;
 };
 
 

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -217,7 +217,7 @@ JSEventListener* EventTarget::attributeEventListener(const AtomString& eventType
             continue;
 
         auto& jsListener = downcast<JSEventListener>(listener);
-        if (jsListener.isAttribute() && &jsListener.isolatedWorld() == &isolatedWorld)
+        if (jsListener.isAttribute() && jsListener.isolatedWorld() == &isolatedWorld)
             return &jsListener;
     }
 

--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -119,7 +119,7 @@ CommandLineAPIHost::EventListenersRecord CommandLineAPIHost::getEventListeners(J
             auto& jsListener = downcast<JSEventListener>(eventListener->callback());
 
             // Hide listeners from other contexts.
-            if (&jsListener.isolatedWorld() != &currentWorld(lexicalGlobalObject))
+            if (jsListener.isolatedWorld() != &currentWorld(lexicalGlobalObject))
                 continue;
 
             auto* function = jsListener.ensureJSFunction(*scriptExecutionContext);

--- a/Source/WebCore/inspector/WebInjectedScriptHost.cpp
+++ b/Source/WebCore/inspector/WebInjectedScriptHost.cpp
@@ -185,7 +185,7 @@ static JSObject* objectForEventTargetListeners(VM& vm, JSGlobalObject* exec, Eve
                 continue;
 
             auto& jsListener = downcast<JSEventListener>(eventListener->callback());
-            if (&jsListener.isolatedWorld() != &currentWorld(*exec))
+            if (jsListener.isolatedWorld() != &currentWorld(*exec))
                 continue;
 
             auto* jsFunction = jsListener.ensureJSFunction(*scriptExecutionContext);

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2081,9 +2081,7 @@ Ref<Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEventListener
     int lineNumber = 0;
     int columnNumber = 0;
     String scriptID;
-    if (is<JSEventListener>(eventListener)) {
-        auto& scriptListener = downcast<JSEventListener>(eventListener.get());
-
+    if (auto* scriptListener = dynamicDowncast<JSEventListener>(eventListener.get()); scriptListener && scriptListener->isolatedWorld()) {
         Document* document = nullptr;
         if (auto* scriptExecutionContext = eventTarget.scriptExecutionContext()) {
             if (is<Document>(scriptExecutionContext))
@@ -2094,14 +2092,14 @@ Ref<Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEventListener
         JSC::JSObject* handlerObject = nullptr;
         JSC::JSGlobalObject* globalObject = nullptr;
 
-        JSC::JSLockHolder lock(scriptListener.isolatedWorld().vm());
+        JSC::JSLockHolder lock(scriptListener->isolatedWorld()->vm());
 
         if (document) {
-            handlerObject = scriptListener.ensureJSFunction(*document);
+            handlerObject = scriptListener->ensureJSFunction(*document);
             if (auto frame = document->frame()) {
                 // FIXME: Why do we need the canExecuteScripts check here?
                 if (frame->script().canExecuteScripts(NotAboutToExecuteScript))
-                    globalObject = frame->script().globalObject(scriptListener.isolatedWorld());
+                    globalObject = frame->script().globalObject(*scriptListener->isolatedWorld());
             }
         }
 


### PR DESCRIPTION
#### 60f12d4262f763634991e8c45652c55420be304d
<pre>
Cherry-pick 252432.1030@safari-7614-branch (433db4f29219). rdar://problem/107335960

    Heap use-after-free in DOMWrapperWorld::~DOMWrapperWorld
    <a href="https://bugs.webkit.org/show_bug.cgi?id=246022">https://bugs.webkit.org/show_bug.cgi?id=246022</a>
    rdar://100763856

    Reviewed by Jonathan Bedard and Ryosuke Niwa.

    Right before a worker terminates, it destroys its WorkerOrWorkletScriptController,
    which destroys the JS VM. Certain objects like DOMWrapperWorld cannot outlive
    the VM since they keep a `VM&amp;&apos; as data member. However, DOMWrapperWorld is
    refcounted and JSEventListeners hold a strong ref to their DOMWrapperWorld. If
    JSEventListeners outlive the VM, then it would lead to a use-after free in the
    DOMWrapperWorld destructor when destroying those JSEventListeners later on.

    We have previously made several attempts to try and unregister all event
    listeners before destroying the VM. However, those attempts were either
    incomplete or led to other crashes. I am therefore trying a different approach
    this time.

    JSEventListeners now register themselves as client of the JSVMClientData (which
    is owned by the VM) and the client gets a `willDestroyVM()` call before the
    VM gets destroyed. This allows JSEventListeners to clear out their data members
    which rely on the VM (DOMWrapperWorld and JSC::Weak data members).

    * Source/WebCore/bindings/js/JSErrorHandler.cpp:
    (WebCore::JSErrorHandler::handleEvent):
    * Source/WebCore/bindings/js/JSEventListener.cpp:
    (WebCore::JSEventListener::JSEventListener):
    (WebCore::JSEventListener::handleEvent):
    (WebCore::JSEventListener::functionName const):
    (WebCore::JSEventListener::willDestroyVM):
    * Source/WebCore/bindings/js/JSEventListener.h:
    (WebCore::JSEventListener::isolatedWorld const):
    (WebCore::JSEventListener::ensureJSFunction const):
    * Source/WebCore/bindings/js/JSLazyEventListener.cpp:
    (WebCore::JSLazyEventListener::initializeJSFunction const):
    * Source/WebCore/bindings/js/WebCoreJSClientData.cpp:
    (WebCore::JSVMClientData::~JSVMClientData):
    * Source/WebCore/bindings/js/WebCoreJSClientData.h:
    (WebCore::JSVMClientData::addClient):
    * Source/WebCore/dom/EventTarget.cpp:
    (WebCore::EventTarget::attributeEventListener):
    * Source/WebCore/inspector/CommandLineAPIHost.cpp:
    (WebCore::CommandLineAPIHost::getEventListeners):
    * Source/WebCore/inspector/WebInjectedScriptHost.cpp:
    (WebCore::objectForEventTargetListeners):
    * Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
    (WebCore::InspectorDOMAgent::buildObjectForEventListener):

    Canonical link: <a href="https://commits.webkit.org/252432.1030@safari-7614-branch">https://commits.webkit.org/252432.1030@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262247@main">https://commits.webkit.org/262247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb7538db108d16b5d13bbef0800cfe6131381f70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1514 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1107 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1005 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1410 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/933 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/918 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/910 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/961 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/1969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/978 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/953 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1023 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/942 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/208 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/246 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/968 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1027 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/202 "Passed tests") | 
<!--EWS-Status-Bubble-End-->