### PR TITLE
ASSERTION FAILED: Unhandled message RemoteSourceBufferProxy_SetTimestampOffset

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -100,6 +100,10 @@ RemoteMediaPlayerProxy::RemoteMediaPlayerProxy(RemoteMediaPlayerManagerProxy& ma
 
 RemoteMediaPlayerProxy::~RemoteMediaPlayerProxy()
 {
+#if ENABLE(MEDIA_SOURCE)
+    if (m_mediaSourceProxy)
+        m_mediaSourceProxy->shutdown();
+#endif
     if (m_performTaskAtMediaTimeCompletionHandler)
         m_performTaskAtMediaTimeCompletionHandler(std::nullopt, std::nullopt);
     setShouldEnableAudioSourceProvider(false);
@@ -154,7 +158,7 @@ void RemoteMediaPlayerProxy::load(URL&& url, std::optional<SandboxExtension::Han
         else
             WTFLogAlways("Unable to create sandbox extension for media url.\n");
     }
-    
+
     m_player->load(url, contentType, keySystem, requiresRemotePlayback);
     getConfiguration(configuration);
     completionHandler(WTFMove(configuration));
@@ -171,6 +175,8 @@ void RemoteMediaPlayerProxy::loadMediaSource(URL&& url, const WebCore::ContentTy
         return;
     }
 
+    if (m_mediaSourceProxy)
+        m_mediaSourceProxy->shutdown();
     m_mediaSourceProxy = adoptRef(*new RemoteMediaSourceProxy(*m_manager->gpuConnectionToWebProcess(), mediaSourceIdentifier, webMParserEnabled, *this));
     m_player->load(url, contentType, *m_mediaSourceProxy);
     getConfiguration(configuration);
@@ -578,7 +584,7 @@ TrackPrivateRemoteIdentifier RemoteMediaPlayerProxy::addRemoteAudioTrackProxy(We
     ASSERT(m_manager && m_manager->gpuConnectionToWebProcess());
     if (!m_manager || !m_manager->gpuConnectionToWebProcess())
         return { };
-    
+
     for (auto& [localTrack, remoteTrack] : m_audioTracks) {
         if (localTrack == track) {
             auto identifier = remoteTrack->identifier();
@@ -612,7 +618,7 @@ TrackPrivateRemoteIdentifier RemoteMediaPlayerProxy::addRemoteVideoTrackProxy(We
     ASSERT(m_manager->gpuConnectionToWebProcess());
     if (!m_manager || !m_manager->gpuConnectionToWebProcess())
         return { };
-    
+
     for (auto& [localTrack, remoteTrack] : m_videoTracks) {
         if (localTrack == track) {
             auto identifier = remoteTrack->identifier();
@@ -645,7 +651,7 @@ TrackPrivateRemoteIdentifier RemoteMediaPlayerProxy::addRemoteTextTrackProxy(Web
     ASSERT(m_manager && m_manager->gpuConnectionToWebProcess());
     if (!m_manager || !m_manager->gpuConnectionToWebProcess())
         return { };
-    
+
     for (auto& [localTrack, remoteTrack] : m_textTracks) {
         if (localTrack == track) {
             auto identifier = remoteTrack->identifier();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -177,6 +177,14 @@ void RemoteMediaSourceProxy::setTimeFudgeFactor(const MediaTime& fudgeFactor)
         m_private->setTimeFudgeFactor(fudgeFactor);
 }
 
+void RemoteMediaSourceProxy::shutdown()
+{
+    if (!m_connectionToWebProcess)
+        return;
+
+    m_connectionToWebProcess->connection().sendWithAsyncReply(Messages::MediaSourcePrivateRemote::MediaSourcePrivateShuttingDown(), [self = RefPtr { this }] { }, m_identifier);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -74,6 +74,8 @@ public:
 
     void failedToCreateRenderer(RendererType) final;
 
+    void shutdown();
+
 private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -79,8 +79,8 @@ MediaSourcePrivateRemote::~MediaSourcePrivateRemote()
     if (m_gpuProcessConnection)
         m_gpuProcessConnection->messageReceiverMap().removeMessageReceiver(Messages::MediaSourcePrivateRemote::messageReceiverName(), m_identifier.toUInt64());
 
-    for (auto it = m_sourceBuffers.begin(), end = m_sourceBuffers.end(); it != end; ++it)
-        (*it)->clearMediaSource();
+    for (auto& sourceBuffer : m_sourceBuffers)
+        sourceBuffer->clearMediaSource();
 }
 
 MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const ContentType& contentType, bool, RefPtr<SourceBufferPrivate>& outPrivate)
@@ -93,7 +93,7 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const Co
     if (m_mimeTypeCache.supportsTypeAndCodecs(parameters) == MediaPlayer::SupportsType::IsNotSupported)
         return AddStatus::NotSupported;
 
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return AddStatus::NotSupported;
 
     auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteMediaSourceProxy::AddSourceBuffer(contentType), m_identifier);
@@ -111,7 +111,7 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateRemote::addSourceBuffer(const Co
 
 void MediaSourcePrivateRemote::durationChanged(const MediaTime& duration)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::DurationChanged(duration), m_identifier);
@@ -119,7 +119,7 @@ void MediaSourcePrivateRemote::durationChanged(const MediaTime& duration)
 
 void MediaSourcePrivateRemote::bufferedChanged(const PlatformTimeRanges& buffered)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::BufferedChanged(buffered), m_identifier);
@@ -150,7 +150,7 @@ MediaPlayer::ReadyState MediaSourcePrivateRemote::readyState() const
 
 void MediaSourcePrivateRemote::setReadyState(MediaPlayer::ReadyState readyState)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SetReadyState(readyState), m_identifier);
@@ -158,7 +158,7 @@ void MediaSourcePrivateRemote::setReadyState(MediaPlayer::ReadyState readyState)
 
 void MediaSourcePrivateRemote::setIsSeeking(bool isSeeking)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     MediaSourcePrivate::setIsSeeking(isSeeking);
@@ -167,7 +167,7 @@ void MediaSourcePrivateRemote::setIsSeeking(bool isSeeking)
 
 void MediaSourcePrivateRemote::waitForSeekCompleted()
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::WaitForSeekCompleted(), m_identifier);
@@ -175,7 +175,7 @@ void MediaSourcePrivateRemote::waitForSeekCompleted()
 
 void MediaSourcePrivateRemote::seekCompleted()
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SeekCompleted(), m_identifier);
@@ -183,7 +183,7 @@ void MediaSourcePrivateRemote::seekCompleted()
 
 void MediaSourcePrivateRemote::setTimeFudgeFactor(const MediaTime& fudgeFactor)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     MediaSourcePrivate::setTimeFudgeFactor(fudgeFactor);
@@ -194,6 +194,14 @@ void MediaSourcePrivateRemote::seekToTime(const MediaTime& time)
 {
     if (m_client)
         m_client->seekToTime(time);
+}
+
+void MediaSourcePrivateRemote::mediaSourcePrivateShuttingDown(CompletionHandler<void()>&& completionHandler)
+{
+    m_shutdown = true;
+    for (auto& sourceBuffer : m_sourceBuffers)
+        sourceBuffer->disconnect();
+    completionHandler();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -86,6 +86,8 @@ private:
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     void seekToTime(const MediaTime&);
+    void mediaSourcePrivateShuttingDown(CompletionHandler<void()>&&);
+    bool isGPURunning() const { return !m_shutdown && m_gpuProcessConnection; }
 
     WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     RemoteMediaSourceIdentifier m_identifier;
@@ -94,6 +96,7 @@ private:
     WeakPtr<WebCore::MediaSourcePrivateClient> m_client;
     Vector<RefPtr<SourceBufferPrivateRemote>> m_sourceBuffers;
     bool m_ended { false };
+    bool m_shutdown { false };
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override { return "MediaSourcePrivateRemote"; }

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in
@@ -27,6 +27,7 @@
 
 messages -> MediaSourcePrivateRemote NotRefCounted {
     SeekToTime(MediaTime time);
+    MediaSourcePrivateShuttingDown() -> ();
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -81,7 +81,7 @@ SourceBufferPrivateRemote::~SourceBufferPrivateRemote()
 
 void SourceBufferPrivateRemote::append(Ref<SharedBuffer>&& data)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().sendWithAsyncReply(Messages::RemoteSourceBufferProxy::Append(IPC::SharedBufferReference { WTFMove(data) }), [] (auto&& bufferHandle) {
@@ -93,7 +93,7 @@ void SourceBufferPrivateRemote::append(Ref<SharedBuffer>&& data)
 
 void SourceBufferPrivateRemote::abort()
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     // When abort() is being issued; this will force the RemoteSourceBufferProxy to abort the current remote source buffer operation
@@ -104,7 +104,7 @@ void SourceBufferPrivateRemote::abort()
 
 void SourceBufferPrivateRemote::resetParserState()
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::ResetParserState(), m_remoteSourceBufferIdentifier);
@@ -112,7 +112,7 @@ void SourceBufferPrivateRemote::resetParserState()
 
 void SourceBufferPrivateRemote::removedFromMediaSource()
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::RemovedFromMediaSource(), m_remoteSourceBufferIdentifier);
@@ -131,7 +131,7 @@ void SourceBufferPrivateRemote::setReadyState(MediaPlayer::ReadyState state)
     if (m_mediaPlayerPrivate)
         m_mediaPlayerPrivate->setReadyState(state);
 
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SetReadyState(state), m_remoteSourceBufferIdentifier);
@@ -142,7 +142,7 @@ void SourceBufferPrivateRemote::setActive(bool active)
     if (!m_mediaSourcePrivate)
         return;
 
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_isActive = active;
@@ -151,7 +151,7 @@ void SourceBufferPrivateRemote::setActive(bool active)
 
 bool SourceBufferPrivateRemote::canSwitchToType(const ContentType& contentType)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return false;
 
     auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteSourceBufferProxy::CanSwitchToType(contentType), m_remoteSourceBufferIdentifier);
@@ -161,7 +161,7 @@ bool SourceBufferPrivateRemote::canSwitchToType(const ContentType& contentType)
 
 void SourceBufferPrivateRemote::setMediaSourceEnded(bool isEnded)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SetMediaSourceEnded(isEnded), m_remoteSourceBufferIdentifier);
@@ -169,7 +169,7 @@ void SourceBufferPrivateRemote::setMediaSourceEnded(bool isEnded)
 
 void SourceBufferPrivateRemote::setMode(SourceBufferAppendMode mode)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SetMode(mode), m_remoteSourceBufferIdentifier);
@@ -180,7 +180,7 @@ void SourceBufferPrivateRemote::updateBufferedFromTrackBuffers(bool sourceIsEnde
     if (!m_mediaSourcePrivate)
         return;
 
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteSourceBufferProxy::UpdateBufferedFromTrackBuffers(sourceIsEnded), m_remoteSourceBufferIdentifier);
@@ -193,8 +193,10 @@ void SourceBufferPrivateRemote::updateBufferedFromTrackBuffers(bool sourceIsEnde
 
 void SourceBufferPrivateRemote::removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentMediaTime, bool isEnded, CompletionHandler<void()>&& completionHandler)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning()) {
+        completionHandler();
         return;
+    }
 
     m_gpuProcessConnection->connection().sendWithAsyncReply(
         Messages::RemoteSourceBufferProxy::RemoveCodedFrames(start, end, currentMediaTime, isEnded), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](auto&& buffered, uint64_t totalTrackBufferSizeInBytes) mutable {
@@ -207,7 +209,7 @@ void SourceBufferPrivateRemote::removeCodedFrames(const MediaTime& start, const 
 
 void SourceBufferPrivateRemote::evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteSourceBufferProxy::EvictCodedFrames(newDataSize, maximumBufferSize, currentTime, isEnded), m_remoteSourceBufferIdentifier);
@@ -221,7 +223,7 @@ void SourceBufferPrivateRemote::evictCodedFrames(uint64_t newDataSize, uint64_t 
 void SourceBufferPrivateRemote::addTrackBuffer(const AtomString& trackId, RefPtr<MediaDescription>&&)
 {
     ASSERT(m_trackIdentifierMap.contains(trackId));
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::AddTrackBuffer(m_trackIdentifierMap.get(trackId)), m_remoteSourceBufferIdentifier);
@@ -229,7 +231,7 @@ void SourceBufferPrivateRemote::addTrackBuffer(const AtomString& trackId, RefPtr
 
 void SourceBufferPrivateRemote::resetTrackBuffers()
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::ResetTrackBuffers(), m_remoteSourceBufferIdentifier);
@@ -237,7 +239,7 @@ void SourceBufferPrivateRemote::resetTrackBuffers()
 
 void SourceBufferPrivateRemote::clearTrackBuffers(bool)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::ClearTrackBuffers(), m_remoteSourceBufferIdentifier);
@@ -246,7 +248,7 @@ void SourceBufferPrivateRemote::clearTrackBuffers(bool)
 
 void SourceBufferPrivateRemote::setAllTrackBuffersNeedRandomAccess()
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SetAllTrackBuffersNeedRandomAccess(), m_remoteSourceBufferIdentifier);
@@ -254,7 +256,7 @@ void SourceBufferPrivateRemote::setAllTrackBuffersNeedRandomAccess()
 
 void SourceBufferPrivateRemote::setGroupStartTimestamp(const MediaTime& timestamp)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SetGroupStartTimestamp(timestamp), m_remoteSourceBufferIdentifier);
