### PR TITLE
Discard decoded image data in Web processes with no foreground tabs

### DIFF
--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -312,6 +312,8 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
     if (IOSApplication::isIBooksStorytime())
         return DecodingMode::Synchronous;
 #endif
+    if (paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting))
+        return DecodingMode::Synchronous;
     if (is<HTMLImageElement>(element())) {
         auto decodingMode = downcast<HTMLImageElement>(*element()).decodingMode();
         if (decodingMode == DecodingMode::Asynchronous)
@@ -322,8 +324,6 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
     if (bitmapImage.isLargeImageAsyncDecodingEnabledForTesting())
         return DecodingMode::Asynchronous;
     if (document().isImageDocument())
-        return DecodingMode::Synchronous;
-    if (paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting))
         return DecodingMode::Synchronous;
     if (!settings().largeImageAsyncDecodingEnabled())
         return DecodingMode::Synchronous;

--- a/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
@@ -175,6 +175,22 @@ public:
         checkInvariants();
     }
 
+    void releaseAllImageResources()
+    {
+        checkInvariants();
+
+        if (!m_nativeImageCount)
+            return;
+
+        m_resources.removeIf([] (const auto& resource) {
+            return std::holds_alternative<Ref<WebCore::NativeImage>>(resource.value);
+        });
+
+        m_nativeImageCount = 0;
+
+        checkInvariants();
+    }
+
 private:
     template <typename T>
     void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<T>&& object, unsigned& counter)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -415,6 +415,12 @@ void RemoteRenderingBackend::releaseAllResources()
     m_remoteResourceCache.releaseAllResources();
 }
 
+void RemoteRenderingBackend::releaseAllImageResources()
+{
+    ASSERT(!RunLoop::isMain());
+    m_remoteResourceCache.releaseAllImageResources();
+}
+
 void RemoteRenderingBackend::releaseRenderingResource(RenderingResourceIdentifier renderingResourceIdentifier)
 {
     // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -126,6 +126,7 @@ private:
     void cacheFont(const WebCore::Font::Attributes&, WebCore::FontPlatformData::Attributes, std::optional<WebCore::RenderingResourceIdentifier>);
     void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&);
     void releaseAllResources();
+    void releaseAllImageResources();
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier);
     void finalizeRenderingUpdate(RenderingUpdateID);
     void markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier, const Vector<WebCore::RenderingResourceIdentifier>&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -36,6 +36,7 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     CacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs> decomposedGlyphs) NotStreamEncodable
     CacheGradient(Ref<WebCore::Gradient> gradient, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     ReleaseAllResources()
+    ReleaseAllImageResources()
     ReleaseRenderingResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -122,6 +122,11 @@ void RemoteResourceCache::releaseAllResources()
     m_resourceHeap.releaseAllResources();
 }
 
