### PR TITLE
Fix build with GCC 13 -Werror

### DIFF
--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -622,8 +622,10 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
             }
             
             ScopeOffset offset = functionSymbolTable->takeNextScopeOffset(NoLockingNecessary);
+IGNORE_GCC_WARNINGS_BEGIN("dangling-reference")
             const Identifier& ident =
                 static_cast<const BindingNode*>(parameters.at(i).first)->boundProperty();
+IGNORE_GCC_WARNINGS_END
             functionSymbolTable->set(NoLockingNecessary, name, SymbolTableEntry(VarOffset(offset)));
             
             OpPutToScope::emit(this, m_lexicalEnvironmentRegister, addConstant(ident), virtualRegisterForArgumentIncludingThis(1 + i), GetPutInfo(ThrowIfNotFound, ResolvedClosureVar, InitializationMode::NotInitialization, ecmaMode), SymbolTableOrScopeDepth::symbolTable(VirtualRegister { symbolTableConstantIndex }), offset.offset());

--- a/Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h
+++ b/Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h
@@ -88,7 +88,9 @@ inline AbstractSlotVisitor::ReferrerContext::ReferrerContext(AbstractSlotVisitor
         // An OpaqueRoot contexts can only be on the leaf.
         RELEASE_ASSERT(!m_previous->m_isOpaqueRootContext);
     }
+IGNORE_GCC_WARNINGS_BEGIN("dangling-pointer")
     m_visitor.m_context = this;
+IGNORE_GCC_WARNINGS_END
 }
 
 inline AbstractSlotVisitor::ReferrerContext::~ReferrerContext()

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -237,11 +237,13 @@ bool DocumentTimeline::animationCanBeRemoved(WebAnimation& animation)
     if (!target || !target->element.isDescendantOf(*m_document))
         return false;
 
+IGNORE_GCC_WARNINGS_BEGIN("dangling-reference")
     auto& style = [&]() -> const RenderStyle& {
         if (auto* renderer = target->renderer())
             return renderer->style();
         return RenderStyle::defaultStyle();
     }();
+IGNORE_GCC_WARNINGS_END
 
     auto resolvedProperty = [&] (AnimatableProperty property) -> AnimatableProperty {
         if (std::holds_alternative<CSSPropertyID>(property))

--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -26,6 +26,7 @@
 
 #include "CSSValue.h"
 #include "ExceptionOr.h"
+#include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
@@ -72,8 +73,8 @@ public:
 
     static const LinearTimingFunction& sharedLinearTimingFunction()
     {
-        static const LinearTimingFunction& function = create().leakRef();
-        return function;
+        static NeverDestroyed<Ref<LinearTimingFunction>> function { create() };
+        return function.get();
     }
 
 private:
@@ -138,8 +139,8 @@ public:
 
     static const CubicBezierTimingFunction& defaultTimingFunction()
     {
-        static const CubicBezierTimingFunction& function = create().leakRef();
-        return function;
+        static NeverDestroyed<Ref<CubicBezierTimingFunction>> function { create() };
+        return function.get();
     }
 
     Ref<CubicBezierTimingFunction> createReversed() const

--- a/Source/WebCore/platform/graphics/AudioTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/AudioTrackPrivate.h
@@ -76,7 +76,7 @@ public:
             m_client->configurationChanged(m_configuration);
     }
     
-    virtual bool operator==(const AudioTrackPrivate& track) const
+    bool operator==(const AudioTrackPrivate& track) const
     {
         return TrackPrivateBase::operator==(track)
             && configuration() == track.configuration()

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivate.h
@@ -77,7 +77,7 @@ public:
 
     CueFormat cueFormat() const { return m_format; }
     
-    virtual bool operator==(const InbandTextTrackPrivate& track) const
+    bool operator==(const InbandTextTrackPrivate& track) const
     {
         return TrackPrivateBase::operator==(track)
             && cueFormat() == track.cueFormat()

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -66,7 +66,7 @@ public:
             client->willRemove();
     }
     
-    virtual bool operator==(const TrackPrivateBase&) const;
+    bool operator==(const TrackPrivateBase&) const;
 
     enum class Type { Video, Audio, Text };
     virtual Type type() const = 0;

--- a/Source/WebCore/platform/graphics/VideoTrackPrivate.h
+++ b/Source/WebCore/platform/graphics/VideoTrackPrivate.h
@@ -72,7 +72,7 @@ public:
             m_client->configurationChanged(m_configuration);
     }
     
