### PR TITLE
Remove DisplayContentsChanged flag

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -336,15 +336,15 @@ void ContainerNode::removeDetachedChildren()
     removeDetachedChildrenInContainer(*this);
 }
 
-static inline bool mayHaveDisplayContents(Element *element)
+static inline bool hasDisplayContents(Element *element)
 {
-    return element && (element->hasDisplayContents() || element->displayContentsChanged());
+    return element && element->hasDisplayContents();
 }
 
 static inline void destroyRenderTreeIfNeeded(Node& child)
 {
     auto childAsElement = dynamicDowncast<Element>(child);
-    if (!child.renderer() && !mayHaveDisplayContents(childAsElement))
+    if (!child.renderer() && !hasDisplayContents(childAsElement))
         return;
     if (childAsElement)
         RenderTreeUpdater::tearDownRenderers(*childAsElement);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3999,7 +3999,6 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
     // FIXME: This is not as efficient as it could be. For example if an ancestor has a non-inherited style change but
     // the styles are otherwise clean we would not need to re-resolve descendants.
     for (auto& element : makeReversedRange(elementsRequiringComputedStyle)) {
-        bool hadDisplayContents = element->hasDisplayContents();
         auto style = document().styleForElementIgnoringPendingStylesheets(*element, computedStyle);
         computedStyle = style.get();
         ElementRareData& rareData = element->ensureElementRareData();
@@ -4015,8 +4014,6 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
         }
         rareData.setComputedStyle(WTFMove(style));
         element->clearNodeFlag(NodeFlag::IsComputedStyleInvalidFlag);
-        if (hadDisplayContents && computedStyle->display() != DisplayType::Contents)
-            element->setDisplayContentsChanged();
 
         if (mode == ResolveComputedStyleMode::RenderedOnly && computedStyle->display() == DisplayType::None)
             return nullptr;
@@ -5350,16 +5347,6 @@ bool Element::hasDuplicateAttribute() const
 void Element::setHasDuplicateAttribute(bool hasDuplicateAttribute)
 {
     setEventTargetFlag(EventTargetFlag::HasDuplicateAttribute, hasDuplicateAttribute);
-}
-
-bool Element::displayContentsChanged() const
-{
-    return hasEventTargetFlag(EventTargetFlag::DisplayContentsChanged);
-}
-
-void Element::setDisplayContentsChanged(bool changed)
-{
-    setEventTargetFlag(EventTargetFlag::DisplayContentsChanged, changed);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -730,9 +730,6 @@ public:
     ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap();
     ExplicitlySetAttrElementsMap* explicitlySetAttrElementsMapIfExists() const;
 
-    bool displayContentsChanged() const;
-    void setDisplayContentsChanged(bool = true);
-
 protected:
     Element(const QualifiedName&, Document&, ConstructionType);
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -165,10 +165,9 @@ protected:
         IsNode = 1 << 1,
         // Element bits
         HasDuplicateAttribute = 1 << 2,
-        DisplayContentsChanged = 1 << 3,
-        HasLangAttr = 1 << 4,
-        HasXMLLangAttr = 1 << 5,
-        EffectiveLangKnownToMatchDocumentElement = 1 << 6,
+        HasLangAttr = 1 << 3,
+        HasXMLLangAttr = 1 << 4,
+        EffectiveLangKnownToMatchDocumentElement = 1 << 5,
     };
 
     EventTargetData& ensureEventTargetData()

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -325,7 +325,7 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
     bool shouldTearDownRenderers = [&]() {
         if (element.isInTopLayer() && elementUpdate.change == Style::Change::Inherited && elementUpdate.style->effectiveSkipsContent())
             return true;
-        return elementUpdate.change == Style::Change::Renderer && (element.renderer() || element.hasDisplayContents() || element.displayContentsChanged());
+        return elementUpdate.change == Style::Change::Renderer && (element.renderer() || element.hasDisplayContents());
     }();
 
     if (shouldTearDownRenderers) {
@@ -339,8 +339,6 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
         tearDownRenderers(element, teardownType, m_builder);
 
         renderingParent().didCreateOrDestroyChildRenderer = true;
-
-        element.setDisplayContentsChanged(false);
     }
 
     bool hasDisplayContents = elementUpdate.style->display() == DisplayType::Contents;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -182,8 +182,6 @@ static bool affectsRenderedSubtree(Element& element, const RenderStyle& newStyle
         return true;
     if (element.renderOrDisplayContentsStyle())
         return true;
-    if (element.displayContentsChanged())
-        return true;
     if (element.rendererIsNeeded(newStyle))
         return true;
     return false;


### PR DESCRIPTION
#### f6cad2b8abe39ea1157c53ec640dab8295e4acc3
<pre>
Remove DisplayContentsChanged flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=254738">https://bugs.webkit.org/show_bug.cgi?id=254738</a>
rdar://107417124

Reviewed by Ryosuke Niwa.

It is not needed anymore with a separate field in ElementRareData for display:contents style.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::hasDisplayContents):
(WebCore::destroyRenderTreeIfNeeded):
(WebCore::mayHaveDisplayContents): Deleted.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolveComputedStyle):
(WebCore::Element::displayContentsChanged const): Deleted.
(WebCore::Element::setDisplayContentsChanged): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateElementRenderer):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::affectsRenderedSubtree):

Canonical link: <a href="https://commits.webkit.org/263359@main">https://commits.webkit.org/263359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a7ff6766ec7a9fd0a94e306bfc2684fba39c728

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4120 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3707 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5129 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4905 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4905 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3191 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3458 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1076 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->