### PR TITLE
Cherry-pick 252432.1036@safari-7614-branch (c553da3adc35). rdar://107367612

### DIFF
--- a/JSTests/stress/regexp-testinline-stacklimits.js
+++ b/JSTests/stress/regexp-testinline-stacklimits.js
@@ -1,0 +1,39 @@
+//@ skip if $buildType == "debug"
+
+const startNumberOfParentheses = 1500;
+const endNumberOfParentheses = 2000;
+const incNumberOfParentheses = 500;
+
+let numberOfParentheses = startNumberOfParentheses;
+
+let regExSource;
+
+function baz() {
+    try {
+        eval(`bar(${regExSource})`);
+    } catch (error) {
+        if (error.toString() != "RangeError: Maximum call stack size exceeded.")
+            print("Expected \"RangeError: Maximum call stack size exceeded.\", Caught: \"" + error + "\"");
+        if (numberOfParentheses >= endNumberOfParentheses)
+            quit(0);
+        throw "Next count";
+    }
+}
+
+function bar(a0) {
+    a0.test("abc");
+}
+
+function foo() {
+    baz();
+    foo();
+}
+
+while (true) {
+    regExSource = `/${'('.repeat(numberOfParentheses)}${')'.repeat(numberOfParentheses)}/`;
+    try {
+        foo();
+    } catch (e) {
+        numberOfParentheses += incNumberOfParentheses;
+    }
+}

--- a/JSTests/wasm/stress/wasm-tuple-return.js
+++ b/JSTests/wasm/stress/wasm-tuple-return.js
@@ -1,0 +1,93 @@
+/*
+    (module
+        (func (export "funcRefFuncRef") (param $p0 f32) (param $p1 funcref) (result funcref funcref)
+            (local.get $p1)
+            (local.get $p1)
+            (return)
+        )
+
+        (func (export "intInt") (param $p0 f32) (param $p1 funcref) (result i32 i32)
+            (i32.const 42)
+            (i32.const 43)
+            (return)
+        )
+
+        (func (export "funcRefInt") (param $p0 f32) (param $p1 funcref) (result funcref i32)
+            (local.get $p1)
+            (i32.const 42)
+            (return)
+        )
+
+        (func (export "intFuncRef1") (param $p0 f32) (param $p1 funcref) (result i32 funcref)
+            (i32.const 42)
+            (local.get $p1)
+            (return)
+        )
+
+        (func (export "intFuncRef2") (param $p0 f32) (param $p1 funcref) (result i64 funcref)
+            (i64.const 0x141414142)
+            (local.get $p1)
+            (return)
+        )
+
+        (func (export "intFuncRef3") (param $p0 funcref) (param $p1 f32) (result i32 funcref)
+            (i32.const 42)
+            (local.get $p0)
+            (return)
+        )
+
+        (func (export "intFuncRef4") (param $p0 funcref) (param $p1 i32) (result i32 funcref)
+            (i32.const 42)
+            (local.get $p0)
+            (return)
+        )
+
+        (func (export "floatFloat1") (param $p0 f32) (param $p1 i32) (result f32 f32)
+            (f32.const 42)
+            (local.get $p0)
+            (return)
+        )
+
+        (func (export "floatFloat2") (param $p0 i32) (param $p1 f32) (result f32 f32)
+            (f32.const 42)
+            (local.get $p1)
+            (return)
+        )
+    )
+*/
+let wasm_code = new Uint8Array([
+    0, 97, 115, 109, 1, 0, 0, 0, 1, 64, 9, 96, 2, 125, 112, 2, 112, 112, 96, 2, 125, 112, 2, 127, 127, 96, 2, 125, 112, 2, 112, 127, 96, 2, 125, 112, 2, 127, 112, 96, 2, 125, 112, 2, 126, 112, 96, 2, 112, 125, 2, 127, 112, 96, 2, 112, 127, 2, 127, 112, 96, 2, 125, 127, 2, 125, 125, 96, 2, 127, 125, 2, 125, 125, 3, 10, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 124, 9, 14, 102, 117, 110, 99, 82, 101, 102, 70, 117, 110, 99, 82, 101, 102, 0, 0, 6, 105, 110, 116, 73, 110, 116, 0, 1, 10, 102, 117, 110, 99, 82, 101, 102, 73, 110, 116, 0, 2, 11, 105, 110, 116, 70, 117, 110, 99, 82, 101, 102, 49, 0, 3, 11, 105, 110, 116, 70, 117, 110, 99, 82, 101, 102, 50, 0, 4, 11, 105, 110, 116, 70, 117, 110, 99, 82, 101, 102, 51, 0, 5, 11, 105, 110, 116, 70, 117, 110, 99, 82, 101, 102, 52, 0, 6, 11, 102, 108, 111, 97, 116, 70, 108, 111, 97, 116, 49, 0, 7, 11, 102, 108, 111, 97, 116, 70, 108, 111, 97, 116, 50, 0, 8, 10, 83, 9, 7, 0, 32, 1, 32, 1, 15, 11, 7, 0, 65, 42, 65, 43, 15, 11, 7, 0, 32, 1, 65, 42, 15, 11, 7, 0, 65, 42, 32, 1, 15, 11, 11, 0, 66, 194, 130, 133, 138, 20, 32, 1, 15, 11, 7, 0, 65, 42, 32, 0, 15, 11, 7, 0, 65, 42, 32, 0, 15, 11, 10, 0, 67, 0, 0, 40, 66, 32, 0, 15, 11, 10, 0, 67, 0, 0, 40, 66, 32, 1, 15, 11
+]);
+
+let wasm_module = new WebAssembly.Module(wasm_code);
+let wasm_instance = new WebAssembly.Instance(wasm_module);
+const {
+    funcRefFuncRef,
+    intInt,
+    funcRefInt,
+    intFuncRef1,
+    intFuncRef2,
+    intFuncRef3,
+    intFuncRef4,
+    floatFloat1,
+    floatFloat2,
+} = wasm_instance.exports
+
+let testTuple = (tuple, expected1, expected2) => {
+    function assert(b) {
+        if (!b)
+            throw new Error("bad");
+    }
+    assert(tuple[0] === expected1);
+    assert(tuple[1] === expected2);
+};
+
+testTuple(funcRefFuncRef(0, null), null, null);
+testTuple(intInt(0, null), 42, 43);
+testTuple(funcRefInt(0, null), null, 42);
+testTuple(intFuncRef1(0, null), 42, null);
+testTuple(intFuncRef2(0, null), 0x141414142n, null);
+testTuple(intFuncRef3(null, null), 42, null);
+testTuple(intFuncRef4(null, 0), 42, null);
+testTuple(floatFloat1(0, 1), 42, 0);
+testTuple(floatFloat2(1, 0), 42, 0);

