### PR TITLE
Refactor StyleRuleCounterStyle for eliminating StyleProperties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/prefix-suffix-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/prefix-suffix-syntax-expected.txt
@@ -15,12 +15,12 @@ PASS @counter-style 'prefix: inherit' is invalid
 PASS @counter-style 'suffix: inherit' is invalid
 PASS @counter-style 'prefix: unset' is invalid
 PASS @counter-style 'suffix: unset' is invalid
-PASS @counter-style 'prefix: url("https://example.com/foo.png")' is valid
-PASS @counter-style 'suffix: url("https://example.com/foo.png")' is valid
-PASS @counter-style 'prefix: url(https://example.com/foo.png)' is valid
-PASS @counter-style 'suffix: url(https://example.com/foo.png)' is valid
-PASS @counter-style 'prefix: linear-gradient(yellow, blue)' is valid
-PASS @counter-style 'suffix: linear-gradient(yellow, blue)' is valid
+FAIL @counter-style 'prefix: url("https://example.com/foo.png")' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'suffix: url("https://example.com/foo.png")' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'prefix: url(https://example.com/foo.png)' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'suffix: url(https://example.com/foo.png)' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'prefix: linear-gradient(yellow, blue)' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'suffix: linear-gradient(yellow, blue)' is valid assert_not_equals: got disallowed value -1
 PASS @counter-style 'prefix: ' is invalid
 PASS @counter-style 'suffix: ' is invalid
 PASS @counter-style 'prefix: foo bar' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/speak-as-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/speak-as-syntax-expected.txt
@@ -1,11 +1,11 @@
 
-PASS @counter-style 'speak-as: auto' is valid
-PASS @counter-style 'speak-as: bullets' is valid
-PASS @counter-style 'speak-as: numbers' is valid
-PASS @counter-style 'speak-as: words' is valid
-PASS @counter-style 'speak-as: spell-out' is valid
-PASS @counter-style 'speak-as: bar' is valid
-PASS @counter-style 'speak-as: spellout' is valid
+FAIL @counter-style 'speak-as: auto' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: bullets' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: numbers' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: words' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: spell-out' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: bar' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: spellout' is valid assert_not_equals: got disallowed value -1
 PASS @counter-style 'speak-as: bullets numbers' is invalid
 PASS @counter-style 'speak-as: none' is invalid
 PASS @counter-style 'speak-as: initial' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/symbols-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/symbols-syntax-expected.txt
@@ -2,7 +2,7 @@
 PASS @counter-style 'symbols: "X"' is valid
 PASS @counter-style 'symbols: "X" "X"' is valid
 PASS @counter-style 'symbols: ident "X"' is valid
-PASS @counter-style 'symbols: ident "X" url("foo.jpg")' is valid
+FAIL @counter-style 'symbols: ident "X" url("foo.jpg")' is valid assert_not_equals: got disallowed value -1
 PASS @counter-style 'symbols: ' is invalid
 PASS @counter-style 'symbols: initial "X" "X"' is invalid
 PASS @counter-style 'symbols: inherit "X" "X"' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-prefix-suffix-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-prefix-suffix-syntax-expected.txt
@@ -15,12 +15,12 @@ PASS @counter-style 'prefix: inherit' is invalid
 PASS @counter-style 'suffix: inherit' is invalid
 PASS @counter-style 'prefix: unset' is invalid
 PASS @counter-style 'suffix: unset' is invalid
-PASS @counter-style 'prefix: url("https://example.com/foo.png")' is valid
-PASS @counter-style 'suffix: url("https://example.com/foo.png")' is valid
-PASS @counter-style 'prefix: url(https://example.com/foo.png)' is valid
-PASS @counter-style 'suffix: url(https://example.com/foo.png)' is valid
-PASS @counter-style 'prefix: linear-gradient(yellow, blue)' is valid
-PASS @counter-style 'suffix: linear-gradient(yellow, blue)' is valid
+FAIL @counter-style 'prefix: url("https://example.com/foo.png")' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'suffix: url("https://example.com/foo.png")' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'prefix: url(https://example.com/foo.png)' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'suffix: url(https://example.com/foo.png)' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'prefix: linear-gradient(yellow, blue)' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'suffix: linear-gradient(yellow, blue)' is valid assert_not_equals: got disallowed value -1
 PASS @counter-style 'prefix: ' is invalid
 PASS @counter-style 'suffix: ' is invalid
 PASS @counter-style 'prefix: foo bar' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-speak-as-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-speak-as-syntax-expected.txt
