### PR TITLE
[WGSL] Validate constraints on type variables when resolving overloads

### DIFF
--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -38,19 +38,20 @@ using AbstractValue = std::variant<NumericVariable, unsigned>;
 struct TypeVariable {
     enum Constraint : uint8_t {
         None = 0,
-        F16 = 1 << 0,
-        F32 = 1 << 1,
-        AbstractFloat = 1 << 2,
+
+        Bool          = 1 << 0,
+        AbstractInt   = 1 << 1,
+        I32           = 1 << 2,
+        U32           = 1 << 3,
+        AbstractFloat = 1 << 4,
+        F32           = 1 << 5,
+        F16           = 1 << 6,
+
         ConcreteFloat = F16 | F32,
         Float = ConcreteFloat | AbstractFloat,
 
-        I32 = 1 << 3,
-        U32 = 1 << 4,
-        AbstractInt = 1 << 5,
         ConcreteInteger = I32 | U32,
         Integer = ConcreteInteger | AbstractInt,
-
-        Bool = 1 << 6,
 
         Scalar = Bool | Integer | Float,
         ConcreteScalar = Bool | ConcreteInteger | ConcreteFloat,

--- a/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
@@ -2,3 +2,26 @@ fn testExplicitTypeArguments() {
   // CHECK-L: no matching overload for initializer vec2<i32>(<AbstractFloat>, <AbstractFloat>)
   let v0 = vec2<i32>(0.0, 0.0);
 }
+
+struct S {
+  x: i32,
+};
+
+fn testConstraints() {
+    var x : S;
+
+    // CHECK-L: no matching overload for operator + (S, S)
+    let x2 = x + x;
+
+    // CHECK-L:  no matching overload for initializer vec2(S, S)
+    let x3 = vec2(x, x);
+
+    // CHECK-L: no matching overload for initializer mat2x2(u32, u32, u32, u32)
+    let x4 = mat2x2(0u, 0u, 0u, 0u);
+
+    // CHECK-L: no matching overload for initializer vec2<S>(S, S)
+    let x5 = vec2<S>(x, x);
+
+    // CHECK-L:  no matching overload for initializer vec2<S>(vec2<<AbstractInt>>)
+    let x6 = vec2<S>(vec2(0, 0));
+}


### PR DESCRIPTION
#### 8f488e02e9be1fff9a916ce0d395b05e5bc0134b
<pre>
[WGSL] Validate constraints on type variables when resolving overloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=254669">https://bugs.webkit.org/show_bug.cgi?id=254669</a>
rdar://problem/107370152

Reviewed by Myles C. Maxfield.

Type variables don&apos;t always accept any type, they usually have constraints such
as &quot;the type must be a floating point&quot; or the like. We were already specifying
the constraints, but not validating it. This patch modifies Overload::assign
to validate that a type actually satisfies the constraints before the assignment.

* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::considerCandidate):
(WGSL::OverloadResolver::unify):
(WGSL::OverloadResolver::assign):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/tests/invalid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/262328@main">https://commits.webkit.org/262328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/297dbad6e3b330b1aef3e327caf04758d60160a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1121 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1279 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1261 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1909 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1132 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1146 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1184 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2244 "268 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1094 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1163 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/314 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1221 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->