### PR TITLE
innerHTML escapes <, >, &, and nbsp inside noembed, noframes, iframe and plaintext

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing-html-fragments/tokenizer-modes-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing-html-fragments/tokenizer-modes-001-expected.txt
@@ -3,10 +3,10 @@ PASS </title> should not break out of title.
 PASS </textarea> should not break out of textarea.
 PASS </style> should not break out of style.
 PASS </xmp> should not break out of xmp.
-FAIL </iframe> should not break out of iframe. assert_equals: expected "</iframe><div>" but got "&lt;/iframe&gt;&lt;div&gt;"
-FAIL </noembed> should not break out of noembed. assert_equals: expected "</noembed><div>" but got "&lt;/noembed&gt;&lt;div&gt;"
-FAIL </noframes> should not break out of noframes. assert_equals: expected "</noframes><div>" but got "&lt;/noframes&gt;&lt;div&gt;"
+PASS </iframe> should not break out of iframe.
+PASS </noembed> should not break out of noembed.
+PASS </noframes> should not break out of noframes.
 PASS </script> should not break out of script.
 FAIL </noscript> should not break out of noscript. assert_equals: expected "</noscript><div>" but got "&lt;/noscript&gt;&lt;div&gt;"
-FAIL </plaintext> should not break out of plaintext. assert_equals: expected "</plaintext><div>" but got "&lt;/plaintext&gt;&lt;div&gt;"
+PASS </plaintext> should not break out of plaintext.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-expected.txt
@@ -21,9 +21,9 @@ PASS innerHTML 18 <style><&></style>
 PASS innerHTML 19 <script type="test"><&></script>
 PASS innerHTML 20 <&>
 PASS innerHTML 21 <xmp><&></xmp>
-FAIL innerHTML 22 <iframe><&></iframe> assert_equals: expected "<iframe><&></iframe>" but got "<iframe>&lt;&amp;&gt;</iframe>"
-FAIL innerHTML 23 <noembed><&></noembed> assert_equals: expected "<noembed><&></noembed>" but got "<noembed>&lt;&amp;&gt;</noembed>"
-FAIL innerHTML 24 <noframes><&></noframes> assert_equals: expected "<noframes><&></noframes>" but got "<noframes>&lt;&amp;&gt;</noframes>"
+PASS innerHTML 22 <iframe><&></iframe>
+PASS innerHTML 23 <noembed><&></noembed>
+PASS innerHTML 24 <noframes><&></noframes>
 FAIL innerHTML 25 <noscript><&></noscript> assert_equals: expected "<noscript><&></noscript>" but got "<noscript>&lt;&amp;&gt;</noscript>"
 PASS innerHTML 26 <!--data-->
 PASS innerHTML 27 <a><b><c></c></b><d>e</d><f><g>h</g></f></a>
@@ -50,9 +50,9 @@ PASS outerHTML 18 <span><style><&></style></span>
 PASS outerHTML 19 <span><script type="test"><&></script></span>
 PASS outerHTML 20 <script type="test"><&></script>
 PASS outerHTML 21 <span><xmp><&></xmp></span>
-FAIL outerHTML 22 <span><iframe><&></iframe></span> assert_equals: expected "<span><iframe><&></iframe></span>" but got "<span><iframe>&lt;&amp;&gt;</iframe></span>"
-FAIL outerHTML 23 <span><noembed><&></noembed></span> assert_equals: expected "<span><noembed><&></noembed></span>" but got "<span><noembed>&lt;&amp;&gt;</noembed></span>"
-FAIL outerHTML 24 <span><noframes><&></noframes></span> assert_equals: expected "<span><noframes><&></noframes></span>" but got "<span><noframes>&lt;&amp;&gt;</noframes></span>"
+PASS outerHTML 22 <span><iframe><&></iframe></span>
+PASS outerHTML 23 <span><noembed><&></noembed></span>
+PASS outerHTML 24 <span><noframes><&></noframes></span>
 FAIL outerHTML 25 <span><noscript><&></noscript></span> assert_equals: expected "<span><noscript><&></noscript></span>" but got "<span><noscript>&lt;&amp;&gt;</noscript></span>"
 PASS outerHTML 26 <span><!--data--></span>
 PASS outerHTML 27 <span><a><b><c></c></b><d>e</d><f><g>h</g></f></a></span>

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -375,7 +375,9 @@ EntityMask MarkupAccumulator::entityMaskForText(const Text& text) const
     if (text.parentElement())
         parentName = &text.parentElement()->tagQName();
 
-    if (parentName && (*parentName == scriptTag || *parentName == styleTag || *parentName == xmpTag))
+    if (parentName && (*parentName == scriptTag || *parentName == styleTag || *parentName == xmpTag 
+        || *parentName == noembedTag || *parentName == noframesTag || *parentName == plaintextTag 
+        || *parentName == iframeTag))
         return EntityMaskInCDATA;
     return EntityMaskInHTMLPCDATA;
 }


### PR DESCRIPTION
#### a641fc693f57c0b0910a0c2bbb13796b34544ef1
<pre>
innerHTML escapes &lt;, &gt;, &amp;, and nbsp inside noembed, noframes, iframe and plaintext

<a href="https://bugs.webkit.org/show_bug.cgi?id=45338">https://bugs.webkit.org/show_bug.cgi?id=45338</a>

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Gecko / Firefox and Blink / Chromium.

Partial Merge - <a href="https://chromium-review.googlesource.com/c/chromium/src/+/886646">https://chromium-review.googlesource.com/c/chromium/src/+/886646</a>

This patch update to serialize &apos;noembed&apos;, &apos;noframes&apos;, &apos;iframe&apos; and &apos;plaintext&apos; tags as per Web-Spec [1].

[1] <a href="https://html.spec.whatwg.org/#serialising-html-fragments">https://html.spec.whatwg.org/#serialising-html-fragments</a>

NOTE - &apos;noscript&apos; tag need special handling, so it will be done separately.

* Source/WebCore/editing/MarkupAccumulator.cpp:
(MarkupAccumulator::entityMaskForText): Update to accommodate other tags
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing-html-fragments/tokenizer-modes-001-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/262285@main">https://commits.webkit.org/262285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe0bb2058294b500d37246faed35fea97cf5db9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1143 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1079 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/984 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/978 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2058 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/957 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/279 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1040 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->