### PR TITLE
Update fast/scrolling/mac/scrollbars tests to use new UIHelper scrollbar state function

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-hovered.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-hovered.html
@@ -42,12 +42,13 @@
             iframeWindow.internals.setUsesOverlayScrollbars(true);
 
             debug('Initial state');
-            debug(iframeWindow.internals.verticalScrollbarState(scroller));
+            var scrollbarState = await UIHelper.verticalScrollbarState(scroller);
+            debug(scrollbarState);
 
             debug('Hovering vertical scrollbar should show expanded scrollbar');
             await UIHelper.mouseWheelScrollAt(x, y);
-            await UIHelper.waitForCondition(() => {
-                let state = iframeWindow.internals.verticalScrollbarState(scroller);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
                 let enabled = state.indexOf('enabled') != -1;
                 let expanded = state.indexOf('expanded') != -1;
                 if (enabled && expanded)
@@ -58,8 +59,8 @@
             debug('Unhovering vertical scrollbar should hide it');
             await UIHelper.moveMouseAndWaitForFrame(x - 10, y);
             await UIHelper.moveMouseAndWaitForFrame(x - 20, y);
-            await UIHelper.waitForCondition(() => {
-                let state = iframeWindow.internals.verticalScrollbarState(scroller);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
                 let thumbHidden = state.indexOf('visible_thumb') == -1;
                 let trackHidden = state.indexOf('visible_track') == -1;
                 if (thumbHidden && trackHidden)

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-reveal.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-reveal.html
@@ -42,12 +42,13 @@
             iframeWindow.internals.setUsesOverlayScrollbars(true);
 
             debug('Initial state');
-            debug(iframeWindow.internals.verticalScrollbarState(scroller));
+            var scrollbarState = await UIHelper.verticalScrollbarState(scroller);
+            debug(scrollbarState);
 
             debug('MayBegin should show the scrollbar');
             await UIHelper.mouseWheelMayBeginAt(x, y);
-            await UIHelper.waitForCondition(() => {
-                let state = iframeWindow.internals.verticalScrollbarState(scroller);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
                 let visible = state.indexOf('visible_thumb') != -1;
                 if (visible)
                     testPassed('Scrollbar state: ' + state);
@@ -57,8 +58,8 @@
             debug('Cancelled should hide the scrollbar');
             await UIHelper.mouseWheelCancelAt(x, y);
 
-            await UIHelper.waitForCondition(() => {
-                let state = iframeWindow.internals.verticalScrollbarState(scroller);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
                 let hidden = state.indexOf('visible_thumb') == -1;
                 if (hidden)
                     testPassed('Scrollbar state: ' + state);

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-hovered.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-hovered.html
@@ -40,12 +40,13 @@
             const y = scrollerBounds.top + 10;
 
             debug('Initial state');
-            debug(internals.verticalScrollbarState(scroller));
+            var scrollbarState = await UIHelper.verticalScrollbarState(scroller);
+            debug(scrollbarState);
 
             debug('Hovering vertical scrollbar should show expanded scrollbar');
             await UIHelper.mouseWheelScrollAt(x, y);
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState(scroller);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
                 let enabled = state.indexOf('enabled') != -1;
                 let expanded = state.indexOf('expanded') != -1;
                 if (enabled && expanded)
@@ -56,8 +57,8 @@
             debug('Unhovering vertical scrollbar should hide it');
             await UIHelper.moveMouseAndWaitForFrame(x - 10, y);
             await UIHelper.moveMouseAndWaitForFrame(x - 20, y);
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState(scroller);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
                 let thumbHidden = state.indexOf('visible_thumb') == -1;
                 let trackHidden = state.indexOf('visible_track') == -1;
                 if (thumbHidden && trackHidden)

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html
@@ -40,12 +40,13 @@
             const y = scrollerBounds.top + 10;
 
             debug('Initial state');
-            debug(internals.verticalScrollbarState(scroller));
+            var scrollbarState = await UIHelper.verticalScrollbarState(scroller);
+            debug(scrollbarState);
 
             debug('MayBegin should show the scrollbar');
             await UIHelper.mouseWheelMayBeginAt(x, y);
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState(scroller);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
                 let visible = state.indexOf('visible_thumb') != -1;
                 if (visible)
                     testPassed('Scrollbar state: ' + state);
@@ -55,8 +56,8 @@
             debug('Cancelled should hide the scrollbar');
             await UIHelper.mouseWheelCancelAt(x, y);
 
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState(scroller);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
                 let hidden = state.indexOf('visible_thumb') == -1;
                 if (hidden)
                     testPassed('Scrollbar state: ' + state);

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-hovered.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-hovered.html
@@ -21,14 +21,15 @@
                 return;
             
             debug('Document');
-            debug(internals.verticalScrollbarState());
+            verticalScrollbarStateForRoot = await UIHelper.verticalScrollbarState();
+            debug(verticalScrollbarStateForRoot);
             
             let windowWidth = window.innerWidth;
 
             debug('Hovering vertical scrollbar should show expanded scrollbar');
             await UIHelper.mouseWheelScrollAt(windowWidth - 8, 10);
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState();
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState();
                 let expanded = state.indexOf('expanded') != -1;
                 if (expanded)
                     testPassed('Scrollbar state: ' + state);
@@ -38,8 +39,8 @@
             debug('Unhovering vertical scrollbar should hide it');
             await UIHelper.moveMouseAndWaitForFrame(windowWidth - 20, 10);
             await UIHelper.moveMouseAndWaitForFrame(windowWidth - 25, 10);
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState();
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState();
                 let thumbHidden = state.indexOf('visible_thumb') == -1;
                 let trackHidden = state.indexOf('visible_track') == -1;
                 if (thumbHidden && trackHidden)

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-reveal.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-reveal.html
@@ -24,14 +24,15 @@
             }
             
             debug('Initial state');
-            debug(internals.verticalScrollbarState());
+            verticalScrollbarStateForRoot = await UIHelper.verticalScrollbarState();
+            debug(verticalScrollbarStateForRoot);
             
             let windowWidth = window.innerWidth;
 
             debug('MayBegin should show the scrollbar');
             await UIHelper.mouseWheelMayBeginAt(100, 100);
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState();
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState();
                 let visible = state.indexOf('visible_thumb') != -1;
                 if (visible)
                     testPassed('Scrollbar state: ' + state);
@@ -41,8 +42,8 @@
             debug('Cancelled should hide the scrollbar');
             await UIHelper.mouseWheelCancelAt(100, 100);
 
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState();
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState();
                 let hidden = state.indexOf('visible_thumb') == -1;
                 if (hidden)
                     testPassed('Scrollbar state: ' + state);

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-state-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-state-expected.txt
@@ -7,11 +7,11 @@ Document
 enabled
 none
 overflow:auto
-PASS internals.verticalScrollbarState(autoScroller) is "enabled"
-PASS internals.horizontalScrollbarState(autoScroller) is "none"
+PASS verticalScrollbarStateForAuto is "enabled"
+PASS horizontalScrollbarStateForAuto is "none"
 overflow:scroll
-PASS internals.verticalScrollbarState(scrollScroller) is "enabled"
-PASS internals.horizontalScrollbarState(scrollScroller) is "none"
+PASS verticalScrollbarStateForScroll is "enabled"
+PASS horizontalScrollbarStateForScroll is "none"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-state.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-state.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
     <style>
@@ -22,6 +22,7 @@
         }
     </style>
     <script src="../../../../resources/js-test-pre.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
     <script>
         jsTestIsAsync = true;
         
@@ -30,25 +31,30 @@
         
         window.internals.setUsesOverlayScrollbars(true);
 
-        window.addEventListener('load', () => {
+        window.addEventListener('load', async () => {
             description('Test scrollbar state internals');
             if (!window.internals)
                 return;
             
             debug('Document');
-            debug(internals.verticalScrollbarState());
-            debug(internals.horizontalScrollbarState());
+            verticalScrollbarStateForRoot = await UIHelper.verticalScrollbarState();
+            horizontalScrollbarStateForRoot = await UIHelper.horizontalScrollbarState();
+            debug(verticalScrollbarStateForRoot);
+            debug(horizontalScrollbarStateForRoot);
 
             autoScroller = document.querySelector('.auto.scroller')
             scrollScroller = document.querySelector('.scroll.scroller')
-
             debug('overflow:auto');
-            shouldBeEqualToString('internals.verticalScrollbarState(autoScroller)', 'enabled');
-            shouldBeEqualToString('internals.horizontalScrollbarState(autoScroller)', 'none');
+            verticalScrollbarStateForAuto = await UIHelper.verticalScrollbarState(autoScroller);
+            horizontalScrollbarStateForAuto = await UIHelper.horizontalScrollbarState(autoScroller);
+            shouldBeEqualToString('verticalScrollbarStateForAuto', 'enabled');
+            shouldBeEqualToString('horizontalScrollbarStateForAuto', 'none');
 
             debug('overflow:scroll');
-            shouldBeEqualToString('internals.verticalScrollbarState(scrollScroller)', 'enabled');
-            shouldBeEqualToString('internals.horizontalScrollbarState(scrollScroller)', 'none');
+            verticalScrollbarStateForScroll = await UIHelper.verticalScrollbarState(scrollScroller);
+            horizontalScrollbarStateForScroll = await UIHelper.horizontalScrollbarState(scrollScroller);
+            shouldBeEqualToString('verticalScrollbarStateForScroll', 'enabled');
+            shouldBeEqualToString('horizontalScrollbarStateForScroll', 'none');
 
             finishJSTest();
         }, false);

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-state-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-state-expected.txt
@@ -4,14 +4,14 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Document
-PASS internals.verticalScrollbarState() is "enabled"
-PASS internals.horizontalScrollbarState() is "none"
+PASS verticalScrollbarStateForRoot is "enabled"
+PASS horizontalScrollbarStateForRoot is "none"
 overflow:auto
-PASS internals.verticalScrollbarState(autoScroller) is "enabled"
-PASS internals.horizontalScrollbarState(autoScroller) is "none"
+PASS verticalScrollbarStateForAuto is "enabled"
+PASS horizontalScrollbarStateForAuto is "none"
 overflow:scroll
-PASS internals.verticalScrollbarState(scrollScroller) is "enabled"
-PASS internals.horizontalScrollbarState(scrollScroller) is "disabled"
+PASS verticalScrollbarStateForScroll is "enabled"
+PASS horizontalScrollbarStateForScroll is "none"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-state.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-state.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
     <style>
@@ -22,31 +22,38 @@
         }
     </style>
     <script src="../../../../resources/js-test-pre.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
     <script>
         jsTestIsAsync = true;
         
         let autoScroller;
         let scrollScroller;
 
-        window.addEventListener('load', () => {
+        window.addEventListener('load', async () => {
             description('Test scrollbar state internals');
             if (!window.internals)
                 return;
             
             debug('Document');
-            shouldBeEqualToString('internals.verticalScrollbarState()', 'enabled');
-            shouldBeEqualToString('internals.horizontalScrollbarState()', 'none');
+            verticalScrollbarStateForRoot = await UIHelper.verticalScrollbarState();
+            horizontalScrollbarStateForRoot = await UIHelper.horizontalScrollbarState();
+            shouldBeEqualToString('verticalScrollbarStateForRoot', 'enabled');
+            shouldBeEqualToString('horizontalScrollbarStateForRoot', 'none');
 
             autoScroller = document.querySelector('.auto.scroller')
             scrollScroller = document.querySelector('.scroll.scroller')
 
             debug('overflow:auto');
-            shouldBeEqualToString('internals.verticalScrollbarState(autoScroller)', 'enabled');
-            shouldBeEqualToString('internals.horizontalScrollbarState(autoScroller)', 'none');
+            verticalScrollbarStateForAuto = await UIHelper.verticalScrollbarState(autoScroller);
+            horizontalScrollbarStateForAuto = await UIHelper.horizontalScrollbarState(autoScroller);
+            shouldBeEqualToString('verticalScrollbarStateForAuto', 'enabled');
+            shouldBeEqualToString('horizontalScrollbarStateForAuto', 'none');
 
             debug('overflow:scroll');
-            shouldBeEqualToString('internals.verticalScrollbarState(scrollScroller)', 'enabled');
-            shouldBeEqualToString('internals.horizontalScrollbarState(scrollScroller)', 'disabled');
+            verticalScrollbarStateForScroll = await UIHelper.verticalScrollbarState(scrollScroller);
+            horizontalScrollbarStateForScroll = await UIHelper.horizontalScrollbarState(scrollScroller);
+            shouldBeEqualToString('verticalScrollbarStateForScroll', 'enabled');
+            shouldBeEqualToString('horizontalScrollbarStateForScroll', 'none');
 
             finishJSTest();
         }, false);

--- a/LayoutTests/fast/scrolling/mac/scrollbars/select-overlay-scrollbar-hovered.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/select-overlay-scrollbar-hovered.html
@@ -35,12 +35,13 @@
             const y = selectBounds.top + 10;
 
             debug('Initial state');
-            debug(internals.verticalScrollbarState(select));
+            verticalScrollbarStateForSelect = await UIHelper.verticalScrollbarState(select);
+            debug(verticalScrollbarStateForSelect);
 
             debug('Hovering vertical scrollbar should show expanded scrollbar');
             await UIHelper.mouseWheelScrollAt(x, y);
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState(select);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(select);
                 let expanded = state.indexOf('expanded') != -1;
                 if (expanded)
                     testPassed('Scrollbar state: ' + state);
@@ -50,8 +51,8 @@
             debug('Unhovering vertical scrollbar should hide it');
             await UIHelper.moveMouseAndWaitForFrame(x - 10, y);
             await UIHelper.moveMouseAndWaitForFrame(x - 20, y);
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState(select);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(select);
                 let thumbHidden = state.indexOf('visible_thumb') == -1;
                 let trackHidden = state.indexOf('visible_track') == -1;
                 if (thumbHidden && trackHidden)

--- a/LayoutTests/fast/scrolling/mac/scrollbars/select-overlay-scrollbar-reveal.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/select-overlay-scrollbar-reveal.html
@@ -35,12 +35,13 @@
             const y = selectBounds.top + 10;
 
             debug('Initial state');
-            debug(internals.verticalScrollbarState(select));
+            var scrollbarState = await UIHelper.verticalScrollbarState(select);
+            debug(scrollbarState);
 
             debug('MayBegin should show the scrollbar');
             await UIHelper.mouseWheelMayBeginAt(x, y);
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState(select);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(select);
                 let visible = state.indexOf('visible_thumb') != -1;
                 if (visible)
                     testPassed('Scrollbar state: ' + state);
@@ -50,8 +51,8 @@
             debug('Cancelled should hide the scrollbar');
             await UIHelper.mouseWheelCancelAt(x, y);
 
-            await UIHelper.waitForCondition(() => {
-                let state = internals.verticalScrollbarState(select);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(select);
                 let hidden = state.indexOf('visible_thumb') == -1;
                 if (hidden)
                     testPassed('Scrollbar state: ' + state);

--- a/LayoutTests/fast/scrolling/mac/scrollbars/very-wide-overlay-scrollbar.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/very-wide-overlay-scrollbar.html
@@ -25,8 +25,8 @@
         {
             let scroller = document.querySelector('.scroller');
             await UIHelper.mouseWheelMayBeginAt(100, 100);
-            await UIHelper.waitForCondition(() => {
-                let state = internals.horizontalScrollbarState(scroller);
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.horizontalScrollbarState(scroller);
                 console.log(state);
                 return state.indexOf('visible_thumb') != -1;
             });

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -178,6 +178,15 @@ window.UIHelper = class UIHelper {
         }
     }
 
+    static async waitForConditionAsync(conditionFunc)
+    {
+        var condition = await conditionFunc();
+        while (!condition) {
+            await UIHelper.animationFrame();
+            condition = await conditionFunc();
+        }
+    }
+
     static sendEventStream(eventStream)
     {
         const eventStreamAsString = JSON.stringify(eventStream);
@@ -862,20 +871,21 @@ window.UIHelper = class UIHelper {
 
     static scrollbarState(scroller, isVertical)
     {
+        var internalFunctions = scroller ? scroller.ownerDocument.defaultView.internals : internals;
         if (!this.isWebKit2() || this.isIOSFamily())
             return Promise.resolve();
         if (internals.isUsingUISideCompositing()) {
             return new Promise(resolve => {
                 testRunner.runUIScript(`(function() {
                     uiController.doAfterNextStablePresentationUpdate(function() {
-                        uiController.uiScriptComplete(uiController.scrollbarStateForScrollingNodeID(${internals.scrollingNodeIDForNode(scroller)}, ${isVertical}));
+                        uiController.uiScriptComplete(uiController.scrollbarStateForScrollingNodeID(${internalFunctions.scrollingNodeIDForNode(scroller)}, ${isVertical}));
                     });
                 })()`, state => {
                     resolve(state);
                 });
             });    
         } else {
-            return isVertical ? Promise.resolve(internals.verticalScrollbarState(scroller)) : Promise.resolve(internals.horizontalScrollbarState(scroller));
+            return isVertical ? Promise.resolve(internalFunctions.verticalScrollbarState(scroller)) : Promise.resolve(internalFunctions.horizontalScrollbarState(scroller));
         }
     }
 


### PR DESCRIPTION
#### 3a9451dba31381654b6b9ebd65f21d083a36b474
<pre>
Update fast/scrolling/mac/scrollbars tests to use new UIHelper scrollbar state function
<a href="https://bugs.webkit.org/show_bug.cgi?id=254698">https://bugs.webkit.org/show_bug.cgi?id=254698</a>
rdar://107389069

Reviewed by Simon Fraser.

Update the scrollbar tests to use the new infrastructure. When in non UI-side compositing mode
UIHelper.horizontal/verticalScrollbarState will use the old internals function, and when in
UI-side compositing mode, it will use the new UIScriptController function.

* LayoutTests/fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-hovered.html:
* LayoutTests/fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-reveal.html:
* LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-hovered.html:
* LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html:
* LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-hovered.html:
* LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-reveal.html:
* LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-state-expected.txt:
* LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-state.html:
* LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-state-expected.txt:
* LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-state.html:
* LayoutTests/fast/scrolling/mac/scrollbars/select-overlay-scrollbar-hovered.html:
* LayoutTests/fast/scrolling/mac/scrollbars/select-overlay-scrollbar-reveal.html:
* LayoutTests/fast/scrolling/mac/scrollbars/very-wide-overlay-scrollbar.html:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async waitForConditionAsync):
(window.UIHelper.scrollbarState.return.new.Promise.):
(window.UIHelper.scrollbarState.return.new.Promise):
(window.UIHelper.scrollbarState):
(window.UIHelper.verticalScrollbarState):
(window.UIHelper.horizontalScrollbarState):

Canonical link: <a href="https://commits.webkit.org/262561@main">https://commits.webkit.org/262561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5230b6cd541f0b304d9d0905fa5d64c2d289640

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2799 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1968 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1735 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2644 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1659 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1719 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1706 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1661 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1670 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/460 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1821 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->