### PR TITLE
REGRESSION (259663@main): lowes.com: Product image is blank

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/grid-item-image-percentage-min-height-computes-as-0-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/grid-item-image-percentage-min-height-computes-as-0-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+</style>
+</head>
+<body>
+    <img src="/css/support/60x60-green.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/grid-item-image-percentage-min-height-computes-as-0.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/grid-item-image-percentage-min-height-computes-as-0.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css2/#propdef-min-height">
+<link rel="match" href="grid-item-image-percentage-min-height-computes-as-0-ref.html">
+<meta name="assert" content="Image percentage min-height cannot be resolved and used value should be 0">
+<style>
+.grid {
+  display: grid;
+}
+.grid-item {
+    display: grid;
+}
+.grid-item img {
+    height: var(--grid-item-height, auto);
+    min-height: 100%;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="grid-item">
+        <img src="/css/support/60x60-green.png">
+    </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+</style>
+</head>
+<body>
+    <img src="/css/support/60x60-green.png">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css2/#propdef-max-height">
+<link rel="match" href="nested-flexbox-image-percentage-max-height-computes-as-none-ref.html">
+<meta name="assert" content="Image percentage max-height cannot be resolved and used value should be none">
+<style>
+body {  
+  height: 100px; 
+}
+svg {
+  position: relative;
+  max-width: 100%; 
+  max-height: 100%;
+  contain: size;
+  contain-intrinsic-size: 60px 60px;
+  aspect-ratio: 1/1;
+}
+.outer-flexbox { 
+  display: flex; 
+  width: 100%; 
+  height: 100%; 
+}
+.outer-flexbox-item { 
+  position: relative; 
+  min-width: 100%; 
+}
+.inner-flexbox { 
+  position: absolute; 
+  display: flex; 
+  inset: 0px; 
+}
+</style>
+</head>
+<body>
+  <div class="outer-flexbox">
+    <div class="outer-flexbox-item">
+      <div class="inner-flexbox">
+        <div>
+          <svg viewBox="0 0 1 1" style="background: green"></svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3327,8 +3327,11 @@ LayoutUnit RenderBox::computeLogicalHeightWithoutLayout() const
 
 std::optional<LayoutUnit> RenderBox::computeLogicalHeightUsing(SizeType heightType, const Length& height, std::optional<LayoutUnit> intrinsicContentHeight) const
 {
-    if (is<RenderReplaced>(this))
-        return computeReplacedLogicalHeightUsing(heightType, height) + borderAndPaddingLogicalHeight();
+    if (is<RenderReplaced>(this)) {
+        if ((heightType == MinSize || heightType == MaxSize) && !replacedMinMaxLogicalHeightComputesAsNone(heightType))
+            return computeReplacedLogicalHeightUsing(heightType, height) + borderAndPaddingLogicalHeight();
+        return std::nullopt;
+    }
     if (std::optional<LayoutUnit> logicalHeight = computeContentAndScrollbarLogicalHeightUsing(heightType, height, intrinsicContentHeight))
         return adjustBorderBoxLogicalHeightForBoxSizing(logicalHeight.value());
     return std::nullopt;
@@ -3643,6 +3646,13 @@ LayoutUnit RenderBox::computeReplacedLogicalHeightRespectingMinMaxHeight(LayoutU
 LayoutUnit RenderBox::computeReplacedLogicalHeightUsing(SizeType heightType, Length logicalHeight) const
 {
     ASSERT(heightType == MinSize || heightType == MainOrPreferredSize || !logicalHeight.isAuto());
+#if ASSERT_ENABLED
+    // This function should get called with MinSize/MaxSize only if replacedMinMaxLogicalHeightComputesAsNone
+    // returns false, otherwise we should not try to compute those values as they may be incorrect. The caller
+    // should make sure this condition holds before calling this function
+    if (heightType == MinSize || heightType == MaxSize)
+        ASSERT(!replacedMinMaxLogicalHeightComputesAsNone(heightType));
+#endif
     if (heightType == MinSize && logicalHeight.isAuto())
         return adjustContentBoxLogicalHeightForBoxSizing(std::optional<LayoutUnit>(0));
 


### PR DESCRIPTION
#### d4ec309d5e6769e10098079b5b9c09ae917418a0
<pre>
REGRESSION (259663@main): lowes.com: Product image is blank
<a href="https://bugs.webkit.org/show_bug.cgi?id=254603">https://bugs.webkit.org/show_bug.cgi?id=254603</a>
rdar://106926883

Reviewed by Alan Baradlay.

The product image on Lowes had a structure that is very similar
to the following that results in the product image not rendering
correctly (having a width and height of 0). I made some slight
modifications to make it easier to digest, but the following is
indicative of the issue that is causing the image to show up as blank.

body {
  height: 50px;
}
img {
  position: relative;
  max-width: 100%;
  max-height: 100%;
}
.outer-flexbox {
  display: flex;
  width: 100%;
  height: 100%;
}
.outer-flexbox-item {
  position: relative;
  min-width: 100%;
}
.inner-flexbox {
  position: absolute;
  display: flex;
  inset: 0px;
}
&lt;/style&gt;

&lt;div class=&quot;outer-flexbox&quot;&gt;
    &lt;div class=&quot;outer-flexbox-item&quot;&gt;
        &lt;div class=&quot;inner-flexbox&quot;&gt;
            &lt;div&gt;
                &lt;img src=&quot;/css/support/60x60-green.png&quot;&gt;
            &lt;/div&gt;
        &lt;/div&gt;
    &lt;/div&gt;
&lt;/div&gt;

The problem arises when we layout the outer-flexbox and eventually
recurse into the image to compute its preferred width. During this
process, we attempt to compute the max-height by resolving the percentage value, but we end up
incorrectly computing a max-height of 0. This max-height computation is
done when we reach RenderBox::computeLogicalHeightUsing and end up
calling RenderBox::computeReplacedLogicalHeightUsing with a heightType
of MaxSize. computeReplacedLogicalHeightUsing will calculate this height
differently depending on the LengthType of the passed in height and in the
case of this scenario we fall into the LengthType::Percent case for
max-height. Since this code is unable to resolve this height (due to the
fact its containing block depends on the size of its content), it
returns a value of 0. This 0 value ends up affecting not only the size
of the image in both the width and height dimensions, but also affects
the flex item of the inner flexbox and the size of the inner flexbox as
part of a flex item for the outer flexbox.

The solution here is to modify computeLogicalHeightUsing to check if
the min/max height would compute to 0/none depending on the heightType.
Ideally, the caller should not have to do this (like how it is done in
RenderBox::computeReplacedLogicalHeightRespectingMinMaxHeight), and
this would be done handled in computeReplacedLogicalHeightUsing, but
a couple of call sites make this type of change tricky. It is
particularly when computeReplacedLogicalHeightUsing with a heightType of
MainOrPreferredSize since these call sites expect the function to return
a definite value, so it is not clear what would be the correct logic if
it instead returned an empty optional.

To accomplish this, we can use the existing helper function
replacedMinMaxLogicalHeightComputesAsNone, which returns true in this
example to indicate that the used value of max-height should be treated
as none. This was actually already being used in the other call site:
computeReplacedLogicalHeightRespectingMinMaxHeight. To make it more
difficult to call this function when replacedMinMaxLogicalHeightComputesAsNone
returns false, I added an assert to trigger in that problematic scenario.

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/grid-item-image-percentage-min-height-computes-as-0-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/grid-item-image-percentage-min-height-computes-as-0.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/nested-flexbox-image-percentage-max-height-computes-as-none.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeLogicalHeightUsing const):
(WebCore::RenderBox::computeReplacedLogicalHeightUsing const):

Canonical link: <a href="https://commits.webkit.org/262342@main">https://commits.webkit.org/262342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a5dd34b9e8a97b9508840f0641fc3991dff06d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1010 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1203 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1156 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1072 "7 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1798 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1077 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1048 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1088 "7 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2175 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1014 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1067 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/320 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1117 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->