### PR TITLE
REGRESSION(258561@main): :user-valid/:user-invalid stopped working

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt
@@ -1,5 +1,5 @@
 
 
-PASS :user-invalid selector should be supported
+PASS :user-invalid selector should respond to user action
 PASS :user-error selector should not be supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid.html
@@ -1,16 +1,59 @@
 <!doctype html>
 <title>Support for the :user-invalid pseudo-class</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
 <link rel="help" href="https://drafts.csswg.org/selectors/#user-pseudos">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<input value="bar" pattern="foo">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+input {
+  border: 2px solid black;
+}
+
+input:user-valid {
+  border-color: green;
+}
+
+input:user-invalid {
+  border-color: red;
+}
+</style>
+
+<input id="initially-invalid" type="email" value="foo">
+
 <script>
-test(() => {
-  const input = document.querySelector('input');
+promise_test(async () => {
+  const input = document.querySelector("#initially-invalid");
   assert_false(input.validity.valid, "Should be invalid");
   // The selector can't match because no interaction has happened.
   assert_false(input.matches(':user-invalid'));
-}, ':user-invalid selector should be supported');
+
+  assert_false(input.matches(":user-valid"), "Initially does not match :user-valid");
+  assert_false(input.matches(":user-invalid"), "Initially does not match :user-invalid");
+
+  await test_driver.click(input);
+  input.blur();
+
+  assert_false(input.matches(":user-valid"), "No change happened, still does not match :user-valid");
+  assert_false(input.matches(":user-invalid"), "No change happened, still does not match :user-invalid");
+
+  await test_driver.click(input);
+  await test_driver.send_keys(input, "not an email");
+  input.blur();
+
+  assert_true(input.matches(":user-invalid"), "Typed an invalid email, :user-invalid now matches");
+  assert_false(input.matches(":user-valid"), "Typed an invalid email, :user-valid does not match");
+
+  input.value = "";
+  await test_driver.click(input);
+  await test_driver.send_keys(input, "test@example.com");
+  input.blur();
+
+  assert_true(input.matches(":user-valid"), "Put a valid email, :user-valid now matches");
+  assert_false(input.matches(":user-invalid"), "Put an valid email, :user-invalid no longer matches");
+}, ':user-invalid selector should respond to user action');
 
 // historical: https://github.com/w3c/csswg-drafts/issues/1329
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS :user-valid selector should be supported
+PASS :user-valid selector should respond to user action
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid.html
@@ -1,14 +1,55 @@
 <!doctype html>
 <title>Support for the :user-valid pseudo-class</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
 <link rel="help" href="https://drafts.csswg.org/selectors/#user-pseudos">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<input>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+input {
+  border: 2px solid black;
+}
+
+input:user-valid {
+  border-color: green;
+}
+
+input:user-invalid {
+  border-color: red;
+}
+</style>
+
+<input id="initially-valid" type="email">
+
 <script>
-test(() => {
-  const input = document.querySelector('input');
+promise_test(async () => {
+  const input = document.querySelector("#initially-valid");
   assert_true(input.validity.valid);
   // The selector can't match because no interaction has happened.
   assert_false(input.matches(':user-valid'));
-}, ':user-valid selector should be supported');
+
+  assert_false(input.matches(":user-valid"), "Initially does not match :user-valid");
+  assert_false(input.matches(":user-invalid"), "Initially does not match :user-invalid");
+
+  await test_driver.click(input);
+  input.blur();
+
+  assert_false(input.matches(":user-valid"), "No change happened, still does not match :user-valid");
+  assert_false(input.matches(":user-invalid"), "No change happened, still does not match :user-invalid");
+
+  await test_driver.click(input);
+  await test_driver.send_keys(input, "test@example.com");
+  input.blur();
+
+  assert_true(input.matches(":user-valid"), "Typed a valid email, :user-valid now matches");
+  assert_false(input.matches(":user-invalid"), "Typed a valid email, :user-invalid does not match");
+
+  input.required = true;
+  input.value = "";
+
+  assert_false(input.matches(":user-valid"), "Cleared required input, :user-valid no longer matches");
+  assert_true(input.matches(":user-invalid"), "Cleared required input, :user-invalid now matches");
+}, ":user-valid selector should respond to user action");
 </script>

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL :user-invalid selector should respond to user action assert_true: Typed an invalid email, :user-invalid now matches expected true got false
+PASS :user-error selector should not be supported
+

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL :user-valid selector should respond to user action assert_true: Typed a valid email, :user-valid now matches expected true got false
+

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -43,6 +43,8 @@ public:
 
     bool matchesValidPseudoClass() const override { return ValidatedFormListedElement::matchesValidPseudoClass(); }
     bool matchesInvalidPseudoClass() const override { return ValidatedFormListedElement::matchesInvalidPseudoClass(); }
+    bool matchesUserValidPseudoClass() const override { return ValidatedFormListedElement::matchesUserValidPseudoClass(); }
+    bool matchesUserInvalidPseudoClass() const override { return ValidatedFormListedElement::matchesUserInvalidPseudoClass(); }
 
     bool isDisabledFormControl() const final { return isDisabled(); }
     bool supportsFocus() const override { return !isDisabled(); }


### PR DESCRIPTION
#### bc8d5b0f582f1f25dd48a6d84f51aeb29dd1e20b
<pre>
REGRESSION(258561@main): :user-valid/:user-invalid stopped working
<a href="https://bugs.webkit.org/show_bug.cgi?id=254571">https://bugs.webkit.org/show_bug.cgi?id=254571</a>
&lt;rdar://problem/107300848&gt;

Reviewed by Tim Nguyen.

This change adds missing virtual method overrides to fix :user-valid / :user-invalid
pseudoclasses, similar to those we have for :valid / :invalid.
They are necessary because ValidatedFormListedElement doesn&apos;t inherit from Element.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/user-valid.html:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-invalid-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/selectors/user-valid-expected.txt:
* Source/WebCore/html/HTMLFormControlElement.h:

Co-authored-by: Tim Nguyen &lt;ntim@apple.com&gt;

Canonical link: <a href="https://commits.webkit.org/262512@main">https://commits.webkit.org/262512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1371afd1bb85309a5f5dcfc25828176bfec6ef65

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2692 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1654 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1782 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1597 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2531 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1496 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1624 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2695 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1654 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1575 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1716 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/183 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->