### PR TITLE
[CSS Fonts] Implement animation support for FontSizeAdjust metrics two-value syntax

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-size-adjust-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-size-adjust-interpolation-expected.txt
@@ -307,32 +307,32 @@ PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-widt
 PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (0.6) should be [ch-width 0.8]
 PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1) should be [ch-width 1.2]
 PASS Web Animations: property <font-size-adjust> from [ch-width 0.2] to [ch-width 1.2] at (1.5) should be [ch-width 1.7]
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0 "
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.2 "
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.5 "
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.7 "
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.8 "
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.2 "
-FAIL CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.7 "
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0 "
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.2 "
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.5 "
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.7 "
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.8 "
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.2 "
-FAIL CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.7 "
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [ex-height 0.2] assert_equals: expected "0.2 " but got "0 "
+PASS CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS CSS Transitions: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS CSS Transitions with transition: all: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2]
+PASS CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [ex-height 0.2]
 PASS CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [ex-height 0.2]
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [ex-height 0.2] assert_equals: expected "0.2 " but got "0.5 "
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.7 "
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.8 "
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.2 "
-FAIL CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.7 "
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [ex-height 0.2] assert_equals: expected "0.2 " but got "0 "
+PASS CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [ex-height 0.2]
+PASS CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2]
+PASS CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2]
+PASS CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS CSS Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2]
+PASS Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (-0.3) should be [ex-height 0.2]
 PASS Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0) should be [ex-height 0.2]
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [ex-height 0.2] assert_equals: expected "0.2 " but got "0.5 "
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.7 "
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "0.8 "
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.2 "
-FAIL Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2] assert_equals: expected "cap - height 1.2 " but got "1.7 "
+PASS Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.3) should be [ex-height 0.2]
+PASS Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.5) should be [cap-height 1.2]
+PASS Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (0.6) should be [cap-height 1.2]
+PASS Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1) should be [cap-height 1.2]
+PASS Web Animations: property <font-size-adjust> from [ex-height 0.2] to [cap-height 1.2] at (1.5) should be [cap-height 1.2]
 


### PR DESCRIPTION
#### 0a83efdbed5c5535b98961df55b4f0b5156dd6a5
<pre>
[CSS Fonts] Implement animation support for FontSizeAdjust metrics two-value syntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=254266">https://bugs.webkit.org/show_bug.cgi?id=254266</a>

Reviewed by Tim Nguyen.

This change brings animation support for the font-size-adjust CSS property.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-size-adjust-interpolation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:

Canonical link: <a href="https://commits.webkit.org/262374@main">https://commits.webkit.org/262374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3997eb73d90aa4828a9804de0d79586ca81446b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1108 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1268 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1883 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1123 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1175 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2234 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1085 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1154 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/338 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1208 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->