### PR TITLE
[CSS] Implement CSSOM insertRule() on StyleRule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
@@ -1,13 +1,13 @@
 
-FAIL Simple CSSOM manipulation of subrules The operation is not supported.
-FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('& .broken {}', 3); }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException IndexSizeError: property "code" is equal to 9, expected 1
-FAIL Simple CSSOM manipulation of subrules 2 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('& .broken {}', -1); }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException IndexSizeError: property "code" is equal to 9, expected 1
-FAIL Simple CSSOM manipulation of subrules 3 assert_throws_dom: function "() => { ss.cssRules[0].deleteRule(5); }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException IndexSizeError: property "code" is equal to 9, expected 1
+PASS Simple CSSOM manipulation of subrules
+PASS Simple CSSOM manipulation of subrules 1
+PASS Simple CSSOM manipulation of subrules 2
+PASS Simple CSSOM manipulation of subrules 3
 PASS Simple CSSOM manipulation of subrules 4
-FAIL Simple CSSOM manipulation of subrules 5 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('% {}'); }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
+PASS Simple CSSOM manipulation of subrules 5
 PASS Simple CSSOM manipulation of subrules 6
-FAIL Simple CSSOM manipulation of subrules 7 The operation is not supported.
-PASS Simple CSSOM manipulation of subrules 8
-FAIL Simple CSSOM manipulation of subrules 9 assert_throws_dom: function "() => { ss.cssRules[0].insertRule('div & {}'); }" threw object "NotSupportedError: The operation is not supported." that is not a DOMException SyntaxError: property "code" is equal to 9, expected 12
+FAIL Simple CSSOM manipulation of subrules 7 assert_equals: @supports is added expected ".a {\n  color: red;\n  & .b { color: green; }\n  @supports selector(&) {\n  & div { font-size: 10px; }\n}\n  & .c { color: blue; }\n}" but got ".a {\n  color: red;\n  & .b { color: green; }\n  @supports selector(&) {\n}\n  & .c { color: blue; }\n}"
+FAIL Simple CSSOM manipulation of subrules 8 assert_equals: color is changed, new rule is ignored expected ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  & .c { color: blue; }\n}" but got ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  @supports selector(&) {\n}\n  & .c { color: blue; }\n}"
+FAIL Simple CSSOM manipulation of subrules 9 assert_equals: one rule is kept unchanged, the other is changed expected ".a {\n  color: red;\n  & .b { color: green; }\n  .c div.b &, div & { color: blue; }\n}" but got ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  @supports selector(&) {\n}\n  & .c { color: blue; }\n}"
 FAIL Simple CSSOM manipulation of subrules 10 assert_equals: invalid rule containing ampersand is kept in serialization expected ".a {\n  :is(!& .foo, .b) { color: green; }\n}" but got ".a {\n  :is(.b) { color: green; }\n}"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Simple CSSOM manipulation of subrules
-FAIL Simple CSSOM manipulation of subrules 1 assert_throws_dom: function "() => { ss.cssRules[0].cssRules[0].insertRule('@font-face {}', 0); }" did not throw
+PASS Simple CSSOM manipulation of subrules 1
 

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -47,6 +47,7 @@ protected:
     StyleRuleGroup& groupRule() { return m_groupRule; }
     void reattach(StyleRuleBase&) override;
     void appendCSSTextForItems(StringBuilder&) const;
+    RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&) override;
 
     // https://drafts.csswg.org/cssom/#serialize-a-css-rule
     void cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& rules) const;

--- a/Source/WebCore/css/CSSRule.cpp
+++ b/Source/WebCore/css/CSSRule.cpp
@@ -58,4 +58,21 @@ const CSSParserContext& CSSRule::parserContext() const
     return styleSheet ? styleSheet->contents().parserContext() : strictCSSParserContext();
 }
 