--- a/LayoutTests/editing/editability/design-mode-does-not-inherit-across-frames-expected.txt
+++ b/LayoutTests/editing/editability/design-mode-does-not-inherit-across-frames-expected.txt
@@ -1,0 +1,13 @@
+This tests that design mode does not inherit across frame boundaries.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS iframe.contentDocument.designMode is "off"
+PASS document.designMode = "on"; iframe.contentDocument.designMode is "off"
+PASS document.designMode = "off"; iframe.contentDocument.designMode is "off"
+PASS iframe.contentDocument.designMode = "on"; iframe.contentDocument.designMode is "on"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/editability/design-mode-does-not-inherit-across-frames.html
+++ b/LayoutTests/editing/editability/design-mode-does-not-inherit-across-frames.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests that design mode does not inherit across frame boundaries.');
+
+const iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+shouldBeEqualToString('iframe.contentDocument.designMode', 'off');
+shouldBeEqualToString('document.designMode = "on"; iframe.contentDocument.designMode', 'off');
+shouldBeEqualToString('document.designMode = "off"; iframe.contentDocument.designMode', 'off');
+shouldBeEqualToString('iframe.contentDocument.designMode = "on"; iframe.contentDocument.designMode', 'on');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/content/quote-display-contents-crash-expected.txt
+++ b/LayoutTests/fast/css/content/quote-display-contents-crash-expected.txt
@@ -1,0 +1,1 @@
+Pass if no crash.

--- a/LayoutTests/fast/css/content/quote-display-contents-crash.html
+++ b/LayoutTests/fast/css/content/quote-display-contents-crash.html
@@ -1,0 +1,18 @@
+<style>
+  q { border-image: url(about:blank); }
+  label:focus-within { display: contents; }
+</style>
+<script>
+if (window.testRunner)
+   testRunner.dumpAsText();
+function runTest() {
+   label.remove();
+   document.write("Pass if no crash.");
+}
+</script>
+<body onload="runTest()">
+  <label id="label" >
+    <textarea autofocus></textarea>
+    <q></q>
+  </label>
+</body>

--- a/LayoutTests/fast/dom/HTMLElement/iscontenteditable-designmodeon-allinherit-subframe-expected.txt
+++ b/LayoutTests/fast/dom/HTMLElement/iscontenteditable-designmodeon-allinherit-subframe-expected.txt
@@ -8,5 +8,5 @@ PASS successfullyParsed is true
 TEST COMPLETE
 document.designMode = "on"
 PASS subDocument.getElementById("div").contentEditable is "inherit"
-PASS subDocument.getElementById("div").isContentEditable is true
+PASS subDocument.getElementById("div").isContentEditable is false
 

--- a/LayoutTests/fast/dom/HTMLElement/iscontenteditable-designmodeon-allinherit-subframe.html
+++ b/LayoutTests/fast/dom/HTMLElement/iscontenteditable-designmodeon-allinherit-subframe.html
@@ -16,7 +16,7 @@ function runTest()
 
     subDocument = document.getElementById("subframe").contentDocument;
     shouldBe('subDocument.getElementById("div").contentEditable', '"inherit"');
-    shouldBe('subDocument.getElementById("div").isContentEditable', 'true');
+    shouldBe('subDocument.getElementById("div").isContentEditable', 'false');
 
     document.getElementById("subframe").style.display= 'none';
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/wildcard-host-checks-path.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/wildcard-host-checks-path.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test that using a wildcard in the host component will still check for a match in the path component
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/wildcard-host-checks-path.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/wildcard-host-checks-path.sub.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta http-equiv="Content-Security-Policy" content="img-src http://*/content-security-policy/generic/support;">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+    var t = async_test("Test that using a wildcard in the host component will still check for a match in the path component");
+    window.addEventListener("securitypolicyviolation", t.step_func_done((e) => {
+        assert_equals(e.violatedDirective, "img-src");
+        assert_equals(e.blockedURI, "http://{{domains[www2]}}:{{ports[http][0]}}/content-security-policy/support/fail.png");
+    }));
+</script>
+<img src="http://{{domains[www2]}}:{{ports[http][0]}}/content-security-policy/support/fail.png"
+     onload="t.step(() => { assert_unreached('image should not have loaded.'); t.done(); });">
+</body>

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -15164,6 +15164,9 @@ IGNORE_CLANG_WARNINGS_END
 
                 CCallHelpers::JumpList done;
 
