### PR TITLE
Clean up IOSurfaceSPI

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h
@@ -27,64 +27,11 @@
 
 #if HAVE(IOSURFACE)
 
-#if PLATFORM(MAC) || USE(APPLE_INTERNAL_SDK)
-
-#include <IOSurface/IOSurface.h>
-
-#else
-
-#include <CoreFoundation/CFBase.h>
-#include <mach/mach_port.h>
-#include <wtf/spi/cocoa/IOReturnSPI.h>
-#include <wtf/spi/cocoa/IOTypesSPI.h>
-
-typedef struct __IOSurface *IOSurfaceRef;
-
-#endif
+#import <IOSurface/IOSurface.h>
 
 #ifdef __OBJC__
 #import <IOSurface/IOSurfaceObjC.h>
 #endif
-
-WTF_EXTERN_C_BEGIN
-
-extern const CFStringRef kIOSurfaceAllocSize;
-extern const CFStringRef kIOSurfaceBytesPerElement;
-extern const CFStringRef kIOSurfaceBytesPerRow;
-extern const CFStringRef kIOSurfaceCacheMode;
-extern const CFStringRef kIOSurfaceColorSpace;
-extern const CFStringRef kIOSurfaceHeight;
-extern const CFStringRef kIOSurfacePixelFormat;
-extern const CFStringRef kIOSurfaceWidth;
-extern const CFStringRef kIOSurfaceElementWidth;
-extern const CFStringRef kIOSurfaceElementHeight;
-extern const CFStringRef kIOSurfaceName;
-extern const CFStringRef kIOSurfacePlaneWidth;
-extern const CFStringRef kIOSurfacePlaneHeight;
-extern const CFStringRef kIOSurfacePlaneBytesPerRow;
-extern const CFStringRef kIOSurfacePlaneOffset;
-extern const CFStringRef kIOSurfacePlaneSize;
-extern const CFStringRef kIOSurfacePlaneInfo;
-
-size_t IOSurfaceAlignProperty(CFStringRef property, size_t value);
-IOSurfaceRef IOSurfaceCreate(CFDictionaryRef properties);
-mach_port_t IOSurfaceCreateMachPort(IOSurfaceRef buffer);
-size_t IOSurfaceGetAllocSize(IOSurfaceRef buffer);
-void *IOSurfaceGetBaseAddress(IOSurfaceRef buffer);
-size_t IOSurfaceGetBytesPerRow(IOSurfaceRef buffer);
-size_t IOSurfaceGetHeight(IOSurfaceRef buffer);
-size_t IOSurfaceGetPropertyMaximum(CFStringRef property);
-size_t IOSurfaceGetWidth(IOSurfaceRef buffer);
-OSType IOSurfaceGetPixelFormat(IOSurfaceRef buffer);
-void IOSurfaceIncrementUseCount(IOSurfaceRef buffer);
-Boolean IOSurfaceIsInUse(IOSurfaceRef buffer);
-IOReturn IOSurfaceLock(IOSurfaceRef buffer, uint32_t options, uint32_t *seed);
-IOSurfaceRef IOSurfaceLookupFromMachPort(mach_port_t);
-IOReturn IOSurfaceUnlock(IOSurfaceRef buffer, uint32_t options, uint32_t *seed);
-size_t IOSurfaceGetWidthOfPlane(IOSurfaceRef buffer, size_t planeIndex);
-size_t IOSurfaceGetHeightOfPlane(IOSurfaceRef buffer, size_t planeIndex);
-
-WTF_EXTERN_C_END
 
 #if USE(APPLE_INTERNAL_SDK)
 
@@ -118,12 +65,6 @@ kern_return_t IOSurfaceSetOwnershipIdentity(IOSurfaceRef buffer, mach_port_t tas
 WTF_EXTERN_C_END
 
 #endif
-
-WTF_EXTERN_C_BEGIN
-
-IOReturn IOSurfaceSetPurgeable(IOSurfaceRef buffer, uint32_t newState, uint32_t *oldState);
-
-WTF_EXTERN_C_END
 
 #if HAVE(IOSURFACE_ACCELERATOR)
 #if USE(APPLE_INTERNAL_SDK)


### PR DESCRIPTION
#### 15c397bc6535d62cd0a15d672442ac3ee1d42639
<pre>
Clean up IOSurfaceSPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=254753">https://bugs.webkit.org/show_bug.cgi?id=254753</a>
rdar://problem/107427508

Reviewed by NOBODY (OOPS!).

IOSurfaceSPI contains a number of IOSurface definitions of constants and functions
and conditional includes which are unnecessary since they are shipping
in public API on the versions of macOS and iOS (and tvOS, watchOS) that
WebKit supports. This removes those redundancies from the header.

* Source/WTF/wtf/spi/cocoa/IOSurfaceSPI.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15c397bc6535d62cd0a15d672442ac3ee1d42639

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1291 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1326 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1366 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1160 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1379 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1320 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1302 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/1379 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/1366 "Failed to compile WebKit") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/1379 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/1366 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1173 "layout-tests (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1140 "Built successfully and passed tests") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1186 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/1366 "Failed to compile WebKit") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2287 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1269 "Built successfully and passed tests") | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1233 "Failed to compile WebKit") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1325 "Built successfully") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1172 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/1366 "Failed to compile WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/266 "Passed tests") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1260 "Failed to compile WebKit") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1328 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/263 "Passed tests") | 
<!--EWS-Status-Bubble-End-->