### PR TITLE
Avoid smart pointers where we can use convinence initializers

### DIFF
--- a/Source/JavaScriptCore/API/JSContext.mm
+++ b/Source/JavaScriptCore/API/JSContext.mm
@@ -417,10 +417,10 @@
 + (JSContext *)contextWithJSGlobalContextRef:(JSGlobalContextRef)globalContext
 {
     JSVirtualMachine *virtualMachine = [JSVirtualMachine virtualMachineWithContextGroupRef:toRef(&toJS(globalContext)->vm())];
-    auto context = retainPtr([virtualMachine contextForGlobalContextRef:globalContext]);
+    JSContext *context = [virtualMachine contextForGlobalContextRef:globalContext];
     if (!context)
-        context = adoptNS([[JSContext alloc] initWithGlobalContextRef:globalContext]);
-    return context.autorelease();
+        context = [[[JSContext alloc] initWithGlobalContextRef:globalContext] autorelease];
+    return context;
 }
 
 @end

--- a/Source/JavaScriptCore/API/JSManagedValue.mm
+++ b/Source/JavaScriptCore/API/JSManagedValue.mm
@@ -61,14 +61,14 @@ static JSManagedValueHandleOwner& managedValueHandleOwner()
 
 + (JSManagedValue *)managedValueWithValue:(JSValue *)value
 {
-    return adoptNS([[self alloc] initWithValue:value]).autorelease();
+    return [[[self alloc] initWithValue:value] autorelease];
 }
 
 + (JSManagedValue *)managedValueWithValue:(JSValue *)value andOwner:(id)owner
 {
-    auto managedValue = adoptNS([[self alloc] initWithValue:value]);
-    [value.context.virtualMachine addManagedReference:managedValue.get() withOwner:owner];
-    return managedValue.autorelease();
+    JSManagedValue *managedValue = [[self alloc] initWithValue:value];
+    [value.context.virtualMachine addManagedReference:managedValue withOwner:owner];
+    return [managedValue autorelease];
 }
 
 - (instancetype)init

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -408,7 +408,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
             return [attachmentView accessibilityElements];
     }
 
-    auto array = adoptNS([[NSMutableArray alloc] init]);
+    NSMutableArray *array = [NSMutableArray array];
     for (const auto& child : self.axBackingObject->children()) {
         auto* wrapper = child->wrapper();
         if (child->isAttachment()) {
@@ -425,7 +425,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     }
 #endif
 
-    return array.autorelease();
+    return array;
 }
 
 - (NSInteger)accessibilityElementCount

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -544,15 +544,15 @@ static NSDictionary *textReplacementChangeDictionary(AXCoreObject& object, AXTex
     NSUInteger length = [text length];
     if (!length)
         return nil;
-    auto change = adoptNS([[NSMutableDictionary alloc] initWithCapacity:4]);
+    NSMutableDictionary *change = [NSMutableDictionary dictionaryWithCapacity:4];
     [change setObject:@(platformEditTypeForWebCoreEditType(type)) forKey:NSAccessibilityTextEditType];
     if (length > AXValueChangeTruncationLength) {
         [change setObject:@(length) forKey:NSAccessibilityTextChangeValueLength];
         text = [text substringToIndex:AXValueChangeTruncationLength];
     }
     [change setObject:text forKey:NSAccessibilityTextChangeValue];
-    addTextMarkerFor(change.get(), object, markerTarget);
-    return change.autorelease();
+    addTextMarkerFor(change, object, markerTarget);
+    return change;
 }
 
 void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject* object, AXTextEditType type, const String& text, const VisiblePosition& position)

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -409,15 +409,13 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
     RefPtr<AXCoreObject> backingObject = [self baseUpdateBackingStore];
     if (!backingObject)
         return nil;
-    
-    RetainPtr<NSMutableArray<AXCustomContent *>> accessibilityCustomContent = nil;
+
     auto extendedDescription = backingObject->extendedDescription();
-    if (extendedDescription.length()) {
-        accessibilityCustomContent = adoptNS([[NSMutableArray alloc] init]);
-        [accessibilityCustomContent addObject:[PAL::getAXCustomContentClass() customContentWithLabel:WEB_UI_STRING("description", "description detail") value:extendedDescription]];
+    if (!extendedDescription.length()) {
+        return nil;
     }
-    
-    return accessibilityCustomContent.autorelease();
+
+    return @[ [PAL::getAXCustomContentClass() customContentWithLabel:WEB_UI_STRING("description", "description detail") value:extendedDescription] ];
 }
 #endif
 

