### PR TITLE
[WGSL] Add support for constructors with explicit type arguments

### DIFF
--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -89,7 +89,7 @@ struct OverloadCandidate {
     AbstractType result;
 };
 
-Type* resolveOverloads(TypeStore&, const Vector<OverloadCandidate>&, const Vector<Type*>&);
+Type* resolveOverloads(TypeStore&, const Vector<OverloadCandidate>&, const Vector<Type*>& valueArguments, const Vector<Type*>& typeArguments);
 
 } // namespace WGSL
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -98,7 +98,7 @@ private:
     bool unify(Type*, Type*) WARN_UNUSED_RETURN;
     bool isBottom(Type*) const;
     std::optional<unsigned> extractInteger(AST::Expression&);
-    Type* chooseOverload(const String&, const Vector<Type*>&);
+    Type* chooseOverload(const String&, const Vector<Type*>& valueArguments, const Vector<Type*>& typeArguments);
 
     ShaderModule& m_shaderModule;
     Type* m_inferredType { nullptr };
@@ -305,7 +305,7 @@ void TypeChecker::visit(AST::BinaryExpression& binary)
     // FIXME: this needs to resolve overloads, not just unify both types
     auto* leftType = infer(binary.leftExpression());
     auto* rightType = infer(binary.rightExpression());
-    auto* result = chooseOverload(toString(binary.operation()), { leftType, rightType });
+    auto* result = chooseOverload(toString(binary.operation()), { leftType, rightType }, { });
     if (result)
         inferred(result);
     else
@@ -331,26 +331,46 @@ void TypeChecker::visit(AST::CallExpression& call)
         arguments.append(infer(argument));
 
     auto& target = call.target();
-    if (is<AST::NamedTypeName>(target)) {
-        auto& namedTarget = downcast<AST::NamedTypeName>(target);
-        auto* result = chooseOverload(namedTarget.name(), arguments);
+    bool isNamedType = is<AST::NamedTypeName>(target);
+    bool isParameterizedType = is<AST::ParameterizedTypeName>(target);
+    if (isNamedType || isParameterizedType) {
+        Vector<Type*> typeArguments;
+        String targetName = [&]() -> String {
+            if (isNamedType)
+                return downcast<AST::NamedTypeName>(target).name();
+            auto& parameterizedType = downcast<AST::ParameterizedTypeName>(target);
+            typeArguments.append(resolve(parameterizedType.elementType()));
+            return AST::ParameterizedTypeName::baseToString(parameterizedType.base());
+        }();
+        auto* result = chooseOverload(targetName, arguments, typeArguments);
         if (result)
             inferred(result);
         else {
-            StringPrintStream argumentsString;
+            StringPrintStream valueArgumentsStream;
             bool first = true;
             for (auto* argument : arguments) {
                 if (!first)
-                    argumentsString.print(", ");
+                    valueArgumentsStream.print(", ");
                 first = false;
-                argumentsString.print(*argument);
+                valueArgumentsStream.print(*argument);
             }
-            typeError(call.span(), "no matching overload for initializer ", namedTarget.name(), "(", argumentsString.toString(), ")");
+            StringPrintStream typeArgumentsStream;
+            first = true;
+            if (typeArguments.size()) {
+                typeArgumentsStream.print("<");
+                for (auto* typeArgument : typeArguments) {
+                    if (!first)
+                        typeArgumentsStream.print(", ");
+                    first = false;
+                    typeArgumentsStream.print(*typeArgument);
+                }
+                typeArgumentsStream.print(">");
+            }
+            typeError(call.span(), "no matching overload for initializer ", targetName, typeArgumentsStream.toString(), "(", valueArgumentsStream.toString(), ")");
         }
         return;
     }
 
-    // FIXME: add support parameterized type constructors (e.g. vec4<f32>(...))
     // FIXME: add support for user-defined function calls
     auto* result = resolve(target);
     inferred(result);
@@ -513,12 +533,12 @@ void TypeChecker::vectorFieldAccess(const Types::Vector& vector, AST::FieldAcces
     inferred(m_types.constructType(base, vector.element));
 }
 
-Type* TypeChecker::chooseOverload(const String& operation, const Vector<Type*>& arguments)
+Type* TypeChecker::chooseOverload(const String& operation, const Vector<Type*>& valueArguments, const Vector<Type*>& typeArguments)
 {
     auto it = m_overloadedOperations.find(operation);
     if (it == m_overloadedOperations.end())
         return nullptr;
-    return resolveOverloads(m_types, it->value, arguments);
+    return resolveOverloads(m_types, it->value, valueArguments, typeArguments);
 }
 
 Type* TypeChecker::infer(AST::Expression& expression)

--- a/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
@@ -1,0 +1,4 @@
+fn testExplicitTypeArguments() {
+  // CHECK-L: no matching overload for initializer vec2<i32>(<AbstractFloat>, <AbstractFloat>)
+  let v0 = vec2<i32>(0.0, 0.0);
+}

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -101,15 +101,15 @@ fn testTextureSample() {
 }
 
 fn testVec2() {
-  // FIXME: overload resolution should support explicitly instantiating variables
-  // let v1 = vec2<i32>(vec2(0, 0));
+  let v0 = vec2<f32>(0, 0);
+  let v1 = vec2<i32>(vec2(0, 0));
   let v2 = vec2(vec2(0, 0));
   let v3 = vec2(0, 0);
 }
 
 fn testVec3() {
-  // FIXME: overload resolution should support explicitly instantiating variables
-  // let v1 = vec3<i32>(vec3(0, 0, 0));
+  let v0 = vec3<f32>(0, 0, 0);
+  let v1 = vec3<i32>(vec3(0, 0, 0));
   let v2 = vec3(vec3(0, 0, 0));
   let v3 = vec3(0, 0, 0);
   let v4 = vec3(vec2(0, 0), 0);
@@ -117,8 +117,8 @@ fn testVec3() {
 }
 
 fn testVec4() {
-  // FIXME: overload resolution should support explicitly instantiating variables
-  // let v1 = vec4<i32>(vec4(0, 0, 0, 0));
+  let v0 = vec4<f32>(0, 0, 0, 0);
+  let v1 = vec4<i32>(vec4(0, 0, 0, 0));
   let v2 = vec4(vec4(0, 0, 0, 0));
   let v3 = vec4(0, 0, 0, 0);
   let v4 = vec4(0, vec2(0, 0), 0);


### PR DESCRIPTION
#### 81eb4d4bbe45337831bc1e9bef61185ab55d4ea2
<pre>
[WGSL] Add support for constructors with explicit type arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=254653">https://bugs.webkit.org/show_bug.cgi?id=254653</a>
rdar://problem/107358772

Reviewed by Myles C. Maxfield.

Add support explicitly providing type arguments for constructors, such as `vecN&lt;T&gt;(...)`

* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::OverloadResolver):
(WGSL:: const):
(WGSL::OverloadResolver::considerCandidate):
(WGSL::OverloadResolver::calculateRank):
(WGSL::OverloadResolver::unify):
(WGSL::OverloadResolver::assign):
(WGSL::OverloadResolver::resolve const const):
(WGSL::resolveOverloads):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/invalid/overload.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/262325@main">https://commits.webkit.org/262325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4727af4ff0cf1288faeefd61a9928f035bbf504b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1114 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1348 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1273 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1255 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1157 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1905 "Failed to checkout and rebase branch from PR 12100") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1187 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1146 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/1905 "Failed to checkout and rebase branch from PR 12100") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1140 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1177 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/1905 "Failed to checkout and rebase branch from PR 12100") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1188 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1156 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/311 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1215 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->