### PR TITLE
REGRESSION (iOS 16.4): Photo library picker shows videos even for accept="image/*"

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -67,8 +67,9 @@ SOFT_LINK_CLASS(PhotosUIPrivate, PUActivityProgressController)
 #if HAVE(PHOTOS_UI)
 SOFT_LINK_FRAMEWORK(PhotosUI)
 SOFT_LINK_CLASS(PhotosUI, PHPickerConfiguration)
-SOFT_LINK_CLASS(PhotosUI, PHPickerViewController)
+SOFT_LINK_CLASS(PhotosUI, PHPickerFilter)
 SOFT_LINK_CLASS(PhotosUI, PHPickerResult)
+SOFT_LINK_CLASS(PhotosUI, PHPickerViewController)
 #endif
 
 enum class WKFileUploadPanelImagePickerType : uint8_t {
@@ -869,6 +870,13 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
     [configuration setSelectionLimit:_allowMultipleFiles ? 0 : 1];
     [configuration setPreferredAssetRepresentationMode:PHPickerConfigurationAssetRepresentationModeCompatible];
     [configuration _setAllowsDownscaling:YES];
+
+    if (auto allowedImagePickerType = _allowedImagePickerTypes.toSingleValue()) {
+        if (*allowedImagePickerType == WKFileUploadPanelImagePickerType::Image)
+            [configuration setFilter:[getPHPickerFilterClass() imagesFilter]];
+        else
+            [configuration setFilter:[getPHPickerFilterClass() videosFilter]];
+    }
 
     _uploadFileManager = adoptNS([[NSFileManager alloc] init]);
     _uploadFileCoordinator = adoptNS([[NSFileCoordinator alloc] init]);


### PR DESCRIPTION
#### 6c610b79ff6cd385bf83f1f2390b7b79a2de0d78
<pre>
REGRESSION (iOS 16.4): Photo library picker shows videos even for accept=&quot;image/*&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=254604">https://bugs.webkit.org/show_bug.cgi?id=254604</a>
rdar://107330772

Reviewed by Wenson Hsieh.

255435@main replaced usage of `UIImagePickerController` with `PHPickerViewController`
to display the photo library picker. Previously the accepted types were restricted
using `-[UIImagePickerController setMediaTypes:]`. However, the old filtering logic
was not ported over to `PHPickerViewController`, resulting in the picker always
displaying both images and video.

* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:

Fix by adopting `PHPickerFilter` to filter the type of media if needed.

Canonical link: <a href="https://commits.webkit.org/262275@main">https://commits.webkit.org/262275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92fcd564867282910f22886a6d8b25a936923190

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1625 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/917 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1114 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/951 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/945 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/993 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2014 "260 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/926 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/974 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1007 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/110 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->