### PR TITLE
[Flatpak] Update webkit-flatpak-run-nightly for 22.08 SDK and new revision semantics

### DIFF
--- a/Tools/Scripts/webkit-flatpak-run-nightly
+++ b/Tools/Scripts/webkit-flatpak-run-nightly
@@ -29,7 +29,7 @@ import urllib.request
 from html.parser import HTMLParser
 
 REPO = "https://software.igalia.com/flatpak-refs/webkit-sdk.flatpakrepo"
-SDK_BRANCH = "21.08"
+SDK_BRANCH = "22.08"
 USER_DIR = os.path.expanduser("~/.cache/wk-nightly")
 
 def spinning_cursor():
@@ -66,13 +66,13 @@ def ensure_sdk(build_type):
         flatpak("install", "--user", "-y", "webkit-nightly", f"org.webkit.Sdk.Debug//{branch}")
 
 def get_build_path(platform, build_type, revision_number):
-    dirname = f"{platform}-{build_type}-r{revision_number}"
+    dirname = f"{platform}-{build_type}-{revision_number}"
     return os.path.join(tempfile.gettempdir(), dirname)
 
 def get_revision_number(build_name):
-    match = re.match(r'.*_r([0-9]+)\.zip$', build_name)
+    match = re.match(r'.*_([0-9@a-z]+)_\d+\.zip$', build_name)
     if match:
-        return int(match.group(1))
+        return match.groups()[0]
 
 def ensure_extracted_build(args):
     build_type = args.build_type.lower()


### PR DESCRIPTION
#### 754676deb196e649c481dcfaaca466ca0d7c2257
<pre>
[Flatpak] Update webkit-flatpak-run-nightly for 22.08 SDK and new revision semantics
<a href="https://bugs.webkit.org/show_bug.cgi?id=254740">https://bugs.webkit.org/show_bug.cgi?id=254740</a>

Reviewed by Adrian Perez de Castro.

* Tools/Scripts/webkit-flatpak-run-nightly: Update to 22.08 SDK and number@branchname revisions.

Canonical link: <a href="https://commits.webkit.org/262702@main">https://commits.webkit.org/262702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f73f72300eac6056f0c48a4b7bd578109b72d2c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1133 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1289 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1933 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1143 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1159 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1204 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2259 "260 api tests failed or timed out") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1195 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1116 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1173 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/577 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->