### PR TITLE
[UI-side compositing] [GPU Process] Emailing a webpage from Safari causes the tab to stop rendering

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -990,7 +990,18 @@ bool WebPageProxy::useGPUProcessForDOMRenderingEnabled() const
     if (id useGPUProcessForDOMRendering = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKit2GPUProcessForDOMRendering"])
         return [useGPUProcessForDOMRendering boolValue];
 
-    return preferences().useGPUProcessForDOMRenderingEnabled();
+    if (preferences().useGPUProcessForDOMRenderingEnabled())
+        return true;
+
+    HashSet<RefPtr<const WebPageProxy>> visitedPages;
+    visitedPages.add(this);
+    for (auto* page = m_configuration->relatedPage(); page && !visitedPages.contains(page); page = page->configuration().relatedPage()) {
+        if (page->preferences().useGPUProcessForDOMRenderingEnabled())
+            return true;
+        visitedPages.add(page);
+    }
+
+    return false;
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### e74572e8106c6580f74f5193d363810560f6b9fd
<pre>
[UI-side compositing] [GPU Process] Emailing a webpage from Safari causes the tab to stop rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=254683">https://bugs.webkit.org/show_bug.cgi?id=254683</a>
rdar://107329972

Reviewed by Simon Fraser.

When sharing a webpage via Mail, Safari first generates a web archive from the existing web view&apos;s
content, and then creates an offscreen web view *backed by the tab&apos;s existing web process*, which we
then use to load the web archive and perform reader extraction heuristics.

However, when the DOM GPU process experimental feature flag is enabled for Safari tabs, it only
affects the web view used for rendering the main page content; importantly, this related web view
does not have DOM GPUP enabled.

When subsequently loading the web archive data via this reader web view, we end up *disabling* GPUP
for DOM rendering in the original tab&apos;s web process, due to the following code:

```
bool usingGPUProcessForDOMRendering = m_shouldRenderDOMInGPUProcess &amp;&amp; DrawingArea::supportsGPUProcessRendering(m_drawingAreaType);
WebProcess::singleton().setUseGPUProcessForDOMRendering(usingGPUProcessForDOMRendering);
```

The current implementation of GPUP for DOM rendering doesn&apos;t handle on-the-fly GPUP disablement —
and in fact, in the case where IOKit has already been blocked in the web process, it&apos;s impossible to
disable GPUP at all once a page has been created with all the relevant GPUP flags enabled.

As such, we mitigate this by simply forcing DOM GPUP to be enabled (regardless of preferences state)
for a web view, if its related web view already has DOM GPUP enabled. Once DOM GPUP is enabled by
default, this won&apos;t be an issue anyway, since all web views will be created with consistent feature
flag statuses.

Test: GPUProcess.GPUProcessForDOMRenderingCarriesOverFromRelatedPage

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::useGPUProcessForDOMRenderingEnabled const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm:
(-[NSUserDefaults swizzled_objectForKey:]):
(TestWebKitAPI::EnableUISideCompositingScope::EnableUISideCompositingScope):
(TestWebKitAPI::EnableUISideCompositingScope::~EnableUISideCompositingScope):

Add a new RAII helper class to temporarily swizzle out `-objectForKey:`, in order to forcibly enable
UI-side compositing for this test, as it&apos;s necessary to exercise the bug fix. Note that I&apos;m using
swizzling here to avoid also enabling UI-side compositing for downstream API tests, even if the test
crashes or times out.

(TestWebKitAPI::TEST):
(convertToCGImage): Deleted.
(getPixelIndex): Deleted.
(TEST): Deleted.
(runMemoryPressureExitTest): Deleted.
(waitUntilCaptureState): Deleted.

Canonical link: <a href="https://commits.webkit.org/262296@main">https://commits.webkit.org/262296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/404f156327fc06e8cb522bd1979ed9c7c8b0e76b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1201 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1155 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1741 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1057 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1047 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1087 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1094 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1066 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/288 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1116 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->