--- a/Source/WebCore/bridge/objc/WebScriptObject.mm
+++ b/Source/WebCore/bridge/objc/WebScriptObject.mm
@@ -116,7 +116,7 @@ id createJSWrapper(JSC::JSObject* object, RefPtr<JSC::Bindings::RootObject>&& or
 {
     if (id wrapper = getJSWrapper(object))
         return wrapper;
-    return adoptNS([[WebScriptObject alloc] _initWithJSObject:object originRootObject:WTFMove(origin) rootObject:WTFMove(root)]).autorelease();
+    return [[[WebScriptObject alloc] _initWithJSObject:object originRootObject:WTFMove(origin) rootObject:WTFMove(root)] autorelease];
 }
 
 static void addExceptionToConsole(JSC::JSGlobalObject* lexicalGlobalObject, JSC::Exception* exception)
@@ -648,11 +648,11 @@ static void getListFromNSArray(JSC::JSGlobalObject* lexicalGlobalObject, NSArray
 
 @implementation WebUndefined
 
-+ (instancetype)allocWithZone:(NSZone *)zone
++ (instancetype)alloc
 {
     static NeverDestroyed<RetainPtr<WebUndefined>> sharedUndefined;
     if (!sharedUndefined.get())
-        sharedUndefined.get() = adoptNS([super allocWithZone:zone]);
+        sharedUndefined.get() = adoptNS([super alloc]);
     return [sharedUndefined.get() retain];
 }
 
@@ -708,7 +708,7 @@ IGNORE_WARNINGS_END
 
 + (WebUndefined *)undefined
 {
-    return adoptNS([[WebUndefined alloc] init]).autorelease();
+    return [[[WebUndefined alloc] init] autorelease];
 }
 
 @end

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -231,7 +231,7 @@ static BOOL resultIsURL(DDResultRef result)
     if (!result)
         return NO;
     
-    static NeverDestroyed<RetainPtr<NSSet>> urlTypes = [NSSet setWithObjects:
+    static NeverDestroyed<RetainPtr<NSSet>> urlTypes = [[NSSet alloc] initWithObjects:
         (NSString *)PAL::get_DataDetectorsCore_DDBinderHttpURLKey(),
         (NSString *)PAL::get_DataDetectorsCore_DDBinderWebURLKey(),
         (NSString *)PAL::get_DataDetectorsCore_DDBinderMailURLKey(),

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
@@ -147,14 +147,13 @@ void AudioSessionIOS::setPresentingProcesses(Vector<audit_token_t>&& auditTokens
     if (![session respondsToSelector:@selector(setAuditTokensForProcessAssertion:error:)])
         return;
 
-    auto nsAuditTokens = adoptNS([[NSMutableArray alloc] init]);
+    NSMutableArray *nsAuditTokens = [NSMutableArray arrayWithCapacity:auditTokens.size()];
     for (auto& token : auditTokens) {
-        auto nsToken = adoptNS([[NSData alloc] initWithBytes:token.val length:sizeof(token.val)]);
-        [nsAuditTokens addObject:nsToken.get()];
+        [nsAuditTokens addObject:[NSData dataWithBytes:token.val length:sizeof(token.val)]];
     }
 
     NSError *error = nil;
-    [session setAuditTokensForProcessAssertion:nsAuditTokens.get() error:&error];
+    [session setAuditTokensForProcessAssertion:nsAuditTokens error:&error];
     if (error)
         RELEASE_LOG_ERROR(Media, "Failed to set audit tokens for process assertion with error: %@", error.localizedDescription);
 #else

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -257,9 +257,9 @@ ImageDecoderCG::ImageDecoderCG(FragmentedSharedBuffer& data, AlphaOption, GammaA
         utiHint = adoptCF(CGImageSourceGetTypeWithData(data.makeContiguous()->createCFData().get(), nullptr, nullptr));
     
     if (utiHint) {
-        const void* key = kCGImageSourceTypeIdentifierHint;
-        const void* value = utiHint.get();
-        auto options = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, &key, &value, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+        CFTypeRef key[] = { kCGImageSourceTypeIdentifierHint };
+        CFTypeRef value[] = { utiHint.get() };
+        auto options = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, key, value, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
         m_nativeDecoder = adoptCF(CGImageSourceCreateIncremental(options.get()));
     } else
         m_nativeDecoder = adoptCF(CGImageSourceCreateIncremental(nullptr));

--- a/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
+++ b/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
@@ -75,7 +75,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSArray<NSString *> *)web_fileUploadContentTypes
 {
-    auto types = adoptNS([NSMutableArray new]);
+    auto types = [NSMutableArray array];
     for (NSString *identifier in self.registeredTypeIdentifiers) {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (UTTypeConformsTo((__bridge CFStringRef)identifier, kUTTypeURL))
@@ -92,7 +92,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             [types addObject:identifier];
     }
 
-    return types.autorelease();
+    return types;
 }
 
 @end
@@ -571,7 +571,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (_loadResults.isEmpty())
         return @[ ];
 
-    auto values = adoptNS([[NSMutableArray alloc] init]);
+    NSMutableArray *values = [NSMutableArray array];
     RetainPtr<WebItemProviderPasteboard> retainedSelf = self;
     [itemSet enumerateIndexesUsingBlock:[retainedSelf, pasteboardType, values] (NSUInteger index, BOOL *) {
         NSItemProvider *provider = [retainedSelf itemProviderAtIndex:index];
@@ -581,7 +581,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (NSData *loadedData = [retainedSelf _preLoadedDataConformingToType:pasteboardType forItemProviderAtIndex:index])
             [values addObject:loadedData];
     }];
-    return values.autorelease();
+    return values;
 }
 
 static NSArray<Class<NSItemProviderReading>> *allLoadableClasses()
@@ -617,7 +617,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (_loadResults.isEmpty())
         return @[ ];
 
-    auto values = adoptNS([[NSMutableArray alloc] init]);
+    NSMutableArray *values = [NSMutableArray array];
     RetainPtr<WebItemProviderPasteboard> retainedSelf = self;
     [itemSet enumerateIndexesUsingBlock:[retainedSelf, pasteboardType, values] (NSUInteger index, BOOL *) {
         NSItemProvider *provider = [retainedSelf itemProviderAtIndex:index];
@@ -637,7 +637,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             [values addObject:readObject];
     }];
 
-    return values.autorelease();
+    return values;
 }
 
 - (NSInteger)changeCount
@@ -647,9 +647,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSArray<NSURL *> *)fileUploadURLsAtIndex:(NSUInteger)index fileTypes:(NSArray<NSString *> **)outFileTypes
 {
-    auto fileTypes = adoptNS([NSMutableArray new]);
-    auto fileURLs = adoptNS([NSMutableArray new]);
-
     if (index >= _loadResults.size())
         return @[ ];
 
@@ -657,6 +654,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (![result canBeRepresentedAsFileUpload])
         return @[ ];
 
+    NSMutableArray *fileTypes = [NSMutableArray array];
+    NSMutableArray *fileURLs = [NSMutableArray array];
     for (NSString *contentType in [result itemProvider].web_fileUploadContentTypes) {
         if (NSURL *url = [result fileURLForType:contentType]) {
             [fileTypes addObject:contentType];
@@ -664,8 +663,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
     }
 
-    *outFileTypes = fileTypes.autorelease();
-    return fileURLs.autorelease();
+    *outFileTypes = fileTypes;
+    return fileURLs;
 }
 
 - (NSArray<NSURL *> *)allDroppedFileURLs

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
@@ -503,12 +503,12 @@ NS_ASSUME_NONNULL_END
     if (_invalidated)
         return nil;
 
-    auto task = adoptNS([[WebCoreNSURLSessionDataTask alloc] initWithSession:self identifier:++_nextTaskIdentifier request:request]);
+    WebCoreNSURLSessionDataTask *task = [[WebCoreNSURLSessionDataTask alloc] initWithSession:self identifier:++_nextTaskIdentifier request:request];
     {
         Locker<Lock> locker(_dataTasksLock);
-        _dataTasks.add(task.get());
+        _dataTasks.add(task);
     }
-    return (NSURLSessionDataTask *)task.autorelease();
+    return [(NSURLSessionDataTask *)task autorelease];
 }
 
 - (NSURLSessionDataTask *)dataTaskWithURL:(NSURL *)url
@@ -786,22 +786,22 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
 
 - (NSURLRequest *)originalRequest
 {
-    return adoptNS([_originalRequest copy]).autorelease();
+    return [[_originalRequest copy] autorelease];
 }
 
 - (NSURLRequest *)currentRequest
 {
-    return adoptNS([_currentRequest copy]).autorelease();
+    return [[_currentRequest copy] autorelease];
 }
 
 - (NSError *)error
 {
-    return adoptNS([_error copy]).autorelease();
+    return [[_error copy] autorelease];
 }
 
 - (NSString *)taskDescription
 {
-    return adoptNS([_taskDescription copy]).autorelease();
+    return [[_taskDescription copy] autorelease];
 }
 
 - (void)setTaskDescription:(NSString *)description

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -118,7 +118,7 @@ static PKPaymentErrorCode toPKPaymentErrorCode(WebCore::ApplePayErrorCode code)
 
 static NSError *toNSError(const WebCore::ApplePayError& error)
 {
-    auto userInfo = adoptNS([[NSMutableDictionary alloc] init]);
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
     [userInfo setObject:error.message() forKey:NSLocalizedDescriptionKey];
 
     if (auto contactField = error.contactField()) {
@@ -192,7 +192,7 @@ static NSError *toNSError(const WebCore::ApplePayError& error)
             [userInfo setObject:postalAddressKey forKey:PKPaymentErrorPostalAddressUserInfoKey];
     }
 
-    return [NSError errorWithDomain:PKPaymentErrorDomain code:toPKPaymentErrorCode(error.code()) userInfo:userInfo.get()];
+    return [NSError errorWithDomain:PKPaymentErrorDomain code:toPKPaymentErrorCode(error.code()) userInfo:userInfo];
 }
 
 static RetainPtr<NSArray> toNSErrors(const Vector<RefPtr<WebCore::ApplePayError>>& errors)

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -1144,11 +1144,11 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
     if (!_allowedClasses)
         return [NSSet set];
 
-    auto result = adoptNS([[NSMutableSet alloc] init]);
+    NSMutableSet *result = [NSMutableSet set];
     for (auto allowedClass : *_allowedClasses)
         [result addObject:(__bridge Class)allowedClass];
 
-    return result.autorelease();
+    return result;
 }
 
 @end

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm
@@ -184,14 +184,14 @@ static void initializeMethods(_WKRemoteObjectInterface *interface, Protocol *pro
 
 - (NSString *)debugDescription
 {
-    auto result = adoptNS([[NSMutableString alloc] initWithFormat:@"<%@: %p; protocol = \"%@\"; identifier = \"%@\"\n", NSStringFromClass(self.class), self, _identifier.get(), NSStringFromProtocol(_protocol)]);
+    NSMutableString *result = [NSMutableString stringWithFormat:@"<%@: %p; protocol = \"%@\"; identifier = \"%@\"\n", NSStringFromClass(self.class), self, _identifier.get(), NSStringFromProtocol(_protocol)];
 
     auto descriptionForClasses = [](auto& allowedClasses) {
-        auto result = adoptNS([[NSMutableString alloc] initWithString:@"["]);
+        NSMutableString *result = [NSMutableString stringWithString:@"["];
         bool needsComma = false;
 
         auto descriptionForArgument = [](auto& allowedArgumentClasses) {
-            auto result = adoptNS([[NSMutableString alloc] initWithString:@"{"]);
+            NSMutableString *result = [NSMutableString stringWithString:@"{"];
 
             auto orderedArgumentClasses = copyToVector(allowedArgumentClasses);
             std::sort(orderedArgumentClasses.begin(), orderedArgumentClasses.end(), [](CFTypeRef a, CFTypeRef b) {
@@ -208,7 +208,7 @@ static void initializeMethods(_WKRemoteObjectInterface *interface, Protocol *pro
             }
 
             [result appendString:@"}"];
-            return result.autorelease();
+            return result;
         };
 
         for (auto& argumentClasses : allowedClasses) {
@@ -220,7 +220,7 @@ static void initializeMethods(_WKRemoteObjectInterface *interface, Protocol *pro
         }
 
         [result appendString:@"]"];
-        return result.autorelease();
+        return result;
     };
 
     for (auto& selectorAndMethod : _methods) {
@@ -231,7 +231,7 @@ static void initializeMethods(_WKRemoteObjectInterface *interface, Protocol *pro
     }
 
     [result appendString:@">\n"];
-    return result.autorelease();
+    return result;
 }
 
 static HashSet<CFTypeRef>& classesForSelectorArgument(_WKRemoteObjectInterface *interface, SEL selector, NSUInteger argumentIndex, bool replyBlock)

--- a/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfiguration.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfiguration.mm
@@ -64,10 +64,10 @@ std::optional<PaymentSetupConfiguration> PaymentSetupConfiguration::decode(IPC::
     static NeverDestroyed<RetainPtr<NSArray>> allowedClasses;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        auto allowed = adoptNS([[NSMutableArray alloc] initWithCapacity:1]);
         if (auto pkPaymentSetupConfigurationClass = PAL::getPKPaymentSetupConfigurationClass())
-            [allowed addObject:pkPaymentSetupConfigurationClass];
-        allowedClasses.get() = adoptNS([allowed copy]);
+            allowedClasses.get() = @[ pkPaymentSetupConfigurationClass ];
+        else
+            allowedClasses.get() = @[];
     });
 
     auto configuration = IPC::decode<PKPaymentSetupConfiguration>(decoder, allowedClasses.get().get());

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -181,19 +181,19 @@ static constexpr NSString *baseURLKey = @"WK.baseURL";
     BOOL hasBaseURL;
     [coder decodeValueOfObjCType:"c" at:&hasBaseURL size:sizeof(hasBaseURL)];
 
-    RetainPtr<NSURL> baseURL;
+    NSURL *baseURL = nil;
     if (hasBaseURL)
         baseURL = (NSURL *)[coder decodeObjectOfClass:NSURL.class forKey:baseURLKey];
 
     NSUInteger length;
     if (auto bytes = (UInt8 *)[coder decodeBytesWithReturnedLength:&length]) {
-        m_wrappedURL = bridge_cast(adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, length, kCFStringEncodingUTF8, bridge_cast(baseURL.get()), true)));
+        m_wrappedURL = bridge_cast(adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, length, kCFStringEncodingUTF8, bridge_cast(baseURL), true)));
         if (!m_wrappedURL)
             LOG_ERROR("Failed to decode NSURL due to invalid encoding of length %d. Substituting a blank URL", length);
     }
 
     if (!m_wrappedURL)
-        m_wrappedURL = [NSURL URLWithString:@""];
+        m_wrappedURL = [[NSURL alloc] initWithString:@""];
 
     return selfPtr.leakRef();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -116,13 +116,13 @@ static NSString *dataTypesToString(NSSet *dataTypes)
 
 - (NSString *)description
 {
-    auto result = adoptNS([[NSMutableString alloc] initWithFormat:@"<%@: %p; displayName = %@; dataTypes = { %@ }", NSStringFromClass(self.class), self, self.displayName, dataTypesToString(self.dataTypes)]);
+    NSMutableString *result = [NSMutableString stringWithFormat:@"<%@: %p; displayName = %@; dataTypes = { %@ }", NSStringFromClass(self.class), self, self.displayName, dataTypesToString(self.dataTypes)];
 
     if (auto* dataSize = self._dataSize)
         [result appendFormat:@"; _dataSize = { %llu bytes }", dataSize.totalSize];
 
     [result appendString:@">"];
-    return result.autorelease();
+    return result;
 }
 
 - (NSString *)displayName

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -444,12 +444,12 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 + (void)_fetchAllIdentifiers:(void(^)(NSArray<NSUUID *> *))completionHandler
 {
     auto completionHandlerCopy = makeBlockPtr(completionHandler);
-    WebKit::WebsiteDataStore::fetchAllDataStoreIdentifiers([completionHandlerCopy](auto&& identifiers) {
-        auto result = adoptNS([[NSMutableArray alloc] initWithCapacity:identifiers.size()]);
+    WebKit::WebsiteDataStore::fetchAllDataStoreIdentifiers([completionHandlerCopy](auto &&identifiers) {
+        NSMutableArray *result = [NSMutableArray arrayWithCapacity:identifiers.size()];
         for (auto identifier : identifiers)
             [result addObject:(NSUUID *)identifier];
 
-        completionHandlerCopy(result.autorelease());
+        completionHandlerCopy(result);
     });
 }
 
@@ -1050,11 +1050,11 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 -(void)_getAllBackgroundFetchIdentifiers:(void(^)(NSArray<NSString *> *identifiers))completionHandler
 {
 #if ENABLE(SERVICE_WORKER)
-    _websiteDataStore->networkProcess().getAllBackgroundFetchIdentifiers(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)] (auto identifiers) {
-        auto result = adoptNS([[NSMutableArray alloc] initWithCapacity:identifiers.size()]);
+    _websiteDataStore->networkProcess().getAllBackgroundFetchIdentifiers(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)](auto identifiers) {
+        NSMutableArray *result = [NSMutableArray arrayWithCapacity:identifiers.size()];
         for (auto identifier : identifiers)
             [result addObject:(NSString *)identifier];
-        completionHandler(result.autorelease());
+        completionHandler(result);
     });
 #else
     completionHandler(nil);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
@@ -60,11 +60,12 @@ IGNORE_WARNINGS_END
 
 + (instancetype)downloadWithDownload:(WKDownload *)download
 {
-    if (_WKDownload *wrapper = [downloadWrapperMap() objectForKey:download])
+    _WKDownload *wrapper;
+    if ((wrapper = [downloadWrapperMap() objectForKey:download]))
         return wrapper;
-    auto wrapper = adoptNS([[_WKDownload alloc] initWithDownload2:download]);
-    [downloadWrapperMap() setObject:wrapper.get() forKey:download];
-    return wrapper.autorelease();
+    wrapper = [[_WKDownload alloc] initWithDownload2:download];
+    [downloadWrapperMap() setObject:wrapper forKey:download];
+    return [wrapper autorelease];
 }
 
 - (void)cancel

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -735,7 +735,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
     }
     credentialMap[cbor::CBORValue(WebCore::applicationTagKey)] = cbor::CBORValue(WTFMove(*decodedResponse));
     auto serializedCredential = cbor::CBORWriter::write(cbor::CBORValue(WTFMove(credentialMap)));
-    return adoptNS([[NSData alloc] initWithBytes:serializedCredential.value().data() length:serializedCredential.value().size()]).autorelease();
+    return [NSData dataWithBytes:serializedCredential.value().data() length:serializedCredential.value().size()];
 #else
     return nullptr;
 #endif // ENABLE(WEB_AUTHN)
@@ -1109,14 +1109,13 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
 
 + (NSData *)encodeMakeCredentialCommandWithClientDataJSON:(NSData *)clientDataJSON options:(_WKPublicKeyCredentialCreationOptions *)options userVerificationAvailability:(_WKWebAuthenticationUserVerificationAvailability)userVerificationAvailability authenticatorSupportedExtensions:(NSArray<NSString *> *)authenticatorSupportedExtensions
 {
-    RetainPtr<NSData> encodedCommand;
 #if ENABLE(WEB_AUTHN)
     auto hash = produceClientDataJsonHash(clientDataJSON);
     auto encodedVector = fido::encodeMakeCredentialRequestAsCBOR(hash, [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), fido::AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
-    encodedCommand = adoptNS([[NSData alloc] initWithBytes:encodedVector.data() length:encodedVector.size()]);
+    return [NSData dataWithBytes:encodedVector.data() length:encodedVector.size()];
+#else
+    return nil;
 #endif
-
-    return encodedCommand.autorelease();
 }
 
 + (NSData *)encodeGetAssertionCommandWithClientDataJSON:(NSData *)clientDataJSON options:(_WKPublicKeyCredentialRequestOptions *)options userVerificationAvailability:(_WKWebAuthenticationUserVerificationAvailability)userVerificationAvailability
@@ -1126,14 +1125,13 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
 
 + (NSData *)encodeGetAssertionCommandWithClientDataJSON:(NSData *)clientDataJSON options:(_WKPublicKeyCredentialRequestOptions *)options userVerificationAvailability:(_WKWebAuthenticationUserVerificationAvailability)userVerificationAvailability authenticatorSupportedExtensions:(NSArray<NSString *> *)authenticatorSupportedExtensions
 {
-    RetainPtr<NSData> encodedCommand;
 #if ENABLE(WEB_AUTHN)
     auto hash = produceClientDataJsonHash(clientDataJSON);
     auto encodedVector = fido::encodeGetAssertionRequestAsCBOR(hash, [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
-    encodedCommand = adoptNS([[NSData alloc] initWithBytes:encodedVector.data() length:encodedVector.size()]);
+    return [NSData dataWithBytes:encodedVector.data() length:encodedVector.size()];
+#else
+    return nil;
 #endif
-
-    return encodedCommand.autorelease();
 }
 
 + (NSData *)encodeMakeCredentialCommandWithClientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialCreationOptions *)options userVerificationAvailability:(_WKWebAuthenticationUserVerificationAvailability)userVerificationAvailability
@@ -1143,13 +1141,12 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
 
 + (NSData *)encodeMakeCredentialCommandWithClientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialCreationOptions *)options userVerificationAvailability:(_WKWebAuthenticationUserVerificationAvailability)userVerificationAvailability authenticatorSupportedExtensions:(NSArray<NSString *> *)authenticatorSupportedExtensions
 {
-    RetainPtr<NSData> encodedCommand;
 #if ENABLE(WEB_AUTHN)
     auto encodedVector = fido::encodeMakeCredentialRequestAsCBOR(vectorFromNSData(clientDataHash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), fido::AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
-    encodedCommand = adoptNS([[NSData alloc] initWithBytes:encodedVector.data() length:encodedVector.size()]);
+    return [NSData dataWithBytes:encodedVector.data() length:encodedVector.size()];
+#else
+    return nil;
 #endif
-
-    return encodedCommand.autorelease();
 }
 
 + (NSData *)encodeGetAssertionCommandWithClientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialRequestOptions *)options userVerificationAvailability:(_WKWebAuthenticationUserVerificationAvailability)userVerificationAvailability
@@ -1159,13 +1156,12 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
 
 + (NSData *)encodeGetAssertionCommandWithClientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialRequestOptions *)options userVerificationAvailability:(_WKWebAuthenticationUserVerificationAvailability)userVerificationAvailability authenticatorSupportedExtensions:(NSArray<NSString *> *)authenticatorSupportedExtensions
 {
-    RetainPtr<NSData> encodedCommand;
 #if ENABLE(WEB_AUTHN)
     auto encodedVector = fido::encodeGetAssertionRequestAsCBOR(vectorFromNSData(clientDataHash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
-    encodedCommand = adoptNS([[NSData alloc] initWithBytes:encodedVector.data() length:encodedVector.size()]);
+    return [NSData dataWithBytes:encodedVector.data() length:encodedVector.size()];
+#else
+    return nil;
 #endif
-
-    return encodedCommand.autorelease();
 }
 
 - (void)setMockConfiguration:(NSDictionary *)configuration

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -958,7 +958,7 @@ NSString *WebExtension::generatedBackgroundContent()
         return [NSString stringWithFormat:@"<script src=\"%@\"></script>", scriptPath];
     });
 
-    m_generatedBackgroundContent = [NSString stringWithFormat:@"<!DOCTYPE html>\n<body>\n%@\n</body>", [scriptTagsArray componentsJoinedByString:@"\n"]];
+    m_generatedBackgroundContent = [[NSString alloc] initWithFormat:@"<!DOCTYPE html>\n<body>\n%@\n</body>", [scriptTagsArray componentsJoinedByString:@"\n"]];
 
     return m_generatedBackgroundContent.get();
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
@@ -115,7 +115,7 @@ void CcidConnection::transact(Vector<uint8_t>&& data, DataReceivedCallback&& cal
     [m_smartCard beginSessionWithReply:makeBlockPtr([this, data = WTFMove(data), callback = WTFMove(callback)] (BOOL success, NSError *error) mutable {
         if (!success)
             return;
-        [m_smartCard transmitRequest:adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]).autorelease() reply:makeBlockPtr([this, callback = WTFMove(callback)](NSData * _Nullable nsResponse, NSError * _Nullable error) mutable {
+        [m_smartCard transmitRequest:[NSData dataWithBytes:data.data() length:data.size()] reply:makeBlockPtr([this, callback = WTFMove(callback)](NSData * _Nullable nsResponse, NSError * _Nullable error) mutable {
             [m_smartCard endSession];
             callOnMainRunLoop([response = vectorFromNSData(nsResponse), callback = WTFMove(callback)] () mutable {
                 callback(WTFMove(response));

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -593,8 +593,9 @@ void LocalAuthenticator::continueMakeCredentialAfterAttested(Vector<uint8_t>&& c
     cbor::CBORValue::MapValue attestationStatementMap;
     {
         Vector<cbor::CBORValue> cborArray;
-        for (size_t i = 0; i < [certificates count]; i++)
-            cborArray.append(cbor::CBORValue(vectorFromNSData((NSData *)adoptCF(SecCertificateCopyData((__bridge SecCertificateRef)certificates[i])).get())));
+        cborArray.reserveInitialCapacity([certificates count]);
+        for (id certificate in certificates)
+            cborArray.append(cbor::CBORValue(vectorFromNSData((NSData *)adoptCF(SecCertificateCopyData((__bridge SecCertificateRef)certificate)).get())));
         attestationStatementMap[cbor::CBORValue("x5c")] = cbor::CBORValue(WTFMove(cborArray));
     }
     auto attestationObject = buildAttestationObject(WTFMove(authData), "apple"_s, WTFMove(attestationStatementMap), creationOptions.attestation);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
@@ -81,7 +81,8 @@
 #if USE(APPKIT)
     return adoptNS([[NSImage alloc] initWithCGImage:nativeImage->platformImage().get() size:NSZeroSize]).autorelease();
 #else
-    return adoptNS([[UIImage alloc] initWithCGImage:nativeImage->platformImage().get()]).autorelease();
+    // imageWithCGImage exists for UIImage, but not NSImage
+    return [UIImage imageWithCGImage:nativeImage->platformImage().get()];
 #endif
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -252,7 +252,7 @@ void InjectedBundle::extendClassesForParameterCoder(API::Array& classes)
 NSSet* InjectedBundle::classesForCoder()
 {
     if (!m_classesForCoder)
-        m_classesForCoder = [NSSet setWithObjects:[NSArray class], [NSData class], [NSDate class], [NSDictionary class], [NSNull class], [NSNumber class], [NSSet class], [NSString class], [NSTimeZone class], [NSURL class], [NSUUID class], [WKBrowsingContextHandle class], nil];
+        m_classesForCoder = [[NSSet alloc] initWithObjects:[NSArray class], [NSData class], [NSDate class], [NSDictionary class], [NSNull class], [NSNumber class], [NSSet class], [NSString class], [NSTimeZone class], [NSURL class], [NSUUID class], [WKBrowsingContextHandle class], nil];
 
     return m_classesForCoder.get();
 }

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -531,19 +531,19 @@ void WebProcess::updateProcessName(IsInProcessInitialization isInProcessInitiali
     RetainPtr<NSString> applicationName;
     switch (m_processType) {
     case ProcessType::Inspector:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Inspector", "Visible name of Web Inspector's web process. The argument is the application name."), (NSString *)m_uiProcessName];
+        applicationName = [[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Inspector", "Visible name of Web Inspector's web process. The argument is the application name."), (NSString *)m_uiProcessName];
         break;
     case ProcessType::ServiceWorker:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Service Worker (%@)", "Visible name of Service Worker process. The argument is the application name."), (NSString *)m_uiProcessName, (NSString *)m_registrableDomain.string()];
+        applicationName = [[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Service Worker (%@)", "Visible name of Service Worker process. The argument is the application name."), (NSString *)m_uiProcessName, (NSString *)m_registrableDomain.string()];
         break;
     case ProcessType::PrewarmedWebContent:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Prewarmed)", "Visible name of the web process. The argument is the application name."), (NSString *)m_uiProcessName];
+        applicationName = [[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Prewarmed)", "Visible name of the web process. The argument is the application name."), (NSString *)m_uiProcessName];
         break;
     case ProcessType::CachedWebContent:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Cached)", "Visible name of the web process. The argument is the application name."), (NSString *)m_uiProcessName];
+        applicationName = [[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Cached)", "Visible name of the web process. The argument is the application name."), (NSString *)m_uiProcessName];
         break;
     case ProcessType::WebContent:
-        applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Web Content", "Visible name of the web process. The argument is the application name."), (NSString *)m_uiProcessName];
+        applicationName = [[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content", "Visible name of the web process. The argument is the application name."), (NSString *)m_uiProcessName];
         break;
     }
 

--- a/Source/WebKitLegacy/mac/Misc/WebNSObjectExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSObjectExtras.mm
@@ -69,7 +69,7 @@ static bool returnTypeIsObject(NSInvocation *invocation)
         // Now autorelease it on the calling thread.
         id returnValue;
         [invocation getReturnValue:&returnValue];
-        adoptNS(returnValue).autorelease();
+        [returnValue autorelease];
     }
 }
 
@@ -111,12 +111,12 @@ static bool returnTypeIsObject(NSInvocation *invocation)
 
 + (id)_webkit_invokeOnMainThread
 {
-    return adoptNS([[WebMainThreadInvoker alloc] initWithTarget:self]).autorelease();
+    return [[[WebMainThreadInvoker alloc] initWithTarget:self] autorelease];
 }
 
 - (id)_webkit_invokeOnMainThread
 {
-    return adoptNS([[WebMainThreadInvoker alloc] initWithTarget:self]).autorelease();
+    return [[[WebMainThreadInvoker alloc] initWithTarget:self] autorelease];
 }
 
 @end

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginContainerCheck.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginContainerCheck.mm
@@ -72,7 +72,7 @@
 
 + (id)checkWithRequest:(NSURLRequest *)request target:(NSString *)target resultObject:(id)obj selector:(SEL)selector controller:(id <WebPluginContainerCheckController>)controller contextInfo:(id)contextInfo /*optional*/
 {
-    return adoptNS([[self alloc] initWithRequest:request target:target resultObject:obj selector:selector controller:controller contextInfo:contextInfo]).autorelease();
+    return [[[self alloc] initWithRequest:request target:target resultObject:obj selector:selector controller:controller contextInfo:contextInfo] autorelease];
 }
 
 - (void)dealloc

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
@@ -439,7 +439,7 @@ static RetainPtr<NSArray>& additionalWebPlugInPaths()
 {
     NSMutableSet *newPlugins = [NSMutableSet set];
     NSEnumerator *directoryEnumerator = [[self _plugInPaths] objectEnumerator];
-    auto uniqueFilenames = adoptNS([[NSMutableSet alloc] init]);
+    NSMutableSet *uniqueFilenames = [NSMutableSet set];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSString *pluginDirectory;
     while ((pluginDirectory = [directoryEnumerator nextObject]) != nil) {

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -910,11 +910,10 @@ void WebFrameLoaderClient::dispatchUnableToImplementPolicy(const WebCore::Resour
 static NSDictionary *makeFormFieldValuesDictionary(WebCore::FormState& formState)
 {
     auto& textFieldValues = formState.textFieldValues();
-    size_t size = textFieldValues.size();
-    auto dictionary = adoptNS([[NSMutableDictionary alloc] initWithCapacity:size]);
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithCapacity:textFieldValues.size()];
     for (auto& value : textFieldValues)
         [dictionary setObject:value.second forKey:value.first];
-    return dictionary.autorelease();
+    return dictionary;
 }
 
 void WebFrameLoaderClient::dispatchWillSendSubmitEvent(Ref<WebCore::FormState>&& formState)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -797,7 +797,7 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
 
 - (NSArray *)webView:(WebView *)sender contextMenuItemsForElement:(NSDictionary *)element defaultMenuItems:(NSArray *)defaultMenuItems
 {
-    auto menuItems = adoptNS([[NSMutableArray alloc] init]);
+    NSMutableArray *menuItems = [NSMutableArray array];
 
     for (NSMenuItem *item in defaultMenuItems) {
         switch (item.tag) {
@@ -814,7 +814,7 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
         }
     }
 
-    return menuItems.autorelease();
+    return menuItems;
 }
 
 // MARK: -

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -1138,28 +1138,29 @@ static NSControlStateValue kit(TriState state)
 
 + (NSArray *)_excludedElementsForAttributedStringConversion
 {
-    auto elements = adoptNS([[NSMutableArray alloc] initWithObjects:
+#if !ENABLE(ATTACHMENT_ELEMENT)
+    return @[
+#else
+    NSMutableArray *elements = [NSMutableArray arrayWithObjects:
+#endif
         // Omit style since we want style to be inline so the fragment can be easily inserted.
         @"style",
         // Omit xml so the result is not XHTML.
-        @"xml",
-        // Omit tags that will get stripped when converted to a fragment anyway.
         @"doctype", @"html", @"head", @"body",
         // Omit deprecated tags.
         @"applet", @"basefont", @"center", @"dir", @"font", @"menu", @"s", @"strike", @"u",
-        // Omit object so no file attachments are part of the fragment.
 #if !ENABLE(ATTACHMENT_ELEMENT)
         // Omit object so no file attachments are part of the fragment.
-        @"object",
-#endif
-        nil]);
+        @"object"
+    ];
+#else
+    nil];
 
-#if ENABLE(ATTACHMENT_ELEMENT)
     if (!WebCore::DeprecatedGlobalSettings::attachmentElementEnabled())
         [elements addObject:@"object"];
-#endif
 
-    return elements.autorelease();
+    return elements;
+#endif
 }
 
 - (DOMDocumentFragment *)_documentFragmentFromPasteboard:(NSPasteboard *)pasteboard inContext:(DOMRange *)context allowPlainText:(BOOL)allowPlainText
@@ -3733,7 +3734,7 @@ static RetainPtr<NSArray> customMenuFromDefaultItems(WebView *webView, const Web
     if (![menuItems count])
         return nil;
 
-    auto menu = adoptNS([[NSMenu alloc] init]);
+    NSMenu *menu = [[NSMenu alloc] init];
 
     for (NSMenuItem *item in menuItems.get()) {
         [menu addItem:item];
@@ -3748,7 +3749,7 @@ static RetainPtr<NSArray> customMenuFromDefaultItems(WebView *webView, const Web
 
     [[WebMenuTarget sharedMenuTarget] setMenuController:&page->contextMenuController()];
     
-    return menu.autorelease();
+    return [menu autorelease];
 }
 
 #endif // PLATFORM(MAC)
@@ -6962,9 +6963,9 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
 - (NSArray *)pasteboardTypesForSelection
 {
     if ([self _canSmartCopyOrDelete]) {
-        auto types = adoptNS([[[self class] _selectionPasteboardTypes] mutableCopy]);
+        NSMutableArray *types = [[[self class] _selectionPasteboardTypes] mutableCopy];
         [types addObject:WebSmartPastePboardType];
-        return types.autorelease();
+        return [types autorelease];
     }
     return [[self class] _selectionPasteboardTypes];
 }
@@ -7001,7 +7002,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
 - (NSAttributedString *)_legacyAttributedStringFrom:(DOMNode *)startContainer offset:(int)startOffset to:(DOMNode *)endContainer offset:(int)endOffset
 {
     if (!startContainer || !endContainer)
-        return adoptNS([[NSAttributedString alloc] init]).autorelease();
+        return [[[NSAttributedString alloc] init] autorelease];
     return attributedString(WebCore::SimpleRange { { *core(startContainer), static_cast<unsigned>(startOffset) },
         { *core(endContainer), static_cast<unsigned>(endOffset) } }).nsAttributedString().autorelease();
 }
@@ -7010,7 +7011,7 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
 {
     auto document = core([[self _frame] DOMDocument]);
     if (!document)
-        return adoptNS([[NSAttributedString alloc] init]).autorelease();
+        return [[[NSAttributedString alloc] init] autorelease];
     auto range = makeRangeSelectingNodeContents(*document);
     if (auto result = attributedString(range).nsAttributedString())
         return result.autorelease();
@@ -7021,10 +7022,10 @@ static CGImageRef selectionImage(WebCore::LocalFrame* frame, bool forceBlackText
 {
     auto frame = core([self _frame]);
     if (!frame)
-        return adoptNS([[NSAttributedString alloc] init]).autorelease();
+        return [[[NSAttributedString alloc] init] autorelease];
     auto range = frame->selection().selection().firstRange();
     if (!range)
-        return adoptNS([[NSAttributedString alloc] init]).autorelease();
+        return [[[NSAttributedString alloc] init] autorelease];
     if (auto result = attributedString(*range).nsAttributedString())
         return result.autorelease();
     return editingAttributedString(*range).nsAttributedString().autorelease();

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -885,13 +885,13 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
         [attributedString addAttribute:NSForegroundColorAttributeName value:[NSColor colorWithDeviceWhite:0.0f alpha:1.0f] range:wholeStringRange];
     [attributedString endEditing];
     
-    auto selectionImage = adoptNS([[NSImage alloc] initWithSize:[self selectionRect].size]);
+    NSImage *selectionImage = [[NSImage alloc] initWithSize:[self selectionRect].size];
     
     [selectionImage lockFocus];
     [attributedString drawAtPoint:NSZeroPoint];
     [selectionImage unlockFocus];
 
-    return selectionImage.autorelease();
+    return [selectionImage autorelease];
 }
 
 - (NSRect)selectionImageRect
@@ -1335,8 +1335,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (scaleFactor == 1.0)
         return unscaledAttributedString;
     
-    auto result = adoptNS([unscaledAttributedString mutableCopy]);
-    unsigned int length = [result length];
+    NSMutableAttributedString *result = [unscaledAttributedString mutableCopy];
+    NSUInteger length = [result length];
     NSRange effectiveRange = NSMakeRange(0,0);
     
     [result beginEditing];    
@@ -1347,7 +1347,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             // FIXME: We can't scale the font if we don't know what it is. We should always know what it is,
             // but sometimes don't due to PDFKit issue 5089411. When that's addressed, we can remove this
             // early continue.
-            LOG_ERROR("no font attribute found in range %@ for attributed string \"%@\" on page %@ (see radar 5089411)", NSStringFromRange(effectiveRange), result.get(), [[dataSource request] URL]);
+            LOG_ERROR("no font attribute found in range %@ for attributed string \"%@\" on page %@ (see radar 5089411)", NSStringFromRange(effectiveRange), result, [[dataSource request] URL]);
             continue;
         }
         
@@ -1356,7 +1356,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
     [result endEditing];
     
-    return result.autorelease();
+    return [result autorelease];
 }
 
 - (void)_setTextMatches:(NSArray *)array

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -339,12 +339,12 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 #if !PLATFORM(IOS_FAMILY)
 - (NSFileWrapper *)_fileWrapperRepresentation
 {
-    auto wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:[self data]]);
+    NSFileWrapper *wrapper = [[NSFileWrapper alloc] initRegularFileWithContents:[self data]];
     NSString *filename = [self _suggestedFilename];
     if (!filename || ![filename length])
         filename = [[self URL] _webkit_suggestedFilenameWithMIMEType:[self MIMEType]];
     [wrapper setPreferredFilename:filename];
-    return wrapper.autorelease();
+    return [wrapper autorelease];
 }
 #endif
 
@@ -355,7 +355,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     NSURLResponse *response = nil;
     if (_private->coreResource)
         response = _private->coreResource->response().nsURLResponse();
-    return response ? response : adoptNS([[NSURLResponse alloc] init]).autorelease();
+    return response ? response : [[[NSURLResponse alloc] init] autorelease];
 }
 
 - (NSString *)_stringValue

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -2708,15 +2708,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return nil;
     }
 
-    unsigned count = [menuItems count];
-    if (!count)
+    if (![menuItems count])
         return nil;
 
-    auto menu = adoptNS([[NSMenu alloc] init]);
-    for (unsigned i = 0; i < count; i++)
-        [menu addItem:[menuItems objectAtIndex:i]];
+    NSMenu *menu = [[NSMenu alloc] init];
+    for (NSMenuItem *item in items)
+        [menu addItem:item];
 
-    return menu.autorelease();
+    return [menu autorelease];
 }
 #endif
 
@@ -4030,7 +4029,7 @@ IGNORE_WARNINGS_END
     auto intRect = WebCore::enclosingIntRect(rect);
     auto range = WebCore::VisibleSelection(coreFrame->visiblePositionForPoint(intRect.minXMinYCorner()),
         coreFrame->visiblePositionForPoint(intRect.maxXMaxYCorner())).toNormalizedRange();
-    return adoptNS([[WebTextIterator alloc] initWithRange:kit(range)]).autorelease();
+    return [[[WebTextIterator alloc] initWithRange:kit(range)] autorelease];
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -5210,14 +5209,14 @@ IGNORE_WARNINGS_END
     NSMutableDictionary *viewTypes = [WebFrameView _viewTypesAllowImageTypeOmission:YES];
     NSEnumerator *enumerator = [viewTypes keyEnumerator];
     id key;
-    auto array = adoptNS([[NSMutableArray alloc] init]);
+    NSMutableArray *array = [NSMutableArray array];
 
     while ((key = [enumerator nextObject])) {
         if ([viewTypes objectForKey:key] == [WebHTMLView class])
             [array addObject:key];
     }
 
-    return array.autorelease();
+    return array;
 }
 
 + (void)setMIMETypesShownAsHTML:(NSArray *)MIMETypes
@@ -5230,11 +5229,10 @@ IGNORE_WARNINGS_END
             [WebView _unregisterViewClassAndRepresentationClassForMIMEType:key];
     }
 
-    int i, count = [MIMETypes count];
-    for (i = 0; i < count; i++) {
+    for (NSString *MIMEType in MIMETypes) {
         [WebView registerViewClass:[WebHTMLView class]
                 representationClass:[WebHTMLRepresentation class]
-                forMIMEType:[MIMETypes objectAtIndex:i]];
+                forMIMEType:MIMEType];
     }
 }
 


### PR DESCRIPTION
#### cbd682e8d2841580e93f0c2622355ac49dcca9f4
<pre>
Avoid smart pointers where we can use convinence initializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=254676">https://bugs.webkit.org/show_bug.cgi?id=254676</a>

Reviewed by NOBODY (OOPS!).

There is no reason to retain or worry about objects that are known to be
autoreleased, such as those from convenience initializers.

* Source/JavaScriptCore/API/JSContext.mm:
* Source/JavaScriptCore/API/JSManagedValue.mm:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
* Source/WebCore/bridge/objc/WebScriptObject.mm:
* Source/WebCore/editing/cocoa/DataDetection.mm:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
* Source/WebCore/platform/ios/WebItemProviderPasteboard.mm:
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm:
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm:
* Source/WebKit/Shared/ApplePay/cocoa/PaymentSetupConfiguration.mm:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm:
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
* Source/WebKitLegacy/mac/Misc/WebNSObjectExtras.mm:
* Source/WebKitLegacy/mac/Plugins/WebPluginContainerCheck.mm:
* Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
* Source/WebKitLegacy/mac/WebView/WebResource.mm:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7e7395d954fca6ee35e95cc7d666c7c3958af09

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3199 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4958 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3306 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3370 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3034 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3282 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4736 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3473 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3036 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3770 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3306 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/953 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3317 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3862 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3560 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1066 "Passed tests") | 
<!--EWS-Status-Bubble-End-->