### PR TITLE
[ews-build.webkit.org] Allow for PRs comprised of cherry-picks to include multiple commits

### DIFF
--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6688,7 +6688,7 @@ class TestValidateSquashed(BuildStepMixinAdditions, unittest.TestCase):
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         logEnviron=False,
-                        command=['git', 'log', '--oneline', 'HEAD', '^origin/main', '--max-count=2'],
+                        command=['git', 'log', '--oneline', 'HEAD', '^origin/main', '--max-count=51'],
                         )
             + 0
             + ExpectShell.log('stdio', stdout='e1eb24603493 (HEAD -> eng/pull-request-branch) First line of commit\n'),
@@ -6702,7 +6702,7 @@ class TestValidateSquashed(BuildStepMixinAdditions, unittest.TestCase):
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         logEnviron=False,
-                        command=['git', 'log', '--oneline', 'HEAD', '^origin/main', '--max-count=2'],
+                        command=['git', 'log', '--oneline', 'HEAD', '^origin/main', '--max-count=51'],
                         )
             + 0
             + ExpectShell.log('stdio', stdout='''e1eb24603493 (HEAD -> eng/pull-request-branch) Commit Series (3)
@@ -6724,7 +6724,7 @@ class TestValidateSquashed(BuildStepMixinAdditions, unittest.TestCase):
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         logEnviron=False,
-                        command=['git', 'log', '--oneline', 'eng/pull-request-branch', '^main', '--max-count=2'],
+                        command=['git', 'log', '--oneline', 'eng/pull-request-branch', '^main', '--max-count=51'],
                         )
             + 0
             + ExpectShell.log('stdio', stdout='e1eb24603493 (HEAD -> eng/pull-request-branch) First line of commit\n'),
@@ -6740,7 +6740,7 @@ class TestValidateSquashed(BuildStepMixinAdditions, unittest.TestCase):
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         logEnviron=False,
-                        command=['git', 'log', '--oneline', 'eng/pull-request-branch', '^main', '--max-count=2'],
+                        command=['git', 'log', '--oneline', 'eng/pull-request-branch', '^main', '--max-count=51'],
                         )
             + 0
             + ExpectShell.log('stdio', stdout='''e1eb24603493 (HEAD -> eng/pull-request-branch) Commit Series (3)
@@ -6762,7 +6762,7 @@ class TestValidateSquashed(BuildStepMixinAdditions, unittest.TestCase):
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         logEnviron=False,
-                        command=['git', 'log', '--oneline', 'eng/pull-request-branch', '^main', '--max-count=2'],
+                        command=['git', 'log', '--oneline', 'eng/pull-request-branch', '^main', '--max-count=51'],
                         )
             + 0
             + ExpectShell.log('stdio', stdout=''),
@@ -6771,6 +6771,49 @@ class TestValidateSquashed(BuildStepMixinAdditions, unittest.TestCase):
         rc = self.runStep()
         self.assertEqual(self.getProperty('comment_text'), 'This change contains multiple commits which are not squashed together, blocking PR #1234. Please squash the commits to land.')
         self.assertEqual(self.getProperty('build_finish_summary'), 'Can only land squashed commits')
