### PR TITLE
Keyboard scrolling in WebKit with Page Up / Down is no longer smooth

### DIFF
--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -1012,20 +1012,22 @@ static bool executeRemoveFormat(LocalFrame& frame, Event*, EditorCommandSource, 
     return true;
 }
 
-static bool executeScrollPageBackward(LocalFrame& frame, Event* event, EditorCommandSource, const String&)
+static bool executeScrollPageBackward(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
     if (frame.eventHandler().shouldUseSmoothKeyboardScrollingForFocusedScrollableArea()) {
-        auto isKeyRepeat = event && event->isKeyboardEvent() && downcast<KeyboardEvent>(*event).repeat();
+        auto isKeyRepeat = frame.eventHandler().isProcessingKeyRepeatForPotentialScroll();
+        frame.eventHandler().setProcessingKeyRepeatForPotentialScroll(false);
         return frame.eventHandler().keyboardScrollRecursively(ScrollDirection::ScrollUp, ScrollGranularity::Page, nullptr, isKeyRepeat);
     }
 
     return frame.eventHandler().logicalScrollRecursively(ScrollBlockDirectionBackward, ScrollGranularity::Page);
 }
 
-static bool executeScrollPageForward(LocalFrame& frame, Event* event, EditorCommandSource, const String&)
+static bool executeScrollPageForward(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
     if (frame.eventHandler().shouldUseSmoothKeyboardScrollingForFocusedScrollableArea()) {
-        auto isKeyRepeat = event && event->isKeyboardEvent() && downcast<KeyboardEvent>(*event).repeat();
+        auto isKeyRepeat = frame.eventHandler().isProcessingKeyRepeatForPotentialScroll();
+        frame.eventHandler().setProcessingKeyRepeatForPotentialScroll(false);
         return frame.eventHandler().keyboardScrollRecursively(ScrollDirection::ScrollDown, ScrollGranularity::Page, nullptr, isKeyRepeat);
     }
 

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -330,6 +330,10 @@ public:
 
     bool isHandlingWheelEvent() const { return m_isHandlingWheelEvent; }
 
+    void setProcessingKeyRepeatForPotentialScroll(bool processingKeyRepeatForPotentialScroll) { m_isProcessingKeyRepeatForPotentialScroll = processingKeyRepeatForPotentialScroll; }
+
+    bool isProcessingKeyRepeatForPotentialScroll() const { return m_isProcessingKeyRepeatForPotentialScroll; }
+
     WEBCORE_EXPORT void setImmediateActionStage(ImmediateActionStage stage);
     ImmediateActionStage immediateActionStage() const { return m_immediateActionStage; }
 
@@ -573,6 +577,7 @@ private:
     bool m_currentWheelEventAllowsScrolling { true };
     bool m_svgPan { false };
     bool m_eventHandlerWillResetCapturingMouseEventsElement { false };
+    bool m_isProcessingKeyRepeatForPotentialScroll { false };
 
     enum SelectionInitiationState : uint8_t { HaveNotStartedSelection, PlacedCaret, ExtendedSelection };
     SelectionInitiationState m_selectionInitiationState { HaveNotStartedSelection };

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -273,6 +273,9 @@ bool WebPage::executeKeypressCommandsInternal(const Vector<WebCore::KeypressComm
                 eventWasHandled |= frame.editor().insertText(commands[i].text, event);
             }
         } else {
+            if (commands[i].commandName == "scrollPageDown:"_s || commands[i].commandName == "scrollPageUp:"_s)
+                frame.eventHandler().setProcessingKeyRepeatForPotentialScroll(event && event->repeat());
+
             Editor::Command command = frame.editor().command(commandNameForSelectorName(commands[i].commandName));
             if (command.isSupported()) {
                 bool commandExecutedByEditor = command.execute(event);


### PR DESCRIPTION
#### f3426a32f875f4109c07a83d596f9e29539ad46e
<pre>
Keyboard scrolling in WebKit with Page Up / Down is no longer smooth
<a href="https://bugs.webkit.org/show_bug.cgi?id=254624">https://bugs.webkit.org/show_bug.cgi?id=254624</a>
rdar://107214002

Reviewed by Simon Fraser.

In `executeScrollPageForward` and `executeScrollPageBackward`, the check for `isKeyRepeat` would
always return `false`, since the passed in `Event*` was always `nullptr`. Therefore, keyboard
scrolling with Page Up or Page Down would not use the new smooth keyboard scrolling mechanism.

This PR fixes this by propogating a bool value in `EventHandler` if the associated event is a key
repeat or not. This information is passed in `executeKeypressCommandsInternal`, which is then read
within the `executeScrollPage*` functions (and then immediately reset to preserve state).

* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeScrollPageBackward):
(WebCore::executeScrollPageForward):
* Source/WebCore/page/EventHandler.h:
(WebCore::EventHandler::setProcessingKeyRepeatForPotentialScroll):
(WebCore::EventHandler::isProcessingKeyRepeatForPotentialScroll const):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::executeKeypressCommandsInternal):

Canonical link: <a href="https://commits.webkit.org/262466@main">https://commits.webkit.org/262466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e678f57a5f05b1b98debcef8a2998b4d45c0312a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1694 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1645 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1468 "1 flakes 115 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2309 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1417 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1390 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1319 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2476 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1301 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1397 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/397 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1514 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->