### PR TITLE
[GStreamer][MSE] Append pipeline is counting streams incorrectly with new init segments

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-detach-crash.html
+++ b/LayoutTests/media/media-source/media-source-seek-detach-crash.html
@@ -52,6 +52,7 @@
         run('sourceBuffer.appendBuffer(loader.initSegment())');
         setTimeout(() => { run('video.currentTime = 2'); });
         video.addEventListener('error', endTestLater);
+        waitForEventOn(sourceBuffer, 'update', failTest, false, true);
     }
     </script>
 </head>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2168,8 +2168,6 @@ webkit.org/b/189343 imported/w3c/web-platform-tests/xhr/sync-no-timeout.any.html
 webkit.org/b/189345 http/tests/media/clearkey/collect-webkit-media-session.html [ Skip ]
 
 media/encrypted-media [ Pass ]
-webkit.org/b/254664 media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html [ Failure ]
-
 
 webkit.org/b/205857 media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html [ Skip ]
 webkit.org/b/205860 media/encrypted-media/mock-MediaKeySession-remove.html [ Skip ]

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -459,36 +459,58 @@ void AppendPipeline::didReceiveInitializationSegment()
             trackIndex++;
         }
     } else {
-        // Since we don't rely on the demuxer pad-added signal and this pipeline is not
-        // stream-aware, we need to account for stream topology changes ourselves.
-        unsigned videoPadsCount = 0;
-        unsigned audioPadsCount = 0;
-        unsigned textPadsCount = 0;
+        HashSet<String> videoPadStreamIDs;
+        HashSet<String> audioPadStreamIDs;
+        HashSet<String> textPadStreamIDs;
         for (auto pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_src_pads(m_demux.get())))) {
-            if (gst_pad_is_linked(pad))
-                continue;
             auto [parsedCaps, streamType, presentationSize] = parseDemuxerSrcPadCaps(adoptGRef(gst_pad_get_current_caps(pad)).get());
+            UNUSED_VARIABLE(parsedCaps);
+            UNUSED_VARIABLE(presentationSize);
+            String streamID = String::fromLatin1(GUniquePtr<char>(gst_pad_get_stream_id(pad)).get());
             if (streamType == StreamType::Audio)
-                audioPadsCount++;
+                audioPadStreamIDs.add(WTFMove(streamID));
             else if (streamType == StreamType::Video)
-                videoPadsCount++;
+                videoPadStreamIDs.add(WTFMove(streamID));
             else if (streamType == StreamType::Text)
-                textPadsCount++;
+                textPadStreamIDs.add(WTFMove(streamID));
         }
 
         unsigned videoTracksCount = 0;
         unsigned audioTracksCount = 0;
         unsigned textTracksCount = 0;
+        bool doAudioTrackStreamIDsMatch = true;
+        bool doVideoTrackStreamIDsMatch = true;
+        bool doTextTrackStreamIDsMatch = true;
         for (const auto& track : m_tracks) {
-            if (track->streamType == StreamType::Audio)
+            GUniquePtr<char> streamIDAsCharacters(gst_pad_get_stream_id(track->entryPad.get()));
+            String streamID = String::fromLatin1(streamIDAsCharacters.get());
+            if (track->streamType == StreamType::Audio) {
                 audioTracksCount++;
-            else if (track->streamType == StreamType::Video)
+                if (streamID.isEmpty() || !audioPadStreamIDs.contains(streamID))
+                    doAudioTrackStreamIDsMatch = false;
+            } else if (track->streamType == StreamType::Video) {
                 videoTracksCount++;
-            else if (track->streamType == StreamType::Text)
+                if (streamID.isEmpty() || !videoPadStreamIDs.contains(streamID))
+                    doVideoTrackStreamIDsMatch = false;
+            } else if (track->streamType == StreamType::Text) {
                 textTracksCount++;
+                if (streamID.isEmpty() || !textPadStreamIDs.contains(streamID))
+                    doTextTrackStreamIDsMatch = false;
+            }
         }
 