+        return rc
+
+    def test_success_multiple_commits_cherry_pick(self):
+        self.setupStep(ValidateSquashed())
+        self.setProperty('github.number', '1234')
+        self.setProperty('github.base.ref', 'main')
+        self.setProperty('github.head.ref', 'eng/pull-request-branch')
+        self.setProperty('classification', ['Cherry-pick'])
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logEnviron=False,
+                        command=['git', 'log', '--oneline', 'eng/pull-request-branch', '^main', '--max-count=51'],
+                        )
+            + 0
+            + ExpectShell.log('stdio', stdout='''e1eb24603493 (HEAD -> eng/pull-request-branch) Cherry-pick cdebfa
+08abb9ddcbb5 Cherry-pick abcdef
+45cf3efe4dfb Cherry-pick fedcba
+'''),
+        )
+        self.expectOutcome(result=SUCCESS, state_string='Commit sequence is entirely cherry-picks')
+        rc = self.runStep()
+        self.assertEqual(self.getProperty('commit_count'), 3)
+        return rc
+
+    def test_failure_too_many_commits_cherry_pick(self):
+        self.setupStep(ValidateSquashed())
+        self.setProperty('github.number', '1234')
+        self.setProperty('github.base.ref', 'main')
+        self.setProperty('github.head.ref', 'eng/pull-request-branch')
+        self.setProperty('classification', ['Cherry-pick'])
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logEnviron=False,
+                        command=['git', 'log', '--oneline', 'eng/pull-request-branch', '^main', '--max-count=51'],
+                        )
+            + 0
+            + ExpectShell.log('stdio', stdout='e1eb24603493 (HEAD -> eng/pull-request-branch) Cherry-pick cdebfa\n' + 50 * '08abb9ddcbb5 Cherry-pick abcdef\n'),
+        )
+        self.expectOutcome(result=FAILURE, state_string='Too many commits in a pull-request')
+        rc = self.runStep()
+        self.assertEqual(self.getProperty('commit_count'), 51)
+        self.assertEqual(self.getProperty('comment_text'), 'Policy allows for multiple cherry-picks to be landed simultaneously but there is a limit of 50, blocking PR #1234 because it has 51 commits. Please break this change into multiple pull requests.')
+        self.assertEqual(self.getProperty('build_finish_summary'), 'Too many commits in a pull-request')
         return rc
 
 
@@ -6859,6 +6902,17 @@ class TestAddReviewerToCommitMessage(BuildStepMixinAdditions, unittest.TestCase)
         self.setProperty('github.base.ref', 'main')
         self.setProperty('github.head.ref', 'eng/pull-request-branch')
         self.setProperty('reviewers_full_names', [])
+        self.expectOutcome(result=SKIPPED, state_string='finished (skipped)')
+        return self.runStep()
+
+    def test_skip_cherry_pick(self):
+        self.setupStep(AddReviewerToCommitMessage())
+        self.setProperty('github.number', '1234')
+        self.setProperty('github.base.ref', 'main')
+        self.setProperty('github.head.ref', 'eng/pull-request-branch')
+        self.setProperty('reviewers_full_names', ['WebKit Reviewer', 'Other Reviewer'])
+        self.setProperty('owners', ['webkit-commit-queue'])
+        self.setProperty('classification', ['Cherry-pick'])
         self.expectOutcome(result=SKIPPED, state_string='finished (skipped)')
         return self.runStep()
 
@@ -7130,6 +7184,65 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
         self.expectOutcome(result=SUCCESS, state_string='Canonicalized commit')
         return self.runStep()
 
+    def test_success_multiple_commits(self):
+        self.setupStep(Canonicalize())
+        self.setProperty('github.number', '1234')
+        self.setProperty('github.base.ref', 'main')
+        self.setProperty('github.head.ref', 'eng/pull-request-branch')
+        self.setProperty('owners', ['webkit-commit-queue'])
+        self.setProperty('remote', 'origin')
+        self.setProperty('commit_count', 4)
+
+        gmtoffset = int(time.localtime().tm_gmtoff * 100 / (60 * 60))
+        fixed_time = int(time.time())
+        date = f'{int(time.time())} {gmtoffset}'
+        time.time = lambda: fixed_time
+
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                timeout=300,
+                logEnviron=False,
+                env=self.ENV,
+                command=['/bin/sh', '-c', 'rm .git/identifiers.json || true'],
+            ) + 0, ExpectShell(
+                workdir='wkdir',
+                timeout=300,
+                logEnviron=False,
+                env=self.ENV,
+                command=['git', 'pull', 'origin', 'main', '--rebase'],
+            ) + 0, ExpectShell(
+                workdir='wkdir',
+                timeout=300,
+                logEnviron=False,
+                env=self.ENV,
+                command=['git', 'branch', '-f', 'main', 'eng/pull-request-branch'],
+            ) + 0, ExpectShell(
+                workdir='wkdir',
+                timeout=300,
+                logEnviron=False,
+                env=self.ENV,
+                command=['git', 'checkout', 'main'],
+            ) + 0, ExpectShell(
+                workdir='wkdir',
+                timeout=300,
+                logEnviron=False,
+                env=self.ENV,
+                command=['python3', 'Tools/Scripts/git-webkit', 'canonicalize', '-n', '4'],
+            ) + 0, ExpectShell(workdir='wkdir',
+                logEnviron=False,
+                env=self.ENV,
+                timeout=300,
+                command=[
+                    'git', 'filter-branch', '-f',
+                    '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}';GIT_COMMITTER_NAME='WebKit Committer';GIT_COMMITTER_EMAIL='committer@webkit.org'".format(date=date),
+                    'HEAD...HEAD~1',
+                ],
+            ) + 0,
+        )
+        self.expectOutcome(result=SUCCESS, state_string='Canonicalized commits')
+        return self.runStep()
+
     def test_success_branch(self):
         self.setupStep(Canonicalize())
         self.setProperty('github.number', '1234')
