### PR TITLE
[WGSL] Add typing for unary expressions

### DIFF
--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -52,10 +52,12 @@ struct TypeVariable {
 
         ConcreteInteger = I32 | U32,
         Integer = ConcreteInteger | AbstractInt,
+        SignedInteger = I32 | AbstractInt,
 
         Scalar = Bool | Integer | Float,
         ConcreteScalar = Bool | ConcreteInteger | ConcreteFloat,
 
+        SignedNumber = Float | SignedInteger,
         Number = Float | Integer,
     };
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -64,6 +64,7 @@ public:
     void visit(AST::BinaryExpression&) override;
     void visit(AST::IdentifierExpression&) override;
     void visit(AST::CallExpression&) override;
+    void visit(AST::UnaryExpression&) override;
 
     // Literal Expressions
     void visit(AST::BoolLiteral&) override;
@@ -374,6 +375,16 @@ void TypeChecker::visit(AST::CallExpression& call)
     // FIXME: add support for user-defined function calls
     auto* result = resolve(target);
     inferred(result);
+}
+
+void TypeChecker::visit(AST::UnaryExpression& unary)
+{
+    auto* argument = infer(unary.expression());
+    auto* result = chooseOverload(toString(unary.operation()), { argument }, { });
+    if (result)
+        inferred(result);
+    else
+        typeError(unary.span(), "no matching overload for operator ", toString(unary.operation()), " (", *argument, ")");
 }
 
 // Literal Expressions

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -12,6 +12,11 @@ operator :*, {
     [T < Float, C, R].(Vector[T, R], Matrix[T, C, R]) => Vector[T, C],
 }
 
+operator :-, {
+  [T < SignedNumber].(T) => T,
+  [T < SignedNumber, N].(Vector[T, N]) => Vector[T, N],
+}
+
 operator :textureSample, {
     [].(Texture[F32, Texture1d], Sampler, F32) => Vector[F32, 4],
     [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2]) => Vector[F32, 4],

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -293,6 +293,7 @@ module DSL
         ConcreteInteger = Constraint.new(:ConcreteInteger)
         ConcreteFloat = Constraint.new(:ConcreteFloat)
         ConcreteScalar = Constraint.new(:ConcreteScalar)
+        SignedNumber = Constraint.new(:SignedNumber)
         EOS
     end
 

--- a/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
@@ -24,4 +24,10 @@ fn testConstraints() {
 
     // CHECK-L:  no matching overload for initializer vec2<S>(vec2<<AbstractInt>>)
     let x6 = vec2<S>(vec2(0, 0));
+
+    // CHECK-L: no matching overload for operator - (u32)
+    let x7 = -1u;
+
+    // CHECK-L: no matching overload for operator - (vec2<u32>)
+    let x8 = -vec2(1u, 1u);
 }

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -202,3 +202,9 @@ fn testMatrixConstructor() {
     let m4 = mat4x4(vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0));
   }
 }
+
+fn testUnaryMinus() {
+  let x = 1;
+  let x1 = -x;
+  let x2 = -vec2(1, 1);
+}


### PR DESCRIPTION
#### f46788aa00cb6852bf31148375ffc762cdb48642
<pre>
[WGSL] Add typing for unary expressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=254748">https://bugs.webkit.org/show_bug.cgi?id=254748</a>
rdar://107424606

Reviewed by Myles C. Maxfield.

Make UnaryExpression use the existing overload resolution infrastructure. For
now, I only added declarations for unary minus, but I&apos;ll add more operators
as we go.

* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/invalid/overload.wgsl:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/262398@main">https://commits.webkit.org/262398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6385a9e8fff6781c9fffc902974ed24d85ecfbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2372 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1274 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1539 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1462 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2213 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1337 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1297 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1321 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1336 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1374 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1304 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/359 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1416 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->