### PR TITLE
[WGSL] WTF::Vector no longer needs the explicit namespace

### DIFF
--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -78,13 +78,13 @@ struct AbstractMatrix {
 };
 
 struct OverloadCandidate {
-    WTF::Vector<TypeVariable, 1> typeVariables;
-    WTF::Vector<NumericVariable, 2> numericVariables;
-    WTF::Vector<AbstractType, 2> parameters;
+    Vector<TypeVariable, 1> typeVariables;
+    Vector<NumericVariable, 2> numericVariables;
+    Vector<AbstractType, 2> parameters;
     AbstractType result;
 };
 
-Type* resolveOverloads(TypeStore&, const WTF::Vector<OverloadCandidate>&, const WTF::Vector<Type*>&);
+Type* resolveOverloads(TypeStore&, const Vector<OverloadCandidate>&, const Vector<Type*>&);
 
 } // namespace WGSL
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -98,7 +98,7 @@ private:
     bool unify(Type*, Type*) WARN_UNUSED_RETURN;
     bool isBottom(Type*) const;
     std::optional<unsigned> extractInteger(AST::Expression&);
-    Type* chooseOverload(const String&, const WTF::Vector<Type*>&);
+    Type* chooseOverload(const String&, const Vector<Type*>&);
 
     ShaderModule& m_shaderModule;
     Type* m_inferredType { nullptr };
@@ -106,7 +106,7 @@ private:
     TypeStore& m_types;
     Vector<Error> m_errors;
     // FIXME: maybe these should live in the context
-    HashMap<String, WTF::Vector<OverloadCandidate>> m_overloadedOperations;
+    HashMap<String, Vector<OverloadCandidate>> m_overloadedOperations;
 };
 
 TypeChecker::TypeChecker(ShaderModule& shaderModule)
@@ -513,7 +513,7 @@ void TypeChecker::vectorFieldAccess(const Types::Vector& vector, AST::FieldAcces
     inferred(m_types.constructType(base, vector.element));
 }
 
-Type* TypeChecker::chooseOverload(const String& operation, const WTF::Vector<Type*>& arguments)
+Type* TypeChecker::chooseOverload(const String& operation, const Vector<Type*>& arguments)
 {
     auto it = m_overloadedOperations.find(operation);
     if (it == m_overloadedOperations.end())

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -47,15 +47,15 @@ class ShaderModule;
 struct SuccessfulCheck {
     SuccessfulCheck() = delete;
     SuccessfulCheck(SuccessfulCheck&&);
-    SuccessfulCheck(WTF::Vector<Warning>&&, UniqueRef<ShaderModule>&&);
+    SuccessfulCheck(Vector<Warning>&&, UniqueRef<ShaderModule>&&);
     ~SuccessfulCheck();
-    WTF::Vector<Warning> warnings;
+    Vector<Warning> warnings;
     UniqueRef<ShaderModule> ast;
 };
 
 struct FailedCheck {
-    WTF::Vector<Error> errors;
-    WTF::Vector<Warning> warnings;
+    Vector<Error> errors;
+    Vector<Warning> warnings;
 };
 
 struct SourceMap {
@@ -146,12 +146,12 @@ struct BindGroupLayoutEntry {
 
 struct BindGroupLayout {
     // Metal's [[id(n)]] indices are equal to the index into this vector.
-    WTF::Vector<BindGroupLayoutEntry> entries;
+    Vector<BindGroupLayoutEntry> entries;
 };
 
 struct PipelineLayout {
     // Metal's [[buffer(n)]] indices are equal to the index into this vector.
-    WTF::Vector<BindGroupLayout> bindGroupLayouts;
+    Vector<BindGroupLayout> bindGroupLayouts;
 };
 
 namespace Reflection {


### PR DESCRIPTION
#### 024cc6b236d244bd5f0798ec9f346d305511ba97
<pre>
[WGSL] WTF::Vector no longer needs the explicit namespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=254654">https://bugs.webkit.org/show_bug.cgi?id=254654</a>
rdar://107359112

Reviewed by Myles C. Maxfield.

At one point, we had another Vector type used for type checking in the WGSL
namespace, which conflicted with WTF::Vector. Since then, we moved it into
WGSL::Types::Vector, and it&apos;s no longer necessary to use the qualified WTF::Vector

* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/WGSL.h:

Canonical link: <a href="https://commits.webkit.org/262316@main">https://commits.webkit.org/262316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/884d309c2e6b79cae5b297491c9e9f0a505543c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1673 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/936 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1133 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1552 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/970 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/966 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2043 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/944 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/997 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1028 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/120 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->