### PR TITLE
Build fix around std::variant in SourceBrush for Clang/libstdc++

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBrush.cpp
+++ b/Source/WebCore/platform/graphics/SourceBrush.cpp
@@ -91,7 +91,7 @@ void SourceBrush::setGradient(Ref<Gradient>&& gradient, const AffineTransform& s
 
 void SourceBrush::setPattern(Ref<Pattern>&& pattern)
 {
-    m_brush = { WTFMove(pattern) };
+    m_brush = { Brush::Variant { std::in_place_type<Ref<Pattern>>, WTFMove(pattern) } };
 }
 
 WTF::TextStream& operator<<(TextStream& ts, const SourceBrush& brush)

--- a/Source/WebCore/platform/graphics/SourceBrush.h
+++ b/Source/WebCore/platform/graphics/SourceBrush.h
@@ -42,7 +42,8 @@ public:
             template<typename Decoder> static std::optional<LogicalGradient> decode(Decoder&);
         };
 
-        std::variant<LogicalGradient, Ref<Pattern>> brush;
+        using Variant = std::variant<LogicalGradient, Ref<Pattern>>;
+        Variant brush;
     };
 
     SourceBrush() = default;

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -743,7 +743,7 @@ template<typename... Types> struct ArgumentCoder<std::variant<Types...>> {
                 auto optional = decoder.template decode<typename std::variant_alternative_t<index, std::variant<Types...>>>();
                 if (!optional)
                     return std::nullopt;
-                return std::make_optional<std::variant<Types...>>(WTFMove(*optional));
+                return std::make_optional<std::variant<Types...>>(std::in_place_index<index>, WTFMove(*optional));
             }
             return decode(decoder, std::make_index_sequence<index + 1> { }, i);
         } else


### PR DESCRIPTION
#### fd977228c791d5cf767a1e5b4ed3596add8ed6d5
<pre>
Build fix around std::variant in SourceBrush for Clang/libstdc++
<a href="https://bugs.webkit.org/show_bug.cgi?id=254742">https://bugs.webkit.org/show_bug.cgi?id=254742</a>

Unreviewed, build fix for the SourceBrush::Brush std::variant construction when
using Clang with libstdc++.

Things get mixed up when using Ref&lt;Pattern&gt; for constructing the variant, with
the compiler using it as initialization for the LogicalGradient type, the other
possible type in the variant, which ends up in a compile-time error.

This can be avoided by using the in-place tag when constructing the variant in
the SourceBrush::setPattern() method, specifying which variant-alternative type
should be used.

Similar fix for the same reasons is also needed in the decoding part of the
ArgumentCoder&lt;std::variant&lt;&gt;&gt; specialization, this being problematic due to the
SourceBrush::Brush decoding produced for the generated serializers purpose.
There the variant is constructed with the in-place tag that&apos;s based on the index
value of the alternative.

* Source/WebCore/platform/graphics/SourceBrush.cpp:
(WebCore::SourceBrush::setPattern):
* Source/WebCore/platform/graphics/SourceBrush.h:
* Source/WebKit/Platform/IPC/ArgumentCoders.h:

Canonical link: <a href="https://commits.webkit.org/262339@main">https://commits.webkit.org/262339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29e045b2fcb965121065e253f86f0f9bfbdf0f2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1297 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1283 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1941 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1152 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1167 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1205 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2270 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1215 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/323 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1242 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->