+bool CSSRule::hasStyleRuleAncestor() const
+{
+    auto current = this->parentRule();
+    while (current) {
+        if (current->styleRuleType() == StyleRuleType::Style)
+            return true;
+
+        current = current->parentRule();
+    }
+    return false;
+}
+
+RefPtr<StyleRuleWithNesting> CSSRule::prepareChildStyleRuleForNesting(StyleRule&)
+{
+    return nullptr;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -30,6 +30,8 @@ namespace WebCore {
 
 class CSSStyleSheet;
 class StyleRuleBase;
+class StyleRule;
+class StyleRuleWithNesting;
 
 struct CSSParserContext;
 
@@ -47,6 +49,8 @@ public:
     void setParentRule(CSSRule*);
     CSSStyleSheet* parentStyleSheet() const;
     CSSRule* parentRule() const { return m_parentIsRule ? m_parentRule : nullptr; }
+    bool hasStyleRuleAncestor() const;
+    virtual RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&);
 
     WEBCORE_EXPORT ExceptionOr<void> setCssText(const String&);
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "CSSStyleRule.h"
 
+#include "CSSGroupingRule.h"
 #include "CSSParser.h"
 #include "CSSRuleList.h"
 #include "CSSStyleSheet.h"
@@ -111,13 +112,10 @@ void CSSStyleRule::setSelectorText(const String& selectorText)
         return;
 
     CSSParser p(parserContext());
+    auto isNestedContext = hasStyleRuleAncestor() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No;
     auto* sheet = parentStyleSheet();
-    auto selectorList = p.parseSelector(selectorText, sheet ? &sheet->contents() : nullptr);
+    auto selectorList = p.parseSelector(selectorText, sheet ? &sheet->contents() : nullptr, isNestedContext);
     if (!selectorList)
-        return;
-
-    // FIXME: We don't support setting nesting parent selector by CSSOM
-    if (selectorList->hasExplicitNestingParent())
         return;
 
     // NOTE: The selector list has to fit into RuleData. <http://webkit.org/b/118369>
@@ -181,9 +179,10 @@ String CSSStyleRule::cssText() const
     return builder.toString();
 }
 
