### PR TITLE
Give WebKit-owned IOSurfaces names

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h
@@ -58,6 +58,7 @@ extern const CFStringRef kIOSurfacePixelFormat;
 extern const CFStringRef kIOSurfaceWidth;
 extern const CFStringRef kIOSurfaceElementWidth;
 extern const CFStringRef kIOSurfaceElementHeight;
+extern const CFStringRef kIOSurfaceName;
 extern const CFStringRef kIOSurfacePlaneWidth;
 extern const CFStringRef kIOSurfacePlaneHeight;
 extern const CFStringRef kIOSurfacePlaneBytesPerRow;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -80,7 +80,7 @@ std::unique_ptr<ImageBufferIOSurfaceBackend> ImageBufferIOSurfaceBackend::create
     if (backendSize.isEmpty())
         return nullptr;
 
-    auto surface = IOSurface::create(creationContext.surfacePool, backendSize, parameters.colorSpace, IOSurface::formatForPixelFormat(parameters.pixelFormat));
+    auto surface = IOSurface::create(creationContext.surfacePool, backendSize, parameters.colorSpace, IOSurface::Name::ImageBuffer, IOSurface::formatForPixelFormat(parameters.pixelFormat));
     if (!surface)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -600,7 +600,7 @@ void GraphicsContextGLCocoa::setDrawingBufferColorSpace(const DestinationColorSp
 bool GraphicsContextGLCocoa::allocateAndBindDisplayBufferBacking()
 {
     ASSERT(!getInternalFramebufferSize().isEmpty());
-    auto backing = IOSurface::create(nullptr, getInternalFramebufferSize(), m_drawingBufferColorSpace);
+    auto backing = IOSurface::create(nullptr, getInternalFramebufferSize(), m_drawingBufferColorSpace, IOSurface::Name::GraphicsContextGL);
     if (!backing)
         return false;
     if (m_resourceOwner)

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -48,6 +48,7 @@ namespace WebCore {
 class IOSurfacePool;
 
 enum class PixelFormat : uint8_t;
+enum class RenderingPurpose : uint8_t;
 enum class SetNonVolatileResult : uint8_t;
 
 using IOSurfaceSeed = uint32_t;
@@ -56,6 +57,20 @@ using PlatformDisplayID = uint32_t;
 class IOSurface final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    enum class Name : uint8_t {
+        Default,
+        DOM,
+        Canvas,
+        GraphicsContextGL,
+        ImageBuffer,
+        ImageBufferShareableMapped,
+        LayerBacking,
+        MediaPainting,
+        Snapshot,
+        ShareableSnapshot,
+        ShareableLocalSnapshot,
+    };
+
     enum class Format {
         BGRX,
         BGRA,
@@ -101,7 +116,7 @@ public:
         uint32_t m_flags;
     };
 
-    WEBCORE_EXPORT static std::unique_ptr<IOSurface> create(IOSurfacePool*, IntSize, const DestinationColorSpace&, Format = Format::BGRA);
+    WEBCORE_EXPORT static std::unique_ptr<IOSurface> create(IOSurfacePool*, IntSize, const DestinationColorSpace&, Name = Name::Default, Format = Format::BGRA);
     WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromImage(IOSurfacePool*, CGImageRef);
 
     WEBCORE_EXPORT static std::unique_ptr<IOSurface> createFromSendRight(const WTF::MachSendRight&&);
@@ -126,6 +141,9 @@ public:
     WEBCORE_EXPORT RetainPtr<CGImageRef> createImage(CGContextRef);
     // Passed in context is the context through which the contents was drawn.
     WEBCORE_EXPORT static RetainPtr<CGImageRef> sinkIntoImage(std::unique_ptr<IOSurface>, RetainPtr<CGContextRef>);
+
+    WEBCORE_EXPORT static Name nameForRenderingPurpose(RenderingPurpose);
+    Name name() const { return m_name; }
 
 #ifdef __OBJC__
     id asLayerContents() const { return (__bridge id)m_surface.get(); }
@@ -158,7 +176,7 @@ public:
 
 #if HAVE(IOSURFACE_ACCELERATOR)
     WEBCORE_EXPORT static bool allowConversionFromFormatToFormat(Format, Format);
-    WEBCORE_EXPORT static void convertToFormat(IOSurfacePool*, std::unique_ptr<WebCore::IOSurface>&& inSurface, Format, Function<void(std::unique_ptr<WebCore::IOSurface>)>&&);
+    WEBCORE_EXPORT static void convertToFormat(IOSurfacePool*, std::unique_ptr<WebCore::IOSurface>&& inSurface, Name, Format, Function<void(std::unique_ptr<WebCore::IOSurface>)>&&);
 #endif // HAVE(IOSURFACE_ACCELERATOR)
 
     WEBCORE_EXPORT void setOwnershipIdentity(const ProcessIdentity&);
@@ -167,12 +185,14 @@ public:
     RetainPtr<CGContextRef> createCompatibleBitmap(unsigned width, unsigned height);
 
 private:
-    IOSurface(IntSize, const DestinationColorSpace&, Format, bool& success);
+    IOSurface(IntSize, const DestinationColorSpace&, Name, Format, bool& success);
     IOSurface(IOSurfaceRef, std::optional<DestinationColorSpace>&&);
 
     void setColorSpaceProperty();
     void ensureColorSpace();
     std::optional<DestinationColorSpace> surfaceColorSpace() const;
+
+    void setName(Name name) { m_name = name; }
 
     struct BitmapConfiguration {
         CGBitmapInfo bitmapInfo;
@@ -191,6 +211,8 @@ private:
     RetainPtr<IOSurfaceRef> m_surface;
 
     static std::optional<IntSize> s_maximumSize;
+
+    Name m_name;
 
     WEBCORE_EXPORT friend WTF::TextStream& operator<<(WTF::TextStream&, const WebCore::IOSurface&);
 };

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -45,19 +45,51 @@
 
 namespace WebCore {
 
-std::unique_ptr<IOSurface> IOSurface::create(IOSurfacePool* pool, IntSize size, const DestinationColorSpace& colorSpace, Format pixelFormat)
+static auto surfaceNameToNSString(IOSurface::Name name)
+{
+    switch (name) {
+    case IOSurface::Name::Default:
+        return @"WebKit";
+    case IOSurface::Name::DOM:
+        return @"WebKit DOM";
+    case IOSurface::Name::Canvas:
+        return @"WebKit Canvas";
+    case IOSurface::Name::GraphicsContextGL:
+        return @"WebKit GraphicsContextGL";
+    case IOSurface::Name::ImageBuffer:
+        return @"WebKit ImageBuffer";
+    case IOSurface::Name::ImageBufferShareableMapped:
+        return @"WebKit ImageBufferShareableMapped";
+    case IOSurface::Name::LayerBacking:
+        return @"WebKit LayerBacking";
+    case IOSurface::Name::MediaPainting:
+        return @"WebKit MediaPainting";
+    case IOSurface::Name::Snapshot:
+        return @"WKWebView Snapshot";
+    case IOSurface::Name::ShareableSnapshot:
+        return @"WKWebView Snapshot (shareable)";
+    case IOSurface::Name::ShareableLocalSnapshot:
+        return @"WKWebView Snapshot (shareable local)";
+    }
+}
+
+std::unique_ptr<IOSurface> IOSurface::create(IOSurfacePool* pool, IntSize size, const DestinationColorSpace& colorSpace, IOSurface::Name name, Format pixelFormat)
 {
     ASSERT(ProcessCapabilities::canUseAcceleratedBuffers());
 
     if (pool) {
         if (auto cachedSurface = pool->takeSurface(size, colorSpace, pixelFormat)) {
             LOG_WITH_STREAM(IOSurface, stream << "IOSurface::create took from pool: " << *cachedSurface);
+            if (cachedSurface->name() != name) {
+                IOSurfaceSetValue(cachedSurface->surface(), kIOSurfaceName, surfaceNameToNSString(name));
+                cachedSurface->setName(name);
+            }
             return cachedSurface;
         }
     }
 
     bool success = false;
-    auto surface = std::unique_ptr<IOSurface>(new IOSurface(size, colorSpace, pixelFormat, success));
+    auto surface = std::unique_ptr<IOSurface>(new IOSurface(size, colorSpace, name, pixelFormat, success));
     if (!success) {
         LOG(IOSurface, "IOSurface::create failed to create %dx%d surface", size.width(), size.height());
         return nullptr;
@@ -91,7 +123,7 @@ std::unique_ptr<IOSurface> IOSurface::createFromImage(IOSurfacePool* pool, CGIma
     size_t width = CGImageGetWidth(image);
     size_t height = CGImageGetHeight(image);
 
-    auto surface = IOSurface::create(pool, IntSize(width, height), DestinationColorSpace { CGImageGetColorSpace(image) });
+    auto surface = IOSurface::create(pool, IntSize(width, height), DestinationColorSpace { CGImageGetColorSpace(image) }, Name::ImageBuffer);
     if (!surface)
         return nullptr;
     auto context = surface->createPlatformContext();
@@ -105,7 +137,7 @@ void IOSurface::moveToPool(std::unique_ptr<IOSurface>&& surface, IOSurfacePool* 
         pool->addSurface(WTFMove(surface));
 }
 
-static NSDictionary *optionsForBiplanarSurface(IntSize size, unsigned pixelFormat, size_t firstPlaneBytesPerPixel, size_t secondPlaneBytesPerPixel)
+static NSDictionary *optionsForBiplanarSurface(IntSize size, unsigned pixelFormat, size_t firstPlaneBytesPerPixel, size_t secondPlaneBytesPerPixel, IOSurface::Name name)
 {
     int width = size.width();
     int height = size.height();
@@ -145,10 +177,11 @@ static NSDictionary *optionsForBiplanarSurface(IntSize size, unsigned pixelForma
         (id)kIOSurfaceCacheMode: @(kIOMapWriteCombineCache),
 #endif
         (id)kIOSurfacePlaneInfo: planeInfo,
+        (id)kIOSurfaceName: surfaceNameToNSString(name)
     };
 }
 
-static NSDictionary *optionsFor32BitSurface(IntSize size, unsigned pixelFormat)
+static NSDictionary *optionsFor32BitSurface(IntSize size, unsigned pixelFormat, IOSurface::Name name)
 {
     int width = size.width();
     int height = size.height();
@@ -172,15 +205,17 @@ static NSDictionary *optionsFor32BitSurface(IntSize size, unsigned pixelFormat)
 #if PLATFORM(IOS_FAMILY)
         (id)kIOSurfaceCacheMode: @(kIOMapWriteCombineCache),
 #endif
-        (id)kIOSurfaceElementHeight: @(1)
+        (id)kIOSurfaceElementHeight: @(1),
+        (id)kIOSurfaceName: surfaceNameToNSString(name)
     };
 
 }
 
-IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, Format format, bool& success)
+IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, IOSurface::Name name, Format format, bool& success)
     : m_format(format)
     , m_colorSpace(colorSpace)
     , m_size(size)
+    , m_name(name)
 {
     ASSERT(!success);
     ASSERT(!size.isEmpty());
@@ -190,18 +225,18 @@ IOSurface::IOSurface(IntSize size, const DestinationColorSpace& colorSpace, Form
     switch (format) {
     case Format::BGRX:
     case Format::BGRA:
-        options = optionsFor32BitSurface(size, 'BGRA');
+        options = optionsFor32BitSurface(size, 'BGRA', name);
         break;
 #if HAVE(IOSURFACE_RGB10)
     case Format::RGB10:
-        options = optionsFor32BitSurface(size, 'w30r');
+        options = optionsFor32BitSurface(size, 'w30r', name);
         break;
     case Format::RGB10A8:
-        options = optionsForBiplanarSurface(size, 'b3a8', 4, 1);
+        options = optionsForBiplanarSurface(size, 'b3a8', 4, 1, name);
         break;
 #endif
     case Format::YUV422:
-        options = optionsForBiplanarSurface(size, '422f', 1, 1);
+        options = optionsForBiplanarSurface(size, '422f', 1, 1, name);
         break;
     }
     m_surface = adoptCF(IOSurfaceCreate((CFDictionaryRef)options));
@@ -491,7 +526,7 @@ bool IOSurface::allowConversionFromFormatToFormat(Format sourceFormat, Format de
     return true;
 }
 
-void IOSurface::convertToFormat(IOSurfacePool* pool, std::unique_ptr<IOSurface>&& inSurface, Format format, WTF::Function<void(std::unique_ptr<IOSurface>)>&& callback)
+void IOSurface::convertToFormat(IOSurfacePool* pool, std::unique_ptr<IOSurface>&& inSurface, Name name, Format format, WTF::Function<void(std::unique_ptr<IOSurface>)>&& callback)
 {
     static IOSurfaceAcceleratorRef accelerator;
     if (!accelerator) {
@@ -511,7 +546,7 @@ void IOSurface::convertToFormat(IOSurfacePool* pool, std::unique_ptr<IOSurface>&
         return;
     }
 
-    auto destinationSurface = IOSurface::create(pool, inSurface->size(), inSurface->colorSpace(), format);
+    auto destinationSurface = IOSurface::create(pool, inSurface->size(), inSurface->colorSpace(), name, format);
     if (!destinationSurface) {
         callback(nullptr);
         return;
@@ -614,6 +649,37 @@ IOSurface::Format IOSurface::formatForPixelFormat(PixelFormat format)
     return IOSurface::Format::BGRA;
 }
 
+IOSurface::Name IOSurface::nameForRenderingPurpose(RenderingPurpose purpose)
+{
+    switch (purpose) {
+    case RenderingPurpose::Unspecified:
+        return Name::ImageBufferShareableMapped;
+
+    case RenderingPurpose::Canvas:
+        return Name::Canvas;
+
+    case RenderingPurpose::DOM:
+        return Name::DOM;
+
+    case RenderingPurpose::LayerBacking:
+        return Name::LayerBacking;
+
+    case RenderingPurpose::Snapshot:
+        return Name::Snapshot;
+
+    case RenderingPurpose::ShareableSnapshot:
+        return Name::ShareableSnapshot;
+
+    case RenderingPurpose::ShareableLocalSnapshot:
+        return Name::ShareableLocalSnapshot;
+
+    case RenderingPurpose::MediaPainting:
+        return Name::MediaPainting;
+    }
+
+    return Name::Default;
+}
+
 TextStream& operator<<(TextStream& ts, IOSurface::Format format)
 {
     switch (format) {
@@ -653,7 +719,7 @@ static TextStream& operator<<(TextStream& ts, SetNonVolatileResult state)
 
 TextStream& operator<<(TextStream& ts, const IOSurface& surface)
 {
-    return ts << "IOSurface " << surface.surfaceID() << " size " << surface.size() << " format " << surface.m_format << " state " << surface.state();
+    return ts << "IOSurface " << surface.surfaceID() << " name " << [surfaceNameToNSString(surface.name()) UTF8String] << " size " << surface.size() << " format " << surface.m_format << " state " << surface.state();
 }
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1205,7 +1205,7 @@ static void addOverlayEventRegions(WebCore::PlatformLayerIdentifier layerID, con
 #else
     WebCore::IOSurface::Format snapshotFormat = WebCore::IOSurface::Format::BGRA;
 #endif
-    auto surface = WebCore::IOSurface::create(nullptr, WebCore::expandedIntSize(snapshotSize), WebCore::DestinationColorSpace::SRGB(), snapshotFormat);
+    auto surface = WebCore::IOSurface::create(nullptr, WebCore::expandedIntSize(snapshotSize), WebCore::DestinationColorSpace::SRGB(), WebCore::IOSurface::Name::Snapshot, snapshotFormat);
     if (!surface)
         return nullptr;
     CARenderServerRenderLayerWithTransform(MACH_PORT_NULL, self.layer.context.contextId, reinterpret_cast<uint64_t>(self.layer), surface->surface(), 0, 0, &transform);
@@ -1214,7 +1214,7 @@ static void addOverlayEventRegions(WebCore::PlatformLayerIdentifier layerID, con
     WebCore::IOSurface::Format compressedFormat = WebCore::IOSurface::Format::YUV422;
     if (WebCore::IOSurface::allowConversionFromFormatToFormat(snapshotFormat, compressedFormat)) {
         auto viewSnapshot = WebKit::ViewSnapshot::create(nullptr);
-        WebCore::IOSurface::convertToFormat(nullptr, WTFMove(surface), WebCore::IOSurface::Format::YUV422, [viewSnapshot](std::unique_ptr<WebCore::IOSurface> convertedSurface) {
+        WebCore::IOSurface::convertToFormat(nullptr, WTFMove(surface), WebCore::IOSurface::Name::Snapshot, WebCore::IOSurface::Format::YUV422, [viewSnapshot](std::unique_ptr<WebCore::IOSurface> convertedSurface) {
             if (convertedSurface)
                 viewSnapshot->setSurface(WTFMove(convertedSurface));
         });
@@ -3800,7 +3800,7 @@ static bool isLockdownModeWarningNeeded()
     NSString *displayName = self.window.screen.displayConfiguration.name;
     if (displayName && !self.window.hidden) {
         TraceScope snapshotScope(RenderServerSnapshotStart, RenderServerSnapshotEnd);
-        auto surface = WebCore::IOSurface::create(nullptr, WebCore::expandedIntSize(WebCore::FloatSize(imageSize)), WebCore::DestinationColorSpace::SRGB());
+        auto surface = WebCore::IOSurface::create(nullptr, WebCore::expandedIntSize(WebCore::FloatSize(imageSize)), WebCore::DestinationColorSpace::SRGB(), WebCore::IOSurface::Name::Snapshot);
         if (!surface) {
             completionHandler(nullptr);
             return;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> ImageBufferShareable
     if (backendSize.isEmpty())
         return nullptr;
 
-    auto surface = IOSurface::create(creationContext.surfacePool, backendSize, parameters.colorSpace, IOSurface::formatForPixelFormat(parameters.pixelFormat));
+    auto surface = IOSurface::create(creationContext.surfacePool, backendSize, parameters.colorSpace, IOSurface::nameForRenderingPurpose(parameters.purpose), IOSurface::formatForPixelFormat(parameters.pixelFormat));
     if (!surface)
         return nullptr;
     if (creationContext.resourceOwner)

--- a/Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm
+++ b/Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm
@@ -72,7 +72,7 @@ RefPtr<BitmapContext> createBitmapContextFromWebView(bool onscreen, bool increme
 #else
     WebCore::IOSurface::Format snapshotFormat = WebCore::IOSurface::Format::BGRA;
 #endif
-    auto surface = WebCore::IOSurface::create(nullptr, WebCore::expandedIntSize(snapshotSize), WebCore::DestinationColorSpace::SRGB(), snapshotFormat);
+    auto surface = WebCore::IOSurface::create(nullptr, WebCore::expandedIntSize(snapshotSize), WebCore::DestinationColorSpace::SRGB(), WebCore::IOSurface::Name::Snapshot, snapshotFormat);
     // FIXME: Something is missing here, nothing draws to surface.
     auto context = surface->createPlatformContext();
     RetainPtr<CGImageRef> cgImage = surface->createImage(context.get());


### PR DESCRIPTION
#### e5edaea039e254b86f390fe75a6b37b291b66998
<pre>
Give WebKit-owned IOSurfaces names
<a href="https://bugs.webkit.org/show_bug.cgi?id=141586">https://bugs.webkit.org/show_bug.cgi?id=141586</a>
rdar://problem/89791501

Reviewed by Simon Fraser.

IOSurfaces can have name metadata attached to them for tools to consume.
This change adds names to surfaces based on the RenderingPurpose they
are being created for. Additionally, surfaces which are stored in the
IOSurfacePool will update the name if a surface is being pulled from the
pool for a different purpose than it was originally created for.

* Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h:

* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::create):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::allocateAndBindDisplayBufferBacking):
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::surfaceNameToNSString):
(WebCore::IOSurface::create):
(WebCore::IOSurface::createFromImage):
(WebCore::optionsForBiplanarSurface):
(WebCore::optionsFor32BitSurface):
(WebCore::IOSurface::IOSurface):
(WebCore::IOSurface::convertToFormat):
(WebCore::IOSurface::nameForRenderingPurpose):
(WebCore::operator&lt;&lt;):

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _takeViewSnapshot]):
(-[WKWebView _snapshotRectAfterScreenUpdates:rectInViewCoordinates:intoImageOfWidth:completionHandler:]):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBackend::create):

* Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm:
(createBitmapContextFromWebView):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262331@main">https://commits.webkit.org/262331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5b312ae0c26370038b412177e0999c69d149845

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1172 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1905 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1029 "Failed to checkout and rebase branch from PR 12138") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1222 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1073 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1032 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1071 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2177 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1148 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1034 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1201 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1090 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/240 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/316 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1141 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1204 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/233 "Passed tests") | 
<!--EWS-Status-Bubble-End-->