### PR TITLE
Support rendering non-native <meter> in vertical writing mode

### DIFF
--- a/LayoutTests/fast/dom/HTMLMeterElement/meter-clone-expected.txt
+++ b/LayoutTests/fast/dom/HTMLMeterElement/meter-clone-expected.txt
@@ -2,8 +2,8 @@ PASS cloned.value is target.value
 PASS internals.shadowPseudoId(clonedInnerElement) is internals.shadowPseudoId(targetInnerElement)
 PASS internals.shadowPseudoId(clonedInnerElement.firstChild) is internals.shadowPseudoId(targetInnerElement.firstChild)
 PASS internals.shadowPseudoId(clonedInnerElement.firstChild.firstChild) is internals.shadowPseudoId(targetInnerElement.firstChild.firstChild)
-PASS clonedInnerElement.firstChild.firstChild.style.width is "70%"
-PASS targetInnerElement.firstChild.firstChild.style.width is "50%"
+PASS clonedInnerElement.firstChild.firstChild.style.inlineSize is "70%"
+PASS targetInnerElement.firstChild.firstChild.style.inlineSize is "50%"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/HTMLMeterElement/meter-clone.html
+++ b/LayoutTests/fast/dom/HTMLMeterElement/meter-clone.html
@@ -3,18 +3,18 @@
 <script src="../../../resources/js-test-pre.js"></script>
 </head>
 <body>
-<meter id="target" min="0" max="100" value="50" style="-webkit-appearance: none;" />
+<meter id="target" min="0" max="100" value="50" style="appearance: none;" />
 <script>
 (function() {
     target = document.getElementById("target");
     cloned = target.cloneNode();
     document.body.insertBefore(cloned, target.nextSibling);
-    
+
     if (!window.internals) {
         debug("You need internals to run this test.");
         return;
     }
-    
+
     targetShadowRoot = internals.shadowRoot(target);
     clonedShadowRoot = internals.shadowRoot(cloned);
     targetInnerElement = targetShadowRoot.querySelector("#inner");
@@ -26,8 +26,8 @@
     shouldBe("internals.shadowPseudoId(clonedInnerElement.firstChild.firstChild)", "internals.shadowPseudoId(targetInnerElement.firstChild.firstChild)");
 
     cloned.value = 70;
-    shouldBe("clonedInnerElement.firstChild.firstChild.style.width", '"70%"');
-    shouldBe("targetInnerElement.firstChild.firstChild.style.width", '"50%"');
+    shouldBe("clonedInnerElement.firstChild.firstChild.style.inlineSize", '"70%"');
+    shouldBe("targetInnerElement.firstChild.firstChild.style.inlineSize", '"50%"');
 })();
 </script>
 <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/dom/HTMLMeterElement/meter-element-markup-expected.txt
+++ b/LayoutTests/fast/dom/HTMLMeterElement/meter-element-markup-expected.txt
@@ -6,7 +6,7 @@ Both meter elements should have a nested shadow box with a width specified:
 |   value="70"
 |   <shadow:root>
 |     <style>
-|       "div#inner { appearance: inherit; box-sizing: inherit; height: 100%; width: 100%; } div#bar { background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd); height: 100%; width: 100%; box-sizing: border-box; } div#value { height: 100%; box-sizing: border-box; } div#value.optimum { background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7); } div#value.suboptimum { background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7); height: 100%; box-sizing: border-box; } div#value.even-less-good { background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77); height: 100%; box-sizing: border-box; }"
+|       "div#inner { appearance: inherit; box-sizing: inherit; height: 100%; width: 100%; } div#bar { background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd); height: 100%; width: 100%; box-sizing: border-box; } div#value { block-size: 100%; box-sizing: border-box; } div#value.optimum { background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7); } div#value.suboptimum { background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7); } div#value.even-less-good { background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77); }"
 |     <div>
 |       id="inner"
 |       pseudo="-webkit-meter-inner-element"
