### PR TITLE
[css-conditional-5] Support `@supports font-format()`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1952,7 +1952,6 @@ imported/w3c/web-platform-tests/css/css-conditional/at-supports-046.html [ Image
 imported/w3c/web-platform-tests/css/css-conditional/at-supports-namespace-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-conditional/at-supports-namespace-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-conditional/css-supports-036.xht [ ImageOnlyFailure ]
-webkit.org/b/254679 imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-format-001.html [ ImageOnlyFailure ]
 webkit.org/b/252153 imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-tech-001.html [ ImageOnlyFailure ]
 webkit.org/b/254682 imported/w3c/web-platform-tests/css/css-conditional/at-supports-047.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL font-format() function accepts a known format assert_equals: expected true but got false
+PASS font-format() function accepts a known format
 PASS font-format() function doesn't accept an unknown format
 PASS font-format() function doesn't accept a format list
 PASS font-format() function doesn't accept a string.

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1607,9 +1607,11 @@ numbers
 words
 // spell-out
 
-// @supports selector()
+// @supports
 // https://drafts.csswg.org/css-conditional-4/#typedef-supports-selector-fn
+// https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-format-fn
 selector
+font-format
 
 // math-style
 // normal

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -8176,6 +8176,19 @@ RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange& range)
     return CSSValueList::createCommaSeparated(name.releaseNonNull());
 }
 
+bool identMatchesSupportedFontFormat(CSSValueID id)
+{
+    return identMatches<
+        CSSValueCollection,
+        CSSValueEmbeddedOpentype,
+        CSSValueOpentype,
+        CSSValueSvg,
+        CSSValueTruetype,
+        CSSValueWoff,
+        CSSValueWoff2
+    >(id);
+}
+
 // MARK: @font-palette-values
 
 RefPtr<CSSValue> consumeFontPaletteValuesOverrideColors(CSSParserTokenRange& range, const CSSParserContext& context)

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -318,6 +318,7 @@ RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange&, const CSSParserCo
 // @font-face descriptor consumers:
 
 RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange&);
