### PR TITLE
Inline a few trivial getters that show on profiles

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2022,11 +2022,6 @@ void Document::setStateForNewFormElements(const Vector<AtomString>& stateVector)
     formController().setStateForNewFormElements(stateVector);
 }
 
-LocalFrameView* Document::view() const
-{
-    return m_frame ? m_frame->view() : nullptr;
-}
-
 Ref<Range> Document::createRange()
 {
     return Range::create(*this);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -622,7 +622,7 @@ public:
     Vector<AtomString> formElementsState() const;
     void setStateForNewFormElements(const Vector<AtomString>&);
 
-    WEBCORE_EXPORT LocalFrameView* view() const; // Can be null.
+    inline LocalFrameView* view() const; // Defined in LocalFrame.h.
     inline Page* page() const; // Defined in Page.h
     const Settings& settings() const { return m_settings.get(); }
     EditingBehavior editingBehavior() const;

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -86,22 +86,12 @@ VisibleSelection VisibleSelection::selectionFromContentsOfNode(Node* node)
     return VisibleSelection(VisiblePosition { firstPositionInNode(node) }, VisiblePosition { lastPositionInNode(node) });
 }
 
-Position VisibleSelection::anchor() const
-{
-    return m_anchor;
-}
-
-Position VisibleSelection::focus() const
-{
-    return m_focus;
-}
-
-Position VisibleSelection::uncanonicalizedStart() const
+const Position& VisibleSelection::uncanonicalizedStart() const
 {
     return m_anchorIsFirst ? m_anchor : m_focus;
 }
 
-Position VisibleSelection::uncanonicalizedEnd() const
+const Position& VisibleSelection::uncanonicalizedEnd() const
 {
     return m_anchorIsFirst ? m_focus : m_anchor;
 }

--- a/Source/WebCore/editing/VisibleSelection.h
+++ b/Source/WebCore/editing/VisibleSelection.h
@@ -60,17 +60,17 @@ public:
     // These functions return the values that were passed in, without the canonicalization done by VisiblePosition.
     // FIXME: When we expand granularity, we canonicalize as a side effect, so expanded values have been made canonical.
     // FIXME: Replace start/range/base/end/firstRange with these, renaming these to the shorter names.
-    Position uncanonicalizedStart() const;
-    Position uncanonicalizedEnd() const;
-    Position anchor() const;
-    Position focus() const;
+    const Position& uncanonicalizedStart() const;
+    const Position& uncanonicalizedEnd() const;
+    const Position& anchor() const { return m_anchor; }
+    const Position& focus() const { return m_focus; }
     WEBCORE_EXPORT std::optional<SimpleRange> range() const;
 
     // FIXME: Rename these to include the word "canonical" or remove.
-    Position base() const { return m_base; }
-    Position extent() const { return m_extent; }
-    Position start() const { return m_start; }
-    Position end() const { return m_end; }
+    const Position& base() const { return m_base; }
+    const Position& extent() const { return m_extent; }
+    const Position& start() const { return m_start; }
+    const Position& end() const { return m_end; }
 
     VisiblePosition visibleStart() const { return VisiblePosition(m_start, isRange() ? Affinity::Downstream : affinity()); }
     VisiblePosition visibleEnd() const { return VisiblePosition(m_end, isRange() ? Affinity::Upstream : affinity()); }

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -368,6 +368,11 @@ inline Document* LocalFrame::document() const
     return m_doc.get();
 }
 
+inline LocalFrameView* Document::view() const
+{
+    return m_frame ? m_frame->view() : nullptr;
+}
+
 WTF::TextStream& operator<<(WTF::TextStream&, const LocalFrame&);
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3811,11 +3811,6 @@ ScrollLatchingController& Page::scrollLatchingController()
         
     return *m_scrollLatchingController;
 }
-
-ScrollLatchingController* Page::scrollLatchingControllerIfExists()
-{
-    return m_scrollLatchingController.get();
-}
 #endif // ENABLE(WHEEL_EVENT_LATCHING)
 
 enum class DispatchedOnDocumentEventLoop : bool { No, Yes };

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -587,7 +587,7 @@ public:
 
 #if ENABLE(WHEEL_EVENT_LATCHING)
     ScrollLatchingController& scrollLatchingController();
-    ScrollLatchingController* scrollLatchingControllerIfExists();
+    ScrollLatchingController* scrollLatchingControllerIfExists() { return m_scrollLatchingController.get(); }
 #endif // ENABLE(WHEEL_EVENT_LATCHING)
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -756,11 +756,6 @@ LayoutRect RenderBox::paddingBoxRect() const
         height() - borderTop() - borderBottom() - horizontalScrollbarHeight());
 }
 
-LayoutRect RenderBox::contentBoxRect() const
-{
-    return { contentBoxLocation(), contentSize() };
-}
-
 LayoutPoint RenderBox::contentBoxLocation() const
 {
     LayoutUnit scrollbarSpace = shouldPlaceVerticalScrollbarOnLeft() ? verticalScrollbarWidth() : 0;

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -952,6 +952,11 @@ inline void RenderBox::setInlineBoxWrapper(LegacyInlineElementBox* boxWrapper)
     m_inlineBoxWrapper = boxWrapper;
 }
 
+inline LayoutRect RenderBox::contentBoxRect() const
+{
+    return { contentBoxLocation(), contentSize() };
+}
+
 LayoutUnit synthesizedBaseline(const RenderBox&, const RenderStyle& parentStyle, LineDirectionMode, BaselineSynthesisEdge);
 
 } // namespace WebCore


### PR DESCRIPTION
#### 01a47ec8beff9c79b765f42896967b5650831203
<pre>
Inline a few trivial getters that show on profiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=254645">https://bugs.webkit.org/show_bug.cgi?id=254645</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::view const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::uncanonicalizedStart const):
(WebCore::VisibleSelection::uncanonicalizedEnd const):
(WebCore::VisibleSelection::anchor const): Deleted.
(WebCore::VisibleSelection::focus const): Deleted.
* Source/WebCore/editing/VisibleSelection.h:
(WebCore::VisibleSelection::anchor const):
(WebCore::VisibleSelection::focus const):
(WebCore::VisibleSelection::base const):
(WebCore::VisibleSelection::extent const):
(WebCore::VisibleSelection::start const):
(WebCore::VisibleSelection::end const):
* Source/WebCore/page/LocalFrame.h:
(WebCore::Document::view const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::scrollLatchingController):
(WebCore::Page::scrollLatchingControllerIfExists): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::scrollLatchingControllerIfExists):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::contentBoxRect const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::contentBoxRect const):

Canonical link: <a href="https://commits.webkit.org/262276@main">https://commits.webkit.org/262276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdd7ea38134e1f90b12fd189f325dadfab376484

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1639 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1118 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1531 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/956 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/951 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2020 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/996 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/930 "3 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/979 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/267 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1013 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->