### PR TITLE
Add masked corners support to InteractionRegions

### DIFF
--- a/LayoutTests/interaction-region/border-radii-expected.txt
+++ b/LayoutTests/interaction-region/border-radii-expected.txt
@@ -1,0 +1,31 @@
+uniform half pill diagonal tongue degenerate changing
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (10,10) width=84 height=52)
+        (borderRadius 12.00),
+        (interaction (117,10) width=83 height=52)
+        (borderRadius 20 0 0 20),
+        (interaction (223,10) width=88 height=52)
+        (borderRadius 16 0 16 0),
+        (interaction (334,10) width=77 height=52)
+        (borderRadius 0 0 10 10),
+        (interaction (434,10) width=102 height=52)
+        (borderRadius 8.00),
+        (interaction (559,10) width=92 height=52)
+        (borderRadius 20.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/border-radii.html
+++ b/LayoutTests/interaction-region/border-radii.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    div {
+        display: inline-block;
+        margin: 10px;
+        padding: 1em;
+        background: blue;
+        color: white;
+        cursor: pointer;
+    }
+    .uniform {
+        border-radius: 12px;
+    }
+    .half-pill {
+        border-radius: 20px 0 0 20px;
+    }
+    .diagonal {
+        border-radius: 16px 0 16px 0;
+    }
+    .tongue {
+        border-radius: 0 0 10px 10px;
+    }
+    .degenerate {
+        border-radius: 2px 16px 10px 18px;
+    }
+    .changed {
+        border-radius: 20px;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<div class="uniform">uniform</div>
+<div class="half-pill">half pill</div>
+<div class="diagonal">diagonal</div>
+<div class="tongue">tongue</div>
+<div class="degenerate">degenerate</div>
+<div class="changing">changing</div>
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    await UIHelper.animationFrame();
+    document.querySelector(".changing").classList.add("changed");
+    if (window.internals) {
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+       testRunner.notifyDone();
+    }
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.h
+++ b/Source/WebCore/page/InteractionRegion.h
@@ -46,21 +46,29 @@ class RenderObject;
 
 struct InteractionRegion {
     enum class Type : bool { Interaction, Occlusion };
+    enum class CornerMask : uint8_t {
+        MinXMinYCorner = 1 << 0,
+        MaxXMinYCorner = 1 << 1,
+        MinXMaxYCorner = 1 << 2,
+        MaxXMaxYCorner = 1 << 3
+    };
 
+    Type type;
     ElementIdentifier elementIdentifier;
     IntRect rectInLayerCoordinates;
     float borderRadius { 0 };
-    Type type;
+    OptionSet<CornerMask> maskedCorners { };
 
     WEBCORE_EXPORT ~InteractionRegion();
 };
 
 inline bool operator==(const InteractionRegion& a, const InteractionRegion& b)
 {
-    return a.elementIdentifier == b.elementIdentifier
+    return a.type == b.type
+        && a.elementIdentifier == b.elementIdentifier
         && a.rectInLayerCoordinates == b.rectInLayerCoordinates
         && a.borderRadius == b.borderRadius
-        && a.type == b.type;
+        && a.maskedCorners == b.maskedCorners;
 }
 
 WEBCORE_EXPORT std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject&, const Region&);

--- a/Source/WebCore/platform/graphics/RoundedRect.h
+++ b/Source/WebCore/platform/graphics/RoundedRect.h
@@ -72,6 +72,7 @@ public:
         Radii transposedRadii() const { return Radii(m_topLeft.transposedSize(), m_topRight.transposedSize(), m_bottomLeft.transposedSize(), m_bottomRight.transposedSize()); }
 
         LayoutUnit minimumRadius() const { return std::min({ m_topLeft.minDimension(), m_topRight.minDimension(), m_bottomLeft.minDimension(), m_bottomRight.minDimension() }); }
+        LayoutUnit maximumRadius() const { return std::max({ m_topLeft.minDimension(), m_topRight.minDimension(), m_bottomLeft.minDimension(), m_bottomRight.minDimension() }); }
 
     private:
         LayoutSize m_topLeft;

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -149,10 +149,11 @@ void EventRegionContext::uniteInteractionRegions(const Region& region, RenderObj
                 
                 for (auto rect : tempRegion.rects()) {
                     m_interactionRegions.append({
+                        InteractionRegion::Type::Interaction,
                         interactionRegion->elementIdentifier,
                         rect,
                         interactionRegion->borderRadius,
-                        InteractionRegion::Type::Interaction
+                        interactionRegion->maskedCorners
                     });
                 }
                 return;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4735,12 +4735,19 @@ struct WebCore::GlobalWindowIdentifier {
 };
 
 [Nested] enum class WebCore::InteractionRegion::Type : bool;
+[Nested, OptionSet] enum class WebCore::InteractionRegion::CornerMask : uint8_t {
+    MinXMinYCorner
+    MaxXMinYCorner
+    MinXMaxYCorner
+    MaxXMaxYCorner
+};
 
 struct WebCore::InteractionRegion {
+    WebCore::InteractionRegion::Type type;
     WebCore::ElementIdentifier elementIdentifier;
     WebCore::IntRect rectInLayerCoordinates;
     float borderRadius;
-    WebCore::InteractionRegion::Type type;
+    OptionSet<WebCore::InteractionRegion::CornerMask> maskedCorners;
 };
 
 [Nested] struct WebCore::Region::Span {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -85,6 +85,22 @@ static void setInteractionRegionOcclusion(CALayer *layer)
     [layer setValue:@(static_cast<bool>(InteractionRegion::Type::Occlusion)) forKey:interactionRegionTypeKey];
 }
 
+static CACornerMask convertToCACornerMask(OptionSet<InteractionRegion::CornerMask> mask)
+{
+    CACornerMask cornerMask = 0;
+
+    if (mask.contains(InteractionRegion::CornerMask::MinXMinYCorner))
+        cornerMask |= kCALayerMinXMinYCorner;
+    if (mask.contains(InteractionRegion::CornerMask::MaxXMinYCorner))
+        cornerMask |= kCALayerMaxXMinYCorner;
+    if (mask.contains(InteractionRegion::CornerMask::MinXMaxYCorner))
+        cornerMask |= kCALayerMinXMaxYCorner;
+    if (mask.contains(InteractionRegion::CornerMask::MaxXMaxYCorner))
+        cornerMask |= kCALayerMaxXMaxYCorner;
+
+    return cornerMask;
+}
+
 void insertInteractionRegionLayersForLayer(NSMutableArray *sublayers, CALayer *layer)
 {
     NSUInteger insertionPoint = 0;
@@ -178,6 +194,8 @@ void updateLayersForInteractionRegions(CALayer *layer, RemoteLayerTreeHost& host
                 configureLayerForInteractionRegion(interactionLayer.get(), interactionRegionGroupName);
 
             [interactionLayer setCornerRadius:region.borderRadius];
+            if (!region.maskedCorners.isEmpty())
+                [interactionLayer setMaskedCorners:convertToCACornerMask(region.maskedCorners)];
 
             if (!foundInPosition)
                 [layer insertSublayer:interactionLayer.get() atIndex:insertionPoint];


### PR DESCRIPTION
#### a349ab55bc80966ce153a39824796e5341d7ce71
<pre>
Add masked corners support to InteractionRegions
<a href="https://bugs.webkit.org/show_bug.cgi?id=254775">https://bugs.webkit.org/show_bug.cgi?id=254775</a>
&lt;rdar://104098230&gt;

Reviewed by Tim Horton.

Use the `CALayer#maskedCorners` property to refine Interaction layers.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebCore/page/InteractionRegion.h:
(WebCore::operator==):
Add a new `maskedCorners` OptionSet to the InteractionRegion struct.
Re-order the members to keep the optional values at the end.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
When a `border-radius` is partially applied to the element, use a
CornerMask to indicate which corners it applies to.
(WebCore::operator&lt;&lt;):
Reflect the corner mask in the test dumps.

* Source/WebCore/platform/graphics/RoundedRect.h:
(WebCore::RoundedRect::Radii::maximumRadius const):
Add a maximum radius method to easily detect cases where a corner mask
is necessary.

* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
Relay the `maskedCorners` value when an InteractionRegion&apos;s rect gets split
by the subtraction. We could refine this in the future once we have
better shape support.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::convertToCACornerMask):
(WebKit::updateLayersForInteractionRegions):
Apply the corner mask to the Interaction CALayer.

* LayoutTests/interaction-region/border-radii-expected.txt: Added.
* LayoutTests/interaction-region/border-radii.html: Added.
Add a new test file covering many `border-radius` scenarios.

Canonical link: <a href="https://commits.webkit.org/262397@main">https://commits.webkit.org/262397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9affdb09ff8bd725d8b05279a5485910cd2099aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1257 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1383 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1435 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2171 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1240 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1294 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2380 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1349 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1283 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/358 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1389 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->