### PR TITLE
[NFC] WebCore: Fix typos regarding "WebCore"

### DIFF
--- a/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
@@ -164,6 +164,6 @@ NSArray *platformSummaryItems(const ApplePayLineItem& total, const Vector<AppleP
     return adoptNS([paymentSummaryItems copy]).autorelease();
 }
 
-} // namespace WebbCore
+} // namespace WebCore
 
 #endif // ENABLE(APPLE_PAY)

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -296,4 +296,4 @@ void FormAttributeTargetObserver::idTargetChanged()
     m_element.formAttributeTargetChanged();
 }
 
-} // namespace Webcore
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -407,4 +407,4 @@ bool HTMLFormControlElement::needsMouseFocusableQuirk() const
     return document().quirks().needsFormControlToBeMouseFocusable();
 }
 
-} // namespace Webcore
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp
@@ -182,4 +182,4 @@ void HTMLMaybeFormAssociatedCustomElement::didUpgradeFormAssociated()
     formAssociatedCustomElementUnsafe().didUpgrade();
 }
 
-} // namespace Webcore
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -881,4 +881,4 @@ void HTMLTextFormControlElement::adjustInnerTextStyle(const RenderStyle& parentS
 #endif
 }
 
-} // namespace Webcore
+} // namespace WebCore

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -502,4 +502,4 @@ void ValidatedFormListedElement::setInteractedWithSinceLastFormSubmitEvent(bool 
     m_wasInteractedWithSinceLastFormSubmitEvent = interactedWith;
 }
 
-} // namespace Webcore
+} // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.h
@@ -40,6 +40,6 @@ private:
     std::optional<MediaCapabilitiesDecodingInfo> videoDecodingCapabilitiesOverride(const VideoConfiguration&) final;
 };
 
-} // namespace Webcore
+} // namespace WebCore
 
 #endif


### PR DESCRIPTION
#### 1e5fe65ea18a449ab703a10b16c55a635aabe36a
<pre>
[NFC] WebCore: Fix typos regarding &quot;WebCore&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=254764">https://bugs.webkit.org/show_bug.cgi?id=254764</a>

Reviewed by Ryosuke Niwa.

No behavioral changes, but fixing typos regarding &quot;WebCore&quot;

* Source/WebCore/html/FormListedElement.cpp:
* Source/WebCore/html/HTMLFormControlElement.cpp:
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
* Source/WebCore/html/ValidatedFormListedElement.cpp:
* Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.h:

Canonical link: <a href="https://commits.webkit.org/262364@main">https://commits.webkit.org/262364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5c2ec16a951fc00ea5c68e7de0e60a8b9c4590c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2220 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1426 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1338 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2063 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1211 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1211 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1246 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1218 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1295 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->