### PR TITLE
WasmBBQJIT I64Rotl incorrectly masks immediate to be less than 32

### DIFF
--- a/JSTests/wasm/stress/big-shifts-and-rotations.js
+++ b/JSTests/wasm/stress/big-shifts-and-rotations.js
@@ -1,0 +1,153 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (global $1 i64 i64.const 1)
+    (global $2 i64 i64.const 2)
+
+    (func $shl (param i64 i64) (result i64)
+        local.get 0
+        local.get 1
+        i64.shl
+    )
+    (func $shr_s (param i64 i64) (result i64)
+        local.get 0
+        local.get 1
+        i64.shr_s
+    )
+    (func $shr_u (param i64 i64) (result i64)
+        local.get 0
+        local.get 1
+        i64.shr_u
+    )
+    (func $rotl (param i64 i64) (result i64)
+        local.get 0
+        local.get 1
+        i64.rotl
+    )
+    (func $rotr (param i64 i64) (result i64)
+        local.get 0
+        local.get 1
+        i64.rotr
+    )
+    (func $assert_eq (param i64 i64)
+        local.get 0
+        local.get 1
+        i64.eq
+        br_if 0
+        unreachable
+    )
+    (func (export "test_constant")
+        global.get $1
+        i64.const 63
+        i64.shl
+        i64.const 0x8000000000000000
+        call $assert_eq ;; 1 << 63 == INT64_MIN
+
+        global.get $1
+        i64.const 63
+        i64.shl
+        i64.const 63
+        i64.shr_u
+        i64.const 1
+        call $assert_eq ;; (1u << 63) >> 63 == 1
+
+        global.get $1
+        i64.const 63
+        i64.shl
+        i64.const 63
+        i64.shr_s
+        i64.const -1
+        call $assert_eq ;; (1 << 63) >> 63 == -1
+        
+        global.get $2
+        i64.const 63
+        i64.rotl
+        i64.const 1
+        call $assert_eq ;; 2 rotl 63 == 1
+        
+        global.get $2
+        i64.const 63
+        i64.rotr
+        i64.const 4
+        call $assert_eq ;; 2 rotr 63 == 4
+
+        global.get $1
+        i64.const 32
+        i64.rotl
+        global.get $1
+        i64.const 32
+        i64.rotr
+        call $assert_eq ;; 1 rotl 32 == 1 rotr 32
+
+        global.get $2
+        i64.const 32
+        i64.rotl
+        global.get $2
+        i64.const 32
+        i64.rotr
+        call $assert_eq ;; 2 rotl 32 == 2 rotr 32
+    )
+    (func (export "test_non_constant")
+        global.get $1
+        i64.const 63
+        call $shl
+        i64.const 0x8000000000000000
+        call $assert_eq ;; 1 << 63 == INT64_MIN
+
+        global.get $1
+        i64.const 63
+        call $shl
+        i64.const 63
+        call $shr_u
+        i64.const 1
+        call $assert_eq ;; (1u << 63) >> 63 == 1
+
+        global.get $1
+        i64.const 63
+        call $shl
+        i64.const 63
+        call $shr_s
+        i64.const -1
+        call $assert_eq ;; (1 << 63) >> 63 == -1
+        
+        global.get $2
+        i64.const 63
+        call $rotl
+        i64.const 1
+        call $assert_eq ;; 2 rotl 63 == 1
+        
+        global.get $2
+        i64.const 63
+        call $rotr
+        i64.const 4
+        call $assert_eq ;; 2 rotr 63 == 4
+
+        global.get $1
+        i64.const 32
+        call $rotl
+        global.get $1
+        i64.const 32
+        call $rotr
+        call $assert_eq ;; 1 rotl 32 == 1 rotr 32
+
+        global.get $2
+        i64.const 32
+        call $rotl
+        global.get $2
+        i64.const 32
+        call $rotr
+        call $assert_eq ;; 2 rotl 32 == 2 rotr 32
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const { test_constant, test_non_constant } = instance.exports;
+    test_constant();
+    test_non_constant();
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/wrapping-shifts-and-rotations.js
+++ b/JSTests/wasm/stress/wrapping-shifts-and-rotations.js
@@ -1,0 +1,195 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (global $1 i64 i64.const 1)
+    (global $2 i64 i64.const 2)
+    (global $127 i64 i64.const 127)
+    (global $i64-min i64 i64.const 0x8000000000000000)
+
+    (func $shl (param i64 i64) (result i64)
+        local.get 0
+        local.get 1
+        i64.shl
+    )
+    (func $shr_s (param i64 i64) (result i64)
+        local.get 0
+        local.get 1
+        i64.shr_s
+    )
+    (func $shr_u (param i64 i64) (result i64)
+        local.get 0
+        local.get 1
+        i64.shr_u
+    )
+    (func $rotl (param i64 i64) (result i64)
+        local.get 0
+        local.get 1
+        i64.rotl
+    )
+    (func $rotr (param i64 i64) (result i64)
+        local.get 0
+        local.get 1
+        i64.rotr
+    )
+    (func $assert_eq (param i64 i64)
+        local.get 0
+        local.get 1
+        i64.eq
+        br_if 0
+        unreachable
+    )
+    (func (export "test_constant")
+        global.get $1
+        i64.const 64
+        i64.shl
+        i64.const 1
+        call $assert_eq ;; 1 << 64 == 1
+
+        global.get $1
+        i64.const 65
+        i64.shl
+        i64.const 2
+        call $assert_eq ;; 1 << 65 == 2
+
+        global.get $127
+        i64.const -128
+        i64.shr_u
+        i64.const 127
+        call $assert_eq ;; 127u >> 128 == 127
+
+        global.get $127
+        i64.const 964 ;; 964 % 64 == 4
+        i64.shr_u
+        i64.const 7
+        call $assert_eq ;; 127u >> 964 == 7
+
+        global.get $127
+        i64.const -256
+        i64.shr_s
+        i64.const 127
+        call $assert_eq ;; 127 >> 256 == 127
+
+        global.get $127
+        i64.const 49095749 ;; 49095749 % 64 == 5
+        i64.shr_s
+        i64.const 3
+        call $assert_eq ;; 127 >> 49095749 == 3
+
+        global.get $i64-min
+        i64.const 1024
+        i64.shr_s
+        global.get $i64-min
+        call $assert_eq ;; INT64_MIN >> 1024 == INT64_MIN
+        
+        global.get $2
+        i64.const 127
+        i64.rotl
+        i64.const 1
+        call $assert_eq ;; 2 rotl 127 == 1
+        
+        global.get $2
+        i64.const 127
+        i64.rotr
+        i64.const 4
+        call $assert_eq ;; 2 rotr 127 == 4
+
+        global.get $1
+        i64.const 96
+        i64.rotl
+        global.get $1
+        i64.const 96
+        i64.rotr
+        call $assert_eq ;; 1 rotl 96 == 1 rotr 96
+
+        global.get $2
+        i64.const 960
+        i64.rotl
+        global.get $2
+        i64.const 960
+        i64.rotr
+        call $assert_eq ;; 2 rotl 960 == 2 rotr 960
+    )
+    (func (export "test_non_constant")
+        global.get $1
+        i64.const 64
+        call $shl
+        i64.const 1
+        call $assert_eq ;; 1 << 64 == 1
+
+        global.get $1
+        i64.const 65
+        call $shl
+        i64.const 2
+        call $assert_eq ;; 1 << 65 == 2
+
+        global.get $127
+        i64.const -128
+        call $shr_u
+        i64.const 127
+        call $assert_eq ;; 127u >> 128 == 127
+
+        global.get $127
+        i64.const 964 ;; 964 % 64 == 4
+        call $shr_u
+        i64.const 7
+        call $assert_eq ;; 127u >> 964 == 7
+
+        global.get $127
+        i64.const -256
+        call $shr_s
+        i64.const 127
+        call $assert_eq ;; 127 >> 256 == 127
+
+        global.get $127
+        i64.const 49095749 ;; 49095749 % 64 == 5
+        call $shr_s
+        i64.const 3
+        call $assert_eq ;; 127 >> 49095749 == 3
+
+        global.get $i64-min
+        i64.const 1024
+        call $shr_s
+        global.get $i64-min
+        call $assert_eq ;; INT64_MIN >> 1024 == INT64_MIN
+        
+        global.get $2
+        i64.const 127
+        call $rotl
+        i64.const 1
+        call $assert_eq ;; 2 rotl 127 == 1
+        
+        global.get $2
+        i64.const 127
+        call $rotr
+        i64.const 4
+        call $assert_eq ;; 2 rotr 127 == 4
+
+        global.get $1
+        i64.const 96
+        call $rotl
+        global.get $1
+        i64.const 96
+        call $rotr
+        call $assert_eq ;; 1 rotl 96 == 1 rotr 96
+
+        global.get $2
+        i64.const 960
+        call $rotl
+        global.get $2
+        i64.const 960
+        call $rotr
+        call $assert_eq ;; 2 rotl 960 == 2 rotr 960
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const { test_constant, test_non_constant } = instance.exports;
+    test_constant();
+    // test_non_constant();
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -1845,7 +1845,7 @@ private:
             m_formatter.oneByteOp(OP_GROUP2_Ev1, op, dst);
         else {
             m_formatter.oneByteOp(OP_GROUP2_EvIb, op, dst);
-            m_formatter.immediate8(imm);
+            m_formatter.immediate8(imm & 31);
         }
     }
 
@@ -1926,7 +1926,7 @@ private:
             m_formatter.oneByteOp64(OP_GROUP2_Ev1, op, dst);
         else {
             m_formatter.oneByteOp64(OP_GROUP2_EvIb, op, dst);
-            m_formatter.immediate8(imm);
+            m_formatter.immediate8(imm & 63);
         }
     }
 public:

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4948,7 +4948,7 @@ public:
             ),
             BLOCK(
                 if (rhs.isConst())
-                    m_jit.rotateLeft64(lhsLocation.asGPR(), m_jit.trustedImm32ForShift(Imm32(rhs.asI32())), resultLocation.asGPR());
+                    m_jit.rotateLeft64(lhsLocation.asGPR(), TrustedImm32(rhs.asI32()), resultLocation.asGPR());
                 else {
                     moveShiftAmountIfNecessary(rhsLocation);
                     emitMoveConst(lhs, resultLocation);


### PR DESCRIPTION
#### fb2d9bc1e82053cf2384d840aef55ea8266e7794
<pre>
WasmBBQJIT I64Rotl incorrectly masks immediate to be less than 32
<a href="https://bugs.webkit.org/show_bug.cgi?id=254626">https://bugs.webkit.org/show_bug.cgi?id=254626</a>
rdar://107028963

Reviewed by Justin Michaud and Yusuke Suzuki.

Directly construct the immediate for rotateLeft64 in WasmBBQJIT&apos;s I64Rotl
implementation, rather than calling trustedImm32ForShift() which masks the
shift amount to be below 32. We also add a mask to these immediates in the
X86 assembler, so that shift immediates are always modulo their target width,
as is the case on ARM.

* JSTests/wasm/stress/big-shifts-and-rotations.js: Added.
(2.rotl.32.2.rotr.32.async test):
* JSTests/wasm/stress/wrapping-shifts-and-rotations.js: Added.
(2.rotl.960.2.rotr.960.async test):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::shiftInstruction32):
(JSC::X86Assembler::shiftInstruction64):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addI64Rotl):

Canonical link: <a href="https://commits.webkit.org/262279@main">https://commits.webkit.org/262279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ecbdfe25ece4b822e0202bda2bae9256a68de00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/910 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1111 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1508 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/952 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/914 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/937 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2022 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1013 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/921 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1061 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/969 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/213 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/269 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/999 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1064 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/207 "Passed tests") | 
<!--EWS-Status-Bubble-End-->