### PR TITLE
webgl/1.0.x/conformance/extensions/webgl-multi-draw.html times out frequently

### DIFF
--- a/LayoutTests/webgl/resources/webkit-webgl-test-harness.js
+++ b/LayoutTests/webgl/resources/webkit-webgl-test-harness.js
@@ -1,9 +1,6 @@
 "use strict";
 (function() {
-  var numFailures = 0;
-  var resultsList = null;
-  var resultNum = 1;
-
+  let resultMessages = [];
   if (window.testRunner && !window.layoutTestController) {
     window.layoutTestController = window.testRunner;
   }
@@ -23,21 +20,6 @@
     window.internals.settings.setWebGLErrorsToConsoleEnabled(false);
   }
 
-  var list = function(msg, color) {
-    if (!resultsList) {
-      resultsList = document.createElement("ul");
-      document.getElementById("result").appendChild(resultsList);
-    }
-
-    var item = document.createElement("li");
-    item.appendChild(document.createTextNode(msg));
-    if (color) {
-      item.style.color = color;
-    }
-
-    resultsList.appendChild(item);
-  }
-
   var log = function(msg, color) {
     var div = document.createElement("div");
     div.appendChild(document.createTextNode(msg));
@@ -49,22 +31,21 @@
 
   window.webglTestHarness = {
     reportResults: function(url, success, msg) {
-      if (success) {
-        list(`[ ${resultNum}: PASS ] ${msg}`, "green");
-      } else {
-        list(`[ ${resultNum}: FAIL ] ${msg}`, "red");
-        ++numFailures;
-      }
-
-      ++resultNum;
+      resultMessages.push({success, msg});
     },
 
     notifyFinished: function(url) {
-      var iframe = document.getElementById("iframe");
+      let numFailures = resultMessages.reduce((v, {success, msg}) => { return v + !success }, 0);
       if (numFailures > 0) {
+        resultMessages.forEach(({success, msg}, index) => {
+          if (success)
+            log(`[ ${index}: PASS ] ${msg}`, "green");
+          else
+            log(`[ ${index}: FAIL ] ${msg}`, "red");
+        })
         log(`[ FAIL ] ${numFailures} failures reported`, "red");
       } else {
-        resultsList.innerHTML = "";
+        var iframe = document.getElementById("iframe");
         iframe.innerHTML = "";
         log("[ PASS ] All tests passed", "green");
       }


### PR DESCRIPTION
#### 97c802f322e5825b71a7b58699c589e1fa23c1f7
<pre>
webgl/1.0.x/conformance/extensions/webgl-multi-draw.html times out frequently
<a href="https://bugs.webkit.org/show_bug.cgi?id=254660">https://bugs.webkit.org/show_bug.cgi?id=254660</a>
rdar://107364131

Reviewed by Matt Woodrow.

WebGL tests are run inside a iframe in order to pass the context version
as an url parameter. The test assertion messages
are copied to the wrapper DOM in order to report the failures to
layout tests.

Avoid using &lt;ul&gt;&lt;li&gt;message&lt;/li&gt; ... in the copied wrapper messages.
list items update the marker number (RenderListItem::updateListMarkerNumbers())
for each update for each message. This appears to be very slow on Debug.
The test webgl-multi-draw.html has 11000 messages, so this test times out
frequently on Debug.

Instead, report the messages to divs once the test finishes.

Reduces the debug runtime of webgl-multi-draw.html from 37s to 11s.

* LayoutTests/webgl/resources/webkit-webgl-test-harness.js:
(window.webglTestHarness.reportResults):
(window.webglTestHarness.notifyFinished):
(list): Deleted.

Canonical link: <a href="https://commits.webkit.org/262318@main">https://commits.webkit.org/262318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb5841b55606a911dc76825bcf6b9313a190f11b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1686 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/950 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1145 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1571 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/986 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/980 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2060 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1025 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/959 "1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1007 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/303 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1042 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->