+// FIXME: share all methods below with CSSGroupingRule.
+
 void CSSStyleRule::cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& rules) const
 {
-    // FIXME: share this with CSSGroupingRule.
     for (unsigned index = 0 ; index < nestedRules().size() ; index++) {
         // We put the declarations at the upper level when the rule:
         // - is a style rule
@@ -191,7 +190,7 @@ void CSSStyleRule::cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& 
         // - has no child rules
         auto childRule = nestedRules()[index];
         if (childRule->isStyleRuleWithNesting()) {
-            auto& nestedStyleRule = downcast<StyleRuleWithNesting>(childRule.get());
+            auto& nestedStyleRule = downcast<StyleRuleWithNesting>(childRule);
             if (nestedStyleRule.originalSelectorList().hasOnlyNestingSelector() && nestedStyleRule.nestedRules().isEmpty()) {
                 decls.append(nestedStyleRule.properties().asText());
                 continue;
@@ -214,16 +213,57 @@ void CSSStyleRule::reattach(StyleRuleBase& rule)
         m_propertiesCSSOMWrapper->reattach(m_styleRule->mutableProperties());
 }
 
-ExceptionOr<unsigned> CSSStyleRule::insertRule(const String&, unsigned)
+ExceptionOr<unsigned> CSSStyleRule::insertRule(const String& ruleString, unsigned index)
 {
-    // FIXME: to implement (or use CSSGroupingRule).
-    return Exception { NotSupportedError };
+    ASSERT(m_childRuleCSSOMWrappers.size() == nestedRules().size());
+
+    if (index > nestedRules().size())
+        return Exception { IndexSizeError };
+
+    auto* styleSheet = parentStyleSheet();
+    RefPtr<StyleRuleBase> newRule = CSSParser::parseRule(parserContext(), styleSheet ? &styleSheet->contents() : nullptr, ruleString, CSSParserEnum::IsNestedContext::Yes);
+    if (!newRule)
+        return Exception { SyntaxError };
+    // We only accepts style rule or group rule (@media,...) inside style rules.
+    if (!newRule->isStyleRuleWithNesting() && !newRule->isGroupRule())
+        return Exception { HierarchyRequestError };
+
+    if (m_styleRule->isStyleRule()) {
+        // Call the parent rule (or parent stylesheet if top-level) to transform the current StyleRule to StyleRuleWithNesting.
+        auto parent = parentRule();
+        auto styleRuleWithNesting = parent ? parent->prepareChildStyleRuleForNesting(m_styleRule) : styleSheet->prepareChildStyleRuleForNesting(WTFMove(m_styleRule.get()));
+        ASSERT(styleRuleWithNesting);
+        m_styleRule = *styleRuleWithNesting;
+    }
+
+    CSSStyleSheet::RuleMutationScope mutationScope(this);
+    ASSERT(m_styleRule->isStyleRuleWithNesting());
+    downcast<StyleRuleWithNesting>(m_styleRule).nestedRules().insert(index, newRule.releaseNonNull());
+    m_childRuleCSSOMWrappers.insert(index, RefPtr<CSSRule>());
+    return index;
 }
 
-ExceptionOr<void> CSSStyleRule::deleteRule(unsigned)
+ExceptionOr<void> CSSStyleRule::deleteRule(unsigned index)
 {
-    // FIXME: to implement (or use CSSGroupingRule).
-    return Exception { NotSupportedError };
+    ASSERT(m_childRuleCSSOMWrappers.size() == nestedRules().size());
+
+    if (index >= nestedRules().size()) {
+        // IndexSizeError: Raised if the specified index does not correspond to a
+        // rule in the media rule list.
+        return Exception { IndexSizeError };
+    }
+
+    ASSERT(m_styleRule->isStyleRuleWithNesting());
+    auto& rules = downcast<StyleRuleWithNesting>(m_styleRule).nestedRules();
+    
+    CSSStyleSheet::RuleMutationScope mutationScope(this);
+    rules.remove(index);
+
+    if (m_childRuleCSSOMWrappers[index])
+        m_childRuleCSSOMWrappers[index]->setParentRule(nullptr);
+    m_childRuleCSSOMWrappers.remove(index);
+
+    return { };
 }
 
 unsigned CSSStyleRule::length() const

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -176,6 +176,20 @@ Node* CSSStyleSheet::ownerNode() const
     return m_ownerNode.get();
 }
 
+RefPtr<StyleRuleWithNesting> CSSStyleSheet::prepareChildStyleRuleForNesting(StyleRule&& styleRule)
+{
+    RuleMutationScope scope(this);
+    auto& rules = m_contents->m_childRules;
+    for (size_t i = 0 ; i < rules.size() ; i++) {
+        if (rules[i] == &styleRule) {
+            auto styleRuleWithNesting = StyleRuleWithNesting::create(WTFMove(styleRule));
+            rules[i] = styleRuleWithNesting.ptr();
+            return styleRuleWithNesting;
+        }        
+    }
+    return { };
+}
+
 CSSStyleSheet::WhetherContentsWereClonedForMutation CSSStyleSheet::willMutateRules()
 {
     // If we are the only client it is safe to mutate.

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -47,7 +47,10 @@ class DeferredPromise;
 class Document;
 class Element;
 class WeakPtrImplWithEventTargetData;
+class StyleRule;
+class StyleRuleBase;
 class StyleRuleKeyframes;
+class StyleRuleWithNesting;
 class StyleSheetContents;
 
 namespace Style {
@@ -117,6 +120,7 @@ public:
 
     bool hadRulesMutation() const { return m_mutatedRules; }
     void clearHadRulesMutation() { m_mutatedRules = false; }
+    RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&&);
 
     enum RuleMutationType { OtherMutation, RuleInsertion, KeyframesRuleMutation, RuleReplace };
     enum WhetherContentsWereClonedForMutation { ContentsWereNotClonedForMutation = 0, ContentsWereClonedForMutation };

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -315,12 +315,24 @@ StyleRuleWithNesting::StyleRuleWithNesting(const StyleRuleWithNesting& other)
     , m_nestedRules(other.m_nestedRules.map( [](auto& rule) { return rule->copy(); }))
     , m_originalSelectorList(other.m_originalSelectorList)
 {
+}
 
+StyleRuleWithNesting::StyleRuleWithNesting(StyleRule&& styleRule)
+    : StyleRule(WTFMove(styleRule))
+    , m_nestedRules({ })
+    , m_originalSelectorList(selectorList())
+{ 
+    setType(StyleRuleType::StyleWithNesting);
 }
 
 Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)
 { 
     return adoptRef(* new StyleRuleWithNesting(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(selectors), WTFMove(nestedRules)));
+}
+
+Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(StyleRule&& styleRule)
+{ 
+    return adoptRef(* new StyleRuleWithNesting(WTFMove(styleRule)));
 }
 
 StyleRuleWithNesting::StyleRuleWithNesting(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -64,7 +64,7 @@ public:
     bool isNamespaceRule() const { return type() == StyleRuleType::Namespace; }
     bool isMediaRule() const { return type() == StyleRuleType::Media; }
     bool isPageRule() const { return type() == StyleRuleType::Page; }
-    bool isStyleRule() const { return type() == StyleRuleType::Style || type() == StyleRuleType::StyleWithNesting; }
+    bool isStyleRule() const { return type() == StyleRuleType::Style; }
     bool isStyleRuleWithNesting() const { return type() == StyleRuleType::StyleWithNesting; }
     bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container; }
     bool isSupportsRule() const { return type() == StyleRuleType::Supports; }
@@ -158,15 +158,20 @@ class StyleRuleWithNesting final : public StyleRule {
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleWithNesting);
 public:
     static Ref<StyleRuleWithNesting> create(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+    static Ref<StyleRuleWithNesting> create(StyleRule&&);
     Ref<StyleRuleWithNesting> copy() const;
+    ~StyleRuleWithNesting();
 
     const Vector<Ref<StyleRuleBase>>& nestedRules() const { return m_nestedRules; }
+    Vector<Ref<StyleRuleBase>>& nestedRules() { return m_nestedRules; }
     const CSSSelectorList& originalSelectorList() const { return m_originalSelectorList; }
+
+protected:
     StyleRuleWithNesting(const StyleRuleWithNesting&);
-    ~StyleRuleWithNesting();
 
 private:
     StyleRuleWithNesting(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&, Vector<Ref<StyleRuleBase>>&& nestedRules);
+    StyleRuleWithNesting(StyleRule&&);
 
     Vector<Ref<StyleRuleBase>> m_nestedRules;
     CSSSelectorList m_originalSelectorList;
@@ -280,6 +285,9 @@ public:
 
     void wrapperInsertRule(unsigned, Ref<StyleRuleBase>&&);
     void wrapperRemoveRule(unsigned);
+
+    friend class CSSGroupingRule;
+    friend class CSSStyleSheet;
 
 protected:
     StyleRuleGroup(StyleRuleType, Vector<RefPtr<StyleRuleBase>>&&);

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -150,6 +150,8 @@ public:
 
     void setLoadErrorOccured() { m_didLoadErrorOccur = true; }
 
+    friend class CSSStyleSheet;
+
 private:
     WEBCORE_EXPORT StyleSheetContents(StyleRuleImport* ownerRule, const String& originalURL, const CSSParserContext&);
     StyleSheetContents(const StyleSheetContents&);

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -71,9 +71,9 @@ void CSSParser::parseSheetForInspector(const CSSParserContext& context, StyleShe
     return CSSParserImpl::parseStyleSheetForInspector(string, context, sheet, observer);
 }
 
-RefPtr<StyleRuleBase> CSSParser::parseRule(const CSSParserContext& context, StyleSheetContents* sheet, const String& string)
+RefPtr<StyleRuleBase> CSSParser::parseRule(const CSSParserContext& context, StyleSheetContents* sheet, const String& string, CSSParserEnum::IsNestedContext isNestedContext)
 {
-    return CSSParserImpl::parseRule(string, context, sheet, CSSParserImpl::AllowImportRules);
+    return CSSParserImpl::parseRule(string, context, sheet, CSSParserImpl::AllowImportRules, isNestedContext);
 }
 
 RefPtr<StyleRuleKeyframe> CSSParser::parseKeyframeRule(const String& string)

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -55,7 +55,7 @@ public:
 
     void parseSheet(StyleSheetContents&, const String&);
     
-    static RefPtr<StyleRuleBase> parseRule(const CSSParserContext&, StyleSheetContents*, const String&);
+    static RefPtr<StyleRuleBase> parseRule(const CSSParserContext&, StyleSheetContents*, const String&, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
     
     RefPtr<StyleRuleKeyframe> parseKeyframeRule(const String&);
     static Vector<double> parseKeyframeKeyList(const String&);

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -69,8 +69,9 @@ CSSParserImpl::CSSParserImpl(const CSSParserContext& context, StyleSheetContents
 {
 }
 
-CSSParserImpl::CSSParserImpl(const CSSParserContext& context, const String& string, StyleSheetContents* styleSheet, CSSParserObserverWrapper* wrapper)
-    : m_context(context)
+CSSParserImpl::CSSParserImpl(const CSSParserContext& context, const String& string, StyleSheetContents* styleSheet, CSSParserObserverWrapper* wrapper, CSSParserEnum::IsNestedContext isNestedContext)
+    : m_isAlwaysNestedContext(isNestedContext)
+    , m_context(context)
     , m_styleSheet(styleSheet)
     , m_tokenizer(wrapper ? CSSTokenizer::tryCreate(string, *wrapper) : CSSTokenizer::tryCreate(string))
     , m_observerWrapper(wrapper)
@@ -166,9 +167,9 @@ bool CSSParserImpl::parseDeclarationList(MutableStyleProperties* declaration, co
     return declaration->addParsedProperties(results);
 }
 
-RefPtr<StyleRuleBase> CSSParserImpl::parseRule(const String& string, const CSSParserContext& context, StyleSheetContents* styleSheet, AllowedRulesType allowedRules)
+RefPtr<StyleRuleBase> CSSParserImpl::parseRule(const String& string, const CSSParserContext& context, StyleSheetContents* styleSheet, AllowedRulesType allowedRules, CSSParserEnum::IsNestedContext isNestedContext)
 {
-    CSSParserImpl parser(context, string, styleSheet);
+    CSSParserImpl parser(context, string, styleSheet, nullptr, isNestedContext);
     CSSParserTokenRange range = parser.tokenizer()->tokenRange();
     range.consumeWhitespace();
     if (range.atEnd())
@@ -1162,7 +1163,7 @@ void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange
                 auto rule = consumeQualifiedRule(range, AllowedRulesType::RegularRules);
                 if (!rule)
                     break;
-                if (!rule->isStyleRule())
+                if (!rule->isStyleRuleWithNesting())
                     break;
                 topContext().m_parsedRules.append(*rule);
                 break;

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -71,7 +71,7 @@ class MutableStyleProperties;
 class CSSParserImpl {
     WTF_MAKE_NONCOPYABLE(CSSParserImpl);
 public:
-    CSSParserImpl(const CSSParserContext&, const String&, StyleSheetContents* = nullptr, CSSParserObserverWrapper* = nullptr);
+    CSSParserImpl(const CSSParserContext&, const String&, StyleSheetContents* = nullptr, CSSParserObserverWrapper* = nullptr, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
 
     enum AllowedRulesType {
         // As per css-syntax, css-cascade and css-namespaces, @charset rules
@@ -94,7 +94,7 @@ public:
     static CSSParser::ParseResult parseCustomPropertyValue(MutableStyleProperties*, const AtomString& propertyName, const String&, bool important, const CSSParserContext&);
     static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(const String&, const Element*);
     static bool parseDeclarationList(MutableStyleProperties*, const String&, const CSSParserContext&);
-    static RefPtr<StyleRuleBase> parseRule(const String&, const CSSParserContext&, StyleSheetContents*, AllowedRulesType);
+    static RefPtr<StyleRuleBase> parseRule(const String&, const CSSParserContext&, StyleSheetContents*, AllowedRulesType, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
     static void parseStyleSheet(const String&, const CSSParserContext&, StyleSheetContents&);
     static CSSSelectorList parsePageSelector(CSSParserTokenRange, StyleSheetContents*);
 
@@ -181,9 +181,10 @@ private:
     }
     bool isNestedContext()
     {
-        return m_styleRuleNestingDepth && context().cssNestingEnabled;
+        return (m_isAlwaysNestedContext == CSSParserEnum::IsNestedContext::Yes || m_styleRuleNestingDepth) && context().cssNestingEnabled;
     }
 
+    CSSParserEnum::IsNestedContext m_isAlwaysNestedContext { CSSParserEnum::IsNestedContext::No }; // Do we directly start in a nested context (for CSSOM)
     unsigned m_styleRuleNestingDepth { 0 };
     Vector<NestingContext> m_nestingContextStack { NestingContext { } };
     const CSSParserContext& m_context;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -143,6 +143,11 @@ CSSSelectorList CSSSelectorParser::consumeRelativeSelectorList(CSSParserTokenRan
 
 CSSSelectorList CSSSelectorParser::consumeNestedSelectorList(CSSParserTokenRange& range)
 {
+    // We explicitely avoid starting a nested selector list with ident-like token
+    // This is already handled by parsing algorithm, but the CSSOM can bypass it.
+    if (range.peek().type() == IdentToken || range.peek().type() == FunctionToken)
+        return { };
+
     return consumeSelectorList(range, [&] (CSSParserTokenRange& range) {
         return consumeNestedComplexSelector(range);
     });


### PR DESCRIPTION
#### 90d00dc15a7b02dda4a6088e22cbdc363b66e567
<pre>
[CSS] Implement CSSOM insertRule() on StyleRule
<a href="https://bugs.webkit.org/show_bug.cgi?id=254601">https://bugs.webkit.org/show_bug.cgi?id=254601</a>
rdar://107322119

Reviewed by Antti Koivisto.

This patch handles the transformation of old-school StyleRule object (without a children vector)
to a StyleRuleWithNesting object when necessary.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalid-inner-rules-expected.txt:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::insertRule):
(WebCore::CSSGroupingRule::prepareChildStyleRuleForNesting):
* Source/WebCore/css/CSSGroupingRule.h:
* Source/WebCore/css/CSSRule.cpp:
(WebCore::CSSRule::hasStyleRuleAncestor const):
(WebCore::CSSRule::prepareChildStyleRuleForNesting):
* Source/WebCore/css/CSSRule.h:
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::setSelectorText):
(WebCore::CSSStyleRule::cssTextForDeclsAndRules const):
(WebCore::CSSStyleRule::insertRule):
(WebCore::CSSStyleRule::deleteRule):
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::prepareChildStyleRuleForNesting):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::m_originalSelectorList):
(WebCore::StyleRuleWithNesting::StyleRuleWithNesting):
(WebCore::StyleRuleWithNesting::create):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isStyleRule const):
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseRule):
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::CSSParserImpl):
(WebCore::CSSParserImpl::parseRule):
(WebCore::CSSParserImpl::consumeDeclarationListOrStyleBlockHelper):
* Source/WebCore/css/parser/CSSParserImpl.h:
(WebCore::CSSParserImpl::isNestedContext):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeNestedSelectorList):

Canonical link: <a href="https://commits.webkit.org/262394@main">https://commits.webkit.org/262394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ccfeda58e0829671bef12d783629a6a00d2bfb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2358 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1393 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2092 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1204 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1227 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1259 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2392 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1166 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1231 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/355 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1311 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->