+                // If we have a JIT failure, then we'll fallback to the operationCase. Keep the return code for the branch after the PatchPoint.
+                done.append(jit.branch32(CCallHelpers::Equal, returnGPR, CCallHelpers::TrustedImm32(static_cast<int32_t>(Yarr::JSRegExpResult::JITCodeFailure))));
+
                 auto failedMatch = jit.branch32(CCallHelpers::LessThan, returnGPR, CCallHelpers::TrustedImm32(0));
 
                 // Saved cached result.
@@ -15191,7 +15194,8 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->effects.writes = HeapRange::top();
 
         ValueFromBlock inlineresult = m_out.anchor(patchpoint);
-        m_out.jump(continuation);
+
+        m_out.branch(m_out.equal(patchpoint, m_out.constInt32(static_cast<int32_t>(Yarr::JSRegExpResult::JITCodeFailure))), unsure(operationCase), unsure(continuation));
 
         m_out.appendTo(operationCase, continuation);
         ValueFromBlock operationResult;

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -161,6 +161,9 @@ public:
 #if ENABLE(YARR_JIT)
     Yarr::YarrCodeBlock* getRegExpJITCodeBlock()
     {
+        if (m_state != JITCode)
+            return nullptr;
+
         return m_regExpJITCode.get();
     }
 #endif

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -1270,6 +1270,11 @@ auto LLIntGenerator::addReturn(const ControlType& data, Stack& returnValues) -> 
         return { };
     }
 
+    // We should materialize locals when return more than one values, since 
+    // it might clobber arguments before use them (see examples in wasm-tuple-return.js).
+    if (returnValues.size() > 1)
+        materializeConstantsAndLocals(returnValues);
+
     // no need to drop keep here, since we have to move anyway
     unifyValuesWithBlock(callInformationForCallee(*data.m_signature->as<FunctionSignature>()), returnValues);
     WasmRet::emit(this);

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -844,13 +844,13 @@ class YarrGenerator final : public YarrJITInfo {
         MacroAssembler::JumpList finishExiting;
         if (!m_abortExecution.empty()) {
             m_abortExecution.link(&m_jit);
-            m_jit.move(MacroAssembler::TrustedImmPtr((void*)static_cast<size_t>(-2)), m_regs.returnRegister);
+            m_jit.move(MacroAssembler::TrustedImmPtr((void*)static_cast<size_t>(JSRegExpResult::JITCodeFailure)), m_regs.returnRegister);
             finishExiting.append(m_jit.jump());
         }
 
         if (!m_hitMatchLimit.empty()) {
             m_hitMatchLimit.link(&m_jit);
-            m_jit.move(MacroAssembler::TrustedImmPtr((void*)static_cast<size_t>(-1)), m_regs.returnRegister);
+            m_jit.move(MacroAssembler::TrustedImmPtr((void*)static_cast<size_t>(JSRegExpResult::ErrorNoMatch)), m_regs.returnRegister);
         }
 
         finishExiting.link(&m_jit);
@@ -4709,7 +4709,17 @@ public:
         unsigned callFrameSizeInBytes = alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize);
         if (callFrameSizeInBytes) {
             // Create space on stack for matching context data.
-            m_jit.addPtr(MacroAssembler::TrustedImm32(-callFrameSizeInBytes), MacroAssembler::stackPointerRegister, MacroAssembler::stackPointerRegister);
+            // Note that this stack check cannot clobber m_regs.regT1 as it is needed for the slow path we call if we fail the stack check.
+            m_jit.addPtr(MacroAssembler::TrustedImm32(-callFrameSizeInBytes), MacroAssembler::stackPointerRegister, m_regs.regT0);
+            MacroAssembler::Jump stackOk = m_jit.branchPtr(MacroAssembler::BelowOrEqual, MacroAssembler::AbsoluteAddress(const_cast<VM*>(m_vm)->addressOfSoftStackLimit()), m_regs.regT0);
+
+            // Exceeded stack limit, punt to the interpreter.
+            m_jit.move(MacroAssembler::TrustedImmPtr((void*)static_cast<size_t>(JSRegExpResult::JITCodeFailure)), m_regs.returnRegister);
+            m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.returnRegister2);
+            m_inlinedFailedMatch.append(m_jit.jump());
+
+            stackOk.link(&m_jit);
+            m_jit.move(m_regs.regT0, MacroAssembler::stackPointerRegister);
         }
 
 #ifdef JIT_UNICODE_EXPRESSIONS