-    virtual bool operator==(const VideoTrackPrivate& track) const
+    bool operator==(const VideoTrackPrivate& track) const
     {
         return TrackPrivateBase::operator==(track)
             && configuration() == track.configuration()

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -57,21 +57,25 @@ namespace Style {
 
 static const StyleProperties& leftToRightDeclaration()
 {
+IGNORE_GCC_WARNINGS_BEGIN("dangling-reference")
     static auto& declaration = [] () -> const StyleProperties& {
         auto properties = MutableStyleProperties::create();
         properties->setProperty(CSSPropertyDirection, CSSValueLtr);
         return properties.leakRef();
     }();
+IGNORE_GCC_WARNINGS_END
     return declaration;
 }
 
 static const StyleProperties& rightToLeftDeclaration()
 {
+IGNORE_GCC_WARNINGS_BEGIN("dangling-reference")
     static auto& declaration = [] () -> const StyleProperties& {
         auto properties = MutableStyleProperties::create();
         properties->setProperty(CSSPropertyDirection, CSSValueRtl);
         return properties.leakRef();
     }();
+IGNORE_GCC_WARNINGS_END
     return declaration;
 }
 

--- a/Source/WebCore/svg/SVGPathSeg.h
+++ b/Source/WebCore/svg/SVGPathSeg.h
@@ -79,7 +79,12 @@ public:
 
     virtual unsigned short pathSegType() const = 0;
     virtual String pathSegTypeAsLetter() const = 0;
+
+IGNORE_GCC_WARNINGS_BEGIN("overloaded-virtual")
+    // FIXME: SVGPathSegValue has a templated (and therefore non-virtual) clone
+    // function that hides this one, which is fragile and very confusing.
     virtual Ref<SVGPathSeg> clone() const = 0;
+IGNORE_GCC_WARNINGS_END
 
 protected:
     using SVGProperty::SVGProperty;

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.c
@@ -83,7 +83,7 @@ void pas_fast_megapage_table_initialize_static(pas_fast_megapage_table* table,
 }
 
 void pas_fast_megapage_table_set_by_index(pas_fast_megapage_table* table,
-                                          size_t index, unsigned value,
+                                          size_t index, pas_fast_megapage_kind value,
                                           pas_lock_hold_mode heap_lock_hold_mode)
 {
     pas_fast_megapage_table_impl* instance;

--- a/Tools/TestWebKitAPI/Tests/WTF/BoxPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BoxPtr.cpp
@@ -172,9 +172,9 @@ TEST(WTF_BoxPtr, Assignment)
         BoxPtrLogger* a = BoxPtrLogger::create("a");
         BoxPtr<BoxPtrLogger> ptr = adoptInBoxPtr(a);
         EXPECT_EQ(a, ptr->get());
-        IGNORE_CLANG_WARNINGS_BEGIN("self-move")
+        IGNORE_WARNINGS_BEGIN("self-move")
         ptr = WTFMove(ptr);
-        IGNORE_CLANG_WARNINGS_END
+        IGNORE_WARNINGS_END
         EXPECT_EQ(a, ptr->get());
     }
     EXPECT_STREQ("create(a) delete(a) ", takeLogStr().c_str());

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp
@@ -290,15 +290,9 @@ TEST(WTF_CompactRefPtr, Assignment)
     {
         CompactRefPtr<AlignedRefLogger> ptr(&a);
         EXPECT_EQ(&a, ptr.get());
-#if COMPILER(CLANG)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wself-move"
-#endif
+        IGNORE_WARNINGS_BEGIN("self-move")
         ptr = WTFMove(ptr);
-#if COMPILER(CLANG)
-#pragma clang diagnostic pop
-#endif
+        IGNORE_WARNINGS_END
         EXPECT_EQ(&a, ptr.get());
     }
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());

--- a/Tools/TestWebKitAPI/Tests/WTF/NakedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NakedPtr.cpp
@@ -188,15 +188,9 @@ TEST(WTF_NakedPtr, Assignment)
     {
         NakedPtr<RefLogger> ptr(&a);
         ASSERT_EQ(&a, ptr.get());
-#if COMPILER(CLANG)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wself-move"
-#endif
+        IGNORE_WARNINGS_BEGIN("self-move")
         ptr = WTFMove(ptr);
-#if COMPILER(CLANG)
-#pragma clang diagnostic pop
-#endif
+        IGNORE_WARNINGS_END
         ASSERT_EQ(&a, ptr.get());
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp
@@ -277,15 +277,9 @@ TEST(WTF_PackedRefPtr, Assignment)
     {
         PackedRefPtr<RefLogger> ptr(&a);
         EXPECT_EQ(&a, ptr.get());
-#if COMPILER(CLANG)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wself-move"
-#endif
+        IGNORE_WARNINGS_BEGIN("self-move")
         ptr = WTFMove(ptr);
-#if COMPILER(CLANG)
-#pragma clang diagnostic pop
-#endif
+        IGNORE_WARNINGS_END
         EXPECT_EQ(&a, ptr.get());
     }
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());

--- a/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
@@ -276,15 +276,9 @@ TEST(WTF_RefPtr, Assignment)
     {
         RefPtr<RefLogger> ptr(&a);
         EXPECT_EQ(&a, ptr.get());
-#if COMPILER(CLANG)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wself-move"
-#endif
+        IGNORE_WARNINGS_BEGIN("self-move")
         ptr = WTFMove(ptr);
-#if COMPILER(CLANG)
-#pragma clang diagnostic pop
-#endif
+        IGNORE_WARNINGS_END
         EXPECT_EQ(&a, ptr.get());
     }
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());


