### PR TITLE
Remove Quirks::needsHDRPixelDepthQuirk()

### DIFF
--- a/Source/WebCore/loader/ResourceLoadStatistics.cpp
+++ b/Source/WebCore/loader/ResourceLoadStatistics.cpp
@@ -43,7 +43,7 @@ static void encodeHashSet(KeyedEncoder& encoder, const String& label,  const Str
 {
     if (hashSet.isEmpty())
         return;
-    
+
     encoder.encodeObjects(label, hashSet.begin(), hashSet.end(), [&key](KeyedEncoder& encoderInner, const RegistrableDomain& domain) {
         encoderInner.encodeString(key, domain.string());
     });
@@ -54,7 +54,7 @@ static void encodeOptionSet(KeyedEncoder& encoder, const String& label, const Op
 {
     if (optionSet.isEmpty())
         return;
-    
+
     uint64_t optionSetBitMask = optionSet.toRaw();
     encoder.encodeUInt64(label, optionSetBitMask);
 }
@@ -64,7 +64,7 @@ static void encodeHashSet(KeyedEncoder& encoder, const String& label,  const Str
 {
     if (hashSet.isEmpty())
         return;
-    
+
     encoder.encodeObjects(label, hashSet.begin(), hashSet.end(), [&key](KeyedEncoder& encoderInner, const String& origin) {
         encoderInner.encodeString(key, origin);
     });
@@ -74,7 +74,7 @@ static void encodeFontHashSet(KeyedEncoder& encoder, const String& label, const 
 {
     encodeHashSet(encoder, label, "font"_s, hashSet);
 }
-    
+
 static void encodeCanvasActivityRecord(KeyedEncoder& encoder, const String& label, const CanvasActivityRecord& canvasActivityRecord)
 {
     encoder.encodeObject(label, canvasActivityRecord, [] (KeyedEncoder& encoderInner, const CanvasActivityRecord& canvasActivityRecord) {
@@ -109,7 +109,7 @@ void ResourceLoadStatistics::encode(KeyedEncoder& encoder) const
 
     // Subframe stats
     encodeHashSet(encoder, "subframeUnderTopFrameDomains"_s, "domain"_s, subframeUnderTopFrameDomains);
-    
+
     // Subresource stats
     encodeHashSet(encoder, "subresourceUnderTopFrameDomains"_s, "domain"_s, subresourceUnderTopFrameDomains);
     encodeHashSet(encoder, "subresourceUniqueRedirectsTo"_s, "domain"_s, subresourceUniqueRedirectsTo);
@@ -140,7 +140,7 @@ IGNORE_WARNINGS_BEGIN("unused-result")
     decoder.decodeObjects(label, ignored, [&hashCountedSet](KeyedDecoder& decoderInner, String& domain) {
         if (!decoderInner.decodeString("origin"_s, domain))
             return false;
-        
+
         unsigned count;
         if (!decoderInner.decodeUInt32("count"_s, count))
             return false;
@@ -158,7 +158,7 @@ IGNORE_WARNINGS_BEGIN("unused-result")
     decoder.decodeObjects(label, ignored, [&hashSet, &key](KeyedDecoder& decoderInner, String& domain) {
         if (!decoderInner.decodeString(key, domain))
             return false;
-        
+
         hashSet.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(domain));
         return true;
     });
@@ -181,7 +181,7 @@ IGNORE_WARNINGS_BEGIN("unused-result")
     decoder.decodeObjects(label, ignore, [&hashSet, &key](KeyedDecoder& decoderInner, String& origin) {
         if (!decoderInner.decodeString(key, origin))
             return false;
-        
+
         hashSet.add(origin);
         return true;
     });
@@ -192,7 +192,7 @@ static void decodeFontHashSet(KeyedDecoder& decoder, const String& label, HashSe
 {
     decodeHashSet(decoder, label, "font"_s, hashSet);
 }
-    
+
 static void decodeCanvasActivityRecord(KeyedDecoder& decoder, const String& label, CanvasActivityRecord& canvasActivityRecord)
 {
 IGNORE_WARNINGS_BEGIN("unused-result")
@@ -243,7 +243,7 @@ bool ResourceLoadStatistics::decode(KeyedDecoder& decoder, unsigned modelVersion
         decodeHashCountedSet(decoder, "topFrameUniqueRedirectsTo"_s, topFrameUniqueRedirectsToCounted);
         for (auto& domain : topFrameUniqueRedirectsToCounted.values())
             topFrameUniqueRedirectsTo.add(domain);
-        
+
         HashCountedSet<RegistrableDomain> topFrameUniqueRedirectsFromCounted;
         decodeHashCountedSet(decoder, "topFrameUniqueRedirectsFrom"_s, topFrameUniqueRedirectsFromCounted);
         for (auto& domain : topFrameUniqueRedirectsFromCounted.values())
@@ -358,7 +358,7 @@ static void appendHashSet(StringBuilder& builder, const String& label, const Has
 {
     if (hashSet.isEmpty())
         return;
-    
+
     builder.append("    ", label, ":\n");
     for (auto& entry : hashSet)
         builder.append("        ", entry.string(), '\n');
@@ -369,7 +369,7 @@ static void appendHashSet(StringBuilder& builder, const String& label, const Has
 {
     if (hashSet.isEmpty())
         return;
-    
+
     builder.append("    ", label, ":\n");
     for (auto& entry : hashSet)
         builder.append("        ", entry, '\n');
@@ -402,8 +402,6 @@ static ASCIILiteral screenAPIEnumToString(ScreenAPIsAccessed screenEnum)
         return "width"_s;
     case ScreenAPIsAccessed::ColorDepth:
         return "colorDepth"_s;
-    case ScreenAPIsAccessed::PixelDepth:
-        return "pixelDepth"_s;
     case ScreenAPIsAccessed::AvailLeft:
         return "availLeft"_s;
     case ScreenAPIsAccessed::AvailTop:
@@ -416,7 +414,7 @@ static ASCIILiteral screenAPIEnumToString(ScreenAPIsAccessed screenEnum)
     ASSERT_NOT_REACHED();
     return "Invalid screen API"_s;
 }
-    
+
 static void appendNavigatorAPIOptionSet(StringBuilder& builder, const OptionSet<NavigatorAPIsAccessed>& optionSet)
 {
     if (optionSet.isEmpty())
@@ -425,7 +423,7 @@ static void appendNavigatorAPIOptionSet(StringBuilder& builder, const OptionSet<
     for (auto navigatorAPI : optionSet)
         builder.append("        ", navigatorAPIEnumToString(navigatorAPI), '\n');
 }
-    
+
 static void appendScreenAPIOptionSet(StringBuilder& builder, const OptionSet<ScreenAPIsAccessed>& optionSet)
 {
     if (optionSet.isEmpty())
@@ -468,7 +466,7 @@ String ResourceLoadStatistics::toString() const
 
     // Subframe stats
     appendHashSet(builder, "subframeUnderTopFrameDomains"_s, subframeUnderTopFrameDomains);
-    
+
     // Subresource stats
     appendHashSet(builder, "subresourceUnderTopFrameDomains"_s, subresourceUnderTopFrameDomains);
     appendHashSet(builder, "subresourceUniqueRedirectsTo"_s, subresourceUniqueRedirectsTo);
@@ -517,7 +515,7 @@ void ResourceLoadStatistics::merge(const ResourceLoadStatistics& other)
 
     if (lastSeen < other.lastSeen)
         lastSeen = other.lastSeen;
-    
+
     if (!other.hadUserInteraction) {
         // If user interaction has been reset do so here too.
         // Else, do nothing.
@@ -544,7 +542,7 @@ void ResourceLoadStatistics::merge(const ResourceLoadStatistics& other)
 
     // Subframe stats
     mergeHashSet(subframeUnderTopFrameDomains, other.subframeUnderTopFrameDomains);
-    
+
     // Subresource stats
     mergeHashSet(subresourceUnderTopFrameDomains, other.subresourceUnderTopFrameDomains);
     mergeHashSet(subresourceUniqueRedirectsTo, other.subresourceUniqueRedirectsTo);
@@ -554,7 +552,7 @@ void ResourceLoadStatistics::merge(const ResourceLoadStatistics& other)
     isPrevalentResource |= other.isPrevalentResource;
     isVeryPrevalentResource |= other.isVeryPrevalentResource;
     dataRecordsRemoved = std::max(dataRecordsRemoved, other.dataRecordsRemoved);
-    
+
 #if ENABLE(WEB_API_STATISTICS)
     mergeHashSet(fontsFailedToLoad, other.fontsFailedToLoad);
     mergeHashSet(fontsSuccessfullyLoaded, other.fontsSuccessfullyLoaded);

--- a/Source/WebCore/loader/ResourceLoadStatistics.h
+++ b/Source/WebCore/loader/ResourceLoadStatistics.h
@@ -53,11 +53,10 @@ enum class ScreenAPIsAccessed : uint64_t {
     Height = 1 << 0,
     Width = 1 << 1,
     ColorDepth = 1 << 2,
-    PixelDepth = 1 << 3,
-    AvailLeft = 1 << 4,
-    AvailTop = 1 << 5,
-    AvailHeight = 1 << 6,
-    AvailWidth = 1 << 7,
+    AvailLeft = 1 << 3,
+    AvailTop = 1 << 4,
+    AvailHeight = 1 << 5,
+    AvailWidth = 1 << 6,
 };
 
 struct ResourceLoadStatistics {
@@ -75,7 +74,7 @@ struct ResourceLoadStatistics {
     ResourceLoadStatistics& operator=(ResourceLoadStatistics&&) = default;
 
     static constexpr Seconds NoExistingTimestamp { -1 };
-    
+
     WEBCORE_EXPORT static WallTime reduceTimeResolution(WallTime);
 
     WEBCORE_EXPORT void encode(KeyedEncoder&) const;
@@ -88,7 +87,7 @@ struct ResourceLoadStatistics {
     RegistrableDomain registrableDomain;
 
     WallTime lastSeen;
-    
+
     // User interaction
     bool hadUserInteraction { false };
     // Timestamp. Default value is negative, 0 means it was reset.
@@ -108,7 +107,7 @@ struct ResourceLoadStatistics {
 
     // Subframe stats
     HashSet<RegistrableDomain> subframeUnderTopFrameDomains;
-    
+
     // Subresource stats
     HashSet<RegistrableDomain> subresourceUnderTopFrameDomains;
     HashSet<RegistrableDomain> subresourceUniqueRedirectsTo;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -189,12 +189,12 @@ bool Quirks::shouldDisableContentChangeObserver() const
 {
     if (!needsQuirks())
         return false;
-    
+
     auto& topDocument = m_document->topDocument();
-    
+
     auto host = topDocument.url().host();
     auto isYouTube = host.endsWith(".youtube.com"_s) || host == "youtube.com"_s;
-    
+
     if (isYouTube && (topDocument.url().path().startsWithIgnoringASCIICase("/results"_s) || topDocument.url().path().startsWithIgnoringASCIICase("/watch"_s)))
         return true;
 
@@ -1001,7 +1001,7 @@ bool Quirks::needsCanPlayAfterSeekedQuirk() const
     return m_needsCanPlayAfterSeekedQuirk.value();
 }
 
-// wikipedia.org rdar://54856323 
+// wikipedia.org rdar://54856323
 bool Quirks::shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraints() const
 {
     if (!needsQuirks())
@@ -1206,7 +1206,7 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
     static NeverDestroyed<RegistrableDomain> kinjaDomain { kinjaURL };
 
     static NeverDestroyed<RegistrableDomain> youTubeDomain = RegistrableDomain::uncheckedCreateFromRegistrableDomainString("youtube.com"_s);
-    
+
     static NeverDestroyed<String> loginPopupWindowFeatureString = "toolbar=no,location=yes,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=599,height=600,top=420,left=980.5"_s;
 
     static NeverDestroyed<UserScript> kinjaLoginUserScript { "function triggerLoginForm() { let elements = document.getElementsByClassName('js_header-userbutton'); if (elements && elements[0]) { elements[0].click(); clearInterval(interval); } } let interval = setInterval(triggerLoginForm, 200);"_s, URL(aboutBlankURL()), Vector<String>(), Vector<String>(), UserScriptInjectionTime::DocumentEnd, UserContentInjectedFrames::InjectInTopFrameOnly, WaitForNotificationBeforeInjecting::Yes };
@@ -1310,18 +1310,6 @@ bool Quirks::needsVP9FullRangeFlagQuirk() const
         m_needsVP9FullRangeFlagQuirk = equalLettersIgnoringASCIICase(m_document->url().host(), "www.youtube.com"_s);
 
     return *m_needsVP9FullRangeFlagQuirk;
-}
-
-// youtube.com rdar://66242343
-bool Quirks::needsHDRPixelDepthQuirk() const
-{
-    if (!needsQuirks())
-        return false;
-
-    if (!m_needsHDRPixelDepthQuirk)
-        m_needsHDRPixelDepthQuirk = equalLettersIgnoringASCIICase(m_document->url().host(), "www.youtube.com"_s);
-
-    return *m_needsHDRPixelDepthQuirk;
 }
 
 bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
@@ -1440,13 +1428,13 @@ bool Quirks::allowLayeredFullscreenVideos() const
 {
     if (!needsQuirks())
         return false;
-    
+
     if (!m_allowLayeredFullscreenVideos) {
         auto domain = RegistrableDomain(m_document->topDocument().url());
-        
+
         m_allowLayeredFullscreenVideos = domain == "espn.com"_s;
     }
-    
+
     return *m_allowLayeredFullscreenVideos;
 }
 #endif
@@ -1567,7 +1555,7 @@ bool Quirks::shouldDisableLazyImageLoadingQuirk() const
         return false;
 
     auto* metaElement = m_document->getElementsByTagName("meta"_s)->namedItem("generator"_s);
-    
+
     if (metaElement && metaElement->getAttribute("content"_s) == "Gatsby 4.24.1"_s)
         m_shouldDisableLazyImageLoadingQuirk = true;
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -99,7 +99,7 @@ public:
     WEBCORE_EXPORT static bool shouldAllowNavigationToCustomProtocolWithoutUserGesture(StringView protocol, const SecurityOriginData& requesterOrigin);
 
     WEBCORE_EXPORT bool needsYouTubeMouseOutQuirk() const;
-    
+
     WEBCORE_EXPORT bool shouldAvoidUsingIOS13ForGmail() const;
 
     bool needsGMailOverflowScrollQuirk() const;
@@ -131,8 +131,7 @@ public:
     StorageAccessResult triggerOptionalStorageAccessQuirk(Element&, const PlatformMouseEvent&, const AtomString& eventType, int, Element*, bool isParentProcessAFullWebBrowser, IsSyntheticClick) const;
 
     bool needsVP9FullRangeFlagQuirk() const;
-    bool needsHDRPixelDepthQuirk() const;
-    
+
     bool requiresUserGestureToPauseInPictureInPicture() const;
     bool requiresUserGestureToLoadInPictureInPicture() const;
 
@@ -152,7 +151,7 @@ public:
 #if ENABLE(IMAGE_ANALYSIS)
     bool needsToForceUserSelectAndUserDragWhenInstallingImageOverlay() const;
 #endif
-    
+
 #if PLATFORM(IOS)
     WEBCORE_EXPORT bool allowLayeredFullscreenVideos() const;
 #endif
@@ -204,7 +203,6 @@ private:
     mutable std::optional<bool> m_needsCanPlayAfterSeekedQuirk;
     mutable std::optional<bool> m_shouldBypassAsyncScriptDeferring;
     mutable std::optional<bool> m_needsVP9FullRangeFlagQuirk;
-    mutable std::optional<bool> m_needsHDRPixelDepthQuirk;
     mutable std::optional<bool> m_needsBlackFullscreenBackgroundQuirk;
     mutable std::optional<bool> m_requiresUserGestureToPauseInPictureInPicture;
     mutable std::optional<bool> m_requiresUserGestureToLoadInPictureInPicture;

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -7,13 +7,13 @@
  * are met:
  *
  * 1.  Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer. 
+ *     notice, this list of conditions and the following disclaimer.
  * 2.  Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution. 
+ *     documentation and/or other materials provided with the distribution.
  * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
  *     its contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission. 
+ *     from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -96,21 +96,6 @@ unsigned Screen::colorDepth() const
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::ColorDepth);
     return static_cast<unsigned>(screenDepth(frame->view()));
-}
-
-unsigned Screen::pixelDepth() const
-{
-    RefPtr frame = this->frame();
-    if (!frame)
-        return 0;
-    if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->document(), ScreenAPIsAccessed::PixelDepth);
-
-    auto* document = window()->document();
-    if (!document || !document->quirks().needsHDRPixelDepthQuirk() || !screenSupportsHighDynamicRange(frame->view()))
-        return static_cast<unsigned>(screenDepth(frame->view()));
-
-    return static_cast<unsigned>(screenDepth(frame->view())) + 1;
 }
 
 int Screen::availLeft() const

--- a/Source/WebCore/page/Screen.h
+++ b/Source/WebCore/page/Screen.h
@@ -7,13 +7,13 @@
  * are met:
  *
  * 1.  Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer. 
+ *     notice, this list of conditions and the following disclaimer.
  * 2.  Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution. 
+ *     documentation and/or other materials provided with the distribution.
  * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
  *     its contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission. 
+ *     from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -48,7 +48,6 @@ public:
     int height() const;
     int width() const;
     unsigned colorDepth() const;
-    unsigned pixelDepth() const;
     int availLeft() const;
     int availTop() const;
     int availHeight() const;

--- a/Source/WebCore/page/Screen.idl
+++ b/Source/WebCore/page/Screen.idl
@@ -7,13 +7,13 @@
  * are met:
  *
  * 1.  Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer. 
+ *     notice, this list of conditions and the following disclaimer.
  * 2.  Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution. 
+ *     documentation and/or other materials provided with the distribution.
  * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
  *     its contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission. 
+ *     from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -36,7 +36,7 @@
     readonly attribute long height;
     readonly attribute long width;
     readonly attribute unsigned long colorDepth;
-    readonly attribute unsigned long pixelDepth;
+    [ImplementedAs=colorDepth] readonly attribute unsigned long pixelDepth;
     readonly attribute long availLeft;
     readonly attribute long availTop;
     readonly attribute long availHeight;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -420,7 +420,6 @@ struct CGAffineTransform {
     Height,
     Width,
     ColorDepth,
-    PixelDepth,
     AvailLeft,
     AvailTop,
     AvailHeight,
@@ -1386,7 +1385,7 @@ enum class WebCore::DiagnosticLoggingDomain : uint8_t {
         , DisplayP3
 #endif
 };
-    
+
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::PlatformColorSpace {
     WebCore::PlatformColorSpace::Name get();
 };
@@ -1856,7 +1855,7 @@ class WebCore::AuthenticationChallenge {
     unsigned previousFailureCount();
     WebCore::ResourceResponse failureResponse();
     WebCore::ResourceError error();
-    
+
 #if USE(SOUP)
     uint32_t tlsPasswordFlags();
 #endif
@@ -2288,7 +2287,7 @@ struct WebCore::MediaDecodingConfiguration : WebCore::MediaConfiguration {
     WebCore::MediaDecodingType type;
     bool canExposeVP9;
 };
-    
+
 enum class WebCore::ResourceRequestCachePolicy : uint8_t {
     UseProtocolCachePolicy,
     ReloadIgnoringCacheData,
@@ -2340,7 +2339,7 @@ enum class WebCore::ResourceLoadPriority : uint8_t {
     Opaque,
     Opaqueredirect
 };
-    
+
 [Nested] enum class WebCore::ResourceResponseBase::Source : uint8_t {
     Unknown,
     Network,
@@ -2366,7 +2365,7 @@ enum class WebCore::ResourceLoadPriority : uint8_t {
 
     short m_httpStatusCode;
     std::optional<WebCore::CertificateInfo> m_certificateInfo;
-    
+
     WebCore::ResourceResponseBase::Source m_source;
     WebCore::ResourceResponseBase::Type m_type;
     WebCore::ResourceResponseBase::Tainting m_tainting;
@@ -2831,10 +2830,10 @@ enum class WebCore::DOMPasteAccessResponse : uint8_t {
 };
 
 header: <WebCore/DeviceOrientationOrMotionPermissionState.h>
-enum class WebCore::DeviceOrientationOrMotionPermissionState : uint8_t { 
+enum class WebCore::DeviceOrientationOrMotionPermissionState : uint8_t {
     Granted,
     Denied,
-    Prompt 
+    Prompt
 };
 
 header: <WebCore/ExceptionDetails.h>
@@ -2848,10 +2847,10 @@ header: <WebCore/SecurityPolicyViolationEventDisposition.h>
 enum class WebCore::SecurityPolicyViolationEventDisposition : bool
 
 header: <WebCore/FontAttributeChanges.h>
-enum class WebCore::VerticalAlignChange : uint8_t { 
+enum class WebCore::VerticalAlignChange : uint8_t {
     Superscript,
     Baseline,
-    Subscript 
+    Subscript
 };
 
 header: <WebCore/TextGranularity.h>
@@ -4759,7 +4758,7 @@ class WebCore::Region {
     HasWidth,
     HasHeight
 };
-    
+
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::FilterEffectGeometry {
     WebCore::FloatRect m_boundaries;
     OptionSet<WebCore::FilterEffectGeometry::Flags> m_flags;


### PR DESCRIPTION
#### 95d938e7a998f0e15f36dcb56c1f15469025b70d
<pre>
Remove Quirks::needsHDRPixelDepthQuirk()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254670">https://bugs.webkit.org/show_bug.cgi?id=254670</a>
rdar://107370756

Reviewed by Jer Noble and Brent Fulgham.

Remove a quirk YouTube no longer relies on per code inspection and at the same time make screen.colorDepth and pixelDepth share an implementation.

* Source/WebCore/loader/ResourceLoadStatistics.cpp:
(WebCore::encodeHashSet):
(WebCore::encodeOptionSet):
(WebCore::ResourceLoadStatistics::encode const):
(WebCore::decodeHashCountedSet):
(WebCore::decodeHashSet):
(WebCore::ResourceLoadStatistics::decode):
(WebCore::appendHashSet):
(WebCore::screenAPIEnumToString):
(WebCore::ResourceLoadStatistics::toString const):
(WebCore::ResourceLoadStatistics::merge):
* Source/WebCore/loader/ResourceLoadStatistics.h:

As a side effect, we no longer record pixelDepth separately from colorDepth.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableContentChangeObserver const):
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):
(WebCore::Quirks::allowLayeredFullscreenVideos const):
(WebCore::Quirks::shouldDisableLazyImageLoadingQuirk const):
(WebCore::Quirks::needsHDRPixelDepthQuirk const): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/Screen.cpp:
(WebCore::Screen::pixelDepth const): Deleted.
* Source/WebCore/page/Screen.h:
* Source/WebCore/page/Screen.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/262330@main">https://commits.webkit.org/262330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05ab2a004304adc929de6aca54a49d31ec5a0a3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1987 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1088 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1251 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1228 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1851 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1121 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1105 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2211 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1161 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1131 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/315 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1188 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->