@@ -5093,6 +5103,12 @@ void jitCompileInlinedTest(StackCheck* m_compilationThreadStackChecker, StringVi
 {
     Yarr::ErrorCode errorCode;
     Yarr::YarrPattern pattern(patternString, flags, errorCode);
+
+    if (errorCode != Yarr::ErrorCode::NoError) {
+        // This path cannot clobber jitRegisters.regT1 as it is needed for the slow path we'll end up in.
+        jit.move(MacroAssembler::TrustedImmPtr((void*)static_cast<size_t>(JSRegExpResult::JITCodeFailure)), jitRegisters.returnRegister);
+        return;
+    }
 
     jitRegisters.validate();
 

--- a/Source/WebCore/Modules/contact-picker/ContactsManager.cpp
+++ b/Source/WebCore/Modules/contact-picker/ContactsManager.cpp
@@ -105,8 +105,10 @@ void ContactsManager::select(const Vector<ContactProperty>& properties, const Co
 
     m_contactPickerIsShowing = true;
 
-    frame->page()->chrome().showContactPicker(requestData, [promise = WTFMove(promise), this] (std::optional<Vector<ContactInfo>>&& info) {
-        m_contactPickerIsShowing = false;
+    frame->page()->chrome().showContactPicker(requestData, [promise = WTFMove(promise), weakThis = WeakPtr { *this }] (std::optional<Vector<ContactInfo>>&& info) {
+        if (weakThis)
+            weakThis->m_contactPickerIsShowing = false;
+
         if (info) {
             promise->resolve<IDLSequence<IDLDictionary<ContactInfo>>>(*info);
             return;

--- a/Source/WebCore/Modules/contact-picker/ContactsManager.h
+++ b/Source/WebCore/Modules/contact-picker/ContactsManager.h
@@ -40,7 +40,7 @@ enum class ContactProperty : uint8_t;
 
 struct ContactsSelectOptions;
 
-class ContactsManager final : public RefCounted<ContactsManager> {
+class ContactsManager final : public RefCounted<ContactsManager>, public CanMakeWeakPtr<ContactsManager> {
     WTF_MAKE_ISO_ALLOCATED(ContactsManager);
 public:
     static Ref<ContactsManager> create(Navigator&);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6216,15 +6216,10 @@ void Document::setTransformSource(std::unique_ptr<TransformSource> source)
 
 #endif
 
-void Document::setDesignMode(InheritedBool value)
+void Document::setDesignMode(DesignMode value)
 {
     m_designMode = value;
-    for (RefPtr<Frame> frame = m_frame.get(); frame; frame = frame->tree().traverseNext(m_frame.get())) {
-        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
-        if (!localFrame || !localFrame->document())
-            continue;
-        localFrame->document()->scheduleFullStyleRebuild();
-    }
+    scheduleFullStyleRebuild();
 }
 
 String Document::designMode() const
@@ -6234,23 +6229,8 @@ String Document::designMode() const
 
 void Document::setDesignMode(const String& value)
 {
-    InheritedBool mode;
-    if (equalLettersIgnoringASCIICase(value, "on"_s))
-        mode = on;
-    else if (equalLettersIgnoringASCIICase(value, "off"_s))
-        mode = off;
-    else
-        mode = inherit;
+    DesignMode mode = equalLettersIgnoringASCIICase(value, "on"_s) ? DesignMode::On : DesignMode::Off;
     setDesignMode(mode);
-}
-
-bool Document::inDesignMode() const
-{
-    for (const Document* d = this; d; d = d->parentDocument()) {
-        if (d->m_designMode != inherit)
-            return d->m_designMode;
-    }
-    return false;
 }
 
 Document* Document::parentDocument() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1109,9 +1109,9 @@ public:
     UndoManager& undoManager() const { return m_undoManager.get(); }
 
     // designMode support
-    enum InheritedBool : uint8_t { off = false, on = true, inherit };
-    void setDesignMode(InheritedBool value);
-    bool inDesignMode() const;
+    enum class DesignMode : bool { Off, On };
+    void setDesignMode(DesignMode value);
+    bool inDesignMode() const { return m_designMode == DesignMode::On; }
     WEBCORE_EXPORT String designMode() const;
     WEBCORE_EXPORT void setDesignMode(const String&);
 
@@ -2273,7 +2273,7 @@ private:
 
     TextDirection m_documentElementTextDirection;
 
-    InheritedBool m_designMode { inherit };
+    DesignMode m_designMode { DesignMode::Off };
     BackForwardCacheState m_backForwardCacheState { NotInBackForwardCache };
     ReadyState m_readyState { Complete };
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3984,7 +3984,7 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
         rareData.setComputedStyle(WTFMove(style));
         element->clearNodeFlag(NodeFlag::IsComputedStyleInvalidFlag);
         if (hadDisplayContents && computedStyle->display() != DisplayType::Contents)
-            setDisplayContentsChanged();
+            element->setDisplayContentsChanged();
 
         if (mode == ResolveComputedStyleMode::RenderedOnly && computedStyle->display() == DisplayType::None)
             return nullptr;

--- a/Source/WebCore/page/csp/ContentSecurityPolicySource.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySource.cpp
@@ -93,8 +93,11 @@ static bool wildcardMatches(StringView host, const String& hostWithWildcard)
 bool ContentSecurityPolicySource::hostMatches(const URL& url) const
 {
     auto host = url.host();
-    if (m_hostHasWildcard)
+    if (m_hostHasWildcard) {
+        if (m_host.isEmpty())
+            return true;
         return wildcardMatches(host, m_host);
+    }
     return equalIgnoringASCIICase(host, m_host);
 }
 
@@ -140,7 +143,7 @@ bool ContentSecurityPolicySource::portMatches(const URL& url) const
 
 bool ContentSecurityPolicySource::isSchemeOnly() const
 {
-    return m_host.isEmpty();
+    return m_host.isEmpty() && !m_hostHasWildcard;
 }
 
 ContentSecurityPolicySource::operator SecurityOriginData() const

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -546,9 +546,15 @@ bool RemoteScrollingCoordinatorTransaction::decode(IPC::Decoder& decoder)
         if (!decoder.decode(parentNodeID))
             return false;
 
-        m_scrollingStateTree->insertNode(nodeType, nodeID, parentNodeID, notFound);
+        auto createdNodeID = m_scrollingStateTree->insertNode(nodeType, nodeID, parentNodeID, notFound);
+        if (createdNodeID != nodeID)
+            return false;
+
         auto newNode = m_scrollingStateTree->stateNodeForID(nodeID);
         ASSERT(newNode);
+        if (newNode->nodeType() != nodeType)
+            return false;
+
         ASSERT(!parentNodeID || newNode->parent());
         
         switch (nodeType) {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4515,18 +4515,26 @@ void WebPageProxy::setGapBetweenPages(double gap)
     send(Messages::WebPage::SetGapBetweenPages(gap));
 }
 
+static bool scaleFactorIsValid(double scaleFactor)
+{
+    return scaleFactor > 0 && scaleFactor <= 100;
+}
+
 void WebPageProxy::pageScaleFactorDidChange(double scaleFactor)
 {
+    MESSAGE_CHECK(m_process, scaleFactorIsValid(scaleFactor));
     m_pageScaleFactor = scaleFactor;
 }
 
 void WebPageProxy::pluginScaleFactorDidChange(double pluginScaleFactor)
 {
+    MESSAGE_CHECK(m_process, scaleFactorIsValid(pluginScaleFactor));
     m_pluginScaleFactor = pluginScaleFactor;
 }
 
 void WebPageProxy::pluginZoomFactorDidChange(double pluginZoomFactor)
 {
+    MESSAGE_CHECK(m_process, scaleFactorIsValid(pluginZoomFactor));
     m_pluginZoomFactor = pluginZoomFactor;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -65,6 +65,7 @@ OBJC_CLASS WKPDFPluginAccessibilityObject;
 typedef const struct OpaqueJSContext* JSContextRef;
 typedef struct OpaqueJSValue* JSObjectRef;
 typedef const struct OpaqueJSValue* JSValueRef;
+typedef struct OpaqueJSClass* JSClassRef;
 
 namespace WebCore {
 class AXObjectCache;
@@ -271,6 +272,7 @@ private:
 #endif
 
     JSObjectRef makeJSPDFDoc(JSContextRef);
+    static JSClassRef jsPDFDocClass();
     static JSValueRef jsPDFDocPrint(JSContextRef, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
 
     WeakPtr<PluginView> m_view;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1566,8 +1566,32 @@ static void jsPDFDocFinalize(JSObjectRef object)
     pdfView->deref();
 }
 
+JSClassRef PDFPlugin::jsPDFDocClass()
+{
+    static const JSStaticFunction jsPDFDocStaticFunctions[] = {
+        { "print", jsPDFDocPrint, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { 0, 0, 0 },
+    };
+
+    static const JSClassDefinition jsPDFDocClassDefinition = {
+        0,
+        kJSClassAttributeNone,
+        "Doc",
+        0,
+        0,
+        jsPDFDocStaticFunctions,
+        jsPDFDocInitialize, jsPDFDocFinalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+
+    static JSClassRef jsPDFDocClass = JSClassCreate(&jsPDFDocClassDefinition);
+    return jsPDFDocClass;
+}
+
 JSValueRef PDFPlugin::jsPDFDocPrint(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
+    if (!JSValueIsObjectOfClass(ctx, thisObject, jsPDFDocClass()))
+        return JSValueMakeUndefined(ctx);
+
     auto* pdfPlugin = static_cast<PDFPlugin*>(JSObjectGetPrivate(thisObject));
 
     auto* frame = pdfPlugin->m_frame.get();
@@ -1594,24 +1618,7 @@ FloatSize PDFPlugin::pdfDocumentSizeForPrinting() const
 
 JSObjectRef PDFPlugin::makeJSPDFDoc(JSContextRef ctx)
 {
-    static const JSStaticFunction jsPDFDocStaticFunctions[] = {
-        { "print", jsPDFDocPrint, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
-        { 0, 0, 0 },
-    };
-
-    static const JSClassDefinition jsPDFDocClassDefinition = {
-        0,
-        kJSClassAttributeNone,
-        "Doc",
-        0,
-        0,
-        jsPDFDocStaticFunctions,
-        jsPDFDocInitialize, jsPDFDocFinalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
-    };
-
-    static JSClassRef jsPDFDocClass = JSClassCreate(&jsPDFDocClassDefinition);
-
-    return JSObjectMake(ctx, jsPDFDocClass, this);
+    return JSObjectMake(ctx, jsPDFDocClass(), this);
 }
 
 void PDFPlugin::streamDidFinishLoading()

--- a/Source/WebKitLegacy/mac/WebView/WebJSPDFDoc.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebJSPDFDoc.mm
@@ -42,8 +42,13 @@ static void jsPDFDocFinalize(JSObjectRef object)
     CFRelease(JSObjectGetPrivate(object));
 }
 
+static JSClassRef jsPDFDocClass(void);
+
 static JSValueRef jsPDFDocPrint(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
+    if (!JSValueIsObjectOfClass(ctx, thisObject, jsPDFDocClass()))
+        return JSValueMakeUndefined(ctx);
+
     WebDataSource *dataSource = (__bridge WebDataSource *)JSObjectGetPrivate(thisObject);
 
     WebView *webView = [[dataSource webFrame] webView];
@@ -52,24 +57,28 @@ static JSValueRef jsPDFDocPrint(JSContextRef ctx, JSObjectRef function, JSObject
     return JSValueMakeUndefined(ctx);
 }
 
-static const JSStaticFunction jsPDFDocStaticFunctions[] = {
-    { "print", jsPDFDocPrint, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
-    { 0, 0, 0 },
-};
+static JSClassRef jsPDFDocClass(void)
+{
+    static JSStaticFunction jsPDFDocStaticFunctions[] = {
+        { "print", jsPDFDocPrint, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { 0, 0, 0 },
+    };
 
-static const JSClassDefinition jsPDFDocClassDefinition = {
-    0,
-    kJSClassAttributeNone,
-    "Doc",
-    0,
-    0,
-    jsPDFDocStaticFunctions,
-    jsPDFDocInitialize, jsPDFDocFinalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
-};
+    static JSClassDefinition jsPDFDocClassDefinition = {
+        0,
+        kJSClassAttributeNone,
+        "Doc",
+        0,
+        0,
+        jsPDFDocStaticFunctions,
+        jsPDFDocInitialize, jsPDFDocFinalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+
+    static JSClassRef jsPDFDocClass = JSClassCreate(&jsPDFDocClassDefinition);
+    return jsPDFDocClass;
+}
 
 JSObjectRef makeJSPDFDoc(JSContextRef ctx, WebDataSource *dataSource)
 {
-    static JSClassRef jsPDFDocClass = JSClassCreate(&jsPDFDocClassDefinition);
-
-    return JSObjectMake(ctx, jsPDFDocClass, (__bridge void*)dataSource);
+    return JSObjectMake(ctx, jsPDFDocClass(), (__bridge void*)dataSource);
 }


### PR DESCRIPTION
#### b73837418b94ac2065418bbf068c0560b676bb89
<pre>
Cherry-pick 252432.1036@safari-7614-branch (c553da3adc35). rdar://107367612

    [JSC] RegExp.test inline is missing some stack overflow checks
    <a href="https://bugs.webkit.org/show_bug.cgi?id=250873">https://bugs.webkit.org/show_bug.cgi?id=250873</a>
    rdar://104072550

    Reviewed by Yusuke Suzuki.

    The RegExp.test inline code is missing two stack overflow checks.
     1) When compiling the pattern string to a YarrPattern, we checked for stack overflow,
        but didn&apos;t do anything with the failure.
     2) When allocating the stack space needed to execute the JIT code for the expression
        we need to first check that we have enough stack.
    This change adds checks for both cases using the JSRegExpResult::JITCodeFailure return value when we
    would have overflowed the stack.  The results checking code after the inline code sees that error
    value, it will now call out to the appropriate C++ helper function to perform the match.
    Those functions are capable of throwing Out of Stack exceptions.

    * JSTests/stress/regexp-testinline-stacklimits.js: Added new test.
    (baz):
    (bar):
    (foo):
    (true.string_appeared_here.repeat):
    (true.catch):
    * Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
    (JSC::DFG::SpeculativeJIT::compileRegExpTestInline):
    * Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
    (JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
    * Source/JavaScriptCore/runtime/RegExp.h:
    * Source/JavaScriptCore/yarr/YarrJIT.cpp:
    (JSC::Yarr::jitCompileInlinedTest):

    Canonical link: <a href="https://commits.webkit.org/252432.1036@safari-7614-branch">https://commits.webkit.org/252432.1036@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262356@main">https://commits.webkit.org/262356@main</a>
</pre>
----------------------------------------------------------------------
#### 9f34042e08500512243b35f5a0d01122fd82cdc6
<pre>
Cherry-pick 252432.1034@safari-7614-branch (3ee4a8321986). rdar://107367566

    CSP bypass due to incorrect handling of wildcard character in host expression
    <a href="https://bugs.webkit.org/show_bug.cgi?id=250709">https://bugs.webkit.org/show_bug.cgi?id=250709</a>
    rdar://104335301

    Reviewed by Brent Fulgham and Jonathan Bedard.

    We were treating something like &quot;<a href="https://*/foo&quot">https://*/foo&quot</a>; as being a scheme-only source (so checking only against
    &apos;https&apos;). That is fixed by not only checking for the host-part being an empty string but also whether or not
    the host wildcard flag had been set by the CSP parser. Additionally, we were checking a given URL&apos;s host
    against the wildcard assuming a format like &quot;*.com&quot; instead of the possibility of the catch-all &quot;*&quot; wildcard.

    This change fixes our handling of the wildcard &quot;*&quot; in a directive&apos;s source list by correctly identifying when a
    source is scheme-only and by correctly taking into account the entire host-part wildcard grammar when checking
    a given host against a wildcard pattern.

    * LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/wildcard-host-checks-path.sub-expected.txt: Added.
    * LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/wildcard-host-checks-path.sub.html: Added.
    * Source/WebCore/page/csp/ContentSecurityPolicySource.cpp:
    (WebCore::ContentSecurityPolicySource::hostMatches const):
    (WebCore::ContentSecurityPolicySource::isSchemeOnly const):

    Canonical link: <a href="https://commits.webkit.org/252432.1034@safari-7614-branch">https://commits.webkit.org/252432.1034@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262355@main">https://commits.webkit.org/262355@main</a>
</pre>
----------------------------------------------------------------------
#### f317e5e7b17ad20bd653507fd956cd0251266bf6
<pre>
Cherry-pick 252432.1033@safari-7614-branch (02e324c57689). rdar://107367530

    Possible type confusion bug in RemoteScrollingCoordinatorTransaction::decode
    <a href="https://bugs.webkit.org/show_bug.cgi?id=250742">https://bugs.webkit.org/show_bug.cgi?id=250742</a>
    &lt;rdar://102373218&gt;

    Reviewed by Jonathan Bedard and Ryosuke Niwa.

    RemoteScrollingCoordinatorTransaction::decode() fails to check whether the nodeID returned by
    `m_scrollingStateTree-&gt;insertNode()` is a new one, different from the `nodeID` argument. If so, it
    could indicate that the node type of `m_scrollingStateTree-&gt;stateNodeForID()` does not match
    `nodeType`, leading to type confusion.

    In the UI process, `m_scrollingStateTree-&gt;insertNode()` should never return a different nodeID; this
    only happens when the given nodeType does not match the type of the existing node, which only
    happens in the WebProcess. So if `insertNode()` returns a different nodeID, or when the returned
    node doesn&apos;t have the expected type, we can consider it an IPC decoding error.

    * Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
    (WebKit::RemoteScrollingCoordinatorTransaction::decode):

    Canonical link: <a href="https://commits.webkit.org/252432.1033@safari-7614-branch">https://commits.webkit.org/252432.1033@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262354@main">https://commits.webkit.org/262354@main</a>
</pre>
----------------------------------------------------------------------
#### 936a61795aa447fe1de2039a7d87e19f4ddbc599
<pre>
Cherry-pick 252432.1029@safari-7614-branch (9dda7bfe768d). rdar://107367461

    LLInt WASM argument locals must be read before return values are written
    <a href="https://bugs.webkit.org/show_bug.cgi?id=250482">https://bugs.webkit.org/show_bug.cgi?id=250482</a>
    rdar://103551585

    Reviewed by Justin Michaud.

    Given the wasm code which exports a wasm function `intFuncRef2` as a js function.
    ```
    (func (export &quot;intFuncRef2&quot;) (param $p0 f32) (param $p1 funcref) (result i32 funcref)
        (i32.const 42)
        (local.get $p1)
        (return)
    )
    ```
    The corresponding dumped bytecodes show
    ```
    [   0] enter
    [   1] mov     dst:loc2, src:42(const0)
    [   4] mov     dst:loc3, src:loc2       // loc2 contains the funcref but now replaced with 42
    [   7] ret                              // return [loc2, loc3]
    ```
    which is wrong. Instead we should do
    ```
    [   0] enter
    [   1] mov     dst:loc18, src:42(const0)
    [   4] mov     dst:loc19, src:loc2
    [   7] mov     dst:loc2, src:loc18
    [  10] mov     dst:loc3, src:loc19
    [  13] ret
    ```
    Note that loc2 is both parameter and return lot.

    Locals usually need to be materialized on wasm stack when they are about to be or could
    be clobbered, usually before a control entry, a branch, or redefinition. Previously,
    Return writes only one value to the result slot that clobber one argument slot which
    is fine. Since now wasm function can return tuple that might bring us to the situation
    as shown in above example. We should materialize expression stack when return more than
    one values.

    * JSTests/wasm/stress/tuple-return.js: Added.
    (async test):
    * Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
    (JSC::Wasm::LLIntGenerator::addReturn):

    Canonical link: <a href="https://commits.webkit.org/252432.1029@safari-7614-branch">https://commits.webkit.org/252432.1029@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262353@main">https://commits.webkit.org/262353@main</a>
</pre>
----------------------------------------------------------------------
#### d1805dadb324be69abc61da1fde86e880573fb92
<pre>
Cherry-pick 252432.1026@safari-7614-branch (2a8469e53b2f). rdar://107367418

    Remove inheritance of designMode attribute
    <a href="https://bugs.webkit.org/show_bug.cgi?id=248615">https://bugs.webkit.org/show_bug.cgi?id=248615</a>
    rdar://102868995

    Reviewed by Wenson Hsieh and Jonathan Bedard.

    Stop making design mode inherit across frame boundaries.

    This will prevent a form element from being injected into a victim page via drag &amp; drop
    and the new behavior matches that of Firefox and Chrome.

    * LayoutTests/editing/editability/design-mode-does-not-inherit-across-frames-expected.txt: Added.
    * LayoutTests/editing/editability/design-mode-does-not-inherit-across-frames.html: Added.
    * LayoutTests/fast/dom/HTMLElement/iscontenteditable-designmodeon-allinherit-subframe-expected.txt:
    * LayoutTests/fast/dom/HTMLElement/iscontenteditable-designmodeon-allinherit-subframe.html:
    * Source/WebCore/dom/Document.cpp:
    (WebCore::Document::setDesignMode):
    (WebCore::Document::inDesignMode const): Deleted.
    * Source/WebCore/dom/Document.h:
    (WebCore::Document::inDesignMode const):

    Canonical link: <a href="https://commits.webkit.org/252432.1026@safari-7614-branch">https://commits.webkit.org/252432.1026@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262352@main">https://commits.webkit.org/262352@main</a>
</pre>
----------------------------------------------------------------------
#### c09257499fe971a4134ca8ebab4d642ef4323660
<pre>
Cherry-pick 252432.1024@safari-7614-branch (2ea437d75522). rdar://107367090

    Use-after-free in ContactsManager::select
    <a href="https://bugs.webkit.org/show_bug.cgi?id=250351">https://bugs.webkit.org/show_bug.cgi?id=250351</a>
    rdar://101241436

    Reviewed by Wenson Hsieh and Jonathan Bedard.

    `ContactsManager` can be destroyed prior to receiving the user&apos;s selection, which
    is performed asynchronously. Deploy `WeakPtr` to avoid a use-after-free in this
    scenario.

    A test was unable to be added, as the failure scenario involves opening a new
    Window, using the new Window object&apos;s `navigator.contacts`, and performing user
    interaction. Creating a new Window results in the creation of a new web view,
    however all of our existing UIScriptController hooks only apply to the original
    (main) web view. Consequently, it is not possible to use our testing
    infrastructure to dismiss the contact picker and trigger the callback in the
    failure scenario.

    * Source/WebCore/Modules/contact-picker/ContactsManager.cpp:
    (WebCore::ContactsManager::select):
    * Source/WebCore/Modules/contact-picker/ContactsManager.h:

    Canonical link: <a href="https://commits.webkit.org/252432.1024@safari-7614-branch">https://commits.webkit.org/252432.1024@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262351@main">https://commits.webkit.org/262351@main</a>
</pre>
----------------------------------------------------------------------
#### af3036aa875162ca4088700b8f57f915eec6e36c
<pre>
Cherry-pick 252432.1023@safari-7614-branch (55c2b9caae92). rdar://107367011

    [CoreIPC] Integer overflow in UIProcess from scaling/zoom factors
    <a href="https://bugs.webkit.org/show_bug.cgi?id=250408">https://bugs.webkit.org/show_bug.cgi?id=250408</a>
    rdar://101222657

    Reviewed by Wenson Hsieh and Jonathan Bedard.

    Adds bounds checking via `MESSAGE_CHECK` to the page/plugin scale/zoom `factorDidChange`
    methods in `WebPageProxy` to ensure that overflow will not occur in the web process.

    The bounds were chosen to be `(0, 100]` because a factor of `&lt;= 0.0` does not make sense,
    and `100.0` ia a reasonable upper bound.

    * Source/WebKit/UIProcess/WebPageProxy.cpp:
    (WebKit::WebPageProxy::pageScaleFactorDidChange):
    (WebKit::WebPageProxy::pluginScaleFactorDidChange):
    (WebKit::WebPageProxy::pluginZoomFactorDidChange):

    Canonical link: <a href="https://commits.webkit.org/252432.1023@safari-7614-branch">https://commits.webkit.org/252432.1023@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262350@main">https://commits.webkit.org/262350@main</a>
</pre>
----------------------------------------------------------------------
#### 0ef90805bce10ad4a40adcf8f4a32f72dfbcfa25
<pre>
Cherry-pick 252432.1017@safari-7614-branch (94d37ad7d541). rdar://107366983

        WebKit`WebKit::PDFPlugin::jsPDFDocPrint - type confusion
        <a href="https://bugs.webkit.org/show_bug.cgi?id=249169">https://bugs.webkit.org/show_bug.cgi?id=249169</a>
        rdar://102740487

        Reviewed by Tim Horton, Yusuke Suzuki and Jonathan Bedard.

        When JavaScript is embedded inside a PDF and it invokes the `print()` function,
        the `thisObject` parameter in `PDFPlugin::jsPDFDocPrint` is not guaranteed
        to be the proper type. Currently, we errenously assume it always is the proper
        type, and cast it to `PDFPlugin *`, which results in an object with garbage values.

        This PR protects against this by first checking if the `thisObject` is the correct
        JavaScript object type, before trying to cast it.

        * Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
        * Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
        (WebKit::PDFPlugin::jsPDFDocClass):
        (WebKit::PDFPlugin::jsPDFDocPrint):
        (WebKit::PDFPlugin::makeJSPDFDoc):

        Canonical link: <a href="https://commits.webkit.org/252432.1017@safari-7614-branch">https://commits.webkit.org/252432.1017@safari-7614-branch</a>

Canonical link: <a href="https://commits.webkit.org/262349@main">https://commits.webkit.org/262349@main</a>
</pre>
----------------------------------------------------------------------
#### 3d5ebb9e2ca0a1c9c2dbaab5ff8a00642709eb47
<pre>
Cherry-pick 256843.5@webkit-2022.12-embargoed (312254f5776d). rdar://107366942

    Check displayContentsChanged in destroyRenderTreeIfNeeded
    <a href="https://bugs.webkit.org/show_bug.cgi?id=248776">https://bugs.webkit.org/show_bug.cgi?id=248776</a>
    rdar://102807985&gt;

    Reviewed by Antti Koivisto.

    Check displayContentsChanged in destroyRenderTreeIfNeeded since
    display: contents may be removed due to focus removal while
    removing subtrees but we still need to clean up pseudo elements.

    * LayoutTests/fast/css/content/quote-display-contents-crash-expected.txt: Added.
    * LayoutTests/fast/css/content/quote-display-contents-crash.html: Added.
    * Source/WebCore/dom/ContainerNode.cpp:
    (WebCore::destroyRenderTreeIfNeeded):
    * Source/WebCore/dom/Element.cpp:
    (WebCore::Element::resolveComputedStyle):

    Canonical link: <a href="https://commits.webkit.org/256843.5@webkit-2022.12-embargoed">https://commits.webkit.org/256843.5@webkit-2022.12-embargoed</a>

Canonical link: <a href="https://commits.webkit.org/262348@main">https://commits.webkit.org/262348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95d9f8134f8cad9fef73770f2f34fdeb8dcdbd46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1139 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1299 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1281 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1939 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1149 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1120 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1165 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2267 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1247 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1213 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1304 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1182 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/260 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/325 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1240 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1307 "Built successfully") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/133 "") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/256 "Passed tests") | 
<!--EWS-Status-Bubble-End-->