### PR TITLE
Exiting fullscreen on ign.com fails to restore scroll position

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-restore-scroll-position-overflow-auto-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-restore-scroll-position-overflow-auto-expected.txt
@@ -1,0 +1,6 @@
+This tests that page scroll is restored after fullscreen. Press any key to start the test.
+
+
+EVENT(load)
+EXPECTED ((document.scrollingElement.scrollTop === originalScroll) == 'true') OK
+

--- a/LayoutTests/fullscreen/fullscreen-restore-scroll-position-overflow-auto.html
+++ b/LayoutTests/fullscreen/fullscreen-restore-scroll-position-overflow-auto.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>fullscreen-restore-scroll-position with overflow: auto on body</title>
+        <script src="../media/video-test.js"></script>
+        <script src="../media/media-file.js"></script>
+        <style>
+            .spacer {
+                height: 100vh;
+            }
+            html, body {
+                height: 100%;
+            }
+            body {
+                overflow: auto;
+            }
+            video {
+                width: 50%;
+            }
+        </style>
+    </head>
+    <body>
+    <p>This tests that page scroll is restored after fullscreen. Press any key to start the test.</p>
+    <div class="spacer"></div>
+    <div id="parent">
+        <video id="video" controls></video>
+    </div>
+    <div class="spacer"></div>
+    <script>
+
+        let originalScroll = 0;
+        video = document.getElementsByTagName('video')[0];
+        video.src = findMediaFile('video', '../media/content/test');
+
+        waitFor(window, 'load').then(async event => {
+
+            if (Element.prototype.webkitRequestFullScreen == undefined) {
+                logResult(false, "Element.prototype.webkitRequestFullScreen == undefined");
+                endTest();
+                return;
+            }
+
+            waitFor(video, 'canplaythrough', true);
+
+            originalScroll = document.body.clientHeight;
+            document.scrollingElement.scrollTop = originalScroll;
+            originalScroll = document.scrollingElement.scrollTop;
+
+            document.onwebkitfullscreenchange = async (event) => {
+                if (document.webkitIsFullScreen) {
+                    await sleepFor(1000);
+                    document.webkitExitFullscreen();
+                    return;
+                }
+
+                // scrollTop triggers a layout, so the bug doesn't reproduce if we call it too early.
+                await sleepFor(100);
+
+                await testExpectedEventually("(document.scrollingElement.scrollTop === originalScroll)", true);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            };
+            runWithKeyDown(() => document.getElementById('video').webkitRequestFullScreen());
+        });
+
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2461,6 +2461,9 @@ http/tests/websocket/tests/hybi/multiple-connections-limit.html [ Skip ]
 # Displays blank on WK1
 fullscreen/fullscreen-iframe-navigation.html [ Skip ]
 
+# Timeout on WK1
+fullscreen/fullscreen-restore-scroll-position-overflow-auto.html [ Skip ]
+
 # Timeout testing is not applicable to in-process webgl, only webgl in gpu process.
 fast/canvas/webgl/lose-context-on-timeout-async.html [ Skip ]
 fast/canvas/webgl/lose-context-on-timeout.html [ Skip ]

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -388,8 +388,11 @@ void WebFullScreenManager::saveScrollPosition()
 
 void WebFullScreenManager::restoreScrollPosition()
 {
-    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->corePage()->mainFrame()))
+    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->corePage()->mainFrame())) {
+        // Make sure overflow: hidden is unapplied from the root element before restoring.
+        localMainFrame->view()->forceLayout();
         localMainFrame->view()->setScrollPosition(m_scrollPosition);
+    }
 }
 
 void WebFullScreenManager::setFullscreenInsets(const WebCore::FloatBoxExtent& insets)

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -71,6 +71,9 @@ public:
     void willExitFullScreen();
     void didExitFullScreen();
 
+    void saveScrollPosition();
+    void restoreScrollPosition();
+
     WebCore::Element* element();
 
     void videoControlsManagerDidChange();
@@ -85,8 +88,6 @@ protected:
     void setAnimatingFullScreen(bool);
     void requestRestoreFullScreen();
     void requestExitFullScreen();
-    void saveScrollPosition();
-    void restoreScrollPosition();
     void setFullscreenInsets(const WebCore::FloatBoxExtent&);
     void setFullscreenAutoHideDuration(Seconds);
     void setFullscreenControlsHidden(bool);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -130,6 +130,7 @@ void WKBundlePageSetFullScreenClient(WKBundlePageRef pageRef, WKBundlePageFullSc
 void WKBundlePageWillEnterFullScreen(WKBundlePageRef pageRef)
 {
 #if ENABLE(FULLSCREEN_API)
+    WebKit::toImpl(pageRef)->fullScreenManager()->saveScrollPosition();
     WebKit::toImpl(pageRef)->fullScreenManager()->willEnterFullScreen();
 #else
     UNUSED_PARAM(pageRef);
@@ -158,6 +159,7 @@ void WKBundlePageDidExitFullScreen(WKBundlePageRef pageRef)
 {
 #if ENABLE(FULLSCREEN_API)
     WebKit::toImpl(pageRef)->fullScreenManager()->didExitFullScreen();
+    WebKit::toImpl(pageRef)->fullScreenManager()->restoreScrollPosition();
 #else
     UNUSED_PARAM(pageRef);
 #endif


### PR DESCRIPTION
#### b8bf24826066a38484c8ab1cc31802d712a4a30a
<pre>
Exiting fullscreen on ign.com fails to restore scroll position
<a href="https://bugs.webkit.org/show_bug.cgi?id=254632">https://bugs.webkit.org/show_bug.cgi?id=254632</a>
rdar://106774841

Reviewed by Jer Noble.

The bug is caused by a missing layout in some particular situations (overflow: auto + percentage sizes) before restoring the scroll position.
Adding a call to forceLayout() fixes the issue.

However, in order for the test to work in WebKit Test runner, the save/restoreScrollPosition methods also need to be called in the InjectedBundle.
Safari &amp; minibrowser use a different codepath (involving the UIProcess).

* LayoutTests/fullscreen/fullscreen-restore-scroll-position-overflow-auto-expected.txt: Added.
* LayoutTests/fullscreen/fullscreen-restore-scroll-position-overflow-auto.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::restoreScrollPosition):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageWillEnterFullScreen):
(WKBundlePageDidExitFullScreen):

Canonical link: <a href="https://commits.webkit.org/262281@main">https://commits.webkit.org/262281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c908e9e216c8c8c58867710440d296f6259915a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1636 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/922 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1117 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1532 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/955 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/952 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/999 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2019 "260 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/931 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/939 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/980 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/272 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1014 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->