### PR TITLE
Re-import css/css-conditional WPT

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1952,8 +1952,9 @@ imported/w3c/web-platform-tests/css/css-conditional/at-supports-046.html [ Image
 imported/w3c/web-platform-tests/css/css-conditional/at-supports-namespace-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-conditional/at-supports-namespace-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-conditional/css-supports-036.xht [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-format-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-tech-001.html [ ImageOnlyFailure ]
+webkit.org/b/254679 imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-format-001.html [ ImageOnlyFailure ]
+webkit.org/b/252153 imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-tech-001.html [ ImageOnlyFailure ]
+webkit.org/b/254682 imported/w3c/web-platform-tests/css/css-conditional/at-supports-047.html [ ImageOnlyFailure ]
 
 transitions/svg-text-shadow-transition.html [ Failure ]
 webkit.org/b/137883 transitions/background-transitions.html [ Failure Pass ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -999,6 +999,7 @@
         "web-platform-tests/css/css-conditional/at-supports-001-ref.html",
         "web-platform-tests/css/css-conditional/at-supports-027-ref.html",
         "web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-forgiving-argument-ref.html",
+        "web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations-ref.html",
         "web-platform-tests/css/css-conditional/support/at-media-dynamic-001-inner.html",
         "web-platform-tests/css/css-conditional/support/pass.xht",
         "web-platform-tests/css/css-contain/contain-inline-size-bfc-floats-001-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-047-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-047-expected.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CSS Reftest Reference</title>
+		<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+		<link rel="author" href="http://opera.com" title="Opera Software ASA">
+		<style>
+			div {
+				background-color:green;
+				height:100px;
+				width:100px;
+			}
+		</style>
+	</head>
+	<body>
+		<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+		<div></div>
+	</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-047.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-047.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+	<head>
+		<title>CSS Test (Conditional Rules): In @supports, pseudo elements can be parsed successfully</title>
+		<link rel="author" title="Jan Nicklas" href="https://twitter.com/jantimon">
+		<link rel="help" href="http://www.w3.org/TR/css3-conditional/#at-supports">
+		<link rel="match" href="at-supports-001-ref.html">
+		<style>
+			div {
+				background:red;
+				height:100px;
+				width:100px;
+			}
+			@supports selector(input::placeholder) {
+				div { background-color:green; }
+			}
+		</style>
+	</head>
+	<body>
+		<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+		<div></div>
+	</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-tech-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-tech-001.html
@@ -7,10 +7,10 @@
 <style>
   div {
     background: red;
-    height: 12.5px;
+    height: 10px;
     width: 100px;
   }
-  /* assume all browsers support at least feature-opentype and color-COLRv0 */
+  /* assume all browsers support at least features-opentype and color-COLRv0 */
   @supports font-tech(features-opentype) {
     #test1 { background: green };
   }
@@ -36,6 +36,12 @@
   @supports not font-tech("features-opentype") {
     #test8 { background: green };
   }
+  @supports not font-tech(feature-opentype) {
+    #test9 { background: green };
+  }
+  @supports not font-tech(colors-COLRv0) {
+    #test10 { background: green };
+  }
 </style>
 <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
 <div id=test1></div>
@@ -46,3 +52,5 @@
 <div id=test6></div>
 <div id=test7></div>
 <div id=test8></div>
+<div id=test9></div>
+<div id=test10></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations-expected.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>CSS Conditional Test: @supports selector() detecting invalid in forgiving argument.</title>
+<title>CSS Conditional Test: @supports selector() detecting invalid in logical combinations.</title>
 <link rel="author" title="Byungwoo Lee" href="mailto:blee@igalia.com">
 <style>
   div {
@@ -9,6 +9,8 @@
   }
 </style>
 <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div></div>
+<div></div>
 <div></div>
 <div></div>
 <div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations-ref.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>CSS Conditional Test: @supports selector() detecting invalid in forgiving argument.</title>
+<title>CSS Conditional Test: @supports selector() detecting invalid in logical combinations.</title>
 <link rel="author" title="Byungwoo Lee" href="mailto:blee@igalia.com">
 <style>
   div {
@@ -9,6 +9,8 @@
   }
 </style>
 <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div></div>
+<div></div>
 <div></div>
 <div></div>
 <div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations.html
@@ -1,8 +1,8 @@
 <!doctype html>
-<title>CSS Conditional Test: @supports selector() detecting invalid in forgiving argument.</title>
+<title>CSS Conditional Test: @supports selector() detecting invalid in logical combinations.</title>
 <link rel="author" title="Byungwoo Lee" href="mailto:blee@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-conditional/#at-supports">
-<link rel="match" href="at-supports-selector-detecting-invalid-in-forgiving-argument-ref.html">
+<link rel="match" href="at-supports-selector-detecting-invalid-in-logical-combinations-ref.html">
 <style>
   div.invalid {
     background-color: green;
@@ -23,6 +23,9 @@
   @supports selector(:has(.a)) {
     div.has.valid { background: green };
   }
+  @supports selector(:not(.a)) {
+    div.not.valid { background: green };
+  }
   @supports selector(:is(:foo, .a)) {
     div.is.invalid { background: red };
   }
@@ -32,11 +35,16 @@
   @supports selector(:has(:foo, .a)) {
     div.has.invalid { background: red };
   }
+  @supports selector(:not(:foo, .a)) {
+    div.not.invalid { background: red };
+  }
 </style>
 <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
 <div class="is valid"></div>
 <div class="where valid"></div>
 <div class="has valid"></div>
+<div class="not valid"></div>
 <div class="is invalid"></div>
 <div class="where invalid"></div>
 <div class="has invalid"></div>
+<div class="not invalid"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L4-expected.txt
@@ -11,4 +11,10 @@ PASS selector() with forgiving :where, 1 arg
 PASS selector() with forgiving :where, multiple args
 PASS selector() with forgiving :has, 1 arg
 PASS selector() with forgiving :has, multiple args
+PASS selector() with unforgiving :nth-child, 1 arg
+PASS selector() with unforgiving :nth-last-child, 1 arg
+PASS selector() with unforgiving :nth-child, multiple args
+PASS selector() with unforgiving :nth-last-child, multiple args
+PASS selector() with a non-identifier after :nth-child's An+B index
+PASS selector() with a non-identifier after :nth-last-child's An+B index
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L4.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L4.html
@@ -52,4 +52,28 @@
   test(function() {
     assert_equals(CSS.supports("selector(:has(:foo, div))"), false);
   }, "selector() with forgiving :has, multiple args");
+
+  test(function() {
+      assert_equals(CSS.supports("selector(:nth-child(2n + 3 of :foo))"), false);
+  }, "selector() with unforgiving :nth-child, 1 arg");
+
+  test(function() {
+      assert_equals(CSS.supports("selector(:nth-last-child(2n + 3 of :foo))"), false);
+  }, "selector() with unforgiving :nth-last-child, 1 arg");
+
+  test(function() {
+      assert_equals(CSS.supports("selector(:nth-child(2n + 3 of :foo, div))"), false);
+  }, "selector() with unforgiving :nth-child, multiple args");
+
+  test(function() {
+      assert_equals(CSS.supports("selector(:nth-last-child(2n + 3 of :foo, div))"), false);
+  }, "selector() with unforgiving :nth-last-child, multiple args");
+
+  test(function() {
+      assert_equals(CSS.supports("selector(:nth-child(2n 4))"), false);
+  }, "selector() with a non-identifier after :nth-child's An+B index");
+
+  test(function() {
+      assert_equals(CSS.supports("selector(:nth-last-child(2n 4))"), false);
+  }, "selector() with a non-identifier after :nth-last-child's An+B index");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5-expected.txt
@@ -4,6 +4,7 @@ PASS font-format() function doesn't accept an unknown format
 PASS font-format() function doesn't accept a format list
 PASS font-format() function doesn't accept a string.
 FAIL font-tech() function accepts a known technology assert_equals: expected true but got false
+PASS font-tech() function doesn't accept singular feature-* form for technology
 PASS font-tech() function doesn't accept an unknown technology
 PASS font-tech() function doesn't accept a technology list
 PASS font-tech() function doesn't accept a string.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5.html
@@ -26,14 +26,18 @@
   }, "font-tech() function accepts a known technology");
 
   test(function() {
+    assert_equals(CSS.supports("font-tech(feature-opentype)"), false);
+  }, "font-tech() function doesn't accept singular feature-* form for technology");
+
+  test(function() {
     assert_equals(CSS.supports("font-tech(foobar)"), false);
   }, "font-tech() function doesn't accept an unknown technology");
 
   test(function() {
-    assert_equals(CSS.supports("font-tech(feature-opentype, color-COLRv0)"), false);
+    assert_equals(CSS.supports("font-tech(features-opentype, color-COLRv0)"), false);
   }, "font-tech() function doesn't accept a technology list");
 
   test(function() {
-    assert_equals(CSS.supports("font-tech('feature-opentype')"), false);
+    assert_equals(CSS.supports("font-tech('features-opentype')"), false);
   }, "font-tech() function doesn't accept a string.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-detecting-invalid-in-logical-combinations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-detecting-invalid-in-logical-combinations-expected.txt
@@ -1,4 +1,5 @@
 
+PASS Invalid selector can be detected with CSS.supports()
 PASS Invalid selector can be detected with CSS.supports() even if it is dropped by forgiving parsing
 PASS :is(), :where() or :has() always fails without argument
 PASS :has() always fails inside :has()

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-detecting-invalid-in-logical-combinations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-detecting-invalid-in-logical-combinations.html
@@ -1,10 +1,19 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>CSS.supports() detecting invalid in forgiving argument</title>
+<title>CSS.supports() detecting invalid in logical combinations</title>
 <link rel="help" href="https://www.w3.org/TR/css-conditional-4/#the-css-namespace">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+  test(function() {
+    assert_equals(CSS.supports("selector(:has(:foo))"), false);
+    assert_equals(CSS.supports("selector(:has(.a, :foo))"), false);
+    assert_equals(CSS.supports("selector(:has(:foo, .a))"), false);
+    assert_equals(CSS.supports("selector(:not(:foo))"), false);
+    assert_equals(CSS.supports("selector(:not(.a, :foo))"), false);
+    assert_equals(CSS.supports("selector(:not(:foo, .a))"), false);
+  }, "Invalid selector can be detected with CSS.supports()");
+
   test(function() {
     assert_equals(CSS.supports("selector(:is(:foo))"), false);
     assert_equals(CSS.supports("selector(:is(.a, :foo))"), false);
@@ -14,9 +23,6 @@
     assert_equals(CSS.supports("selector(:where(.a, :foo))"), false);
     assert_equals(CSS.supports("selector(:where(:foo, .a))"), false);
     assert_equals(CSS.supports("selector(:where(:is(:foo, a), .b))"), false);
-    assert_equals(CSS.supports("selector(:has(:foo))"), false);
-    assert_equals(CSS.supports("selector(:has(.a, :foo))"), false);
-    assert_equals(CSS.supports("selector(:has(:foo, .a))"), false);
     assert_equals(CSS.supports("selector(:has(:where(:foo, a), .b))"), false);
   }, "Invalid selector can be detected with CSS.supports() even if it is dropped by forgiving parsing");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/w3c-import.log
@@ -19,6 +19,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L3.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L4.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5.html
-/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-detecting-invalid-in-forgiving-argument.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-detecting-invalid-in-logical-combinations.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/conditional-CSSGroupingRule.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/supports-conditionText.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/w3c-import.log
@@ -123,6 +123,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-045.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-046-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-046.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-047-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-047.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-content-001-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-content-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-content-002-expected.html
@@ -147,9 +149,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-003.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-004-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-004.html
-/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-forgiving-argument-expected.html
-/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-forgiving-argument-ref.html
-/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-forgiving-argument.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-whitespace.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/css-supports-001-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/css-supports-001.xht


### PR DESCRIPTION
#### ed5f99c1f470e4c3615779c1c8dbd9fce8c1805a
<pre>
Re-import css/css-conditional WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=254681">https://bugs.webkit.org/show_bug.cgi?id=254681</a>
rdar://107382110

Reviewed by Brent Fulgham.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d14a5dd7d73fd4492fb52fef372a3823614f3777">https://github.com/web-platform-tests/wpt/commit/d14a5dd7d73fd4492fb52fef372a3823614f3777</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-047-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-047.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-tech-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations-expected.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-forgiving-argument-ref.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations-ref.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-forgiving-argument-expected.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-logical-combinations.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/at-supports-selector-detecting-invalid-in-forgiving-argument.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L4-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L4.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-detecting-invalid-in-logical-combinations-expected.txt: Renamed from LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-detecting-invalid-in-forgiving-argument-expected.txt.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-detecting-invalid-in-logical-combinations.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-selector-detecting-invalid-in-forgiving-argument.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/262292@main">https://commits.webkit.org/262292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cdb039df0affbf164ffdd732595ff5e444b7a1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1007 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1256 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1200 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1153 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1055 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1045 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1085 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1092 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1064 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/282 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1114 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->