### PR TITLE
Always use originSaltFileName to create salt file path in CacheStorageManger

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -147,13 +147,28 @@ static bool writeSizeFile(const String& sizeDirectoryPath, uint64_t size)
     return FileSystem::overwriteEntireFile(sizeFilePath, makeSpan(reinterpret_cast<uint8_t*>(const_cast<char*>(value.data())), value.length())) != -1;
 }
 
+static String saltFilePath(const String& saltDirectory)
+{
+    if (saltDirectory.isEmpty())
+        return emptyString();
+
+    return FileSystem::pathByAppendingComponent(saltDirectory, originSaltFileName);
+}
+
+static FileSystem::Salt readOrMakeSalt(const String& saltPath)
+{
+    if (saltPath.isEmpty())
+        return { };
+
+    return valueOrDefault(FileSystem::readOrMakeSalt(saltPath));
+}
+    
 String CacheStorageManager::cacheStorageOriginDirectory(const String& rootDirectory, const WebCore::ClientOrigin& origin)
 {
     if (rootDirectory.isEmpty())
         return emptyString();
 
-    auto saltFilePath = FileSystem::pathByAppendingComponent(rootDirectory, "salt"_s);
-    auto salt = valueOrDefault(FileSystem::readOrMakeSalt(saltFilePath));
+    auto salt = readOrMakeSalt(saltFilePath(rootDirectory));
     NetworkCache::Key key(origin.topOrigin.toString(), origin.clientOrigin.toString(), { }, { }, salt);
     return FileSystem::pathByAppendingComponent(rootDirectory, key.hashAsString());
 }
@@ -163,11 +178,11 @@ void CacheStorageManager::copySaltFileToOriginDirectory(const String& rootDirect
     if (!FileSystem::fileExists(originDirectory))
         return;
 
-    auto targetFilePath = FileSystem::pathByAppendingComponent(originDirectory, "salt"_s);
+    auto targetFilePath = saltFilePath(originDirectory);
     if (FileSystem::fileExists(targetFilePath))
         return;
 
-    auto sourceFilePath = FileSystem::pathByAppendingComponent(rootDirectory, "salt"_s);
+    auto sourceFilePath = saltFilePath(rootDirectory);
     FileSystem::hardLinkOrCopyFile(sourceFilePath, targetFilePath);
 }
 
@@ -223,17 +238,10 @@ void CacheStorageManager::makeDirty()
     m_updateCounter = nextUpdateNumber();
 }
 
-static FileSystem::Salt readOrMakeSalt(const String& saltDirectory)
-{
-    if (saltDirectory.isEmpty())
-        return { };
-    return valueOrDefault(FileSystem::readOrMakeSalt(FileSystem::pathByAppendingComponent(saltDirectory, originSaltFileName)));
-}
-
 CacheStorageManager::CacheStorageManager(const String& path, CacheStorageRegistry& registry, const std::optional<WebCore::ClientOrigin>& origin, QuotaCheckFunction&& quotaCheckFunction, Ref<WorkQueue>&& queue)
     : m_updateCounter(nextUpdateNumber())
     , m_path(path)
-    , m_salt(readOrMakeSalt(m_path))
+    , m_salt(readOrMakeSalt(saltFilePath(m_path)))
     , m_registry(registry)
     , m_quotaCheckFunction(WTFMove(quotaCheckFunction))
     , m_queue(WTFMove(queue))


### PR DESCRIPTION
#### e14c57a5efec24271da0f3f1bf76ec3faf08baab
<pre>
Always use originSaltFileName to create salt file path in CacheStorageManger
<a href="https://bugs.webkit.org/show_bug.cgi?id=254705">https://bugs.webkit.org/show_bug.cgi?id=254705</a>
rdar://107393253

Reviewed by Youenn Fablet.

* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::saltFilePath):
(WebKit::readOrMakeSalt):
(WebKit::CacheStorageManager::cacheStorageOriginDirectory):
(WebKit::CacheStorageManager::copySaltFileToOriginDirectory):
(WebKit::CacheStorageManager::CacheStorageManager):

Canonical link: <a href="https://commits.webkit.org/262410@main">https://commits.webkit.org/262410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c132c955c8704b4be03964b9b32fe11418ae4274

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1932 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1061 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1231 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1800 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1078 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1085 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1117 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2176 "269 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1044 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/367 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1156 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->