@@ -7379,7 +7492,7 @@ Canonical link: <a href="https://commits.webkit.org/249006@main">https://commits
             ExpectShell(workdir='wkdir',
                         logEnviron=False,
                         timeout=300,
-                        command=['git', 'log', '-1', '--no-decorate'])
+                        command=['git', 'log', '--no-decorate', '-1'])
             + 0
             + ExpectShell.log('stdio', stdout='''commit 44a3b7100bd5dba51c57d874d3e89f89081e7886
 Author: Jonathan Bedard <jbedard@apple.com>
@@ -7442,7 +7555,7 @@ Canonical link: <a href="https://commits.webkit.org/249833@main">https://commits
             ExpectShell(workdir='wkdir',
                         logEnviron=False,
                         timeout=300,
-                        command=['git', 'log', '-1', '--no-decorate'])
+                        command=['git', 'log', '--no-decorate', '-1'])
             + 0
             + ExpectShell.log('stdio', stdout='''commit 6a50b47fd71d922f753c06f46917086c839520b
 Author: Karl Rackler <rackler@apple.com>
@@ -7480,7 +7593,7 @@ Date:   Thu Apr 21 00:25:03 2022 +0000
             ExpectShell(workdir='wkdir',
                         logEnviron=False,
                         timeout=300,
-                        command=['git', 'log', '-1', '--no-decorate'])
+                        command=['git', 'log', '--no-decorate', '-1'])
             + 0
             + ExpectShell.log('stdio', stdout='''commit 44a3b7100bd5dba51c57d874d3e89f89081e7886
 Author: Jonathan Bedard <jbedard@apple.com>
@@ -7504,6 +7617,165 @@ Date:   Tue Mar 29 16:04:35 2022 -0700
         with current_hostname(EWS_BUILD_HOSTNAME):
             rc = yield self.runStep()
             self.assertEqual(self.getProperty('bug_id'), '238553')
+            self.assertEqual(self.getProperty('is_test_gardening'), False)
+            return rc
+
+    def test_success_series(self):
+
+        def update_pr(x, pr_number, title, description, base=None, head=None, repository_url=None):
+            self.assertEqual(pr_number, '1234')
+            self.assertEqual(title, 'Cherry-pick 252432.1026@safari-7614-branch (2a8469e53b2f). rdar://107367418')
+            self.assertEqual(base, 'main')
+            self.assertEqual(head, 'JonWBedard:eng/pull-request-branch')
+
+            self.assertEqual(
+                description,
+                '''#### 9140b95e718e7342366bbcdc29cb1ba0f9328422
+<pre>
+Cherry-pick 252432.1026@safari-7614-branch (2a8469e53b2f). rdar://107367418
+
+    Remove inheritance of designMode attribute
+    <a href="https://bugs.webkit.org/show_bug.cgi?id=248615">https://bugs.webkit.org/show_bug.cgi?id=248615</a>
+    rdar://102868995
+
+    Reviewed by Wenson Hsieh and Jonathan Bedard.
+
+    Stop making design mode inherit across frame boundaries.
+
+    This will prevent a form element from being injected into a victim page via drag &amp; drop
+    and the new behavior matches that of Firefox and Chrome.
+
+    * LayoutTests/editing/editability/design-mode-does-not-inherit-across-frames-expected.txt: Added.
+    * LayoutTests/editing/editability/design-mode-does-not-inherit-across-frames.html: Added.
+    * LayoutTests/fast/dom/HTMLElement/iscontenteditable-designmodeon-allinherit-subframe-expected.txt:
+    * LayoutTests/fast/dom/HTMLElement/iscontenteditable-designmodeon-allinherit-subframe.html:
+    * Source/WebCore/dom/Document.cpp:
+    (WebCore::Document::setDesignMode):
+    (WebCore::Document::inDesignMode const): Deleted.
+    * Source/WebCore/dom/Document.h:
+    (WebCore::Document::inDesignMode const):
+
+    Canonical link: <a href="https://commits.webkit.org/252432.1026@safari-7614-branch">https://commits.webkit.org/252432.1026@safari-7614-branch</a>
+
+Canonical link: <a href="https://commits.webkit.org/262299@main">https://commits.webkit.org/262299@main</a>
+</pre>
+----------------------------------------------------------------------
+#### 6ec5319be307db36a27ea61d208cf68ce84abd67
+<pre>
+Cherry-pick 252432.1024@safari-7614-branch (2ea437d75522). rdar://107367090
+
+    Use-after-free in ContactsManager::select
+    <a href="https://bugs.webkit.org/show_bug.cgi?id=250351">https://bugs.webkit.org/show_bug.cgi?id=250351</a>
+    rdar://101241436
+
+    Reviewed by Wenson Hsieh and Jonathan Bedard.
+
+    `ContactsManager` can be destroyed prior to receiving the user&apos;s selection, which
+    is performed asynchronously. Deploy `WeakPtr` to avoid a use-after-free in this
+    scenario.
+
+    A test was unable to be added, as the failure scenario involves opening a new
+    Window, using the new Window object&apos;s `navigator.contacts`, and performing user
+    interaction. Creating a new Window results in the creation of a new web view,
+    however all of our existing UIScriptController hooks only apply to the original
+    (main) web view. Consequently, it is not possible to use our testing
+    infrastructure to dismiss the contact picker and trigger the callback in the
+    failure scenario.
+
+    * Source/WebCore/Modules/contact-picker/ContactsManager.cpp:
+    (WebCore::ContactsManager::select):
+    * Source/WebCore/Modules/contact-picker/ContactsManager.h:
+
+    Canonical link: <a href="https://commits.webkit.org/252432.1024@safari-7614-branch">https://commits.webkit.org/252432.1024@safari-7614-branch</a>
+
+Canonical link: <a href="https://commits.webkit.org/262298@main">https://commits.webkit.org/262298@main</a>
+</pre>
+''',
+            )
+
+            return defer.succeed(True)
+
+        UpdatePullRequest.update_pr = update_pr
+        self.setupStep(UpdatePullRequest())
+        self.setProperty('github.number', '1234')
+        self.setProperty('github.head.user.login', 'JonWBedard')
+        self.setProperty('github.head.ref', 'eng/pull-request-branch')
+        self.setProperty('github.base.ref', 'main')
+        self.setProperty('commit_count', 2)
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logEnviron=False,
+                        timeout=300,
+                        command=['git', 'log', '--no-decorate', '-2'])
+            + 0
+            + ExpectShell.log('stdio', stdout='''commit 9140b95e718e7342366bbcdc29cb1ba0f9328422
+Author: Jonathan Bedard <jbedard@apple.com>
+Date:   Tue Mar 29 16:04:35 2023 -0700
+
+    Cherry-pick 252432.1026@safari-7614-branch (2a8469e53b2f). rdar://107367418
+
+        Remove inheritance of designMode attribute
+        https://bugs.webkit.org/show_bug.cgi?id=248615
+        rdar://102868995
+
+        Reviewed by Wenson Hsieh and Jonathan Bedard.
+
+        Stop making design mode inherit across frame boundaries.
+
+        This will prevent a form element from being injected into a victim page via drag & drop
+        and the new behavior matches that of Firefox and Chrome.
+
+        * LayoutTests/editing/editability/design-mode-does-not-inherit-across-frames-expected.txt: Added.
+        * LayoutTests/editing/editability/design-mode-does-not-inherit-across-frames.html: Added.
+        * LayoutTests/fast/dom/HTMLElement/iscontenteditable-designmodeon-allinherit-subframe-expected.txt:
+        * LayoutTests/fast/dom/HTMLElement/iscontenteditable-designmodeon-allinherit-subframe.html:
+        * Source/WebCore/dom/Document.cpp:
+        (WebCore::Document::setDesignMode):
+        (WebCore::Document::inDesignMode const): Deleted.
+        * Source/WebCore/dom/Document.h:
+        (WebCore::Document::inDesignMode const):
+
+        Canonical link: https://commits.webkit.org/252432.1026@safari-7614-branch
+
+    Canonical link: https://commits.webkit.org/262299@main
+
+commit 6ec5319be307db36a27ea61d208cf68ce84abd67
+Author: Jonathan Bedard <jbedard@apple.com>
+Date:   Tue Mar 29 16:04:35 2023 -0700
+
+    Cherry-pick 252432.1024@safari-7614-branch (2ea437d75522). rdar://107367090
+
+        Use-after-free in ContactsManager::select
+        https://bugs.webkit.org/show_bug.cgi?id=250351
+        rdar://101241436
+
+        Reviewed by Wenson Hsieh and Jonathan Bedard.
+
+        `ContactsManager` can be destroyed prior to receiving the user's selection, which
+        is performed asynchronously. Deploy `WeakPtr` to avoid a use-after-free in this
+        scenario.
+
+        A test was unable to be added, as the failure scenario involves opening a new
+        Window, using the new Window object's `navigator.contacts`, and performing user
+        interaction. Creating a new Window results in the creation of a new web view,
+        however all of our existing UIScriptController hooks only apply to the original
+        (main) web view. Consequently, it is not possible to use our testing
+        infrastructure to dismiss the contact picker and trigger the callback in the
+        failure scenario.
+
+        * Source/WebCore/Modules/contact-picker/ContactsManager.cpp:
+        (WebCore::ContactsManager::select):
+        * Source/WebCore/Modules/contact-picker/ContactsManager.h:
+
+        Canonical link: https://commits.webkit.org/252432.1024@safari-7614-branch
+
+    Canonical link: https://commits.webkit.org/262298@main
+'''),
+        )
+        self.expectOutcome(result=SUCCESS, state_string='Updated pull request')
+        with current_hostname(EWS_BUILD_HOSTNAME):
+            rc = self.runStep()
+            self.assertEqual(self.getProperty('bug_id'), '248615')
             self.assertEqual(self.getProperty('is_test_gardening'), False)
             return rc
 


### PR DESCRIPTION
#### 1606ea8ade0f444e257a9e0967faf9b57c7ec31f
<pre>
[ews-build.webkit.org] Allow for PRs comprised of cherry-picks to include multiple commits
<a href="https://bugs.webkit.org/show_bug.cgi?id=254701">https://bugs.webkit.org/show_bug.cgi?id=254701</a>
rdar://107391286

Reviewed by Aakash Jain.

Since cherry-picks nessesarily come from elsewhere in the repository, each cherry-pick
has already been verified to build somewhere. While the previous statement may not apply
to the current branch (a commit may rely on code which does not exist on a branch), it is
exceptionally rare for a cherry-pick failure to be fixed by another cherry-pick. This means
that if a sequence of cherry-picks passes EWS, it is very likely that each individual
component of that sequence would pass EWS in isolation.

To facilitate faster repository management, merge-queue should permit patch series which are
comprised entirely of cherry-picks.

* Tools/CISupport/ews-build/steps.py:
(ValidateSquashed.evaluateCommand): If a PR is comprised entirely of cherry-picks, allow
a PR with multiple commits to be landed. Note that we need to let Canonicalize know how
many commits are going to be landed, because it can no longer safely assume &quot;1&quot;.
(AddReviewerToCommitMessage.doStepIf): If a change is classified as a cherry-pick, we do not
want to add reviewers.
(Canonicalize.number_commits_to_canonicalize): Return the number of commits to be canonicalized.
(Canonicalize.run): Use number_commits_to_canonicalize to determine how many commits to canonicalize.
(Canonicalize.getResultSummary): Ditto.
(UpdatePullRequest.run): Update pull-request which contains multiple commits.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/262340@main">https://commits.webkit.org/262340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb870118e87f9f4b13b4b21c6faf6519085ca68d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/1293 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/1329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/1369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/2142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/1280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/1381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/1397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/2142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/1304 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/1381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/1369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/1381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/1369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/1988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/1188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/1369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/1988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/1397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/1283 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/1369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/1262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/134 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->