### PR TITLE
[WGSL] Don't attempt to resolve overloads when one of the arguments is bottom

### DIFF
--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -462,9 +462,6 @@ unsigned OverloadResolver::conversionRankImpl(Type* from, Type* to) const
     if (from == to)
         return 0;
 
-    if (std::holds_alternative<Bottom>(*from))
-        return 0;
-
     // FIXME: refs should also return 0
 
     if (auto* fromPrimitive = std::get_if<Primitive>(from)) {

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -549,6 +549,10 @@ Type* TypeChecker::chooseOverload(const String& operation, const Vector<Type*>& 
     auto it = m_overloadedOperations.find(operation);
     if (it == m_overloadedOperations.end())
         return nullptr;
+    for (auto* argument : valueArguments) {
+        if (isBottom(argument))
+            return m_types.bottomType();
+    }
     return resolveOverloads(m_types, it->value, valueArguments, typeArguments);
 }
 

--- a/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
@@ -31,3 +31,11 @@ fn testConstraints() {
     // CHECK-L: no matching overload for operator - (vec2<u32>)
     let x8 = -vec2(1u, 1u);
 }
+
+fn testBottomOverload() {
+  // CHECK-L: no matching overload for initializer vec2<f32>(<AbstractInt>)
+  let m = vec2<f32>(0);
+
+  // CHECK-NOT-L: no matching overload for operator + (⊥, <AbstractInt>)
+  let x = m + 2;
+}


### PR DESCRIPTION
#### b541f3acecef57ddfee4268fb84008d4fad60dde
<pre>
[WGSL] Don&apos;t attempt to resolve overloads when one of the arguments is bottom
<a href="https://bugs.webkit.org/show_bug.cgi?id=254741">https://bugs.webkit.org/show_bug.cgi?id=254741</a>
rdar://107420386

Reviewed by Myles C. Maxfield.

We use the bottom type to avoid expurious error messages related to a previous
error that has already been reported. In this case, if one of the arguments is
bottom it means that some invalid expressionn made its way into the arguments
and we already reported an error for it. If we attempt to resolve the overload
we&apos;ll unnecessarily report another error, since overload resolution will fail.

* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::conversionRankImpl const):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/tests/invalid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/262401@main">https://commits.webkit.org/262401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18ac4a44c5c57f6eace05dc5d4571bbd6f1d0d11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2083 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1141 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1296 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1148 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1206 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2266 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1122 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1184 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/361 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1243 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->