### PR DESCRIPTION
#### 2b34340acfdb25e9451fa6885ab24727ac1718b8
<pre>
Fix build with GCC 13 -Werror
<a href="https://bugs.webkit.org/show_bug.cgi?id=254758">https://bugs.webkit.org/show_bug.cgi?id=254758</a>

Reviewed by Adrian Perez de Castro.

This allows building with GCC 13 in DEVELOPER_MODE (where warnings are
now fatal).

* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/heap/AbstractSlotVisitorInlines.h:
(JSC::AbstractSlotVisitor::ReferrerContext::ReferrerContext):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::animationCanBeRemoved):
* Source/WebCore/platform/animation/TimingFunction.h:
* Source/WebCore/platform/graphics/AudioTrackPrivate.h:
(WebCore::AudioTrackPrivate::operator== const):
* Source/WebCore/platform/graphics/InbandTextTrackPrivate.h:
(WebCore::InbandTextTrackPrivate::operator== const):
* Source/WebCore/platform/graphics/TrackPrivateBase.h:
* Source/WebCore/platform/graphics/VideoTrackPrivate.h:
(WebCore::VideoTrackPrivate::operator== const):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::leftToRightDeclaration):
(WebCore::Style::rightToLeftDeclaration):
* Source/WebCore/svg/SVGPathSeg.h:
* Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.c:
(pas_fast_megapage_table_set_by_index):
* Tools/TestWebKitAPI/Tests/WTF/BoxPtr.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/NakedPtr.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262664@main">https://commits.webkit.org/262664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46a6edfb850b2bad2b86990783ba249ab38bdd96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2146 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2192 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1949 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2924 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1905 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1805 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1790 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1978 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3095 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2053 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1766 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2206 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1915 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/510 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/543 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2083 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2256 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/625 "Passed tests") | 
<!--EWS-Status-Bubble-End-->