### PR TITLE
[UI-side compositing] Have RemoteLayerTreeScrollingPerformanceData log data after each event

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
@@ -50,6 +50,7 @@ void RemoteLayerTreeScrollingPerformanceData::didCommitLayerTree(const FloatRect
 {
     // FIXME: maybe we only care about newly created tiles?
     appendBlankPixelCount(ScrollingLogEvent::Filled, blankPixelCount(visibleRect));
+    logData();
 }
 
 void RemoteLayerTreeScrollingPerformanceData::didScroll(const FloatRect& visibleRect)
@@ -62,6 +63,7 @@ void RemoteLayerTreeScrollingPerformanceData::didScroll(const FloatRect& visible
         return;
 #endif
     appendBlankPixelCount(ScrollingLogEvent::Exposed, pixelCount);
+    logData();
 }
 
 bool RemoteLayerTreeScrollingPerformanceData::ScrollingLogEvent::canCoalesce(ScrollingLogEvent::EventType type, uint64_t pixelCount) const
@@ -72,6 +74,7 @@ bool RemoteLayerTreeScrollingPerformanceData::ScrollingLogEvent::canCoalesce(Scr
 void RemoteLayerTreeScrollingPerformanceData::didChangeSynchronousScrollingReasons(WTF::MonotonicTime timestamp, uint64_t data)
 {
     appendSynchronousScrollingChange(timestamp, data);
+    logData();
 }
 
 void RemoteLayerTreeScrollingPerformanceData::appendBlankPixelCount(ScrollingLogEvent::EventType eventType, uint64_t blankPixelCount)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1204,8 +1204,6 @@ void WebPageProxy::close()
     if (m_isClosed)
         return;
 
-    logScrollingPerformanceData();
-
     WEBPAGEPROXY_RELEASE_LOG(Loading, "close:");
 
     m_isClosed = true;
@@ -8439,6 +8437,9 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 
 #if PLATFORM(COCOA)
     m_scrollingPerformanceData = nullptr;
+#if PLATFORM(MAC)
+    m_scrollPerformanceDataCollectionEnabled = false;
+#endif
     m_firstLayerTreeTransactionIdAfterDidCommitLoad = { };
 #endif
 
@@ -12086,14 +12087,6 @@ String WebPageProxy::scrollbarStateForScrollingNodeID(int scrollingNodeID, bool 
     return m_scrollingCoordinatorProxy->scrollbarStateForScrollingNodeID(scrollingNodeID, isVertical);
 #else
     return ""_s;
-#endif
-}
-
-void WebPageProxy::logScrollingPerformanceData()
-{
-#if PLATFORM(COCOA)
-    if (m_scrollingPerformanceData)
-        m_scrollingPerformanceData->logData();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1719,7 +1719,6 @@ public:
 
     // Performance logging.
     void logScrollingEvent(uint32_t eventType, MonotonicTime, uint64_t);
-    void logScrollingPerformanceData();
 
     // Form validation messages.
     void showValidationMessage(const WebCore::IntRect& anchorClientRect, const String& message);


### PR DESCRIPTION
#### 715676da19135f162e185afac74ea0d26c653ed8
<pre>
[UI-side compositing] Have RemoteLayerTreeScrollingPerformanceData log data after each event
<a href="https://bugs.webkit.org/show_bug.cgi?id=254747">https://bugs.webkit.org/show_bug.cgi?id=254747</a>
rdar://107424375

Reviewed by Simon Fraser.

Have RemoteLayerTreeScrollingPerformanceData log data after each event to stop ScrollPerf
from crashing due to no scrolling data.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm:
(WebKit::RemoteLayerTreeScrollingPerformanceData::didCommitLayerTree):
(WebKit::RemoteLayerTreeScrollingPerformanceData::didScroll):
(WebKit::RemoteLayerTreeScrollingPerformanceData::didChangeSynchronousScrollingReasons):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::logScrollingPerformanceData): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/262378@main">https://commits.webkit.org/262378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1288d3e0de5a3ef7d21638d6548f9f679e5196b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2261 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1455 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1374 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2107 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1229 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1264 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1236 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1330 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/151 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->