### PR TITLE
Avoid premature canvas readback when post-processing image buffers

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1378,20 +1378,6 @@ CanvasFiltersEnabled:
     WebCore:
       default: false
 
-CanvasNoiseInjectionEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "Canvas Noise Injection"
-  humanReadableDescription: "Enable canvas (2D/WebGL) noise injection"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CanvasUsesAcceleratedDrawing:
   type: bool
   status: embedder

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -358,9 +358,14 @@ RefPtr<ImageBuffer> CanvasBase::allocateImageBuffer(bool usesDisplayListDrawing,
     return ImageBuffer::create(size(), RenderingPurpose::Canvas, 1, colorSpace, pixelFormat, bufferOptions, context);
 }
 
-bool CanvasBase::postProcessPixelBuffer(Ref<PixelBuffer> pixelBuffer, bool wasLastDrawByBitMap, const HashSet<uint32_t>& suppliedColors) const
+bool CanvasBase::shouldInjectNoiseBeforeReadback() const
 {
-    if (!scriptExecutionContext() || !scriptExecutionContext()->noiseInjectionHashSalt() || wasLastDrawByBitMap || !scriptExecutionContext()->settingsValues().canvasNoiseInjectionEnabled)
+    return scriptExecutionContext() && scriptExecutionContext()->noiseInjectionHashSalt();
+}
+
+bool CanvasBase::postProcessPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, bool wasLastDrawByBitMap, const HashSet<uint32_t>& suppliedColors) const
+{
+    if (!shouldInjectNoiseBeforeReadback() || wasLastDrawByBitMap)
         return false;
 
     ASSERT(pixelBuffer->format().pixelFormat == PixelFormat::RGBA8);

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -125,7 +125,9 @@ public:
 
     virtual void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) = 0;
     virtual void dispatchEvent(Event&) = 0;
-    bool postProcessPixelBuffer(Ref<PixelBuffer>, bool, const HashSet<uint32_t>&) const;
+
+    bool shouldInjectNoiseBeforeReadback() const;
+    bool postProcessPixelBuffer(Ref<PixelBuffer>&&, bool, const HashSet<uint32_t>&) const;
 
 protected:
     explicit CanvasBase(IntSize);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1055,7 +1055,7 @@ static inline IntRect computeImageDataRect(ImageBuffer& buffer, int width, int h
 
 void CanvasRenderingContext2DBase::postProcessPixelBuffer() const
 {
-    if (m_wasLastDrawPutImageData || !canvasBase().scriptExecutionContext()->settingsValues().canvasNoiseInjectionEnabled)
+    if (!canvasBase().shouldInjectNoiseBeforeReadback() || m_wasLastDrawPutImageData)
         return;
 
     ImageBuffer* buffer = canvasBase().buffer();


### PR DESCRIPTION
#### c97bb648ce7df7258c98aa137684a14d6e90bec5
<pre>
Avoid premature canvas readback when post-processing image buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=254715">https://bugs.webkit.org/show_bug.cgi?id=254715</a>
rdar://107393842

Reviewed by Simon Fraser and Matthew Finkel.

Bail earlier inside of `CanvasRenderingContext2DBase::postProcessPixelBuffer`, before we attempt to
call `getPixelBuffer` on the image buffer; this avoids extraneous work underneath
`postProcessPixelBuffer` in the case where noise injection is disabled.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Additionally remove a feature flag that is already on by default.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::shouldInjectNoiseBeforeReadback const):

Add a helper method to return whether or not noise injection is enabled.

(WebCore::CanvasBase::postProcessPixelBuffer const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::postProcessPixelBuffer const):

Canonical link: <a href="https://commits.webkit.org/262307@main">https://commits.webkit.org/262307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2e2547febd9821ecef914b6f9f807e16e5c3a4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1962 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1239 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1212 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1831 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1104 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1054 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1135 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2197 "260 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1177 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1146 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1235 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1114 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/249 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/294 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1172 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1238 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/243 "Passed tests") | 
<!--EWS-Status-Bubble-End-->