-        if (videoPadsCount < videoTracksCount || audioPadsCount < audioTracksCount || textPadsCount < textTracksCount) {
+        // Step 3 of the MSE spec append initialization segment algorithm.
+        // 4.5.7.3.1: Verify the following properties. If any of the checks fail then run the append error algorithm and abort these steps.
+        // 4.5.7.3.1.1: The number of audio, video, and text tracks match what was in the first initialization segment.
+        bool doTracksMatch = audioPadStreamIDs.size() == audioTracksCount && videoPadStreamIDs.size() == videoTracksCount && textPadStreamIDs.size() == textTracksCount;
+        // 4.5.7.3.1.2: If more than one track for a single type are present (e.g., 2 audio tracks), then the Track IDs match the ones in the first initialization segment.
+        if (doTracksMatch && audioTracksCount > 1)
+            doTracksMatch = doAudioTrackStreamIDsMatch;
+        if (doTracksMatch && videoTracksCount > 1)
+            doTracksMatch = doVideoTrackStreamIDsMatch;
+        if (doTracksMatch && textTracksCount > 1)
+            doTracksMatch = doTextTrackStreamIDsMatch;
+        if (!doTracksMatch) {
             GST_WARNING_OBJECT(pipeline(), "New demuxed stream topology doesn't match the existing tracks topology");
             m_sourceBufferPrivate.appendParsingFailed();
             return;
@@ -837,7 +859,8 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
         return false;
     }
 
-    if (!matchingTrack->isLinked())
+    GRefPtr<GstCaps> matchingTrackCaps = adoptGRef(gst_pad_get_current_caps(matchingTrack->entryPad.get()));
+    if (!matchingTrack->isLinked() && (!matchingTrackCaps || gst_caps_can_intersect(parsedCaps.get(), matchingTrackCaps.get())))
         linkPadWithTrack(demuxerSrcPad, *matchingTrack);
     else {
         // Unlink from old track and link to new track, by 1. stopping parser/sink, 2. unlinking
@@ -848,8 +871,10 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
 
         auto peer = adoptGRef(gst_pad_get_peer(matchingTrack->entryPad.get()));
         if (peer.get() != demuxerSrcPad) {
-            GST_DEBUG_OBJECT(peer.get(), "Unlinking from track %s", matchingTrack->trackId.string().ascii().data());
-            gst_pad_unlink(peer.get(), matchingTrack->entryPad.get());
+            if (peer) {
+                GST_DEBUG_OBJECT(peer.get(), "Unlinking from track %s", matchingTrack->trackId.string().ascii().data());
+                gst_pad_unlink(peer.get(), matchingTrack->entryPad.get());
+            }
 
             const String& type = m_sourceBufferPrivate.type().containerType();
             if (type.endsWith("webm"_s))


### PR DESCRIPTION
#### 847e28d6e49b2c43727efab967296f483aec55eb
<pre>
[GStreamer][MSE] Append pipeline is counting streams incorrectly with new init segments
<a href="https://bugs.webkit.org/show_bug.cgi?id=254664">https://bugs.webkit.org/show_bug.cgi?id=254664</a>

Reviewed by Alicia Boya Garcia.

When you append another init segment we match GStreamer pads against tracks but we are not counting properly as we are
skipping the pads that are already linked we can end up with less pads than tracks. Besides it is against the spec. We
need to match the number of tracks and track IDs if there are more than one for a kind.

* LayoutTests/media/media-source/media-source-seek-detach-crash.html: Fail the test earlier instead of waiting for a
timeout.
* LayoutTests/platform/glib/TestExpectations: Unmark
media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html as failure. It works now.
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::didReceiveInitializationSegment):
(WebCore::AppendPipeline::recycleTrackForPad):

Canonical link: <a href="https://commits.webkit.org/264676@main">https://commits.webkit.org/264676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b483c022009e8897e40a71571091d37375fc76ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8404 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11271 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8485 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/9541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10152 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7630 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7960 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/7773 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11118 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6718 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2002 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->