### PR TITLE
WasmBBQJIT performs redundant overflow check when dividend is constant

### DIFF
--- a/JSTests/wasm/stress/foldable-division.js
+++ b/JSTests/wasm/stress/foldable-division.js
@@ -1,0 +1,248 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "divsConstantLeft32") (param i32) (result i32)
+        i32.const 729
+        local.get 0
+        i32.div_s
+    )
+
+    (func (export "divuConstantLeft32") (param i32) (result i32)
+        i32.const 729
+        local.get 0
+        i32.div_u
+    )
+
+    (func (export "divsConstantRight32") (param i32) (result i32)
+        local.get 0
+        i32.const 125
+        i32.div_s
+    )
+
+    (func (export "divuConstantRight32") (param i32) (result i32)
+        local.get 0
+        i32.const 125
+        i32.div_u
+    )
+
+    (func (export "divsConstantLeft64") (param i64) (result i64)
+        i64.const 729
+        local.get 0
+        i64.div_s
+    )
+
+    (func (export "divuConstantLeft64") (param i64) (result i64)
+        i64.const 729
+        local.get 0
+        i64.div_u
+    )
+
+    (func (export "divsConstantRight64") (param i64) (result i64)
+        local.get 0
+        i64.const 125
+        i64.div_s
+    )
+
+    (func (export "divuConstantRight64") (param i64) (result i64)
+        local.get 0
+        i64.const 125
+        i64.div_u
+    )
+
+    (func (export "divsByMinusOne32") (param i32) (result i32)
+        local.get 0
+        i32.const -1
+        i32.div_s
+    )
+
+    (func (export "divuByMinusOne32") (param i32) (result i32)
+        local.get 0
+        i32.const -1
+        i32.div_u
+    )
+
+    (func (export "divsIntMin32") (param i32) (result i32)
+        i32.const 0x80000000
+        local.get 0
+        i32.div_s
+    )
+
+    (func (export "divuIntMin32") (param i32) (result i32)
+        i32.const 0x80000000
+        local.get 0
+        i32.div_u
+    )
+
+    (func (export "divsByZero32") (param i32) (result i32)
+        local.get 0
+        i32.const 0
+        i32.div_s
+    )
+
+    (func (export "divuByZero32") (param i32) (result i32)
+        local.get 0
+        i32.const 0
+        i32.div_u
+    )
+
+    (func (export "divsByMinusOne64") (param i64) (result i64)
+        local.get 0
+        i64.const -1
+        i64.div_s
+    )
+
+    (func (export "divuByMinusOne64") (param i64) (result i64)
+        local.get 0
+        i64.const -1
+        i64.div_u
+    )
+
+    (func (export "divsIntMin64") (param i64) (result i64)
+        i64.const 0x8000000000000000
+        local.get 0
+        i64.div_s
+    )
+
+    (func (export "divuIntMin64") (param i64) (result i64)
+        i64.const 0x8000000000000000
+        local.get 0
+        i64.div_u
+    )
+
+    (func (export "divsByZero64") (param i64) (result i64)
+        local.get 0
+        i64.const 0
+        i64.div_s
+    )
+
+    (func (export "divuByZero64") (param i64) (result i64)
+        local.get 0
+        i64.const 0
+        i64.div_u
+    )
+
+    (func (export "foldableDivsByZero32")
+        i32.const 42
+        i32.const 0
+        i32.div_s
+        drop
+    )
+
+    (func (export "foldableDivuByZero32")
+        i32.const 42
+        i32.const 0
+        i32.div_u
+        drop
+    )
+
+    (func (export "foldableDivsMinByMinusOne32")
+        i32.const 0x80000000
+        i32.const -1
+        i32.div_s
+        drop
+    )
+
+    (func (export "foldableDivuByZero64")
+        i64.const 42
+        i64.const 0
+        i64.div_u
+        drop
+    )
+
+    (func (export "foldableDivsByZero64")
+        i64.const 42
+        i64.const 0
+        i64.div_s
+        drop
+    )
+
+    (func (export "foldableDivsMinByMinusOne64")
+        i64.const 0x8000000000000000
+        i64.const -1
+        i64.div_s
+        drop
+    )
+)
+`;
+
+async function test() {
+  const instance = await instantiate(wat, {}, {});
+  const {
+    divsConstantLeft32, divuConstantLeft32,
+    divsConstantRight32, divuConstantRight32,
+    divsConstantLeft64, divuConstantLeft64,
+    divsConstantRight64, divuConstantRight64,
+    divsByMinusOne32, divuByMinusOne32,
+    divsIntMin32, divuIntMin32,
+    divsByZero32, divuByZero32,
+    divsByMinusOne64, divuByMinusOne64,
+    divsIntMin64, divuIntMin64,
+    divsByZero64, divuByZero64,
+    foldableDivsByZero32, foldableDivuByZero32, foldableDivsMinByMinusOne32,
+    foldableDivsByZero64, foldableDivuByZero64, foldableDivsMinByMinusOne64
+  } = instance.exports;
+
+  // 32-bit integers, one constant operand
+
+  assert.eq(divsConstantLeft32(9), 81);
+  assert.eq(divuConstantLeft32(9), 81);
+  assert.eq(divsConstantRight32(3125), 25);
+  assert.eq(divuConstantRight32(3125), 25);
+
+  assert.eq(divsByMinusOne32(42), -42);
+  assert.throws(() => divsByMinusOne32(-0x80000000), WebAssembly.RuntimeError, "Integer overflow");
+
+  assert.eq(divuByMinusOne32(42), 0);
+  assert.eq(divuByMinusOne32(-0x80000000), 0); // Not an error for unsigned division.
+
+  assert.eq(divsIntMin32(4), -0x20000000);
+  assert.throws(() => divsIntMin32(-1), WebAssembly.RuntimeError, "Integer overflow");
+  assert.throws(() => divsIntMin32(0), WebAssembly.RuntimeError, "Division by zero");
+
+  assert.eq(divuIntMin32(1), -0x80000000);
+  assert.eq(divuIntMin32(-1), 0); // Not an error for unsigned division.
+  assert.throws(() => divuIntMin32(0), WebAssembly.RuntimeError, "Division by zero");
+
+  assert.throws(() => divsByZero32(42), WebAssembly.RuntimeError, "Division by zero");
+
+  assert.throws(() => divuByZero32(42), WebAssembly.RuntimeError, "Division by zero");
+
+  // 64-bit integers, one constant operand
+
+  assert.eq(divsConstantLeft64(9n), 81n);
+  assert.eq(divuConstantLeft64(9n), 81n);
+  assert.eq(divsConstantRight64(3125n), 25n);
+  assert.eq(divuConstantRight64(3125n), 25n);
+
+  assert.eq(divsByMinusOne64(42n), -42n);
+  assert.throws(() => divsByMinusOne64(-0x8000000000000000n), WebAssembly.RuntimeError, "Integer overflow");
+
+  assert.eq(divuByMinusOne64(42n), 0n);
+  assert.eq(divuByMinusOne64(-0x8000000000000000n), 0n); // Not an error for unsigned division.
+
+  assert.eq(divsIntMin64(4n), -0x2000000000000000n);
+  assert.throws(() => divsIntMin64(-1n), WebAssembly.RuntimeError, "Integer overflow");
+  assert.throws(() => divsIntMin64(0n), WebAssembly.RuntimeError, "Division by zero");
+
+  assert.eq(divuIntMin64(1n), -0x8000000000000000n);
+  assert.eq(divuIntMin64(-1n), 0n); // Not an error for unsigned division.
+  assert.throws(() => divuIntMin64(0n), WebAssembly.RuntimeError, "Division by zero");
+
+  assert.throws(() => divsByZero64(42n), WebAssembly.RuntimeError, "Division by zero");
+
+  assert.throws(() => divuByZero64(42n), WebAssembly.RuntimeError, "Division by zero");
+
+  // Two constant operands
+
+  assert.throws(foldableDivsByZero32, WebAssembly.RuntimeError, "Division by zero");
+  assert.throws(foldableDivuByZero32, WebAssembly.RuntimeError, "Division by zero");
+  assert.throws(foldableDivsMinByMinusOne32, WebAssembly.RuntimeError, "Integer overflow");
+
+  assert.throws(foldableDivsByZero64, WebAssembly.RuntimeError, "Division by zero");
+  assert.throws(foldableDivuByZero64, WebAssembly.RuntimeError, "Division by zero");
+  assert.throws(foldableDivsMinByMinusOne64, WebAssembly.RuntimeError, "Integer overflow");
+}
+
+assert.asyncTest(test());


### PR DESCRIPTION
#### 700f6525d4cf86039f4771389dddbe111e0b15a1
<pre>
WasmBBQJIT performs redundant overflow check when dividend is constant
<a href="https://bugs.webkit.org/show_bug.cgi?id=254710">https://bugs.webkit.org/show_bug.cgi?id=254710</a>
rdar://106823148

Reviewed by Yusuke Suzuki.

Always skip the integer division overflow check (specifically for the case INT_MIN / -1)
in WasmBBQJIT when the left operand is a constant. This reduces the amount of unnecessary
work checking for erroneous divisions, and also allows the general case to assume neither
operand is a constant when emitting the check.

* JSTests/wasm/stress/foldable-division.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitModOrDiv):

Canonical link: <a href="https://commits.webkit.org/262335@main">https://commits.webkit.org/262335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a55bcd834bf64038cf633b9d4647009048e27f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1145 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1382 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1303 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1289 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1953 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1179 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1127 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1172 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1211 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2275 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1255 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1220 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1312 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1189 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/263 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/318 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1247 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1315 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/258 "Passed tests") | 
<!--EWS-Status-Bubble-End-->