### PR TITLE
fetch should compute its origin from its context

### DIFF
--- a/LayoutTests/http/wpt/fetch/origin-no-cors-disabled-expected.txt
+++ b/LayoutTests/http/wpt/fetch/origin-no-cors-disabled-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Check origin in case referrer is set and CORS is disabled
+

--- a/LayoutTests/http/wpt/fetch/origin-no-cors-disabled.html
+++ b/LayoutTests/http/wpt/fetch/origin-no-cors-disabled.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="help" href="https://fetch.spec.whatwg.org/#response">
+        <meta name="help" href="https://fetch.spec.whatwg.org/#body-mixin">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+promise_test(async () => {
+    if (window.internals) {
+        internals.grantUniversalAccess();
+        internals.disableCORSForURL("http://localhost/WebKit/fetch/resources/echo-origin-cors-disabled.py");
+    }
+
+    const response = await fetch("http://localhost:8800/WebKit/fetch/resources/echo-origin-cors-disabled.py?test-for-cors-disabled", {
+        "referrer": "https://example.com/",
+        "body": "",
+        "method": "POST",
+        "mode": "cors",
+    });
+
+    assert_equals(await response.text(), "http://localhost:8800");
+}, "Check origin in case referrer is set and CORS is disabled");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/http/wpt/fetch/resources/echo-origin-cors-disabled.py
+++ b/LayoutTests/http/wpt/fetch/resources/echo-origin-cors-disabled.py
@@ -1,0 +1,6 @@
+def main(request, response):
+    origin = request.headers.get(b"Origin", "None")
+    response.status = (200, "OK")
+    response.headers.set(b"Content-Type", b'text/plain')
+    response.headers.set(b"Cache-Control", b"max-age=0")
+    return origin

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2309,6 +2309,11 @@ void Page::setCORSDisablingPatterns(Vector<UserContentURLPattern>&& patterns)
     m_corsDisablingPatterns = WTFMove(patterns);
 }
 
+void Page::addCORSDisablingPatternForTesting(UserContentURLPattern&& pattern)
+{
+    m_corsDisablingPatterns.append(WTFMove(pattern));
+}
+
 void Page::setMemoryCacheClientCallsEnabled(bool enabled)
 {
     if (m_areMemoryCacheClientCallsEnabled == enabled)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -710,6 +710,7 @@ public:
 
     WEBCORE_EXPORT void setCORSDisablingPatterns(Vector<UserContentURLPattern>&&);
     const Vector<UserContentURLPattern>& corsDisablingPatterns() const { return m_corsDisablingPatterns; }
+    WEBCORE_EXPORT void addCORSDisablingPatternForTesting(UserContentURLPattern&&);
 
     WEBCORE_EXPORT void setMemoryCacheClientCallsEnabled(bool);
     bool areMemoryCacheClientCallsEnabled() const { return m_areMemoryCacheClientCallsEnabled; }

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -138,7 +138,7 @@ public:
     // Explicitly grant the ability to access very other SecurityOrigin.
     //
     // WARNING: This is an extremely powerful ability. Use with caution!
-    void grantUniversalAccess();
+    WEBCORE_EXPORT void grantUniversalAccess();
     bool hasUniversalAccess() const { return m_universalAccess; }
 
     void grantStorageAccessFromFileURLsQuirk();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -228,6 +228,7 @@
 #include "ThreadableBlobRegistry.h"
 #include "TreeScope.h"
 #include "TypeConversions.h"
+#include "UserContentURLPattern.h"
 #include "UserGestureIndicator.h"
 #include "UserMediaController.h"
 #include "ViewportArguments.h"
@@ -5061,6 +5062,18 @@ ExceptionOr<bool> Internals::pageDefersLoading()
     if (!document || !document->page())
         return Exception { InvalidAccessError };
     return document->page()->defersLoading();
+}
+
+void Internals::grantUniversalAccess()
+{
+    if (auto* document = contextDocument())
+        document->securityOrigin().grantUniversalAccess();
+}
+
+void Internals::disableCORSForURL(const String& url)
+{
+    if (auto* page = contextDocument() ? contextDocument()->page() : nullptr)
+        page->addCORSDisablingPatternForTesting(UserContentURLPattern { url });
 }
 
 RefPtr<File> Internals::createFile(const String& path)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -811,6 +811,9 @@ public:
     void setPageDefersLoading(bool);
     ExceptionOr<bool> pageDefersLoading();
 
+    void grantUniversalAccess();
+    void disableCORSForURL(const String&);
+
     RefPtr<File> createFile(const String&);
     String createTemporaryFile(const String& name, const String& contents);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -881,6 +881,9 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined setPageDefersLoading(boolean defersLoading);
     boolean pageDefersLoading();
 
+    undefined grantUniversalAccess();
+    undefined disableCORSForURL(DOMString url);
+
     File? createFile(DOMString url);
     DOMString createTemporaryFile(DOMString name, DOMString contents);
 


### PR DESCRIPTION
#### 878b8e74ec2f636044a79b02027c044ca08c1462
<pre>
fetch should compute its origin from its context
<a href="https://bugs.webkit.org/show_bug.cgi?id=254734">https://bugs.webkit.org/show_bug.cgi?id=254734</a>
rdar://problem/107414766

Reviewed by Chris Dumez.

In case some security features are disabled, the referrer might not be same origin as the context origin for a fetch request.
In that case, we should still stick to the context origin and not rely on referrer to compute the origin.
We update CachedResourceRequest::updateReferrerAndOriginHeaders accordingly for fetch loads.

* LayoutTests/http/wpt/fetch/origin-no-cors-disabled-expected.txt: Added.
* LayoutTests/http/wpt/fetch/origin-no-cors-disabled.html: Added.
* LayoutTests/http/wpt/fetch/resources/echo-origin-cors-disabled.py: Added.
(main):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::updateReferrerAndOriginHeaders):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::addCORSDisablingPatternForTesting):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/SecurityOrigin.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::grantUniversalAccess):
(WebCore::Internals::disableCORSForURL):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/262403@main">https://commits.webkit.org/262403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a208ea5400f029b56fece22d33135ba5ac51f90f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2062 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1291 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1144 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1157 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1196 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2260 "261 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1114 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1174 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/363 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1232 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->