@@ -19,7 +19,7 @@ Both meter elements should have a nested shadow box with a width specified:
 |           class="optimum"
 |           id="value"
 |           pseudo="-webkit-meter-optimum-value"
-|           style="width: 70%;"
+|           style="inline-size: 70%;"
 |           shadow:pseudoId="-webkit-meter-optimum-value"
 | "\n    "
 | <meter>
@@ -31,7 +31,7 @@ Both meter elements should have a nested shadow box with a width specified:
 |   value="10"
 |   <shadow:root>
 |     <style>
-|       "div#inner { appearance: inherit; box-sizing: inherit; height: 100%; width: 100%; } div#bar { background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd); height: 100%; width: 100%; box-sizing: border-box; } div#value { height: 100%; box-sizing: border-box; } div#value.optimum { background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7); } div#value.suboptimum { background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7); height: 100%; box-sizing: border-box; } div#value.even-less-good { background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77); height: 100%; box-sizing: border-box; }"
+|       "div#inner { appearance: inherit; box-sizing: inherit; height: 100%; width: 100%; } div#bar { background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd); height: 100%; width: 100%; box-sizing: border-box; } div#value { block-size: 100%; box-sizing: border-box; } div#value.optimum { background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7); } div#value.suboptimum { background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7); } div#value.even-less-good { background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77); }"
 |     <div>
 |       id="inner"
 |       pseudo="-webkit-meter-inner-element"
@@ -44,7 +44,7 @@ Both meter elements should have a nested shadow box with a width specified:
 |           class="suboptimum"
 |           id="value"
 |           pseudo="-webkit-meter-suboptimum-value"
-|           style="width: 100%;"
+|           style="inline-size: 100%;"
 |           shadow:pseudoId="-webkit-meter-suboptimum-value"
 | "\n    "
 | <meter>
@@ -56,7 +56,7 @@ Both meter elements should have a nested shadow box with a width specified:
 |   value="10"
 |   <shadow:root>
 |     <style>
-|       "div#inner { appearance: inherit; box-sizing: inherit; height: 100%; width: 100%; } div#bar { background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd); height: 100%; width: 100%; box-sizing: border-box; } div#value { height: 100%; box-sizing: border-box; } div#value.optimum { background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7); } div#value.suboptimum { background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7); height: 100%; box-sizing: border-box; } div#value.even-less-good { background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77); height: 100%; box-sizing: border-box; }"
+|       "div#inner { appearance: inherit; box-sizing: inherit; height: 100%; width: 100%; } div#bar { background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd); height: 100%; width: 100%; box-sizing: border-box; } div#value { block-size: 100%; box-sizing: border-box; } div#value.optimum { background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7); } div#value.suboptimum { background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7); } div#value.even-less-good { background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77); }"
 |     <div>
 |       id="inner"
 |       pseudo="-webkit-meter-inner-element"
@@ -69,6 +69,6 @@ Both meter elements should have a nested shadow box with a width specified:
 |           class="even-less-good"
 |           id="value"
 |           pseudo="-webkit-meter-even-less-good-value"
-|           style="width: 100%;"
+|           style="inline-size: 100%;"
 |           shadow:pseudoId="-webkit-meter-even-less-good-value"
 | "\n  "

--- a/LayoutTests/fast/dom/HTMLMeterElement/meter-writing-mode-expected.html
+++ b/LayoutTests/fast/dom/HTMLMeterElement/meter-writing-mode-expected.html
@@ -4,13 +4,13 @@
 meter {
   width: 50px;
   height: 50px;
-  -webkit-appearance: none;
+  appearance: none;
 }
 </style>
 </head>
 <body>
-<meter min=0 value=30 max=100></meter>
-<meter min=0 value=30 max=100></meter>
+<meter min=0 value=30 max=100 style="writing-mode: vertical-rl;"></meter>
+<meter min=0 value=30 max=100 style="writing-mode: vertical-lr;"></meter>
 <meter min=0 value=30 max=100></meter>
 <meter min=0 value=30 max=100></meter>
 </body>

