### PR TITLE
Avoid heap allocation in jsEventTargetCast()

### DIFF
--- a/Source/WebCore/bindings/js/JSEventTargetCustom.cpp
+++ b/Source/WebCore/bindings/js/JSEventTargetCustom.cpp
@@ -62,15 +62,15 @@ EventTarget* JSEventTarget::toWrapped(VM&, JSValue value)
     return nullptr;
 }
 
-std::unique_ptr<JSEventTargetWrapper> jsEventTargetCast(VM& vm, JSValue thisValue)
+JSEventTargetWrapper jsEventTargetCast(VM& vm, JSValue thisValue)
 {
     if (auto* target = jsDynamicCast<JSEventTarget*>(thisValue))
-        return makeUnique<JSEventTargetWrapper>(target->wrapped(), *target);
+        return { target->wrapped(), *target };
     if (auto* window = toJSDOMGlobalObject<JSLocalDOMWindow>(vm, thisValue))
-        return makeUnique<JSEventTargetWrapper>(window->wrapped(), *window);
+        return { window->wrapped(), *window };
     if (auto* scope = toJSDOMGlobalObject<JSWorkerGlobalScope>(vm, thisValue))
-        return makeUnique<JSEventTargetWrapper>(scope->wrapped(), *scope);
-    return nullptr;
+        return { scope->wrapped(), *scope };
+    return { };
 }
 
 template<typename Visitor>

--- a/Source/WebCore/bindings/js/JSEventTargetCustom.h
+++ b/Source/WebCore/bindings/js/JSEventTargetCustom.h
@@ -34,23 +34,25 @@ namespace WebCore {
 
 // Wrapper type for JSEventTarget's castedThis because JSLocalDOMWindow and JSWorkerGlobalScope do not inherit JSEventTarget.
 class JSEventTargetWrapper {
-    WTF_MAKE_FAST_ALLOCATED;
 public:
+    JSEventTargetWrapper() = default;
+
     JSEventTargetWrapper(EventTarget& wrapped, JSC::JSObject& wrapper)
-        : m_wrapped(wrapped)
-        , m_wrapper(wrapper)
+        : m_wrapped(&wrapped)
+        , m_wrapper(&wrapper)
     { }
 
-    EventTarget& wrapped() { return m_wrapped; }
+    bool isNull() const { return !m_wrapped; }
+    EventTarget& wrapped() { ASSERT(m_wrapped); return *m_wrapped; }
 
-    operator JSC::JSObject&() { return m_wrapper; }
+    operator JSC::JSObject&() { ASSERT(m_wrapper); return *m_wrapper; }
 
 private:
-    EventTarget& m_wrapped;
-    JSC::JSObject& m_wrapper;
+    EventTarget* m_wrapped { nullptr };
+    JSC::JSObject* m_wrapper { nullptr };
 };
 
-std::unique_ptr<JSEventTargetWrapper> jsEventTargetCast(JSC::VM&, JSC::JSValue thisValue);
+JSEventTargetWrapper jsEventTargetCast(JSC::VM&, JSC::JSValue thisValue);
 
 template<> class IDLOperation<JSEventTarget> {
 public:
@@ -65,17 +67,16 @@ public:
 
         auto thisValue = callFrame.thisValue().toThis(&lexicalGlobalObject, JSC::ECMAMode::strict());
         auto thisObject = jsEventTargetCast(vm, thisValue.isUndefinedOrNull() ? JSC::JSValue(&lexicalGlobalObject) : thisValue);
-        if (UNLIKELY(!thisObject))
+        if (UNLIKELY(thisObject.isNull()))
             return throwThisTypeError(lexicalGlobalObject, throwScope, "EventTarget", operationName);
 
-        auto& wrapped = thisObject->wrapped();
-        if (is<LocalDOMWindow>(wrapped)) {
-            auto& window = downcast<LocalDOMWindow>(wrapped);
-            if (!window.frame() || !BindingSecurity::shouldAllowAccessToDOMWindow(&lexicalGlobalObject, window, ThrowSecurityError))
+        auto& wrapped = thisObject.wrapped();
+        if (auto window = dynamicDowncast<LocalDOMWindow>(wrapped)) {
+            if (!window->frame() || !BindingSecurity::shouldAllowAccessToDOMWindow(&lexicalGlobalObject, *window, ThrowSecurityError))
                 return JSC::JSValue::encode(JSC::jsUndefined());
         }
 
-        RELEASE_AND_RETURN(throwScope, (operation(&lexicalGlobalObject, &callFrame, thisObject.get())));
+        RELEASE_AND_RETURN(throwScope, (operation(&lexicalGlobalObject, &callFrame, &thisObject)));
     }
 
 };

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -147,9 +147,9 @@ void MouseEvent::initMouseEventQuirk(JSGlobalObject& state, ScriptExecutionConte
     if (MacApplication::isIAdProducer() || CocoaApplication::isIBooks()) {
         // jsEventTargetCast() does not throw and will silently convert bad input to nullptr.
         auto jsRelatedTarget = jsEventTargetCast(state.vm(), relatedTargetValue);
-        if (!jsRelatedTarget && !relatedTargetValue.isUndefinedOrNull())
+        if (jsRelatedTarget.isNull() && !relatedTargetValue.isUndefinedOrNull())
             scriptExecutionContext.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "Calling initMouseEvent() with a relatedTarget that is not an EventTarget is deprecated."_s);
-        relatedTarget = jsRelatedTarget ? &jsRelatedTarget->wrapped() : nullptr;
+        relatedTarget = jsRelatedTarget.isNull() ? nullptr : &jsRelatedTarget.wrapped();
     } else {
 #else
     UNUSED_PARAM(scriptExecutionContext);


### PR DESCRIPTION
#### fd7c1f2261ac273ed5b757ea85426aef4d00f37c
<pre>
Avoid heap allocation in jsEventTargetCast()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254672">https://bugs.webkit.org/show_bug.cgi?id=254672</a>

Reviewed by Darin Adler.

* Source/WebCore/bindings/js/JSEventTargetCustom.cpp:
(WebCore::jsEventTargetCast):
* Source/WebCore/bindings/js/JSEventTargetCustom.h:
(WebCore::JSEventTargetWrapper::JSEventTargetWrapper):
(WebCore::JSEventTargetWrapper::isValid const):
(WebCore::JSEventTargetWrapper::wrapped):
(WebCore::JSEventTargetWrapper::operator JSC::JSObject&amp;):
(WebCore::IDLOperation&lt;JSEventTarget&gt;::call):
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::initMouseEventQuirk):

Canonical link: <a href="https://commits.webkit.org/262294@main">https://commits.webkit.org/262294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/077a2af025f98a76c67a313edf8e0ec1d304bbba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/996 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1188 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1138 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1701 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1043 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1031 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2126 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1077 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1052 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/285 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1098 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->