### PR TITLE
Make SMIL interval position calculations more resilient

### DIFF
--- a/LayoutTests/svg/animations/simple-duration-mutation-crash-expected.txt
+++ b/LayoutTests/svg/animations/simple-duration-mutation-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/svg/animations/simple-duration-mutation-crash.html
+++ b/LayoutTests/svg/animations/simple-duration-mutation-crash.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script>
+function runAfterLayoutAndPaint(callback, autoNotifyDone) {
+    if (!window.testRunner) {
+        // For manual test. Delay 500ms to allow us to see the visual change
+        // caused by the callback.
+        setTimeout(callback, 500);
+        return;
+    }
+
+    if (autoNotifyDone)
+        testRunner.waitUntilDone();
+
+    // We do requestAnimationFrame and setTimeout to ensure a frame has started
+    // and layout and paint have run. The requestAnimationFrame fires after the
+    // frame has started but before layout and paint. The setTimeout fires
+    // at the beginning of the next frame, meaning that the previous frame has
+    // completed layout and paint.
+    // See http://crrev.com/c/1395193/10/third_party/blink/web_tests/http/tests/resources/run-after-layout-and-paint.js
+    // for more discussions.
+    requestAnimationFrame(function() {
+        setTimeout(function() {
+            callback();
+            if (autoNotifyDone)
+                testRunner.notifyDone();
+        }, 1);
+    });
+}
+</script>
+<svg>
+  <animateTransform id="a" attributeName="transform" values="1 2; 3 4; 5 6"/>
+</svg>
+<p>PASS if no crash</p>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.waitUntilDone();
+}
+onload = function() {
+  setTimeout(function() {
+    var element = document.getElementById("a");
+    element.setAttribute("dur", "0.1s");
+    element.setAttribute("end", "NotARealEvent");
+    runAfterLayoutAndPaint(function() {}, true);
+  });
+};
+</script>

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2013-2014 Google Inc. All rights reserved.
+ * Copyright (C) 2013-2017 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1030,7 +1030,8 @@ float SVGSMILElement::calculateAnimationPercentAndRepeat(SMILTime elapsed, unsig
         if (!fmod(repeatingDuration.value(), simpleDuration.value()))
             --repeat;
 
-        double percent = (m_intervalEnd.value() - m_intervalBegin.value()) / simpleDuration.value();
+        double lastActiveDuration = elapsed >= m_intervalEnd ? m_intervalEnd.value() - m_intervalBegin.value() : repeatingDuration.value();
+        double percent = lastActiveDuration / simpleDuration.value();
         percent = percent - floor(percent);
         if (percent < std::numeric_limits<float>::epsilon() || 1 - percent < std::numeric_limits<float>::epsilon())
             return 1.0f;


### PR DESCRIPTION
#### 41db051039b0b4670106dc3937a4c8598c39ea48
<pre>
Make SMIL interval position calculations more resilient

<a href="https://bugs.webkit.org/show_bug.cgi?id=254702">https://bugs.webkit.org/show_bug.cgi?id=254702</a>

Reviewed by Simon Fraser.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/c9db58439d9c5218b26640fa65780d6dd505734c">https://chromium.googlesource.com/chromium/src.git/+/c9db58439d9c5218b26640fa65780d6dd505734c</a>

When &apos;dur&apos; is mutated, all dependent state is not updated at once, but
rather lazily. This means that we can get into an inconsistent state
where some timing parameters have been applied while some have not, and
code that uses - and thus realizes - the state changes will be first to
observe them. This can for instance lead to an interval position of NaN
being computed, which would wreak havoc when computing values.

For the specific case, we&apos;d first get an &apos;indefinite&apos; simple duration
and compute an interval thereafter. When &apos;dur&apos; is then modified to a
finite value the simple duration will not be updated until the next
frame is computed (triggered by mutation of &apos;end&apos;), leaving us with
a valid/finite simple duration but an infinite interval. (This then
results in arithmetic with Inf, yielding a NaN value for |percent|.)

Properly updating all the interval computation state on mutations is a
somewhat involved task, so paper over it for now by computing the (last)
active duration differently depending on the case we&apos;re in. While this
change is a bit of a workaround, it should be a perfectly reasonable
change on its own.

* Source/WebCore/svg/animations/SVGSMILElement.cpp:
(SVGSMILElement:: calculateAnimationPercentAndRepeat): Update &apos;percent&apos;
* LayoutTests/svg/animations/simple-duration-mutation-crash.html: Add Test Case
* LayoutTests/svg/animations/simple-duration-mutation-crash-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/262425@main">https://commits.webkit.org/262425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b38f137f1d2c6a5589639b2d9b5af011e689cd00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2274 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1364 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1217 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1254 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2388 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1222 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1244 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/372 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1345 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->