### PR TITLE
[WGSL] Add type declarations for all matrix constructors

### DIFF
--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -41,7 +41,8 @@ struct TypeVariable {
         F16 = 1 << 0,
         F32 = 1 << 1,
         AbstractFloat = 1 << 2,
-        Float = F16 | F32 | AbstractFloat,
+        ConcreteFloat = F16 | F32,
+        Float = ConcreteFloat | AbstractFloat,
 
         I32 = 1 << 3,
         U32 = 1 << 4,

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -26,3 +26,15 @@ operator :textureSample, {
     # FIXME: add overloads for texture_depth
     # https://bugs.webkit.org/show_bug.cgi?id=254515
 }
+
+(2..4).each do |columns|
+    (2..4).each do |rows|
+        operator :"mat#{columns}x#{rows}", {
+            # FIXME: overload resolution should support explicitly instantiating variables
+            # [T < ConcreteFloat, S < Float].(Matrix[S, columns, rows]) => Matrix[T, columns, rows],
+            [T < Float].(Matrix[T, columns, rows]) => Matrix[T, columns, rows],
+            [T < Float].(*([T] * columns * rows)) => Matrix[T, columns, rows],
+            [T < Float].(*([Vector[T, rows]] * columns)) => Matrix[T, columns, rows],
+        }
+    end
+end

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -281,6 +281,7 @@ module DSL
         AbstractInt = PrimitiveType.new(:AbstractInt)
 
 
+        S = Variable.new(:S, @TypeVariable)
         T = Variable.new(:T, @TypeVariable)
         N = Variable.new(:N, @NumericVariable)
         C = Variable.new(:C, @NumericVariable)
@@ -289,6 +290,7 @@ module DSL
         Number = Constraint.new(:Number)
         Float = Constraint.new(:Float)
         ConcreteInteger = Constraint.new(:ConcreteInteger)
+        ConcreteFloat = Constraint.new(:ConcreteFloat)
         EOS
     end
 

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -99,3 +99,77 @@ fn testTextureSample() {
     let r = textureSample(t, s, vec3<f32>(0, 0, 0), 0);
   }
 }
+
+fn testMatrixConstructor() {
+  {
+    // FIXME: overload resolution should support explicitly instantiating variables
+    // let m1 = mat2x2<f32>(mat2x2(0.0, 0.0, 0.0, 0.0));
+    let m2 = mat2x2(mat2x2(0.0, 0.0, 0.0, 0.0));
+    let m3 = mat2x2(0.0, 0.0, 0.0, 0.0);
+    let m4 = mat2x2(vec2(0.0, 0.0), vec2(0.0, 0.0));
+  }
+
+  {
+    // FIXME: overload resolution should support explicitly instantiating variables
+    // let m1 = mat2x3<f32>(mat2x3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m2 = mat2x3(mat2x3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m3 = mat2x3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let m4 = mat2x3(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
+  }
+
+  {
+    // FIXME: overload resolution should support explicitly instantiating variables
+    // let m1 = mat2x4<f32>(mat2x4(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m2 = mat2x4(mat2x4(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m3 = mat2x4(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let m4 = mat2x4(vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    // FIXME: overload resolution should support explicitly instantiating variables
+    // let m1 = mat3x2<f32>(mat3x2(0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m2 = mat3x2(mat3x2(0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m3 = mat3x2(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let m4 = mat3x2(vec2(0.0, 0.0), vec2(0.0, 0.0), vec2(0.0, 0.0));
+  }
+
+  {
+    // FIXME: overload resolution should support explicitly instantiating variables
+    // let m1 = mat3x3<f32>(mat3x3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m2 = mat3x3(mat3x3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m3 = mat3x3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let m4 = mat3x3(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
+  }
+
+  {
+    // FIXME: overload resolution should support explicitly instantiating variables
+    // let m1 = mat3x4<f32>(mat3x4(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m2 = mat3x4(mat3x4(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m3 = mat3x4(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let m4 = mat3x4(vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    // FIXME: overload resolution should support explicitly instantiating variables
+    // let m1 = mat4x2<f32>(mat4x2(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m2 = mat4x2(mat4x2(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m3 = mat4x2(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let m4 = mat4x2(vec2(0.0, 0.0), vec2(0.0, 0.0), vec2(0.0, 0.0), vec2(0.0, 0.0));
+  }
+
+  {
+    // FIXME: overload resolution should support explicitly instantiating variables
+    // let m1 = mat4x3<f32>(mat4x3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m2 = mat4x3(mat4x3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m3 = mat4x3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let m4 = mat4x3(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
+  }
+
+  {
+    // FIXME: overload resolution should support explicitly instantiating variables
+    // let m1 = mat4x4<f32>(mat4x4(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m2 = mat4x4(mat4x4(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m3 = mat4x4(mat4x4(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+    let m4 = mat4x4(vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0));
+  }
+}


### PR DESCRIPTION
#### dd93800d7deb2b706a60a1b225e57a1b8d1b9947
<pre>
[WGSL] Add type declarations for all matrix constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=254651">https://bugs.webkit.org/show_bug.cgi?id=254651</a>
rdar://107358275

Reviewed by Myles C. Maxfield.

Add all the possible overloads for matrix constructors. This contains the same
FIXME as PR #12049, but these overloads are necessary before I can add support
for explicit type arguments without breaking the test.

* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/262315@main">https://commits.webkit.org/262315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e48cf912d594ff0636a9aeed1900804cfa0579fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/931 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1126 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1546 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/966 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/961 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2034 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/941 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/989 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/301 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1023 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->