+void RemoteResourceCache::releaseAllImageResources()
+{
+    m_resourceHeap.releaseAllImageResources();
+}
+
 bool RemoteResourceCache::releaseRenderingResource(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
 {
     if (m_resourceHeap.removeImageBuffer(renderingResourceIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -58,6 +58,7 @@ public:
     std::optional<WebCore::SourceImage> cachedSourceImage(QualifiedRenderingResourceIdentifier) const;
 
     void releaseAllResources();
+    void releaseAllImageResources();
     bool releaseRenderingResource(QualifiedRenderingResourceIdentifier);
 
 private:

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -60,7 +60,7 @@ public:
     void backingStoreBecameUnreachable(RemoteLayerBackingStore&);
 
     virtual void prepareBackingStoresForDisplay(RemoteLayerTreeTransaction&);
-    void paintReachableBackingStoreContents();
+    bool paintReachableBackingStoreContents();
 
     void willFlushLayers();
     void willCommitLayerTree(RemoteLayerTreeTransaction&);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -57,10 +57,15 @@ void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLay
     }
 }
 
-void RemoteLayerBackingStoreCollection::paintReachableBackingStoreContents()
+bool RemoteLayerBackingStoreCollection::paintReachableBackingStoreContents()
 {
-    for (auto* backingStore : m_backingStoresNeedingDisplay)
+    bool anyNonEmptyDirtyRegion = false;
+    for (auto* backingStore : m_backingStoresNeedingDisplay) {
+        if (!backingStore->hasEmptyDirtyRegion())
+            anyNonEmptyDirtyRegion = true;
         backingStore->paintContents();
+    }
+    return anyNonEmptyDirtyRegion;
 }
 
 void RemoteLayerBackingStoreCollection::willFlushLayers()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -289,6 +289,13 @@ void RemoteRenderingBackendProxy::releaseRenderingResource(RenderingResourceIden
     send(Messages::RemoteRenderingBackend::ReleaseRenderingResource(renderingResourceIdentifier));
 }
 
+void RemoteRenderingBackendProxy::releaseAllImageResources()
+{
+    if (!m_streamConnection)
+        return;
+    send(Messages::RemoteRenderingBackend::ReleaseAllImageResources());
+}
+
 #if PLATFORM(COCOA)
 auto RemoteRenderingBackendProxy::prepareBuffersForDisplay(const Vector<LayerPrepareBuffersData>& prepareBuffersInput) -> Vector<SwapBuffersResult>
 {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -101,6 +101,7 @@ public:
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheGradient(Ref<WebCore::Gradient>&&);
     void releaseAllRemoteResources();
+    void releaseAllImageResources();
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier);
     void markSurfacesVolatile(Vector<WebCore::RenderingResourceIdentifier>&&, CompletionHandler<void(bool madeAllVolatile)>&&);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -109,6 +109,8 @@ void RemoteResourceCacheProxy::recordImageBufferUse(WebCore::ImageBuffer& imageB
 
 void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
 {
+    WebProcess::singleton().deferNonVisibleProcessEarlyMemoryCleanupTimer();
+
     auto iterator = m_nativeImages.find(image.renderingResourceIdentifier());
     if (iterator != m_nativeImages.end())
         return;
@@ -322,6 +324,13 @@ void RemoteResourceCacheProxy::releaseMemory()
     clearGradientMap();
     m_remoteRenderingBackendProxy.releaseAllRemoteResources();
 }
+
+void RemoteResourceCacheProxy::releaseAllImageResources()
+{
+    clearNativeImageMap();
+    m_remoteRenderingBackendProxy.releaseAllImageResources();
+}
+
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -67,6 +67,7 @@ public:
 
     void remoteResourceCacheWasDestroyed();
     void releaseMemory();
+    void releaseAllImageResources();
     
     unsigned imagesCount() const { return m_nativeImages.size(); }
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -165,6 +165,8 @@ public:
     virtual void adoptLayersFromDrawingArea(DrawingArea&) { }
     virtual void adoptDisplayRefreshMonitorsFromDrawingArea(DrawingArea&) { }
 
+    virtual void setNextRenderingUpdateRequiresSynchronousImageDecoding() { }
+
     void removeMessageReceiverIfNeeded();
     
     WebCore::TiledBacking* mainFrameTiledBacking() const;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -80,7 +80,7 @@ public:
 
     RemoteLayerBackingStoreCollection& backingStoreCollection() { return *m_backingStoreCollection; }
     
-    void setNextRenderingUpdateRequiresSynchronousImageDecoding(bool requireSynchronousDecoding) { m_nextRenderingUpdateRequiresSynchronousImageDecoding = requireSynchronousDecoding; }
+    void setNextRenderingUpdateRequiresSynchronousImageDecoding() { m_nextRenderingUpdateRequiresSynchronousImageDecoding = true; }
     bool nextRenderingUpdateRequiresSynchronousImageDecoding() const { return m_nextRenderingUpdateRequiresSynchronousImageDecoding; }
 
     void adoptLayersFromContext(RemoteLayerTreeContext&);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -188,7 +188,9 @@ void RemoteLayerTreeContext::buildTransaction(RemoteLayerTreeTransaction& transa
     m_backingStoreCollection->prepareBackingStoresForDisplay(transaction);
     m_currentTransaction = nullptr;
 
-    m_backingStoreCollection->paintReachableBackingStoreContents();
+    bool paintedAnyBackingStore = m_backingStoreCollection->paintReachableBackingStoreContents();
+    if (paintedAnyBackingStore)
+        m_nextRenderingUpdateRequiresSynchronousImageDecoding = false;
 
     transaction.setCreatedLayers(copyToVector(m_createdLayers.values()));
     transaction.setDestroyedLayerIDs(WTFMove(m_destroyedLayers));

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -127,6 +127,8 @@ private:
 
     void adoptLayersFromDrawingArea(DrawingArea&) final;
 
+    void setNextRenderingUpdateRequiresSynchronousImageDecoding() final;
+
     class BackingStoreFlusher : public ThreadSafeRefCounted<BackingStoreFlusher> {
     public:
         static Ref<BackingStoreFlusher> create(IPC::Connection*, UniqueRef<IPC::Encoder>&&, Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>>);
@@ -160,7 +162,6 @@ private:
     WebCore::Timer m_updateRenderingTimer;
     bool m_isRenderingSuspended { false };
     bool m_hasDeferredRenderingUpdate { false };
-    bool m_nextRenderingUpdateRequiresSynchronousImageDecoding { false };
     bool m_inUpdateRendering { false };
 
     bool m_waitingForBackingStoreSwap { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4698,6 +4698,17 @@ void WebPage::releaseMemory(Critical)
 #endif
 }
 
+void WebPage::willDestroyDecodedDataForAllImages()
+{
+#if ENABLE(GPU_PROCESS)
+    if (m_remoteRenderingBackendProxy)
+        m_remoteRenderingBackendProxy->remoteResourceCacheProxy().releaseAllImageResources();
+#endif
+
+    if (m_drawingArea)
+        m_drawingArea->setNextRenderingUpdateRequiresSynchronousImageDecoding();
+}
+
 unsigned WebPage::remoteImagesCountForTesting() const
 {
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -457,6 +457,7 @@ public:
     void didCompleteRenderingFrame();
 
     void releaseMemory(WTF::Critical);
+    void willDestroyDecodedDataForAllImages();
 
     unsigned remoteImagesCountForTesting() const;
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -399,6 +399,8 @@ public:
     void setAppBadge(std::optional<WebPageProxyIdentifier>, const WebCore::SecurityOriginData&, std::optional<uint64_t>);
     void setClientBadge(WebPageProxyIdentifier, const WebCore::SecurityOriginData&, std::optional<uint64_t>);
 
+    void deferNonVisibleProcessEarlyMemoryCleanupTimer();
+
 private:
     WebProcess();
     ~WebProcess();
@@ -422,6 +424,8 @@ private:
     void unfreezeAllLayerTrees();
 
     void processSuspensionCleanupTimerFired();
+
+    void destroyDecodedDataForAllImages();
 
     void platformTerminate();
 
@@ -681,7 +685,7 @@ private:
     bool m_processIsSuspended { false };
 
     HashSet<WebCore::PageIdentifier> m_pagesInWindows;
-    WebCore::Timer m_nonVisibleProcessEarlyMemoryCleanupTimer;
+    std::optional<WebCore::DeferrableOneShotTimer> m_nonVisibleProcessEarlyMemoryCleanupTimer;
 
 #if ENABLE(NON_VISIBLE_WEBPROCESS_MEMORY_CLEANUP_TIMER)
     WebCore::Timer m_nonVisibleProcessMemoryCleanupTimer;


### PR DESCRIPTION
#### baeabe11daecb0ce0df709e88ae0ef821f7a2bcb
<pre>
Discard decoded image data in Web processes with no foreground tabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=254768">https://bugs.webkit.org/show_bug.cgi?id=254768</a>
&lt;rdar://problem/107437769&gt;

Reviewed by Said Abou-Hallawa.

To reduce memory footprint, this patch discards decoded image data in
Web processes with no foreground tabs.

Destroying the decoded data means there is a risk of images not
rendering next time we paint, if we had decided to async decode (due to
the images being large, or referenced with &lt;img decode=async&gt;, etc.).
This can manifest in a couple of ways:

1. When switching back to a tab that&apos;s had its decoded image data
   destroyed, we won&apos;t see the effect immediately, since we&apos;ll show the
   page snapshot without painting the page again. By the next time we
   do need to paint (e.g. after the user interacts with the page in some
   way), the image may briefly disappear while we wait for the async
   decode.

2. When hovering over the tab strip, Safari generates thumbnails showing
   the contents of the tabs. Although the image painting is performed
   with PaintBehavior::Snapshotting, this does not currently override
   &lt;img decode=async&gt;, so any previously decoded &lt;img decode=async&gt;
   image will appear blank in the thumbnail.

To avoid these issues, we tell the RemoteLayerTreeDrawingArea to decode
images synchronously in the next rendering update, and adjust
RenderBoxModelObject::decodingModeForImageDraw to prioritize
PaintBehavior::Snapshotting over &lt;img decode=async&gt;.

RemoteLayerTreeDrawingArea can perform no-paint rendering updates when
switching back to a background tab, so we wait until we do some painting
(a backing store has a non-empty dirty region) before clearing
m_nextRenderingUpdateRequiresSynchronousImageDecoding.

WebProcess::m_nonVisibleProcessEarlyMemoryCleanupTimer is changed to a
DeferrableOneShotTimer. If a tab is in the background, and we have
already destroyed the image decoded data, we schedule the timer again.
This avoids the image data persisting if the page thumbnails are
generated. If a tab is in the background, and we haven&apos;t yet destroyed
the image decoded data (i.e., if the timer is pending), then we defer
the timer when an image is painted. This avoids continuously destroying
then regenerating the decoded data, if the page is repeatedly drawing
images in the background.

When the timer fires, we also tell the RemoteResourceCacheProxy to clear
all its image resources at once, rather than have each NativeImage in
its destructor tell the RemoteResourceCacheProxy to remove a single
image resource, to reduce IPC traffic.

For now, we only do this when UI side compositing is enabled, but it
would also be beneficial in other configurations.

* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::decodingModeForImageDraw const):
* Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h:
(WebKit::QualifiedResourceHeap::releaseAllImageResources):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::releaseAllImageResources):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::releaseAllImageResources):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::paintReachableBackingStoreContents):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::releaseAllImageResources):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
(WebKit::RemoteResourceCacheProxy::releaseAllImageResources):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::setNextRenderingUpdateRequiresSynchronousImageDecoding):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
(WebKit::RemoteLayerTreeContext::setNextRenderingUpdateRequiresSynchronousImageDecoding):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::buildTransaction):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::setNextRenderingUpdateRequiresSynchronousImageDecoding):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::activityStateDidChange):
(WebKit::RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willDestroyDecodedDataForAllImages):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::WebProcess):
(WebKit::WebProcess::pageDidEnterWindow):
(WebKit::WebProcess::pageWillLeaveWindow):
(WebKit::WebProcess::nonVisibleProcessEarlyMemoryCleanupTimerFired):
(WebKit::WebProcess::destroyDecodedDataForAllImages):
(WebKit::WebProcess::deferNonVisibleProcessEarlyMemoryCleanupTimer):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/262585@main">https://commits.webkit.org/262585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ece1af1b1a9d9af5aadedcdfb25051c9949cf11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2883 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1804 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1650 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1800 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2901 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1812 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1748 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/482 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1903 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->