### PR TITLE
[git-webkit] Prevent publication of commits for redacted PRs

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.2.2',
+    version='6.2.3',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 2, 2)
+version = Version(6, 2, 3)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -417,19 +417,15 @@ class PullRequest(Command):
             print("Pull request needs to be sent to a secure remote for review")
             original_remote = source_remote
             if len(repository.source_remotes()) < 2:
-                sys.stderr.write("Error. You do not have access to a secure remote to make a pull request for a redacted issue\n")
-                if args.defaults or Terminal.choose(
-                    "Would you like to proceed anyways? \n",
-                    default='No',
-                ) == 'No':
-                    sys.stderr.write("Failed to create pull request due to unsuitable remote\n")
-                    return 1
+                sys.stderr.write('Error. You do not have access to a secure remote to make a pull request for a redacted issue\n')
+                sys.stderr.write('Please consult repository administers to gain access to a secure remote to make this fix against\n')
+                return 1
             else:
                 source_remote = repository.source_remotes()[-1]
                 if args.defaults or Terminal.choose(
                     "Would you like to make a pull request against '{}' instead of '{}'? \n".format(source_remote, original_remote),
-                    default='Yes',
-                ) == 'No':
+                    default='Yes', options=('Yes', 'Cancel')
+                ) == 'Cancel':
                     sys.stderr.write("User declined to create a pull request against the secure remote '{}'\n".format(source_remote))
                     return 1
                 remote_repo = repository.remote(name=source_remote)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -890,35 +890,26 @@ No pre-PR checks to run""")
         ), mocks.local.Git(
             self.path, remote='https://{}'.format(remote.remote),
             remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
-        ) as repo, mocks.local.Svn(), MockTerminal.input('y'):
+        ) as repo, mocks.local.Svn():
 
             repo.staged['added.txt'] = 'added'
-            self.assertEqual(0, program.main(
+            self.assertEqual(1, program.main(
                 args=('pull-request', '-i', 'https://bugs.example.com/show_bug.cgi?id=1', '-v', '--no-history'),
                 path=self.path,
             ))
 
-            self.assertEqual(
-                Tracker.instance().issue(1).comments[-1].content,
-                'Pull request: https://github.example.com/WebKit/WebKit/pull/1',
-            )
-            gh_issue = github.Tracker('https://github.example.com/WebKit/WebKit').issue(1)
-            self.assertEqual(gh_issue.project, 'WebKit')
-            self.assertEqual(gh_issue.component, 'Text')
-
         self.assertEqual(
             captured.stdout.getvalue(),
             "Created the local development branch 'eng/1'\n"
-            "A commit you are uploading references https://bugs.example.com/show_bug.cgi?id=1\n"
-            "https://bugs.example.com/show_bug.cgi?id=1 is a Bugzilla and is thus redacted\n"
-            "Pull request needs to be sent to a secure remote for review\n"
-            "Would you like to proceed anyways? \n"
-            " (Yes/[No]): \n"
-            "Created 'PR 1 | Example issue 1'!\n"
-            "Posted pull request link to https://bugs.example.com/show_bug.cgi?id=1\n"
-            "https://github.example.com/WebKit/WebKit/pull/1\n",
+            'A commit you are uploading references https://bugs.example.com/show_bug.cgi?id=1\n'
+            'https://bugs.example.com/show_bug.cgi?id=1 is a Bugzilla and is thus redacted\n'
+            'Pull request needs to be sent to a secure remote for review\n',
         )
-        self.assertEqual(captured.stderr.getvalue(), 'Error. You do not have access to a secure remote to make a pull request for a redacted issue\n')
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'Error. You do not have access to a secure remote to make a pull request for a redacted issue\n'
+            'Please consult repository administers to gain access to a secure remote to make this fix against\n',
+        )
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
@@ -928,15 +919,6 @@ No pre-PR checks to run""")
                 "Rebased 'eng/1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
-                'Checking if PR already exists...',
-                'PR not found.',
-                "Pushing 'eng/1' to 'fork'...",
-                "Syncing 'main' to remote 'fork'",
-                "Creating pull-request for 'eng/1'...",
-                'Checking issue assignee...',
-                'Checking for pull request link in associated issue...',
-                'Syncing PR labels with issue component...',
-                'Synced PR labels with issue component!',
             ],
         )
 
@@ -968,32 +950,22 @@ No pre-PR checks to run""")
             ]
             repo.head = repo.commits['eng/pr-branch'][-1]
 
-            self.assertEqual(0, program.main(
+            self.assertEqual(1, program.main(
                 args=('pull-request', '-v', '--no-history'),
                 path=self.path,
             ))
 
-            self.assertEqual(
-                Tracker.instance().issue(2).comments[-1].content,
-                'Pull request: https://github.example.com/WebKit/WebKit/pull/1',
-            )
-            gh_issue = github.Tracker('https://github.example.com/WebKit/WebKit').issue(1)
-            self.assertEqual(gh_issue.project, 'WebKit')
-            self.assertEqual(gh_issue.component, 'Scrolling')
-
-        self.maxDiff = None
         self.assertEqual(
             captured.stdout.getvalue(),
             "A commit you are uploading references https://bugs.example.com/show_bug.cgi?id=1\n"
             "https://bugs.example.com/show_bug.cgi?id=1 matches 'component:Text' and is thus redacted\n"
-            "Pull request needs to be sent to a secure remote for review\n"
-            "Would you like to proceed anyways? \n"
-            " (Yes/[No]): \n"
-            "Created 'PR 1 | [Testing] Existing commit'!\n"
-            "Posted pull request link to https://bugs.example.com/show_bug.cgi?id=2\n"
-            "https://github.example.com/WebKit/WebKit/pull/1\n",
+            'Pull request needs to be sent to a secure remote for review\n',
         )
-        self.assertEqual(captured.stderr.getvalue(), 'Error. You do not have access to a secure remote to make a pull request for a redacted issue\n')
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'Error. You do not have access to a secure remote to make a pull request for a redacted issue\n'
+            'Please consult repository administers to gain access to a secure remote to make this fix against\n',
+        )
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
@@ -1003,15 +975,6 @@ No pre-PR checks to run""")
                 "Rebased 'eng/pr-branch' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
-                'Checking if PR already exists...',
-                'PR not found.',
-                "Pushing 'eng/pr-branch' to 'fork'...",
-                "Syncing 'main' to remote 'fork'",
-                "Creating pull-request for 'eng/pr-branch'...",
-                'Checking issue assignee...',
-                'Checking for pull request link in associated issue...',
-                'Syncing PR labels with issue component...',
-                'Synced PR labels with issue component!',
             ],
         )
 


### PR DESCRIPTION
#### 9384f300d86501ffe1075a54af01fd1f185423c7
<pre>
[git-webkit] Prevent publication of commits for redacted PRs
<a href="https://bugs.webkit.org/show_bug.cgi?id=254627">https://bugs.webkit.org/show_bug.cgi?id=254627</a>
rdar://107343169

Reviewed by Dewei Zhu.

Since we have a way of marking issues as exempt from redaction, local tooling
should not aid the user in uploading commits for redacted issues.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_pull_request): Exit program if user declines (or cannot) upload
a redacted change.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/263101@main">https://commits.webkit.org/263101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c5e306d980518bde64f48546f45d47e7dbcecac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/3641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/3687 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/3831 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/5067 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/3615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/3785 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/3730 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/5067 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/3685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/3785 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/3831 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/4892 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/3672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/3785 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/3831 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/4892 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/3785 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/3831 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/4892 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/3694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/3730 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/3601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/3228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/3831 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/3260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/415 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/3505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->