@@ -1,11 +1,11 @@
 
-PASS @counter-style 'speak-as: auto' is valid
-PASS @counter-style 'speak-as: bullets' is valid
-PASS @counter-style 'speak-as: numbers' is valid
-PASS @counter-style 'speak-as: words' is valid
-PASS @counter-style 'speak-as: spell-out' is valid
-PASS @counter-style 'speak-as: bar' is valid
-PASS @counter-style 'speak-as: spellout' is valid
+FAIL @counter-style 'speak-as: auto' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: bullets' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: numbers' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: words' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: spell-out' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: bar' is valid assert_not_equals: got disallowed value -1
+FAIL @counter-style 'speak-as: spellout' is valid assert_not_equals: got disallowed value -1
 PASS @counter-style 'speak-as: bullets numbers' is invalid
 PASS @counter-style 'speak-as: none' is invalid
 PASS @counter-style 'speak-as: initial' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-symbols-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-symbols-syntax-expected.txt
@@ -2,7 +2,7 @@
 PASS @counter-style 'symbols: "X"' is valid
 PASS @counter-style 'symbols: "X" "X"' is valid
 PASS @counter-style 'symbols: ident "X"' is valid
-PASS @counter-style 'symbols: ident "X" url("foo.jpg")' is valid
+FAIL @counter-style 'symbols: ident "X" url("foo.jpg")' is valid assert_not_equals: got disallowed value -1
 PASS @counter-style 'symbols: ' is invalid
 PASS @counter-style 'symbols: initial "X" "X"' is invalid
 PASS @counter-style 'symbols: inherit "X" "X"' is invalid

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -74,7 +74,7 @@ public:
 
     void setFallbackReference(RefPtr<CSSCounterStyle>&&);
     bool isFallbackUnresolved() { return !m_fallbackReference; }