--- a/LayoutTests/fast/dom/HTMLMeterElement/meter-writing-mode.html
+++ b/LayoutTests/fast/dom/HTMLMeterElement/meter-writing-mode.html
@@ -4,15 +4,15 @@
 meter {
   width: 50px;
   height: 50px;
-  -webkit-appearance: none;
+  appearance: none;
   background-color: red; /* should not be visible */
 }
 </style>
 </head>
 <body>
-<meter min=0 value=30 max=100 style="-webkit-writing-mode: vertical-lr;"></meter>
-<meter min=0 value=30 max=100 style="-webkit-writing-mode: vertical-rl;"></meter>
-<meter min=0 value=30 max=100 style="-webkit-writing-mode: horizontal-tb;"></meter>
-<meter min=0 value=30 max=100 style="-webkit-writing-mode: horizontal-bt;"></meter>
+<meter min=0 value=30 max=100 style="writing-mode: vertical-lr;"></meter>
+<meter min=0 value=30 max=100 style="writing-mode: vertical-rl;"></meter>
+<meter min=0 value=30 max=100 style="writing-mode: horizontal-tb;"></meter>
+<meter min=0 value=30 max=100 style="writing-mode: horizontal-bt;"></meter>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -3244,6 +3244,8 @@
         "web-platform-tests/css/css-writing-modes/form-controls-vlr-005.xht",
         "web-platform-tests/css/css-writing-modes/form-controls-vrl-004.xht",
         "web-platform-tests/css/css-writing-modes/form-controls-vrl-005.xht",
+        "web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow-ref.html",
+        "web-platform-tests/css/css-writing-modes/forms/range-input-painting-ref.html",
         "web-platform-tests/css/css-writing-modes/horizontal-rule-vlr-003-ref.xht",
         "web-platform-tests/css/css-writing-modes/horizontal-rule-vrl-002-ref.xht",
         "web-platform-tests/css/css-writing-modes/horizontal-rule-vrl-004-ref.xht",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional-expected.txt