@@ -262,7 +264,7 @@ void SourceBufferPrivateRemote::setGroupStartTimestamp(const MediaTime& timestam
 
 void SourceBufferPrivateRemote::setGroupStartTimestampToEndTimestamp()
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SetGroupStartTimestampToEndTimestamp(), m_remoteSourceBufferIdentifier);
@@ -270,7 +272,7 @@ void SourceBufferPrivateRemote::setGroupStartTimestampToEndTimestamp()
 
 void SourceBufferPrivateRemote::setShouldGenerateTimestamps(bool shouldGenerateTimestamps)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SetShouldGenerateTimestamps(shouldGenerateTimestamps), m_remoteSourceBufferIdentifier);
@@ -278,7 +280,7 @@ void SourceBufferPrivateRemote::setShouldGenerateTimestamps(bool shouldGenerateT
 
 void SourceBufferPrivateRemote::reenqueueMediaIfNeeded(const MediaTime& currentMediaTime)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::ReenqueueMediaIfNeeded(currentMediaTime), m_remoteSourceBufferIdentifier);
@@ -286,7 +288,7 @@ void SourceBufferPrivateRemote::reenqueueMediaIfNeeded(const MediaTime& currentM
 
 void SourceBufferPrivateRemote::resetTimestampOffsetInTrackBuffers()
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::ResetTimestampOffsetInTrackBuffers(), m_remoteSourceBufferIdentifier);
@@ -294,7 +296,7 @@ void SourceBufferPrivateRemote::resetTimestampOffsetInTrackBuffers()
 
 void SourceBufferPrivateRemote::startChangingType()
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::StartChangingType(), m_remoteSourceBufferIdentifier);
@@ -302,7 +304,7 @@ void SourceBufferPrivateRemote::startChangingType()
 
 void SourceBufferPrivateRemote::setTimestampOffset(const MediaTime& timestampOffset)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     SourceBufferPrivate::setTimestampOffset(timestampOffset);
