### PR TITLE
[UI side compositing] Fix swipe tests to work with UI-side compositing

### DIFF
--- a/LayoutTests/swipe/resources/swipe-test.js
+++ b/LayoutTests/swipe/resources/swipe-test.js
@@ -46,6 +46,8 @@ async function startSlowSwipeGesture()
     if (!window.eventSender)
         return;
 
+    await UIHelper.ensurePresentationUpdate();
+
     // Similar to uiController.beginBackSwipe(), but with a gap between events to allow
     // for DOM wheel event handlers to fire.
     eventSender.mouseMoveTo(400, 300);

--- a/LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html
+++ b/LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html
@@ -10,6 +10,7 @@
         border: 1px solid black;
     }
 </style>
+<script src="../resources/ui-helper.js"></script>
 <script src="resources/swipe-test.js"></script>
 <script>
     var logElement;
@@ -66,7 +67,7 @@
         const swipeTarget = document.getElementById('swipeTarget');
         swipeTarget.addEventListener('wheel', () => { }, { passive: true });
 
-        await startSwipeGesture();
+        await startSlowSwipeGesture();
     };
 </script>
 </head>


### PR DESCRIPTION
#### fbbdeface10baf1a91eea6a903a622f5f2abb119
<pre>
[UI side compositing] Fix swipe tests to work with UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=254723">https://bugs.webkit.org/show_bug.cgi?id=254723</a>
rdar://107403038

Reviewed by Tim Horton.

Swipe tests need to wait for the UI process to receive a layer tree commit with the up-to-date
event regions before starting a swipe, so `await UIHelper.ensurePresentationUpdate()` before
swiping.

`swipe-back-with-passive-wheel-listener.html` needs to use the &quot;slow swipe&quot; function that
allows for processing between events, so that the UI process gets a response from the
web process to allow the swipe to start.

* LayoutTests/swipe/resources/swipe-test.js:
(async startSlowSwipeGesture):
* LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html:

Canonical link: <a href="https://commits.webkit.org/262337@main">https://commits.webkit.org/262337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f28c8381ac6da0d3627c1bbc57498d7ffb282be1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1080 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1246 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1843 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1100 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1104 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2203 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1061 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1123 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/322 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1180 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->