@@ -1,0 +1,6 @@
+
+
+FAIL meter[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width assert_equals: expected "16px" but got "18px"
+PASS meter[style="writing-mode: vertical-lr"] block size should match width and inline size should match height
+PASS meter[style="writing-mode: vertical-rl"] block size should match width and inline size should match height
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<link rel="author" title="Di Zhang" href="mailto:dizhangg@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-meter-element-2">
+<title>Meter appearance native writing mode computed style</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<meter value="40" min="0" max="100" style="writing-mode: horizontal-tb"></meter>
+<meter value="40" min="0" max="100" style="writing-mode: vertical-lr"></meter>
+<meter value="40" min="0" max="100" style="writing-mode: vertical-rl"></meter>
+
+<script>
+test(() => {
+  const meter = document.querySelector(`meter[style="writing-mode: horizontal-tb"]`);
+  const style = getComputedStyle(meter);
+  assert_equals(style.blockSize, "16px");
+  assert_equals(style.inlineSize, "80px");
+  assert_equals(style.blockSize, style.height);
+  assert_equals(style.inlineSize, style.width);
+}, `meter[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width`);
+
+for (const writingMode of ["vertical-lr", "vertical-rl"]) {
+  test(() => {
+    const meter = document.querySelector(`meter[style="writing-mode: ${writingMode}"]`);
+    const style = getComputedStyle(meter);
+    assert_equals(style.blockSize, "16px");
+    assert_equals(style.inlineSize, "80px");
+    assert_equals(style.blockSize, style.width);
+    assert_equals(style.inlineSize, style.height);
+  }, `meter[style="writing-mode: ${writingMode}"] block size should match width and inline size should match height`);
+};
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-horizontal.optional-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-horizontal.optional-expected-mismatch.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Di Zhang" href="mailto:dizhangg@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/#the-meter-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Meter appearance native writing mode horizontal</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="meter-appearance-native-horizontal.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The meter element below should match the correct writing mode.</p>
+<meter value="70" min="0" max="100" style="writing-mode: vertical-rl"></meter>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-horizontal.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-horizontal.optional.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Di Zhang" href="mailto:dizhangg@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/#the-meter-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Meter appearance native writing mode horizontal</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="meter-appearance-native-vertical.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The meter element below should match the correct writing mode.</p>
+<meter value="70" min="0" max="100" style="writing-mode: horizontal-tb"></meter>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-vertical.optional-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-vertical.optional-expected-mismatch.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Di Zhang" href="mailto:dizhangg@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/#the-meter-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Meter appearance native writing mode horizontal</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="meter-appearance-native-vertical.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The meter element below should match the correct writing mode.</p>
+<meter value="70" min="0" max="100" style="writing-mode: horizontal-tb"></meter>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-vertical.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-vertical.optional.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Di Zhang" href="mailto:dizhangg@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/#the-meter-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Meter appearance native writing mode horizontal</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="meter-appearance-native-horizontal.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The meter element below should match the correct writing mode.</p>
+<meter value="70" min="0" max="100" style="writing-mode: vertical-rl"></meter>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/w3c-import.log
@@ -22,6 +22,14 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/color-input-appearance-none-horizontal.optional.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/color-input-appearance-none-vertical.optional-expected-mismatch.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/color-input-appearance-none-vertical.optional.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-horizontal.optional-expected-mismatch.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-horizontal.optional.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-vertical.optional-expected-mismatch.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-vertical.optional.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-horizontal.optional-expected-mismatch.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-horizontal.optional.html
@@ -47,6 +55,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-appearance-none-vertical-rtl.optional.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-appearance-none-vertical.optional-expected-mismatch.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-appearance-none-vertical.optional.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-painting-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-ltr-painting-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-ltr-painting.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-rtl-painting-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-rtl-painting.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-native-horizontal.optional-expected-mismatch.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-native-horizontal.optional.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-native-vlr.optional-expected-mismatch.html
@@ -61,6 +74,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-none-vrl.optional.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-size-scrolling-and-sizing.optional.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-block-size.optional.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-vertical-overflow-no-scroll.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/textarea-appearance-native-horizontal.optional-expected-mismatch.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/textarea-appearance-native-horizontal.optional.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/textarea-appearance-native-vlr.optional-expected-mismatch.html

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-expected.txt
@@ -10,5 +10,5 @@ layer at (0,0) size 800x600
       RenderBlock {METER} at (80,0) size 10x60
         RenderBlock {DIV} at (0,0) size 10x60
           RenderBlock {DIV} at (0,0) size 10x60
-            RenderBlock {DIV} at (0,0) size 7x60
+            RenderBlock {DIV} at (0,0) size 10x42
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS meter[style="writing-mode: horizontal-tb"] block size should match height and inline size should match width
+PASS meter[style="writing-mode: vertical-lr"] block size should match width and inline size should match height
+PASS meter[style="writing-mode: vertical-rl"] block size should match width and inline size should match height
+

--- a/Source/WebCore/css/horizontalFormControls.css
+++ b/Source/WebCore/css/horizontalFormControls.css
@@ -25,6 +25,6 @@
 @namespace "http://www.w3.org/1999/xhtml";
 
 /* Every time a new control is supported in vertical writing mode, it should be added here and removed from the html.css rule */
-textarea, progress, input:not([type="button"], [type="submit"], [type="reset"], [type="file"]) {
+textarea, progress, meter, input:not([type="button"], [type="submit"], [type="reset"], [type="file"]) {
     writing-mode: horizontal-tb !important;
 }

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -400,7 +400,7 @@ button {
 }
 
 /* Every time a new control is supported in vertical writing mode, it should be removed from here and added in the horizontalFormControls.css rule */
-select, button, meter, input:is([type="button"], [type="submit"], [type="reset"], [type="file"]) {
+select, button, input:is([type="button"], [type="submit"], [type="reset"], [type="file"]) {
     writing-mode: horizontal-tb !important;
 }
 
@@ -1192,8 +1192,8 @@ meter {
     appearance: auto;
     box-sizing: border-box;
     display: inline-block;
-    height: 1em;
-    width: 5em;
+    block-size: 1em;
+    inline-size: 5em;
     vertical-align: -0.2em;
 }
 

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -209,7 +209,7 @@ static void setValueClass(HTMLElement& element, HTMLMeterElement::GaugeRegion ga
 
 void HTMLMeterElement::didElementStateChange()
 {
-    m_value->setInlineStyleProperty(CSSPropertyWidth, valueRatio()*100, CSSUnitType::CSS_PERCENTAGE);
+    m_value->setInlineStyleProperty(CSSPropertyInlineSize, valueRatio()*100, CSSUnitType::CSS_PERCENTAGE);
     setValueClass(*m_value, gaugeRegion());
 
     if (RenderMeter* render = renderMeter())

--- a/Source/WebCore/html/shadow/meterElementShadow.css
+++ b/Source/WebCore/html/shadow/meterElementShadow.css
@@ -15,7 +15,7 @@ div#bar {
 }
 
 div#value {
-    height: 100%;
+    block-size: 100%;
     box-sizing: border-box;
 }
 
@@ -25,12 +25,8 @@ div#value.optimum {
 
 div#value.suboptimum {
     background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
-    height: 100%;
-    box-sizing: border-box;
 }
 
 div#value.even-less-good {
     background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
-    height: 100%;
-    box-sizing: border-box;
 }


### PR DESCRIPTION
#### f486be28a10145a1cbb817618080f8f3481f2e0d
<pre>
Support rendering non-native &lt;meter&gt; in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=248182">https://bugs.webkit.org/show_bug.cgi?id=248182</a>
rdar://102595455

Reviewed by Aditya Keerthi.

Use logical properties where needed.

Also enable &lt;meter&gt; rendering behind VerticalFormControls preference.

Native rendering will be done separately.

* LayoutTests/fast/dom/HTMLMeterElement/meter-clone-expected.txt:
* LayoutTests/fast/dom/HTMLMeterElement/meter-clone.html:
* LayoutTests/fast/dom/HTMLMeterElement/meter-element-markup-expected.txt:
* LayoutTests/fast/dom/HTMLMeterElement/meter-writing-mode-expected.html:
* LayoutTests/fast/dom/HTMLMeterElement/meter-writing-mode.html:
Adjust tests accordingly.

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-horizontal.optional-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-horizontal.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-vertical.optional-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-vertical.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/w3c-import.log:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/meter-appearance-native-computed-style.optional-expected.txt: Added.
Imported from WPT upstream repo.

* Source/WebCore/css/horizontalFormControls.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
* Source/WebCore/css/html.css:
(select, button, input:is([type=&quot;button&quot;], [type=&quot;submit&quot;], [type=&quot;reset&quot;], [type=&quot;file&quot;])):
(meter):
(select, button, meter, input:is([type=&quot;button&quot;], [type=&quot;submit&quot;], [type=&quot;reset&quot;], [type=&quot;file&quot;])): Deleted.
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::didElementStateChange):
* Source/WebCore/html/shadow/meterElementShadow.css:
(div#value):
(div#value.suboptimum): Remove some redundant rules covered by div#value
(div#value.even-less-good):

Canonical link: <a href="https://commits.webkit.org/262395@main">https://commits.webkit.org/262395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67f51dfb6a5d0fc780a8dd8646af8fa0bfe3b7ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2363 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1530 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1397 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1453 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1290 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1251 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1312 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1329 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2397 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1365 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1297 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/356 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1407 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->