-    bool isExtendsUnresolved() { return m_isExtendedUnresolved; };
+    bool isExtendsUnresolved() { return !m_descriptors.m_isExtendedResolved; };
     bool isExtendsSystem() const { return system() == CSSCounterStyleDescriptors::System::Extends; }
     void extendAndResolve(const CSSCounterStyle&);
 

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -35,11 +35,18 @@ class StyleProperties;
 
 struct CSSCounterStyleDescriptors {
     using Name = AtomString;
-    using Symbol = String;
     using Ranges = Vector<std::pair<int, int>>;
-    using AdditiveSymbols = Vector<std::pair<Symbol, unsigned>>;
+    using SystemData = std::pair<CSSCounterStyleDescriptors::Name, int>;
     // The keywords that can be used as values for the counter-style `system` descriptor.
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-system
+    struct Symbol {
+        bool isCustomIdent { false };
+        String text;
+        bool operator==(const Symbol& other) const { return isCustomIdent == other.isCustomIdent && text == other.text; }
+        bool operator!=(const Symbol& other) const { return !(*this == other); }
+        String cssText() const;
+    };
+    using AdditiveSymbols = Vector<std::pair<Symbol, unsigned>>;
     enum class System : uint8_t {
         Cyclic,
         Numeric,
@@ -62,9 +69,10 @@ struct CSSCounterStyleDescriptors {
         Symbol m_padSymbol;
         bool operator==(const Pad& other) const { return m_padMinimumLength == other.m_padMinimumLength && m_padSymbol == other.m_padSymbol; }
         bool operator!=(const Pad& other) const { return !(*this == other); }
+        String cssText() const;
     };
     struct NegativeSymbols {
-        Symbol m_prefix = "-"_s;
+        Symbol m_prefix = { false, "-"_s };
         Symbol m_suffix;
         bool operator==(const NegativeSymbols& other) const { return m_prefix == other.m_prefix && m_suffix == other.m_suffix; }
         bool operator!=(const NegativeSymbols& other) const { return !(*this == other); }
@@ -104,10 +112,11 @@ struct CSSCounterStyleDescriptors {
     bool operator!=(const CSSCounterStyleDescriptors& other) const { return !(*this == other); }
     void setExplicitlySetDescriptors(const StyleProperties&);
     bool isValid() const;
-    bool areSymbolsValidForSystem() const;
+    static bool areSymbolsValidForSystem(System, const Vector<Symbol>&, const AdditiveSymbols&);
 
-    void setName(Name name) { m_name = WTFMove(name); }
+    void setName(Name);
     void setSystem(System);
+    void setSystemData(SystemData);
     void setNegative(NegativeSymbols);
     void setPrefix(Symbol);
     void setSuffix(Symbol);
@@ -116,6 +125,17 @@ struct CSSCounterStyleDescriptors {
     void setFallbackName(Name);
     void setSymbols(Vector<Symbol>);
     void setAdditiveSymbols(AdditiveSymbols);
+
+    String nameCSSText() const;
+    String systemCSSText() const;
+    String negativeCSSText() const;
+    String prefixCSSText() const;
+    String suffixCSSText() const;
+    String rangesCSSText() const;
+    String padCSSText() const;
+    String fallbackCSSText() const;
+    String symbolsCSSText() const;
+    String additiveSymbolsCSSText() const;
 
     Name m_name;
     System m_system;
@@ -131,15 +151,15 @@ struct CSSCounterStyleDescriptors {
     Name m_extendsName;
     int m_fixedSystemFirstSymbolValue;
     OptionSet<ExplicitlySetDescriptors> m_explicitlySetDescriptors;
+    bool m_isExtendedResolved { false };
 };
 
-CSSCounterStyleDescriptors::Ranges translateRangeFromStyleProperties(const StyleProperties&);
-CSSCounterStyleDescriptors::AdditiveSymbols translateAdditiveSymbolsFromStyleProperties(const StyleProperties&);
-CSSCounterStyleDescriptors::Pad translatePadFromStyleProperties(const StyleProperties&);
-CSSCounterStyleDescriptors::NegativeSymbols translateNegativeSymbolsFromStyleProperties(const StyleProperties&);
-Vector<CSSCounterStyleDescriptors::Symbol> translateSymbolsFromStyleProperties(const StyleProperties&);
-CSSCounterStyleDescriptors::Name translateFallbackNameFromStyleProperties(const StyleProperties&);
-CSSCounterStyleDescriptors::Symbol translatePrefixFromStyleProperties(const StyleProperties&);
-CSSCounterStyleDescriptors::Symbol translateSuffixFromStyleProperties(const StyleProperties&);
-std::pair<CSSCounterStyleDescriptors::Name, int> extractDataFromSystemDescriptor(const StyleProperties&, CSSCounterStyleDescriptors::System);
+CSSCounterStyleDescriptors::Ranges rangeFromCSSValue(Ref<CSSValue>);
+CSSCounterStyleDescriptors::AdditiveSymbols additiveSymbolsFromCSSValue(Ref<CSSValue>);
+CSSCounterStyleDescriptors::Pad padFromCSSValue(Ref<CSSValue>);
+CSSCounterStyleDescriptors::NegativeSymbols negativeSymbolsFromCSSValue(Ref<CSSValue>);
+CSSCounterStyleDescriptors::Symbol symbolFromCSSValue(RefPtr<CSSValue>);
+Vector<CSSCounterStyleDescriptors::Symbol> symbolsFromCSSValue(Ref<CSSValue>);
+CSSCounterStyleDescriptors::Name fallbackNameFromCSSValue(Ref<CSSValue>);
+CSSCounterStyleDescriptors::SystemData extractSystemDataFromCSSValue(RefPtr<CSSValue>, CSSCounterStyleDescriptors::System);
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -34,38 +34,33 @@
 namespace WebCore {
 class StyleRuleCounterStyle final : public StyleRuleBase {
 public:
-    static Ref<StyleRuleCounterStyle> create(const AtomString&, Ref<StyleProperties>&&, CSSCounterStyleDescriptors&&);
+    static Ref<StyleRuleCounterStyle> create(const AtomString&, CSSCounterStyleDescriptors&&);
     ~StyleRuleCounterStyle();
 
     Ref<StyleRuleCounterStyle> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
 
-    const StyleProperties& properties() const { return m_properties; }
     const CSSCounterStyleDescriptors& descriptors() const { return m_descriptors; };
     CSSCounterStyleDescriptors& mutableDescriptors() { return m_descriptors; };
-    RefPtr<CSSValue> getPropertyCSSValue(CSSPropertyID id) const { return m_properties->getPropertyCSSValue(id); }
-    MutableStyleProperties& mutableProperties();
 
     const AtomString& name() const { return m_name; }
-    String system() const { return m_properties->getPropertyValue(CSSPropertySystem); }
-    String negative() const { return m_properties->getPropertyValue(CSSPropertyNegative); }
-    String prefix() const { return m_properties->getPropertyValue(CSSPropertyPrefix); }
-    String suffix() const { return m_properties->getPropertyValue(CSSPropertySuffix); }
-    String range() const { return m_properties->getPropertyValue(CSSPropertyRange); }
-    String pad() const { return m_properties->getPropertyValue(CSSPropertyPad); }
-    String fallback() const { return m_properties->getPropertyValue(CSSPropertyFallback); }
-    String symbols() const { return m_properties->getPropertyValue(CSSPropertySymbols); }
-    String additiveSymbols() const { return m_properties->getPropertyValue(CSSPropertyAdditiveSymbols); }
-    String speakAs() const { return m_properties->getPropertyValue(CSSPropertySpeakAs); }
+    String system() const { return m_descriptors.systemCSSText(); }
+    String negative() const { return m_descriptors.negativeCSSText(); }
+    String prefix() const { return m_descriptors.prefixCSSText(); }
+    String suffix() const { return m_descriptors.suffixCSSText(); }
+    String range() const { return { m_descriptors.rangesCSSText() }; }
+    String pad() const { return m_descriptors.padCSSText(); }
+    String fallback() const { return m_descriptors.fallbackCSSText(); }
+    String symbols() const { return m_descriptors.symbolsCSSText(); }
+    String additiveSymbols() const { return m_descriptors.additiveSymbolsCSSText(); }
+    String speakAs() const { return { }; }
     bool newValueInvalidOrEqual(CSSPropertyID, const RefPtr<CSSValue> newValue) const;
 
     void setName(const AtomString& name) { m_name = name; }
 
 private:
-    explicit StyleRuleCounterStyle(const AtomString&, Ref<StyleProperties>&&, CSSCounterStyleDescriptors&&);
+    explicit StyleRuleCounterStyle(const AtomString&, CSSCounterStyleDescriptors&&);
 
     AtomString m_name;
-    // FIXME: we can get rid of m_properties and use only m_descriptors for storing the descriptors data (rdar://107267784).
-    Ref<StyleProperties> m_properties;
     CSSCounterStyleDescriptors m_descriptors;
 };
 
@@ -106,6 +101,9 @@ private:
     CSSCounterStyleRule(StyleRuleCounterStyle&, CSSStyleSheet* parent);
 
     bool setterInternal(CSSPropertyID, const String&);
+    RefPtr<CSSValue> cssValueFromText(CSSPropertyID, const String&);
+    const CSSCounterStyleDescriptors& descriptors() const { return m_counterStyleRule->descriptors(); }
+    CSSCounterStyleDescriptors& mutableDescriptors() { return m_counterStyleRule->mutableDescriptors(); }
 
     Ref<StyleRuleCounterStyle> m_counterStyleRule;
 };

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -906,11 +906,10 @@ RefPtr<StyleRuleCounterStyle> CSSParserImpl::consumeCounterStyleRule(CSSParserTo
     }
 
     auto declarations = consumeDeclarationListInNewNestingContext(block, StyleRuleType::CounterStyle);
-    auto properties = createStyleProperties(declarations, m_context.mode);
-    auto descriptors = CSSCounterStyleDescriptors::create(name, properties);
+    auto descriptors = CSSCounterStyleDescriptors::create(name, createStyleProperties(declarations, m_context.mode));
     if (!descriptors.isValid())
         return nullptr;
-    return StyleRuleCounterStyle::create(name, WTFMove(properties), WTFMove(descriptors));
+    return StyleRuleCounterStyle::create(name, WTFMove(descriptors));
 }
 
 RefPtr<StyleRuleLayer> CSSParserImpl::consumeLayerRule(CSSParserTokenRange prelude, std::optional<CSSParserTokenRange> block)

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -1847,8 +1847,8 @@ void RenderListMarker::updateContent()
     case ListStyleType::Type::CounterStyle: {
         auto counter = counterStyle();
         ASSERT(counter);
-        auto text = makeString(counter->prefix(), counter->text(m_listItem->value()));
-        m_textWithSuffix = makeString(text, counter->suffix());
+        auto text = makeString(counter->prefix().text, counter->text(m_listItem->value()));
+        m_textWithSuffix = makeString(text, counter->suffix().text);
         m_textWithoutSuffixLength = text.length();
         m_textIsLeftToRightDirection = u_charDirection(text[0]) != U_RIGHT_TO_LEFT;
         break;


### PR DESCRIPTION
#### b96c4a014f188f11c6fdfbb91937d42466fae41e
<pre>
Refactor StyleRuleCounterStyle for eliminating StyleProperties
<a href="https://bugs.webkit.org/show_bug.cgi?id=254524">https://bugs.webkit.org/show_bug.cgi?id=254524</a>
rdar://107267784

Reviewed by Antti Koivisto.

StyleRuleCounterStyle currently stores `StyleProperties` besides
`CSSCounterStyleDescriptors`.
This is used for facilitating serialization and read/write for the
CSSOM api. We can get rid of the `StyleProperties` member and use only
`CSSCounterStyleDescriptors` after we write a serializer for each
descriptor and adapt the setter function for setting only the
`CSSCounterStyleDescriptors` without havint to set the property that
originated the descriptor.

* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/prefix-suffix-syntax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/speak-as-syntax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/symbols-syntax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-prefix-suffix-syntax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-speak-as-syntax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-symbols-syntax-expected.txt:
- We and other browsers don&apos;t support url() as symbol for the
counter-style at-rule, so these should be failing. They were suceeding,
because we parsed it correctly, but since we don&apos;t support it, we
shouldn&apos;t be able to use this value for setting the descriptor.
- We don&apos;t support the speak-as descriptor, it should be failing.
- Note that these tests are duplicated. We should re-import WPT
and get rid of the dupes (rdar://107410996)

* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::CSSCounterStyle::counterForSystemCyclic const):
(WebCore::CSSCounterStyle::counterForSystemFixed const):
(WebCore::CSSCounterStyle::counterForSystemSymbolic const):
(WebCore::CSSCounterStyle::counterForSystemAlphabetic const):
(WebCore::CSSCounterStyle::counterForSystemNumeric const):
(WebCore::CSSCounterStyle::counterForSystemAdditive const):
(WebCore::CSSCounterStyle::applyNegativeSymbols const):
(WebCore::CSSCounterStyle::applyPadSymbols const):
(WebCore::CSSCounterStyle::extendAndResolve):
- Since now Symbols is a struct, to support correct serialization of
custom-ident and string values, we should access the text value
with the .text member.

* Source/WebCore/css/CSSCounterStyle.h:
(WebCore::CSSCounterStyle::isExtendsUnresolved):
- Moving this flag to the descriptor so we can use it for serialization
of the system.

* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
- We are renaming the translating functions, removing the &apos;translate&apos; prefix
to become in better compliance with WebKit style.
- The translation functions are now exposed via the header because when
a descriptor is set via CSSOM, we need to translate its CSSValue to the
descriptor value.
- Each descriptor has now a setter method, which will also take care of
its validation. Before, the validation would happen through setterInternal()
and newValueInvalidOrEqual() methods:
(WebCore::rangeFromStyleProperties):
(WebCore::rangeFromCSSValue):
(WebCore::symbolFromCSSValue):
(WebCore::nameFromCSSValue):
(WebCore::additiveSymbolsFromStyleProperties):
(WebCore::additiveSymbolsFromCSSValue):
(WebCore::padFromStyleProperties):
(WebCore::padFromCSSValue):
(WebCore::negativeSymbolsFromStyleProperties):
(WebCore::negativeSymbolsFromCSSValue):
(WebCore::symbolsFromStyleProperties):
(WebCore::symbolsFromCSSValue):
(WebCore::fallbackNameFromStyleProperties):
(WebCore::fallbackNameFromCSSValue):
(WebCore::prefixFromStyleProperties):
(WebCore::suffixFromStyleProperties):
(WebCore::extractSystemDataFromStyleProperties):
(WebCore::extractSystemDataFromCSSValue):
(WebCore::CSSCounterStyleDescriptors::setExplicitlySetDescriptors):
(WebCore::CSSCounterStyleDescriptors::create):
(WebCore::CSSCounterStyleDescriptors::areSymbolsValidForSystem):
(WebCore::CSSCounterStyleDescriptors::isValid const):
(WebCore::CSSCounterStyleDescriptors::setName):
(WebCore::CSSCounterStyleDescriptors::setSystemData):
(WebCore::CSSCounterStyleDescriptors::setNegative):
(WebCore::CSSCounterStyleDescriptors::setPrefix):
(WebCore::CSSCounterStyleDescriptors::setSuffix):
(WebCore::CSSCounterStyleDescriptors::setRanges):
(WebCore::CSSCounterStyleDescriptors::setPad):
(WebCore::CSSCounterStyleDescriptors::setFallbackName):
(WebCore::CSSCounterStyleDescriptors::setSymbols):
(WebCore::CSSCounterStyleDescriptors::setAdditiveSymbols):
(WebCore::CSSCounterStyleDescriptors::Symbol::cssText const):
(WebCore::CSSCounterStyleDescriptors::nameCSSText const):
(WebCore::CSSCounterStyleDescriptors::systemCSSText const):
(WebCore::CSSCounterStyleDescriptors::negativeCSSText const):
(WebCore::CSSCounterStyleDescriptors::prefixCSSText const):
(WebCore::CSSCounterStyleDescriptors::suffixCSSText const):
(WebCore::CSSCounterStyleDescriptors::rangesCSSText const):
(WebCore::CSSCounterStyleDescriptors::Pad::cssText const):
(WebCore::CSSCounterStyleDescriptors::padCSSText const):
(WebCore::CSSCounterStyleDescriptors::fallbackCSSText const):
(WebCore::CSSCounterStyleDescriptors::symbolsCSSText const):
(WebCore::CSSCounterStyleDescriptors::additiveSymbolsCSSText const):
(WebCore::translateRangeFromStyleProperties): Deleted.
(WebCore::symbolToString): Deleted.
(WebCore::translateAdditiveSymbolsFromStyleProperties): Deleted.
(WebCore::translatePadFromStyleProperties): Deleted.
(WebCore::translateNegativeSymbolsFromStyleProperties): Deleted.
(WebCore::translateSymbolsFromStyleProperties): Deleted.
(WebCore::translateFallbackNameFromStyleProperties): Deleted.
(WebCore::translatePrefixFromStyleProperties): Deleted.
(WebCore::translateSuffixFromStyleProperties): Deleted.
(WebCore::extractDataFromSystemDescriptor): Deleted.
(WebCore::CSSCounterStyleDescriptors::areSymbolsValidForSystem const): Deleted.
* Source/WebCore/css/CSSCounterStyleDescriptors.h:
(WebCore::CSSCounterStyleDescriptors::Symbol::operator== const):
(WebCore::CSSCounterStyleDescriptors::Symbol::operator!= const):
(WebCore::CSSCounterStyleDescriptors::setName): Deleted.
* Source/WebCore/css/CSSCounterStyleRule.cpp:

(WebCore::StyleRuleCounterStyle::StyleRuleCounterStyle):
(WebCore::StyleRuleCounterStyle::create):
- We no longer need to store the StyleProperties used for creating
the CSSCounterStyleDescriptors inside StyleRuleCounterStyle. Now we
store only CSSCounterStyleDescriptors.
(WebCore::CSSCounterStyleRule::CSSValueFromText):
(WebCore::CSSCounterStyleRule::setName):
(WebCore::CSSCounterStyleRule::setSystem):
(WebCore::CSSCounterStyleRule::setNegative):
(WebCore::CSSCounterStyleRule::setPrefix):
(WebCore::CSSCounterStyleRule::setSuffix):
(WebCore::CSSCounterStyleRule::setRange):
(WebCore::CSSCounterStyleRule::setPad):
(WebCore::CSSCounterStyleRule::setFallback):
(WebCore::CSSCounterStyleRule::setSymbols):
(WebCore::CSSCounterStyleRule::setAdditiveSymbols):
(WebCore::CSSCounterStyleRule::setSpeakAs):
(WebCore::symbolsValidForSystem): Deleted.
(WebCore::StyleRuleCounterStyle::newValueInvalidOrEqual const): Deleted.
(WebCore::StyleRuleCounterStyle::mutableProperties): Deleted.
(WebCore::CSSCounterStyleRule::setterInternal): Deleted.
- The CSSCounterStyleRule setters now use the setters of
CSSCounterStyleDescriptors to set each descriptor directly, without
having validating it with setterInternal() and newValueInvalidOrEqual(),
since each setter validates itself.
* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeCounterStyleRule):

* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::updateContent):
- Updating the access of symbol&apos;s via .text member, since it is now
a struct for supporting serialization (see first comments).

Canonical link: <a href="https://commits.webkit.org/262396@main">https://commits.webkit.org/262396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/563b33ccdd515499e1047c181375c43f1a6834d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2364 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1532 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1455 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2205 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1333 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1314 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1332 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2400 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1367 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1219 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1300 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/357 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1409 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->