### PR TITLE
Make SelectorQueryCache global

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -429,7 +429,6 @@ public:
     void invalidateAccessKeyCache();
 
     ExceptionOr<SelectorQuery&> selectorQueryForString(const String&);
-    void clearSelectorQueryCache();
 
     void setViewportArguments(const ViewportArguments& viewportArguments) { m_viewportArguments = viewportArguments; }
     WEBCORE_EXPORT ViewportArguments viewportArguments() const;
@@ -2055,8 +2054,6 @@ private:
     std::unique_ptr<HashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>> m_accessKeyCache;
 
     std::unique_ptr<ConstantPropertyMap> m_constantPropertyMap;
-
-    std::unique_ptr<SelectorQueryCache> m_selectorQueryCache;
 
     RenderPtr<RenderView> m_renderView;
     std::unique_ptr<RenderStyle> m_initialContainingBlockStyle;

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -26,8 +26,10 @@
 #pragma once
 
 #include "CSSSelectorList.h"
+#include "CSSSelectorParser.h"
 #include "ExceptionOr.h"
 #include "NodeList.h"
+#include "SecurityOriginData.h"
 #include "SelectorCompiler.h"
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
@@ -108,9 +110,14 @@ private:
 class SelectorQueryCache {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ExceptionOr<SelectorQuery&> add(const String&, Document&);
+    static SelectorQueryCache& singleton();
+
+    SelectorQuery* add(const String&, const Document&);
+    void clear();
+
 private:
-    HashMap<String, std::unique_ptr<SelectorQuery>> m_entries;
+    using Key = std::tuple<String, CSSSelectorParserContext, SecurityOriginData>;
+    HashMap<Key, std::unique_ptr<SelectorQuery>> m_entries;
 };
 
 inline bool SelectorQuery::matches(Element& element) const

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -49,6 +49,7 @@
 #include "PerformanceLogging.h"
 #include "RenderTheme.h"
 #include "ScrollingThread.h"
+#include "SelectorQuery.h"
 #include "StyleScope.h"
 #include "StyledElement.h"
 #include "TextPainter.h"
@@ -73,10 +74,9 @@ static void releaseNoncriticalMemory(MaintainMemoryCache maintainMemoryCache)
     FontCache::releaseNoncriticalMemoryInAllFontCaches();
 
     GlyphDisplayListCache::singleton().clear();
+    SelectorQueryCache::singleton().clear();
 
     for (auto* document : Document::allDocuments()) {
-        document->clearSelectorQueryCache();
-
         if (auto* renderView = document->renderView())
             LayoutIntegration::LineLayout::releaseCaches(*renderView);
     }


### PR DESCRIPTION
#### bc149c287545dc1e7668aa4a4375c103d4915754
<pre>
Make SelectorQueryCache global
<a href="https://bugs.webkit.org/show_bug.cgi?id=254732">https://bugs.webkit.org/show_bug.cgi?id=254732</a>
rdar://107414722

Reviewed by Chris Dumez.

It is currently per-Document but there is no reason why selectors can&apos;t be shared across documents.

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::CSSSelectorParserContext::operator== const):

Switch to using a separate (and much simpler) CSSSelectorParserContext struct in CSSSelectorParser
instead of CSSParserContext. This is a more compact type to use in a hash key.

(WebCore::add):

Make it hashable.

(WebCore::parseCSSSelector):
(WebCore::CSSSelectorParser::CSSSelectorParser):
(WebCore::CSSSelectorParser::supportsComplexSelector):
(WebCore::CSSSelectorParser::splitCompoundAtImplicitShadowCrossingCombinator):
* Source/WebCore/css/parser/CSSSelectorParser.h:
(WebCore::CSSSelectorParserContextHash::hash):
(WebCore::CSSSelectorParserContextHash::equal):
(WTF::HashTraits&lt;WebCore::CSSSelectorParserContext&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::CSSSelectorParserContext&gt;::isDeletedValue):
(WTF::HashTraits&lt;WebCore::CSSSelectorParserContext&gt;::emptyValue):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setCompatibilityMode):
(WebCore::Document::updateBaseURL):
(WebCore::Document::setBackForwardCacheState):

No need to explicitly clear the cache in these cases, the changes are captured by the cache key.

(WebCore::Document::clearSelectorQueryCache): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorQueryCache::singleton):

Make the cache a singleton.

(WebCore::SelectorQueryCache::add):

The key includes the query string, CSSSelectorParserContext and the document security origin.
Only do a single hash lookup.
Also cache parse failures.

(WebCore::SelectorQueryCache::clear):
(): Deleted.
* Source/WebCore/dom/SelectorQuery.h:
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseNoncriticalMemory):

Canonical link: <a href="https://commits.webkit.org/262362@main">https://commits.webkit.org/262362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1772fe24f0bca367818d5b58148595d476163c95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2210 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1422 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1331 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1254 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1207 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/1213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/329 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1289 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->