### PR TITLE
Some ApplicationManifestParsermember function could be marked as const

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -107,7 +107,7 @@ void ApplicationManifestParser::logDeveloperWarning(const String& message)
         m_document->addConsoleMessage(makeUnique<Inspector::ConsoleMessage>(JSC::MessageSource::Other, JSC::MessageType::Log, JSC::MessageLevel::Warning, makeString("Parsing application manifest "_s, m_manifestURL.string(), ": "_s, message)));
 }
 
-URL ApplicationManifestParser::parseStartURL(const JSON::Object& manifest, const URL& documentURL)
+const URL ApplicationManifestParser::parseStartURL(const JSON::Object& manifest, const URL& documentURL)
 {
     auto value = manifest.getValue("start_url"_s);
     if (!value)
@@ -197,22 +197,22 @@ const std::optional<ScreenOrientationLockType> ApplicationManifestParser::parseO
     return std::nullopt;
 }
 
-String ApplicationManifestParser::parseName(const JSON::Object& manifest)
+const String ApplicationManifestParser::parseName(const JSON::Object& manifest)
 {
     return parseGenericString(manifest, "name"_s);
 }
 
-String ApplicationManifestParser::parseDescription(const JSON::Object& manifest)
+const String ApplicationManifestParser::parseDescription(const JSON::Object& manifest)
 {
     return parseGenericString(manifest, "description"_s);
 }
 
-String ApplicationManifestParser::parseShortName(const JSON::Object& manifest)
+const String ApplicationManifestParser::parseShortName(const JSON::Object& manifest)
 {
     return parseGenericString(manifest, "short_name"_s);
 }
 
-Vector<ApplicationManifest::Icon> ApplicationManifestParser::parseIcons(const JSON::Object& manifest)
+const Vector<ApplicationManifest::Icon> ApplicationManifestParser::parseIcons(const JSON::Object& manifest)
 {
     auto manifestIcons = manifest.getValue("icons"_s);
 
@@ -315,7 +315,7 @@ static bool isInScope(const URL& scopeURL, const URL& targetURL)
     return false;
 }
 
-URL ApplicationManifestParser::parseId(const JSON::Object& manifest, const URL& startURL)
+const URL ApplicationManifestParser::parseId(const JSON::Object& manifest, const URL& startURL)
 {
     auto idValue = manifest.getValue("id"_s);
     if (!idValue)
@@ -345,7 +345,7 @@ URL ApplicationManifestParser::parseId(const JSON::Object& manifest, const URL& 
     return idURL;
 }
 
-URL ApplicationManifestParser::parseScope(const JSON::Object& manifest, const URL& documentURL, const URL& startURL)
+const URL ApplicationManifestParser::parseScope(const JSON::Object& manifest, const URL& documentURL, const URL& startURL)
 {
     URL defaultScope { startURL, "./"_s };
 
@@ -383,12 +383,12 @@ URL ApplicationManifestParser::parseScope(const JSON::Object& manifest, const UR
     return scopeURL;
 }
 
-Color ApplicationManifestParser::parseColor(const JSON::Object& manifest, const String& propertyName)
+const Color ApplicationManifestParser::parseColor(const JSON::Object& manifest, const String& propertyName)
 {
     return CSSParser::parseColorWithoutContext(parseGenericString(manifest, propertyName));
 }
 
-String ApplicationManifestParser::parseGenericString(const JSON::Object& manifest, const String& propertyName)
+const String ApplicationManifestParser::parseGenericString(const JSON::Object& manifest, const String& propertyName)
 {
     auto value = manifest.getValue(propertyName);
     if (!value)

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
@@ -45,18 +45,18 @@ private:
     ApplicationManifestParser(RefPtr<Document>);
     ApplicationManifest parseManifest(const String&, const URL&, const URL&);
 
-    URL parseStartURL(const JSON::Object&, const URL&);
+    const URL parseStartURL(const JSON::Object&, const URL&);
     ApplicationManifest::Display parseDisplay(const JSON::Object&);
     const std::optional<ScreenOrientationLockType> parseOrientation(const JSON::Object&);
-    String parseName(const JSON::Object&);
-    String parseDescription(const JSON::Object&);
-    String parseShortName(const JSON::Object&);
-    URL parseScope(const JSON::Object&, const URL&, const URL&);
-    Vector<ApplicationManifest::Icon> parseIcons(const JSON::Object&);
-    URL parseId(const JSON::Object&, const URL&);
+    const String parseName(const JSON::Object&);
+    const String parseDescription(const JSON::Object&);
+    const String parseShortName(const JSON::Object&);
+    const URL parseScope(const JSON::Object&, const URL&, const URL&);
+    const Vector<ApplicationManifest::Icon> parseIcons(const JSON::Object&);
+    const URL parseId(const JSON::Object&, const URL&);
 
-    Color parseColor(const JSON::Object&, const String& propertyName);
-    String parseGenericString(const JSON::Object&, const String&);
+    const Color parseColor(const JSON::Object&, const String& propertyName);
+    const String parseGenericString(const JSON::Object&, const String&);
 
     void logManifestPropertyNotAString(const String&);
     void logManifestPropertyInvalidURL(const String&);


### PR DESCRIPTION
#### e6724f00e67105e7e46cf78ffbd476487bb06158
<pre>
Some ApplicationManifestParsermember function could be marked as const
<a href="https://bugs.webkit.org/show_bug.cgi?id=254635">https://bugs.webkit.org/show_bug.cgi?id=254635</a>
rdar://107345868

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseStartURL):
(WebCore::ApplicationManifestParser::parseName):
(WebCore::ApplicationManifestParser::parseDescription):
(WebCore::ApplicationManifestParser::parseShortName):
(WebCore::ApplicationManifestParser::parseIcons):
(WebCore::ApplicationManifestParser::parseId):
(WebCore::ApplicationManifestParser::parseScope):
(WebCore::ApplicationManifestParser::parseColor):
(WebCore::ApplicationManifestParser::parseGenericString):
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6724f00e67105e7e46cf78ffbd476487bb06158

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1617 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/914 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1110 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1517 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/946 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/991 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2007 "260 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/925 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/972 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1003 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->