### PR TITLE
Don't include unnecessary direct touch type for mouse gesture recognizer

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10309,7 +10309,7 @@ static BOOL applicationIsKnownToIgnoreMouseEvents(const char* &warningVersion)
     [_mouseGestureRecognizer setEnabled:[self shouldUseMouseGestureRecognizer]];
 #if ENABLE(PENCIL_HOVER)
     [_pencilHoverGestureRecognizer setAllowedTouchTypes:@[ @(UITouchTypePencil)] ];
-    [_mouseGestureRecognizer setAllowedTouchTypes:@[ @(UITouchTypeDirect), @(UITouchTypeIndirectPointer)] ];
+    [_mouseGestureRecognizer setAllowedTouchTypes:@[ @(UITouchTypeIndirectPointer)] ];
     [_pencilHoverGestureRecognizer setEnabled:[self shouldUseMouseGestureRecognizer]];
 #endif
 }


### PR DESCRIPTION
#### 9a98de1df7bfd1ce1e9448bce59d3b8b1e13e348
<pre>
Don&apos;t include unnecessary direct touch type for mouse gesture recognizer
<a href="https://bugs.webkit.org/show_bug.cgi?id=254684">https://bugs.webkit.org/show_bug.cgi?id=254684</a>
rdar://105696890

Reviewed by Megan Gardner.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _configureMouseGestureRecognizer]):
This explicit mention of direct touch introduced in 256074@main has no ill effect,
but causes confusion (because WKMouseGestureRecognizer really only operates on
indirect pointer touches).

Canonical link: <a href="https://commits.webkit.org/262297@main">https://commits.webkit.org/262297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f1e3b2eab9c5f381b40af64c583c78dff33a58c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1149 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1011 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1205 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1157 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1744 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1063 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1093 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2138 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1096 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1072 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/281 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1118 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->