+bool identMatchesSupportedFontFormat(CSSValueID);
 
 // @font-palette-values descriptor consumers:
 

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -226,7 +226,7 @@ static RefPtr<CSSFontFaceSrcResourceValue> consumeFontFaceSrcURI(CSSParserTokenR
         if (!args.atEnd())
             return nullptr;
         if (arg.type() == IdentToken) {
-            if (!CSSPropertyParserHelpers::identMatches<CSSValueCollection, CSSValueEmbeddedOpentype, CSSValueOpentype, CSSValueSvg, CSSValueTruetype, CSSValueWoff, CSSValueWoff2>(arg.id()))
+            if (!CSSPropertyParserHelpers::identMatchesSupportedFontFormat(arg.id()))
                 return nullptr;
         } else if (arg.type() != StringToken)
             return nullptr;

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -123,11 +123,28 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeNegation(CSSParserTo
     return result ? Unsupported : Supported;
 }
 
+// <supports-selector-fn> | <supports-font-format-fn>
+CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFunction(CSSParserTokenRange& range)
+{
+    if (range.peek().type() != FunctionToken)
+        return Invalid;
+
+    switch (range.peek().functionId()) {
+    case CSSValueSelector:
+        return consumeSupportsSelectorFunction(range);
+    case CSSValueFontFormat:
+        return consumeSupportsFontFormatFunction(range);
+    default:
+        return Invalid;
+    }
+}
+
+// <supports-feature> | <general-enclosed>
 CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFeatureOrGeneralEnclosed(CSSParserTokenRange& range)
 {
     if (range.peek().type() == FunctionToken) {
-        if (range.peek().functionId() == CSSValueSelector)
-            return consumeSupportsSelectorFunction(range);
+        if (auto result = consumeSupportsFunction(range); result != Invalid)
+            return result;
 
         range.consumeComponentValue();
         return Unsupported;
@@ -136,10 +153,10 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFeatureOrGen
     return range.peek().type() == IdentToken && m_parser.supportsDeclaration(range) ? Supported : Unsupported;
 }
 
+// <supports-selector-fn>
 CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsSelectorFunction(CSSParserTokenRange& range)
 {
-    if (range.peek().type() != FunctionToken || range.peek().functionId() != CSSValueSelector)
-        return Invalid;
+    ASSERT(range.peek().type() == FunctionToken && range.peek().functionId() == CSSValueSelector);
 
     auto block = range.consumeBlock();
     block.consumeWhitespace();
@@ -147,25 +164,36 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsSelectorFunc
     return CSSSelectorParser::supportsComplexSelector(block, m_parser.context(), m_isNestedContext) ? Supported : Unsupported;
 }
 
+// <supports-font-format-fn>
+CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFontFormatFunction(CSSParserTokenRange& range)
+{
+    ASSERT(range.peek().type() == FunctionToken && range.peek().functionId() == CSSValueFontFormat);
+
+    auto block = range.consumeBlock();
+    block.consumeWhitespace();
+
+    auto isSupported = CSSPropertyParserHelpers::consumeIdent(block, CSSPropertyParserHelpers::identMatchesSupportedFontFormat) ? Supported : Unsupported;
+    if (!block.atEnd())
+        return Unsupported;
+
+    return isSupported;
+}
+
+// <supports-in-parens> = ( <supports-condition> ) | <supports-feature> | <general-enclosed>
 CSSSupportsParser::SupportsResult CSSSupportsParser::consumeConditionInParenthesis(CSSParserTokenRange& range,  CSSParserTokenType startTokenType)
 {
-    // <supports-in-parens> = ( <supports-condition> ) | <supports-feature> | <general-enclosed>
     if (startTokenType == IdentToken && range.peek().type() != LeftParenthesisToken) {
-        if (range.peek().type() == FunctionToken && range.peek().functionId() == CSSValueSelector)
-            return consumeSupportsSelectorFunction(range);
-
+        if (auto result = consumeSupportsFunction(range); result != Invalid)
+            return result;
         return Invalid;
     }
 
     auto innerRange = range.consumeBlock();
     innerRange.consumeWhitespace();
 
-    auto result = consumeCondition(innerRange);
-    if (result != Invalid)
+    if (auto result = consumeCondition(innerRange); result != Invalid)
         return result;
 
-    // <supports-feature> = <supports-selector-fn> | <supports-decl>
-    // <general-enclosed>
     return consumeSupportsFeatureOrGeneralEnclosed(innerRange);
 }
 

--- a/Source/WebCore/css/parser/CSSSupportsParser.h
+++ b/Source/WebCore/css/parser/CSSSupportsParser.h
@@ -60,10 +60,14 @@ private:
 
     SupportsResult consumeCondition(CSSParserTokenRange);
     SupportsResult consumeNegation(CSSParserTokenRange);
+    SupportsResult consumeSupportsFunction(CSSParserTokenRange&);
     SupportsResult consumeSupportsFeatureOrGeneralEnclosed(CSSParserTokenRange&);
     // https://drafts.csswg.org/css-conditional-4/#typedef-supports-selector-fn
-    // <supports-seletor-fn> = selector( <complex-selector> );
+    // <supports-selector-fn> = selector( <complex-selector> );
     SupportsResult consumeSupportsSelectorFunction(CSSParserTokenRange&);
+
+    // https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-format-fn
+    SupportsResult consumeSupportsFontFormatFunction(CSSParserTokenRange&);
 
     SupportsResult consumeConditionInParenthesis(CSSParserTokenRange&, CSSParserTokenType);
 


### PR DESCRIPTION
#### c80f8136b208a12341b3fe2ded610d340330c7dd
<pre>
[css-conditional-5] Support `@supports font-format()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=254679">https://bugs.webkit.org/show_bug.cgi?id=254679</a>
rdar://107381176

Reviewed by Brent Fulgham.

<a href="https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-format-fn">https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-format-fn</a>

Re-use list from `@font-face format()` parsing for `@supports font-face()`.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5-expected.txt:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::identMatchesSupportedFontFormat):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcURI):
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
(WebCore::CSSSupportsParser::consumeSupportsFunction):
(WebCore::CSSSupportsParser::consumeSupportsFeatureOrGeneralEnclosed):
(WebCore::CSSSupportsParser::consumeSupportsSelectorFunction):
(WebCore::CSSSupportsParser::consumeSupportsFontFormatFunction):
(WebCore::CSSSupportsParser::consumeConditionInParenthesis):
* Source/WebCore/css/parser/CSSSupportsParser.h:

Canonical link: <a href="https://commits.webkit.org/262305@main">https://commits.webkit.org/262305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21c1aa1b238fe48e1ee0ef25395df2bf54c77f15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1290 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1230 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1193 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1801 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1121 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1131 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1100 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1154 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/119 "Failed to push commit to Webkit repository") | | | | 
<!--EWS-Status-Bubble-End-->