@@ -311,7 +313,7 @@ void SourceBufferPrivateRemote::setTimestampOffset(const MediaTime& timestampOff
 
 void SourceBufferPrivateRemote::setAppendWindowStart(const MediaTime& appendWindowStart)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SetAppendWindowStart(appendWindowStart), m_remoteSourceBufferIdentifier);
@@ -319,7 +321,7 @@ void SourceBufferPrivateRemote::setAppendWindowStart(const MediaTime& appendWind
 
 void SourceBufferPrivateRemote::setAppendWindowEnd(const MediaTime& appendWindowEnd)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SetAppendWindowEnd(appendWindowEnd), m_remoteSourceBufferIdentifier);
@@ -327,7 +329,7 @@ void SourceBufferPrivateRemote::setAppendWindowEnd(const MediaTime& appendWindow
 
 void SourceBufferPrivateRemote::seekToTime(const MediaTime& mediaTime)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::SeekToTime(mediaTime), m_remoteSourceBufferIdentifier);
@@ -335,7 +337,7 @@ void SourceBufferPrivateRemote::seekToTime(const MediaTime& mediaTime)
 
 void SourceBufferPrivateRemote::updateTrackIds(Vector<std::pair<AtomString, AtomString>>&& trackIdPairs)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     auto identifierPairs = trackIdPairs.map([this](auto& trackIdPair) {
@@ -349,8 +351,10 @@ void SourceBufferPrivateRemote::updateTrackIds(Vector<std::pair<AtomString, Atom
 
 void SourceBufferPrivateRemote::bufferedSamplesForTrackId(const AtomString& trackId, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning()) {
+        completionHandler({ });
         return;
+    }
 
     m_gpuProcessConnection->connection().sendWithAsyncReply(Messages::RemoteSourceBufferProxy::BufferedSamplesForTrackId(m_trackIdentifierMap.get(trackId)), [completionHandler = WTFMove(completionHandler)](auto&& samples) mutable {
         completionHandler(WTFMove(samples));
@@ -359,8 +363,10 @@ void SourceBufferPrivateRemote::bufferedSamplesForTrackId(const AtomString& trac
 
 void SourceBufferPrivateRemote::enqueuedSamplesForTrackID(const AtomString& trackId, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning()) {
+        completionHandler({ });
         return;
+    }
 
     m_gpuProcessConnection->connection().sendWithAsyncReply(Messages::RemoteSourceBufferProxy::EnqueuedSamplesForTrackID(m_trackIdentifierMap.get(trackId)), [completionHandler = WTFMove(completionHandler)](auto&& samples) mutable {
         completionHandler(WTFMove(samples));
@@ -473,7 +479,7 @@ uint64_t SourceBufferPrivateRemote::totalTrackBufferSizeInBytes() const
 
 void SourceBufferPrivateRemote::memoryPressure(uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().sendWithAsyncReply(
@@ -486,7 +492,7 @@ void SourceBufferPrivateRemote::memoryPressure(uint64_t maximumBufferSize, const
 
 MediaTime SourceBufferPrivateRemote::minimumUpcomingPresentationTimeForTrackID(const AtomString& trackID)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return MediaTime::invalidTime();
     auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteSourceBufferProxy::MinimumUpcomingPresentationTimeForTrackID(trackID), m_remoteSourceBufferIdentifier);
 
@@ -495,13 +501,12 @@ MediaTime SourceBufferPrivateRemote::minimumUpcomingPresentationTimeForTrackID(c
 
 void SourceBufferPrivateRemote::setMaximumQueueDepthForTrackID(const AtomString& trackID, uint64_t depth)
 {
-    if (!m_gpuProcessConnection)
+    if (!isGPURunning())
         return;
 
     m_gpuProcessConnection->connection().send(
         Messages::RemoteSourceBufferProxy::SetMaximumQueueDepthForTrackID(trackID, depth), m_remoteSourceBufferIdentifier);
 }
-
 
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& SourceBufferPrivateRemote::logChannel() const

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -66,6 +66,7 @@ public:
     virtual ~SourceBufferPrivateRemote();
 
     void clearMediaSource() { m_mediaSourcePrivate = nullptr; }
+    void disconnect() { m_disconnected = true; }
 
 private:
     SourceBufferPrivateRemote(GPUProcessConnection&, RemoteSourceBufferIdentifier, const MediaSourcePrivateRemote&, const MediaPlayerPrivateRemote&);
@@ -133,6 +134,9 @@ private:
 
     bool m_isActive { false };
     uint64_t m_totalTrackBufferSizeInBytes = { 0 };
+
+    bool isGPURunning() const { return !m_disconnected && m_gpuProcessConnection; }
+    bool m_disconnected { false };
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }


### PR DESCRIPTION
#### 6589260fc1b0ba28063b02e5889fe5c49d74ded1
<pre>
ASSERTION FAILED: Unhandled message RemoteSourceBufferProxy_SetTimestampOffset
<a href="https://bugs.webkit.org/show_bug.cgi?id=249703">https://bugs.webkit.org/show_bug.cgi?id=249703</a>
rdar://103590497

Reviewed by Youenn Fablet.

RemoteMediaSourceProxy is owned by the RemoteMediaPlayerProxy and will
be deleted (as there&apos;s only a single reference count) when it is destroyed.
The RemoteSourceBufferProxies are created by the RemoteMediaSourceProxy
and will be deleted when it too is destroyed.
However, both the MediaSource and SourceBuffer running in the content process
are cycle counted and may live for much longer than their proxied objects
running in the GPU process.

We make the RemoteMediaSourceProxy notify is content process counterpart
which in turn will notify all the associated RemoteSourceBufferProxies
that they are about to shutdown so that they don&apos;t attempt to send messages
that would otherwise be left unhandled.

Fly-by fix: Some CompletionHandlers weren&apos;t called under some circumstances.

Covered by existing tests.

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::~RemoteMediaPlayerProxy):
(WebKit::RemoteMediaPlayerProxy::load):
(WebKit::RemoteMediaPlayerProxy::loadMediaSource):
(WebKit::RemoteMediaPlayerProxy::addRemoteAudioTrackProxy):
(WebKit::RemoteMediaPlayerProxy::addRemoteVideoTrackProxy):
(WebKit::RemoteMediaPlayerProxy::addRemoteTextTrackProxy):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::shutdown):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::~MediaSourcePrivateRemote):
(WebKit::MediaSourcePrivateRemote::addSourceBuffer):
(WebKit::MediaSourcePrivateRemote::durationChanged):
(WebKit::MediaSourcePrivateRemote::bufferedChanged):
(WebKit::MediaSourcePrivateRemote::setReadyState):
(WebKit::MediaSourcePrivateRemote::setIsSeeking):
(WebKit::MediaSourcePrivateRemote::waitForSeekCompleted):
(WebKit::MediaSourcePrivateRemote::seekCompleted):
(WebKit::MediaSourcePrivateRemote::setTimeFudgeFactor):
(WebKit::MediaSourcePrivateRemote::mediaSourcePrivateShuttingDown):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::append):
(WebKit::SourceBufferPrivateRemote::abort):
(WebKit::SourceBufferPrivateRemote::resetParserState):
(WebKit::SourceBufferPrivateRemote::removedFromMediaSource):
(WebKit::SourceBufferPrivateRemote::setReadyState):
(WebKit::SourceBufferPrivateRemote::setActive):
(WebKit::SourceBufferPrivateRemote::canSwitchToType):
(WebKit::SourceBufferPrivateRemote::setMediaSourceEnded):
(WebKit::SourceBufferPrivateRemote::setMode):
(WebKit::SourceBufferPrivateRemote::updateBufferedFromTrackBuffers):
(WebKit::SourceBufferPrivateRemote::removeCodedFrames):
(WebKit::SourceBufferPrivateRemote::evictCodedFrames):
(WebKit::SourceBufferPrivateRemote::addTrackBuffer):
(WebKit::SourceBufferPrivateRemote::resetTrackBuffers):
(WebKit::SourceBufferPrivateRemote::clearTrackBuffers):
(WebKit::SourceBufferPrivateRemote::setAllTrackBuffersNeedRandomAccess):
(WebKit::SourceBufferPrivateRemote::setGroupStartTimestamp):
(WebKit::SourceBufferPrivateRemote::setGroupStartTimestampToEndTimestamp):
(WebKit::SourceBufferPrivateRemote::setShouldGenerateTimestamps):
(WebKit::SourceBufferPrivateRemote::reenqueueMediaIfNeeded):
(WebKit::SourceBufferPrivateRemote::resetTimestampOffsetInTrackBuffers):
(WebKit::SourceBufferPrivateRemote::startChangingType):
(WebKit::SourceBufferPrivateRemote::setTimestampOffset):
(WebKit::SourceBufferPrivateRemote::setAppendWindowStart):
(WebKit::SourceBufferPrivateRemote::setAppendWindowEnd):
(WebKit::SourceBufferPrivateRemote::seekToTime):
(WebKit::SourceBufferPrivateRemote::updateTrackIds):
(WebKit::SourceBufferPrivateRemote::bufferedSamplesForTrackId):
(WebKit::SourceBufferPrivateRemote::enqueuedSamplesForTrackID):
(WebKit::SourceBufferPrivateRemote::memoryPressure):
(WebKit::SourceBufferPrivateRemote::minimumUpcomingPresentationTimeForTrackID):
(WebKit::SourceBufferPrivateRemote::setMaximumQueueDepthForTrackID):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/262333@main">https://commits.webkit.org/262333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d65c6ba57bca877615f9787a36c5742ce5e8440d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1999 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1097 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1260 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1237 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1867 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1114 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1122 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1167 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2227 "268 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1077 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1146 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/319 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1197 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->