### PR TITLE
Stop caching supplied colors for canvas noise injection

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -47,6 +47,10 @@
 #include <atomic>
 #include <wtf/Vector.h>
 
+#if ENABLE(WEB_CRYPTO)
+#include <pal/crypto/CryptoDigest.h>
+#endif
+
 static std::atomic<size_t> s_activePixelMemory { 0 };
 
 namespace WebCore {
@@ -363,18 +367,30 @@ bool CanvasBase::shouldInjectNoiseBeforeReadback() const
     return scriptExecutionContext() && scriptExecutionContext()->noiseInjectionHashSalt();
 }
 
-bool CanvasBase::postProcessPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, bool wasLastDrawByBitMap, const HashSet<uint32_t>& suppliedColors) const
+bool CanvasBase::postProcessPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, bool wasLastDrawByBitMap) const
 {
+#if ENABLE(WEB_CRYPTO)
     if (!shouldInjectNoiseBeforeReadback() || wasLastDrawByBitMap)
         return false;
 
     ASSERT(pixelBuffer->format().pixelFormat == PixelFormat::RGBA8);
 
+    // FIXME: This should be moved into the constructor. There's no reason to recompute this every time.
     constexpr auto contextString { "Canvas2DContextString"_s };
-    unsigned salt = computeHash<String, uint64_t>(contextString, *scriptExecutionContext()->noiseInjectionHashSalt());
+    auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    if (!digest)
+        return false;
+
+    const auto hashSalt = *scriptExecutionContext()->noiseInjectionHashSalt();
+    Vector<uint8_t> message { reinterpret_cast<const uint8_t*>(contextString.characters()), contextString.length() };
+    message.append(reinterpret_cast<const uint8_t*>(&hashSalt), sizeof hashSalt);
+    digest->addBytes(message.data(), message.size());
+    auto result = digest->computeHash();
+    uint64_t salt = *reinterpret_cast<uint64_t*>(result.data());
+
     constexpr int bytesPerPixel = 4;
     auto* bytes = pixelBuffer->bytes();
-    HashMap<uint32_t, uint32_t> pixelColorMap;
+    HashMap<uint32_t, uint32_t> colorMap;
     bool wasPixelBufferModified { false };
 
     for (size_t i = 0; i < pixelBuffer->sizeInBytes(); i += bytesPerPixel) {
@@ -385,45 +401,49 @@ bool CanvasBase::postProcessPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, bool was
         bool isBlack { !redChannel && !greenChannel && !blueChannel };
 
         uint32_t pixel = (redChannel << 24) | (greenChannel << 16) | (blueChannel << 8) | alphaChannel;
-        // FIXME: Consider isEquivalentColor comparision instead of exact match
-        if (!pixel || !alphaChannel || !suppliedColors.isValidValue(pixel) || suppliedColors.contains(pixel))
+        if (!pixel || !alphaChannel || !colorMap.isValidKey(pixel))
             continue;
 
-        if (auto color = pixelColorMap.get(pixel)) {
+        uint32_t modifiedPixel { 0 };
+        if (auto color = colorMap.get(pixel)) {
             alphaChannel = static_cast<uint8_t>(color);
             blueChannel = static_cast<uint8_t>(color >> 8);
             greenChannel = static_cast<uint8_t>(color >> 16);
             redChannel = static_cast<uint8_t>(color >> 24);
-            continue;
+            modifiedPixel = color;
+        } else {
+            const uint64_t pixelHash = computeHash(computeHash(salt, redChannel, greenChannel, blueChannel, alphaChannel));
+            // +/- 13 is roughly ~5% of the 255 max value.
+            const auto clampedFivePercent = static_cast<uint32_t>(((pixelHash * 26) / std::numeric_limits<uint32_t>::max()) - 13);
+
+            const auto clampedColorComponentOffset = [](int colorComponentOffset, int originalComponentValue) {
+                if (colorComponentOffset + originalComponentValue > std::numeric_limits<uint8_t>::max())
+                    return std::numeric_limits<uint8_t>::max() - originalComponentValue;
+                if (colorComponentOffset + originalComponentValue < 0)
+                    return -originalComponentValue;
+                return colorComponentOffset;
+            };
+
+            // If alpha is non-zero and the color channels are zero, then only tweak the alpha channel's value;
+            if (isBlack)
+                alphaChannel += clampedColorComponentOffset(clampedFivePercent, alphaChannel);
+            else {
+                // If alpha and any of the color channels are non-zero, then tweak all of the channels;
+                redChannel += clampedColorComponentOffset(clampedFivePercent, redChannel);
+                greenChannel += clampedColorComponentOffset(clampedFivePercent, greenChannel);
+                blueChannel += clampedColorComponentOffset(clampedFivePercent, blueChannel);
+                alphaChannel += clampedColorComponentOffset(clampedFivePercent, alphaChannel);
+            }
+            modifiedPixel = (redChannel << 24) | (greenChannel << 16) | (blueChannel << 8) | alphaChannel;
+            colorMap.set(pixel, modifiedPixel);
         }
 
-        const uint64_t pixelHash = computeHash(salt, redChannel, greenChannel, blueChannel, alphaChannel);
-        // +/- ~13 is roughly 5% of the 255 max value.
-        const auto clampedFivePercent = static_cast<uint32_t>(((pixelHash * 26) / std::numeric_limits<uint32_t>::max()) - 13);
-
-        const auto clampedColorComponentOffset = [](int colorComponentOffset, int originalComponentValue) {
-            if (colorComponentOffset + originalComponentValue > std::numeric_limits<uint8_t>::max())
-                return std::numeric_limits<uint8_t>::max() - originalComponentValue;
-            if (colorComponentOffset + originalComponentValue < 0)
-                return -originalComponentValue;
-            return colorComponentOffset;
-        };
-
-        // If alpha is non-zero and the color channels are zero, then only tweak the alpha channel's value;
-        if (isBlack)
-            alphaChannel += clampedColorComponentOffset(clampedFivePercent, alphaChannel);
-        else {
-            // If alpha and any of the color channels are non-zero, then tweak all of the channels;
-            redChannel += clampedColorComponentOffset(clampedFivePercent, redChannel);
-            greenChannel += clampedColorComponentOffset(clampedFivePercent, greenChannel);
-            blueChannel += clampedColorComponentOffset(clampedFivePercent, blueChannel);
-            alphaChannel += clampedColorComponentOffset(clampedFivePercent, alphaChannel);
-        }
-        uint32_t modifiedPixel = (redChannel << 24) | (greenChannel << 16) | (blueChannel << 8) | alphaChannel;
-        pixelColorMap.set(pixel, modifiedPixel);
         wasPixelBufferModified = true;
     }
     return wasPixelBufferModified;
+#else
+    return false;
+#endif
 }
 
 size_t CanvasBase::activePixelMemory()

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -127,7 +127,7 @@ public:
     virtual void dispatchEvent(Event&) = 0;
 
     bool shouldInjectNoiseBeforeReadback() const;
-    bool postProcessPixelBuffer(Ref<PixelBuffer>&&, bool, const HashSet<uint32_t>&) const;
+    bool postProcessPixelBuffer(Ref<PixelBuffer>&&, bool) const;
 
 protected:
     explicit CanvasBase(IntSize);

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -816,7 +816,7 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
         return nullptr;
 
     if (pixelBuffer)
-        postProcessPixelBuffer(*pixelBuffer, false, { });
+        postProcessPixelBuffer(*pixelBuffer, false);
 
     return ImageData::create(static_reference_cast<ByteArrayPixelBuffer>(pixelBuffer.releaseNonNull()));
 #else

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1068,7 +1068,7 @@ void CanvasRenderingContext2DBase::postProcessPixelBuffer() const
     if (!is<ByteArrayPixelBuffer>(pixelBuffer))
         return;
 
-    if (canvasBase().postProcessPixelBuffer(*pixelBuffer, false, suppliedColors())) {
+    if (canvasBase().postProcessPixelBuffer(*pixelBuffer, false)) {
         IntSize destOffset { 0, 0 };
         IntRect sourceRect = computeImageDataRect(*buffer, dirtyRect.width(), dirtyRect.height(), dirtyRect, destOffset);
         buffer->putPixelBuffer(*pixelBuffer, sourceRect, IntPoint { destOffset });
@@ -2368,7 +2368,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
 
     ASSERT(pixelBuffer->format().colorSpace == toDestinationColorSpace(computedColorSpace));
 
-    if (canvasBase().postProcessPixelBuffer(*pixelBuffer, m_wasLastDrawPutImageData, suppliedColors())) {
+    if (canvasBase().postProcessPixelBuffer(*pixelBuffer, m_wasLastDrawPutImageData)) {
         IntSize destOffset { 0, 0 };
         IntRect sourceRect = computeImageDataRect(*buffer, imageDataRect.width(), imageDataRect.height(), imageDataRect, destOffset);
         buffer->putPixelBuffer(*pixelBuffer, sourceRect, IntPoint { destOffset });


### PR DESCRIPTION
#### de5510fe4ab3daf4d5aad98914e0e60c730dc813
<pre>
Stop caching supplied colors for canvas noise injection
<a href="https://bugs.webkit.org/show_bug.cgi?id=254735">https://bugs.webkit.org/show_bug.cgi?id=254735</a>
rdar://107298162

Reviewed by NOBODY (OOPS!).

In the initial patch, we cached the supplied colors as an optimization for
deciding which pixel colors should be modified. After some analysis, we found
that was no effective and should be remove.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::postProcessPixelBuffer const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getImageData):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::postProcessPixelBuffer const):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/909089e4eeaf2ac65d5713375f07e0537bc1e552

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2074 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1135 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1293 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1950 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1153 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1161 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2271 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1209 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1117 "1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1177 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1236 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->