### PR TITLE
[ews-build.webkit.org] Classify commits in pull-requests

### DIFF
--- a/Tools/CISupport/ews-build/events_unittest.py
+++ b/Tools/CISupport/ews-build/events_unittest.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2021 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from events import CommitClassifier
+
+
+class TestCommitClassifier(unittest.TestCase):
+    def test_regex_header_filter(self):
+        self.assertTrue(CommitClassifier.HeaderFilter('^[Vv]ersioning\\.?$')('Versioning.'))
+        self.assertTrue(CommitClassifier.HeaderFilter('^[Vv]ersioning\\.?$')('versioning.'))
+        self.assertTrue(CommitClassifier.HeaderFilter('^[Vv]ersioning\\.?$')('Versioning'))
+
+        self.assertFalse(CommitClassifier.HeaderFilter('^[Vv]ersioning\\.?$')('Bumped versioning'))
+        self.assertFalse(CommitClassifier.HeaderFilter('^[Vv]ersioning\\.?$')('Versioning bumped.'))
+
+    def test_fuzzy_header_filter(self):
+        self.assertTrue(CommitClassifier.HeaderFilter({"value": "gardening", "ratio": 85})('[Gardening] Skip n tests'))
+        self.assertTrue(CommitClassifier.HeaderFilter({"value": "gardening", "ratio": 85})('[girdening] Skip n tests'))
+
+        self.assertFalse(CommitClassifier.HeaderFilter({"value": "gardening", "ratio": 85})('[gdening] Skip n tests'))
+
+    def test_commit_class_gardening(self):
+        c = CommitClassifier(
+            name='Gardening',
+            pickable=False,
+            headers=[dict(value='gardening', ratio=85)],
+            paths=[
+                'LayoutTests/',
+                'Tools/TestWebKitAPI',
+            ],
+        )
+        self.assertEqual(c.name, 'Gardening')
+        self.assertFalse(c.pickable)
+        self.assertTrue(c.matches('[Gardening] Skip n tests', ['LayoutTests/TestExpectations']))
+
+        self.assertFalse(c.matches('[Gardening] Skip n tests', []))
+        self.assertFalse(c.matches('[gdening] Skip n tests', ['LayoutTests/TestExpectations']))
+        self.assertFalse(c.matches('[Gardening] Skip n tests', ['Makefile', 'LayoutTests/TestExpectations']))
+
+    def test_commit_class_cherry_pick(self):
+        c = CommitClassifier(
+            name='Cherry-pick',
+            pickable=False,
+            headers=['^[Cc]herry[- ][Pp]ick'],
+        )
+        self.assertEqual(c.name, 'Cherry-pick')
+        self.assertFalse(c.pickable)
+        self.assertTrue(c.matches('Cherry-pick abcde', ['somefile']))
+        self.assertTrue(c.matches('cherry-pick abcde', ['otherfile']))
+        self.assertTrue(c.matches('Cherry-Pick abcde', []))
+        self.assertTrue(c.matches('cherry pick abcde', []))
+
+        self.assertFalse(c.matches('Partial cherry-pick', []))
+        self.assertFalse(c.matches('Took cherry-pick', []))
+
+    def test_commit_class_tools(self):
+        c = CommitClassifier(
+            name='Tools',
+            pickable=True,
+            paths=['Tools', 'LayoutTests', 'metadata'],
+        )
+        self.assertEqual(c.name, 'Tools')
+        self.assertTrue(c.pickable)
+        self.assertTrue(c.matches('Some change', ['Tools/Scripts/git-webkit']))
+        self.assertTrue(c.matches('', ['LayoutTests/some/test.html']))
+        self.assertTrue(c.matches('', ['metadata/contributors.json']))
+        self.assertTrue(c.matches('', ['Tools/Scripts/run-webkit-tests', 'metadata/commit_classes.json']))
+
+        self.assertFalse(c.matches('', []))
+        self.assertFalse(c.matches('', ['metadata/contributors.json', 'Makefile']))

--- a/Tools/CISupport/runUnittests.py
+++ b/Tools/CISupport/runUnittests.py
@@ -48,6 +48,7 @@ def main():
     if args.autoinstall and os.path.isdir(os.path.join(scripts, 'webkitpy')):
         sys.path.insert(0, scripts)
         import webkitpy
+        import rapidfuzz
         from webkitpy.autoinstalled import buildbot
 
     # This is work-around for https://bugs.webkit.org/show_bug.cgi?id=222361


### PR DESCRIPTION
#### 07098ea5d9313615068f339e7f7471b21bfaa9ba
<pre>
[ews-build.webkit.org] Classify commits in pull-requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=254680">https://bugs.webkit.org/show_bug.cgi?id=254680</a>
rdar://107381451

Reviewed by Aakash Jain.

Many EWS steps preform rudimentry and divergent classification of commits.
For example, merge-queue preforms less validation on gardening commits and reverts.
The WebKit Project has a concept of &apos;commit classification&apos; that `git-webkit` uses
to determine which changes on a given branch are novel. To pave the way for EWS to
use the &apos;commit classification&apos; concept, buildrequests need &apos;classification&apos; as one
of their properties.

* Tools/CISupport/ews-build/events.py:
(logging_disabled.__exit__):
(CommitClassifier): Add a class which encapsulates the concept of a commit classification.
(CommitClassifier.HeaderFilter): Add class encapsulating both a regex and fuzzy match
filter to search the title of commits with.
(GitHubEventHandlerNoEdits.commit_classes): Return a cached list of all CommitClassifier
bjects for the WebKit project.
(GitHubEventHandlerNoEdits._get_commit_msg): Clarify why we&apos;re implementing our own
&quot;_get_commit_messages&quot; and (delibrately) disabling this one.
(GitHubEventHandlerNoEdits._get_commit_messages): Return a list of the commit messages
for the commits in this pull request.
(GitHubEventHandlerNoEdits.classifiy): Given a commit message and list of changed
files, return a string representing the CommitClassifier of the provided commit message,
if the commit message matches one of our commit classes.
(GitHubEventHandlerNoEdits.handle_pull_request): Before returning a change, determine
the classification of all commits in the pull-request, so that information can be
included in properties.
* Tools/CISupport/ews-build/events_unittest.py: Added.
* Tools/CISupport/runUnittests.py:
(main): Explicitly import rapidfuzz, since that is an uncommon dependency.

Canonical link: <a href="https://commits.webkit.org/262332@main">https://commits.webkit.org/262332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1820399d48e8e17e37c1dc5520822218a0244402

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1279 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/1314 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/1354 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/2098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/1266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/1367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/1383 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/2098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/1290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/1367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/1354 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1952 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/1367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/1354 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/1952 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/1173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/1354 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1952 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1221 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/1383 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/1269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/1354 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/1248 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/126 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->