### PR TITLE
Delete "All" target from WebGPU

### DIFF
--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -6,21 +6,6 @@
 	objectVersion = 55;
 	objects = {
 
-/* Begin PBXAggregateTarget section */
-		97FA1A8F29C086CE0052D650 /* All */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 97FA1A9029C086CE0052D650 /* Build configuration list for PBXAggregateTarget "All" */;
-			buildPhases = (
-			);
-			dependencies = (
-				97FA1A9729C086E10052D650 /* PBXTargetDependency */,
-				97FA1A9929C086E10052D650 /* PBXTargetDependency */,
-			);
-			name = All;
-			productName = All;
-		};
-/* End PBXAggregateTarget section */
-
 /* Begin PBXBuildFile section */
 		1C0F41EE280940650005886D /* HardwareCapabilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C0F41EC280940650005886D /* HardwareCapabilities.mm */; };
 		1C2CEDEE271E8A7300EDC16F /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C2CEDED271E8A7300EDC16F /* Metal.framework */; };
@@ -189,20 +174,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1CEBD7F12716B2CC00A5254D;
 			remoteInfo = WGSL;
-		};
-		97FA1A9629C086E10052D650 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1CEBD7DA2716AFBA00A5254D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1CEBD7E22716AFBA00A5254D;
-			remoteInfo = WebGPU;
-		};
-		97FA1A9829C086E10052D650 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 1CEBD7DA2716AFBA00A5254D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 97FA1A7E29C085740052D650;
-			remoteInfo = wgslc;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -882,9 +853,6 @@
 					97FA1A7E29C085740052D650 = {
 						CreatedOnToolsVersion = 14.3;
 					};
-					97FA1A8F29C086CE0052D650 = {
-						CreatedOnToolsVersion = 14.3;
-					};
 				};
 			};
 			buildConfigurationList = 1CEBD7DD2716AFBA00A5254D /* Build configuration list for PBXProject "WebGPU" */;
@@ -900,7 +868,6 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				97FA1A8F29C086CE0052D650 /* All */,
 				1CEBD7E22716AFBA00A5254D /* WebGPU */,
 				1CEBD7F12716B2CC00A5254D /* WGSL */,
 				97FA1A7E29C085740052D650 /* wgslc */,
@@ -1017,16 +984,6 @@
 			target = 1CEBD7F12716B2CC00A5254D /* WGSL */;
 			targetProxy = 1CEBD8272716CACC00A5254D /* PBXContainerItemProxy */;
 		};
-		97FA1A9729C086E10052D650 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 1CEBD7E22716AFBA00A5254D /* WebGPU */;
-			targetProxy = 97FA1A9629C086E10052D650 /* PBXContainerItemProxy */;
-		};
-		97FA1A9929C086E10052D650 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 97FA1A7E29C085740052D650 /* wgslc */;
-			targetProxy = 97FA1A9829C086E10052D650 /* PBXContainerItemProxy */;
-		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
@@ -1114,24 +1071,6 @@
 			};
 			name = Production;
 		};
-		97FA1A9129C086CE0052D650 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		97FA1A9229C086CE0052D650 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		97FA1A9329C086CE0052D650 /* Production */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Production;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1171,16 +1110,6 @@
 				97FA1A8329C085740052D650 /* Debug */,
 				97FA1A8429C085740052D650 /* Release */,
 				97FA1A8529C085740052D650 /* Production */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Production;
-		};
-		97FA1A9029C086CE0052D650 /* Build configuration list for PBXAggregateTarget "All" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				97FA1A9129C086CE0052D650 /* Debug */,
-				97FA1A9229C086CE0052D650 /* Release */,
-				97FA1A9329C086CE0052D650 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;


### PR DESCRIPTION
#### 06c98d002cc7a83f4ede33b1e5ce3b39ee277182
<pre>
Delete &quot;All&quot; target from WebGPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=254765">https://bugs.webkit.org/show_bug.cgi?id=254765</a>
rdar://107435715

Unreviewed, build fix.

By default we build the first target of the list, and we don&apos;t want to build wgslc by default.
We could just reorder it, but I don&apos;t think the target is terribly useful, so let&apos;s just delete it.

* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/262361@main">https://commits.webkit.org/262361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ca47777169453370cf32308dfd0a9d4d779ac08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/1337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/1376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/1420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/2240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/1428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/1436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/2240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/1349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/1428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/1420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/1428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/1420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/2086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/1222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/1420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/1436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/1420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/1306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/142 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->