### PR TITLE
Add OMG WASM tracing debug code

### DIFF
--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -56,11 +56,8 @@ constexpr bool alwaysDumpConstructionSite = false;
 #if ASSERT_ENABLED
 String Value::generateCompilerConstructionSite()
 {
-    if (!Options::needDisassemblySupport() || !Options::dumpCompilerConstructionSite())
-        return emptyString();
-
     StringPrintStream s;
-    static constexpr int framesToShow = 60;
+    static constexpr int framesToShow = 15;
     static constexpr int framesToSkip = 0;
     void* samples[framesToShow + framesToSkip];
     int frames = framesToShow + framesToSkip;
@@ -73,13 +70,31 @@ String Value::generateCompilerConstructionSite()
     s.print("[");
     int printed = 0;
     stackTrace.forEach([&] (unsigned, void*, const char* cName) {
-        if (printed > 3)
+        if (printed > 10)
             return;
         auto name = String::fromUTF8(cName);
         if (name.contains("JSC::Wasm::B3IRGenerator::emit"_s)
             || name.contains("JSC::Wasm::B3IRGenerator::add"_s)
             || name.contains("JSC::Wasm::B3IRGenerator::create"_s)
-            || name.contains("JSC::Wasm::B3IRGenerator::end"_s)) {
+            || name.contains("JSC::Wasm::B3IRGenerator::end"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::set"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::get"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::insert"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::constant("_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::fixup"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::load"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::store"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::atomic"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::trunc"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::sanitize"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::restore"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::connect"_s)
+            || name.contains("JSC::Wasm::B3IRGenerator::prepare"_s)) {
+            if (name.contains(">::add"_s)
+                || name.contains(">::translate"_s)
+                || name.contains(">::inlineEnsure"_s)
+                || name.contains(">::KeyValuePairTraits"_s))
+                return;
             if (printed)
                 s.print("|");
             s.print(name.left(name.find('(')));

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -864,8 +864,9 @@ private:
     NO_RETURN_DUE_TO_CRASH static void badKind(Kind, unsigned);
 
 #if ASSERT_ENABLED
-    String m_compilerConstructionSite { generateCompilerConstructionSite() };
+    String m_compilerConstructionSite { emptyString() };
 
+public:
     static String generateCompilerConstructionSite();
 #endif
 

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -519,7 +519,7 @@ struct AirIRGeneratorBase {
     ALWAYS_INLINE void willParseOpcode() { }
     ALWAYS_INLINE void didParseOpcode() { }
     void didFinishParsingLocals() { }
-    void didPopValueFromStack() { }
+    void didPopValueFromStack(ExpressionType, String) { }
     const Ref<TypeDefinition> getTypeDefinition(uint32_t typeIndex) { return m_info.typeSignatures[typeIndex]; }
     void getArrayElementType(uint32_t, StorageType&);
     void getArrayRefType(uint32_t, Type&);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -8447,7 +8447,7 @@ public:
 
     void dump(const ControlStack&, const Stack*) { }
     void didFinishParsingLocals() { }
-    void didPopValueFromStack() { }
+    void didPopValueFromStack(ExpressionType, String) { }
 
     void finalize()
     {

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -256,7 +256,7 @@ public:
         return push(NoConsistencyCheck);
     }
 
-    void didPopValueFromStack() { --m_stackSize; }
+    void didPopValueFromStack(ExpressionType, String) { --m_stackSize; }
     void notifyFunctionUsesSIMD() { ASSERT(Options::useWebAssemblySIMD()); m_usesSIMD = true; }
 
     PartialResult WARN_UNUSED_RETURN addDrop(ExpressionType);
@@ -1775,7 +1775,7 @@ auto LLIntGenerator::atomicStore(ExtAtomicOpType op, Type, ExpressionType pointe
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-    didPopValueFromStack(); // Ignore the result.
+    didPopValueFromStack(result, "LLINT ATOMIC IGNORE"_s); // Ignore the result.
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -131,6 +131,7 @@ void loadValuesIntoBuffer(Probe::Context& context, const StackMap& values, uint6
             default:
                 *bitwise_cast<uint64_t*>(buffer + index * valueSize) = context.gpr(value.gpr());
             }
+            dataLogLnIf(WasmOperationsInternal::verbose, "GPR for value ", index, " ", value.gpr(), " = ", context.gpr(value.gpr()));
         } else if (value.isFPR()) {
             switch (value.type().kind()) {
             case B3::Float:

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -33,6 +33,7 @@
 #include "JSWebAssemblyStruct.h"
 #include "TypedArrayController.h"
 #include "WaiterListManager.h"
+#include "WasmInstance.h"
 
 namespace JSC {
 namespace Wasm {

--- a/Source/JavaScriptCore/wasm/generateWasmB3IRGeneratorInlinesHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmB3IRGeneratorInlinesHeader.py
@@ -165,7 +165,7 @@ class CodeGenerator:
         return result
 
     def makeResult(self, resultValue):
-        return resultValue + ";\n" + "    result = push(resultValue->type());\n" + "    m_currentBlock->appendNew<VariableValue>(m_proc, Set, origin(), result, resultValue);"
+        return resultValue + ";\n" + "    result = push(resultValue);"
 
     def generate(self, wasmOp):
         if len(self.tokens) == 1:


### PR DESCRIPTION
#### 37b14a877442d6b80bac19213962e5376267a110
<pre>
Add OMG WASM tracing debug code
<a href="https://bugs.webkit.org/show_bug.cgi?id=254711">https://bugs.webkit.org/show_bug.cgi?id=254711</a>
rdar://107394100

Reviewed by Yusuke Suzuki.

Add some debugging tools to the OMG generator to trace WASM execution
at runtime.

* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::generateCompilerConstructionSite):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::AirIRGeneratorBase::didPopValueFromStack):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::didPopValueFromStack):
(JSC::Wasm::B3IRGenerator::makePushVariable):
(JSC::Wasm::B3IRGenerator::push):
(JSC::Wasm::B3IRGenerator::addRefFunc):
(JSC::Wasm::B3IRGenerator::getLocal):
(JSC::Wasm::B3IRGenerator::traceValue):
(JSC::Wasm::B3IRGenerator::traceCF):
(JSC::Wasm::B3IRGenerator::setLocal):
(JSC::Wasm::B3IRGenerator::getGlobal):
(JSC::Wasm::B3IRGenerator::setGlobal):
(JSC::Wasm::B3IRGenerator::addLoop):
(JSC::Wasm::B3IRGenerator::addIf):
(JSC::Wasm::B3IRGenerator::addElseToUnreachable):
(JSC::Wasm::B3IRGenerator::addTry):
(JSC::Wasm::B3IRGenerator::emitCatchImpl):
(JSC::Wasm::B3IRGenerator::addThrow):
(JSC::Wasm::B3IRGenerator::addReturn):
(JSC::Wasm::B3IRGenerator::addBranch):
(JSC::Wasm::B3IRGenerator::addEndToUnreachable):
(JSC::Wasm::B3IRGenerator::addCall):
(JSC::Wasm::B3IRGenerator::addCallIndirect):
(JSC::Wasm::B3IRGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::didPopValueFromStack):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::didPopValueFromStack):
(JSC::Wasm::LLIntGenerator::atomicStore):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::loadValuesIntoBuffer):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
* Source/JavaScriptCore/wasm/generateWasmB3IRGeneratorInlinesHeader.py:
(CodeGenerator.makeResult):

Canonical link: <a href="https://commits.webkit.org/262784@main">https://commits.webkit.org/262784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2236fd5b22996b62c058cec9a3cbda24dd62dd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3788 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2483 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2166 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3573 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2043 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2041 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2307 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2204 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3364 "260 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2340 "Built successfully and passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2232 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2024 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2519 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2185 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/567 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/639 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2199 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2571 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2352 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/679 "Passed tests") | 
<!--EWS-Status-Bubble-End-->