### PR TITLE
[UI-side compositing] Fix for assert in scrollbar tests: scrollerImp == scroller->scrollerImp()

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -59,6 +59,7 @@ public:
     NSScrollerImp *scrollerImp() { return m_scrollerImp.get(); }
     void setScrollerImp(NSScrollerImp *imp) { m_scrollerImp = imp; }
     void updateScrollbarStyle();
+    void updatePairScrollerImps();
 
     FloatPoint convertFromContent(const FloatPoint&) const;
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -343,11 +343,7 @@ void ScrollerMac::setHostLayer(CALayer *layer)
 
     [m_scrollerImp setLayer:layer];
 
-    NSScrollerImp *scrollerImp = layer ? m_scrollerImp.get() : nil;
-    if (m_orientation == ScrollbarOrientation::Vertical)
-        m_pair.setVerticalScrollerImp(scrollerImp);
-    else
-        m_pair.setHorizontalScrollerImp(scrollerImp);
+    updatePairScrollerImps();
 }
 
 void ScrollerMac::updateValues()
@@ -368,11 +364,21 @@ void ScrollerMac::updateValues()
 void ScrollerMac::updateScrollbarStyle()
 {
     m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:NSControlSizeRegular horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:takeScrollerImp().get()];
+    updatePairScrollerImps();
 }
 
 FloatPoint ScrollerMac::convertFromContent(const FloatPoint& point) const
 {
     return FloatPoint { [m_hostLayer convertPoint:point fromLayer:[m_hostLayer superlayer]] };
+}
+
+void ScrollerMac::updatePairScrollerImps()
+{
+    NSScrollerImp *scrollerImp = m_hostLayer ? m_scrollerImp.get() : nil;
+    if (m_orientation == ScrollbarOrientation::Vertical)
+        m_pair.setVerticalScrollerImp(scrollerImp);
+    else
+        m_pair.setHorizontalScrollerImp(scrollerImp);
 }
 
 String ScrollerMac::scrollbarState() const


### PR DESCRIPTION
#### 3fb91e2c59ba4db706f2ace5cf12bc71b3db9ddd
<pre>
[UI-side compositing] Fix for assert in scrollbar tests: scrollerImp == scroller-&gt;scrollerImp()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254678">https://bugs.webkit.org/show_bug.cgi?id=254678</a>
rdar://107380404

Reviewed by Simon Fraser.

We need to update the ScrollerPairMac for the new NSScrollerImps created
in ScrollerMac::updateScrollbarStyle.

* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::setHostLayer):
(WebCore::ScrollerMac::updateScrollbarStyle):
(WebCore::ScrollerMac::updatePairScrollerImps):

Canonical link: <a href="https://commits.webkit.org/262301@main">https://commits.webkit.org/262301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a63aa649aadc486a783e7b9657f22aee7f068af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1853 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1199 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1145 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1037 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1038 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1077 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2129 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1085 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1003 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1057 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1106 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/115 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->