### PR TITLE
Implement scroll synchronisation for UI-side compositing.

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(ASYNC_SCROLLING)
 
+#include "AnimationFrameRate.h"
 #include "EventNames.h"
 #include "Logging.h"
 #include "PlatformWheelEvent.h"
@@ -900,6 +901,19 @@ bool ScrollingTree::overlayScrollbarsEnabled()
     Locker locker { m_treeStateLock };
     return m_overlayScrollbarsEnabled;
 }
+
+Seconds ScrollingTree::frameDuration()
+{
+    auto displayFPS = nominalFramesPerSecond().value_or(FullSpeedFramesPerSecond);
+    return 1_s / (double)displayFPS;
+}
+
+Seconds ScrollingTree::maxAllowableRenderingUpdateDurationForSynchronization()
+{
+    constexpr double allowableFrameFraction = 0.5;
+    return allowableFrameFraction * frameDuration();
+}
+
 
 String ScrollingTree::scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> behavior)
 {

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -239,6 +239,9 @@ public:
     WEBCORE_EXPORT void viewWillEndLiveResize();
     WEBCORE_EXPORT void viewSizeDidChange();
     WEBCORE_EXPORT bool overlayScrollbarsEnabled();
+
+    WEBCORE_EXPORT Seconds frameDuration();
+    WEBCORE_EXPORT Seconds maxAllowableRenderingUpdateDurationForSynchronization();
     
 protected:
     WEBCORE_EXPORT WheelEventHandlingResult handleWheelEventWithNode(const PlatformWheelEvent&, OptionSet<WheelEventProcessingSteps>, ScrollingTreeNode*, EventTargeting = EventTargeting::Propagate);

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -415,18 +415,6 @@ void ThreadedScrollingTree::willStartRenderingUpdate()
     m_state = SynchronizationState::InRenderingUpdate;
 }
 
-Seconds ThreadedScrollingTree::frameDuration()
-{
-    auto displayFPS = nominalFramesPerSecond().value_or(FullSpeedFramesPerSecond);
-    return 1_s / (double)displayFPS;
-}
-
-Seconds ThreadedScrollingTree::maxAllowableRenderingUpdateDurationForSynchronization()
-{
-    constexpr double allowableFrameFraction = 0.5;
-    return allowableFrameFraction * frameDuration();
-}
-
 void ThreadedScrollingTree::hasNodeWithAnimatedScrollChanged(bool hasNodeWithAnimatedScroll)
 {
     auto scrollingCoordinator = m_scrollingCoordinator;

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -115,9 +115,6 @@ private:
     
     bool isScrollingSynchronizedWithMainThread() final WTF_REQUIRES_LOCK(m_treeLock);
 
-    Seconds frameDuration();
-    Seconds maxAllowableRenderingUpdateDurationForSynchronization();
-    
     bool scrollingThreadIsActive();
 
     void receivedWheelEventWithPhases(PlatformWheelEventPhase, PlatformWheelEventPhase) final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -395,6 +395,8 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay()
     
     m_didUpdateMessageState = DoesNotNeedDidUpdate;
 
+    m_webPageProxy.scrollingCoordinatorProxy()->sendScrollingTreeNodeDidScroll();
+
     // Waiting for CA to commit is insufficient, because the render server can still be
     // using our backing store. We can improve this by waiting for the render server to commit
     // if we find API to do so, but for now we will make extra buffers if need be.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -90,7 +90,7 @@ public:
     // Called externally when native views move around.
     void viewportChangedViaDelegatedScrolling(const WebCore::FloatPoint& scrollPosition, const WebCore::FloatRect& layoutViewport, double scale);
 
-    void applyScrollingTreeLayerPositionsAfterCommit();
+    virtual void applyScrollingTreeLayerPositionsAfterCommit();
 
     void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
 
@@ -159,6 +159,8 @@ public:
     String scrollbarStateForScrollingNodeID(WebCore::ScrollingNodeID, bool isVertical);
     bool overlayScrollbarsEnabled();
 
+    void sendScrollingTreeNodeDidScroll();
+
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }
 
@@ -168,7 +170,6 @@ protected:
     virtual void didReceiveWheelEvent(bool /* wasHandled */) { }
 
     void sendUIStateChangedIfNecessary();
-    void sendScrollingTreeNodeDidScroll();
     void receivedLastScrollingTreeNodeDidScrollReply();
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -61,6 +61,7 @@ private:
 
     void willCommitLayerAndScrollingTrees() override;
     void didCommitLayerAndScrollingTrees() override;
+    void applyScrollingTreeLayerPositionsAfterCommit() override;
 
 #if ENABLE(SCROLLING_THREAD)
     RefPtr<RemoteLayerTreeEventDispatcher> m_wheelEventDispatcher;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -226,6 +226,12 @@ void RemoteScrollingCoordinatorProxyMac::didCommitLayerAndScrollingTrees()
     scrollingTree()->unlockLayersForHitTesting();
 }
 
+void RemoteScrollingCoordinatorProxyMac::applyScrollingTreeLayerPositionsAfterCommit()
+{
+    RemoteScrollingCoordinatorProxy::applyScrollingTreeLayerPositionsAfterCommit();
+    m_wheelEventDispatcher->renderingUpdateComplete();
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)


### PR DESCRIPTION
#### 318643e7b097508e3ff4d2b513b2530287febe75
<pre>
Implement scroll synchronisation for UI-side compositing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254772">https://bugs.webkit.org/show_bug.cgi?id=254772</a>
&lt;rdar://106293351&gt;

Reviewed by Simon Fraser.

This largely duplicates what ThreadedScrollingTree does, in RemoteLayerTreeEventDispatcher instead.

The main functional difference is that since this code runs in the UI process, we can&apos;t easily
determine if the Web process main thread has rendering scheduled.

The code instead sets a 1ms timeout (on didRefreshDisplay) to wait for the UI process main thread
to acknoweledge the display update. This can fail if the thread is busy, or if we didn&apos;t send
didRefreshDisplay to that thread (which usually runs at a lower refresh rate than the scrolling thread).

If the timeout elapses, then scroll positions are immediately applied, but the synchronization state
isn&apos;t set to Desynchronized, since this happens every second frame (when the scrolling thread refreshes
at 120hz).

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::frameDuration):
(WebCore::ScrollingTree::maxAllowableRenderingUpdateDurationForSynchronization):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::frameDuration): Deleted.
(WebCore::ThreadedScrollingTree::maxAllowableRenderingUpdateDurationForSynchronization): Deleted.
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::internalHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::didRefreshDisplay):
(WebKit::RemoteLayerTreeEventDispatcher::scheduleDelayedRenderingUpdateDetectionTimer):
(WebKit::RemoteLayerTreeEventDispatcher::delayedRenderingUpdateDetectionTimerFired):
(WebKit::RemoteLayerTreeEventDispatcher::waitForRenderingUpdateCompletionOrTimeout):
(WebKit::RemoteLayerTreeEventDispatcher::mainThreadDisplayDidRefresh):
(WebKit::RemoteLayerTreeEventDispatcher::renderingUpdateComplete):
(WebKit::RemoteLayerTreeEventDispatcher::windowScreenDidChange):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
(WebKit::RemoteLayerTreeEventDispatcher::WTF_GUARDED_BY_LOCK):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::applyScrollingTreeLayerPositionsAfterCommit):

Canonical link: <a href="https://commits.webkit.org/262535@main">https://commits.webkit.org/262535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b65bda3bdd0fc82c4815c1ca9f36faf3303f237

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2713 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1907 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1673 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1512 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1643 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2719 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1488 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1594 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/447 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1736 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->