### PR TITLE
Re-import html/semantics/disabled-elements WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt
@@ -1,0 +1,23 @@
+hello world child  hello world child
+
+FAIL Testing mousedown events when clicking child of disabled button. assert_equals: parent element received mousedown events expected false but got true
+FAIL Testing mousedown events when clicking child of disabled my-control. assert_equals: parent element received mousedown events expected false but got true
+PASS Testing mousedown events when clicking disabled button.
+PASS Testing mousedown events when clicking disabled my-control.
+FAIL Testing mouseup events when clicking child of disabled button. assert_equals: parent element received mouseup events expected false but got true
+FAIL Testing mouseup events when clicking child of disabled my-control. assert_equals: parent element received mouseup events expected false but got true
+PASS Testing mouseup events when clicking disabled button.
+PASS Testing mouseup events when clicking disabled my-control.
+FAIL Testing pointerdown events when clicking child of disabled button. assert_equals: target element received pointerdown events expected true but got false
+FAIL Testing pointerdown events when clicking child of disabled my-control. assert_equals: target element received pointerdown events expected true but got false
+FAIL Testing pointerdown events when clicking disabled button. assert_equals: parent element received pointerdown events expected true but got false
+FAIL Testing pointerdown events when clicking disabled my-control. assert_equals: parent element received pointerdown events expected true but got false
+FAIL Testing pointerup events when clicking child of disabled button. assert_equals: target element received pointerup events expected true but got false
+FAIL Testing pointerup events when clicking child of disabled my-control. assert_equals: target element received pointerup events expected true but got false
+FAIL Testing pointerup events when clicking disabled button. assert_equals: parent element received pointerup events expected true but got false
+FAIL Testing pointerup events when clicking disabled my-control. assert_equals: parent element received pointerup events expected true but got false
+FAIL Testing click events when clicking child of disabled button. assert_equals: parent element received click events expected false but got true
+FAIL Testing click events when clicking child of disabled my-control. assert_equals: parent element received click events expected false but got true
+PASS Testing click events when clicking disabled button.
+PASS Testing click events when clicking disabled my-control.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/issues/2368">
+<link rel=help href="https://github.com/whatwg/html/issues/5886">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+
+<div id=targetparent>
+  <button disabled>
+    hello world
+    <span style="border: 1px solid black">child</span>
+  </button>
+  <my-control disabled>
+    hello world
+    <span style="border: 1px solid black">child</span>
+  </my-control>
+</div>
+
+<script>
+customElements.define('my-control', class extends HTMLElement {
+  static get formAssociated() { return true; }
+});
+
+['mousedown', 'mouseup', 'pointerdown', 'pointerup', 'click'].forEach(eventName => {
+  [true, false].forEach(clickChildElement => {
+    for (const target of targetparent.children) {
+      promise_test(async () => {
+        let parentReceivedEvent = false;
+        targetparent.addEventListener(eventName, () => parentReceivedEvent = true);
+
+        let targetReceivedEvent = false;
+        target.addEventListener(eventName, () => targetReceivedEvent = true);
+
+        let childReceivedEvent = false;
+        let targetchild = target.firstElementChild;
+        targetchild.addEventListener(eventName, () => childReceivedEvent = true);
+
+        await test_driver.click(clickChildElement ? targetchild : target);
+
+        const parentShouldReceiveEvents = eventName.startsWith('pointer');
+        assert_equals(parentReceivedEvent, parentShouldReceiveEvents,
+                      `parent element received ${eventName} events`);
+
+        const targetShouldReceiveEvents = eventName.startsWith('pointer');
+        assert_equals(targetReceivedEvent, targetShouldReceiveEvents,
+                      `target element received ${eventName} events`);
+        assert_equals(childReceivedEvent, clickChildElement,
+                      `child element received ${eventName} events`);
+      }, `Testing ${eventName} events when clicking ${clickChildElement ? 'child of ' : ''}disabled ${target.localName}.`);
+    }
+  });
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative-expected.txt
@@ -1,0 +1,34 @@
+                                            Span
+Span Text
+
+PASS Untrusted key events on <input>, observed from <form>
+PASS Untrusted key events on <select disabled=""></select>, observed from <form>
+PASS Untrusted key events on <textarea disabled=""></textarea>, observed from <form>
+PASS Untrusted key events on <input disabled="" type="button">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="checkbox">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="color" value="#000000">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="date">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="datetime-local">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="email">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="file">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="image">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="month">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="number">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="password">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="radio">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="range" value="0">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="reset">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="search">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="submit">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="tel">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="text">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="time">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="url">, observed from <form>
+PASS Untrusted key events on <input disabled="" type="week">, observed from <form>
+PASS Untrusted key events on <fieldset disabled=""><span tabindex="0">Span</span></fieldset>, observed from <form>
+PASS Trusted key events on <fieldset disabled=""><span tabindex="0">Span</span></fieldset>, observed from <form>
+PASS Untrusted key events on <button disabled=""><span tabindex="0">Span</span></button>, observed from <form>
+PASS Trusted key events on <button disabled=""><span tabindex="0">Span</span></button>, observed from <form>
+FAIL Untrusted key events on <custom-control disabled="">Text</custom-control>, observed from <form> assert_array_equals: Observed events lengths differ, expected array ["keydown", "keyup"] length 2, got [] length 0
+PASS Trusted key events on <custom-control disabled="">Text</custom-control>, observed from <form>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>KeyboardEvent propagation on disabled form elements</title>
+<link rel="author" href="mailto:avandolder@mozilla.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script>
+  class CustomControl extends HTMLElement {
+    static get formAssociated() {return true;}
+
+    constructor() {
+      super();
+      this.internals = this.attachInternals();
+
+      this.attachShadow({mode: "open", delegatesFocus: true});
+      this.shadowRoot.append(
+        document.querySelector("template").content.cloneNode(true)
+      );
+    }
+
+    get target() {
+      return this.shadowRoot.getElementById("target");
+    }
+  }
+
+  customElements.define("custom-control", CustomControl)
+</script>
+
+<template>
+  <div tabindex="0" id="target">
+    <slot></slot>
+  </div>
+</template>
+
+<div tabindex="0" id="reset"></div>
+
+<form id="form">
+  <input> <!-- Sanity check with non-disabled control -->
+  <select disabled></select>
+  <textarea disabled></textarea>
+  <input disabled type="button">
+  <input disabled type="checkbox">
+  <input disabled type="color" value="#000000">
+  <input disabled type="date">
+  <input disabled type="datetime-local">
+  <input disabled type="email">
+  <input disabled type="file">
+  <input disabled type="image">
+  <input disabled type="month">
+  <input disabled type="number">
+  <input disabled type="password">
+  <input disabled type="radio">
+  <input disabled type="range" value="0">
+  <input disabled type="reset">
+  <input disabled type="search">
+  <input disabled type="submit">
+  <input disabled type="tel">
+  <input disabled type="text">
+  <input disabled type="time">
+  <input disabled type="url">
+  <input disabled type="week">
+
+  <fieldset disabled><span tabindex="0">Span</span></fieldset>
+  <button disabled><span tabindex="0">Span</span></button>
+  <custom-control disabled>Text</custom-control>
+</form>
+
+<script>
+  const keyEvents = ["keydown", "keyup"];
+
+  function setupTest(t, element, observingElement) {
+    const observedEvents = [];
+    const controller = new AbortController();
+    const {signal} = controller;
+    const listenerFn = t.step_func(event => {
+      observedEvents.push(event.type);
+    });
+    for (const event of keyEvents) {
+      observingElement.addEventListener(event, listenerFn, {signal});
+    }
+    t.add_cleanup(() => controller.abort());
+
+    const target = element;
+    return {target, observedEvents};
+  }
+
+  function fire_trusted_key_events(target) {
+    const actions = new test_driver.Actions();
+    return actions.keyDown("a").keyUp("a").send();
+  }
+
+  function fire_untrusted_key_events(target) {
+    target.dispatchEvent(new KeyboardEvent("keydown", {bubbles: true}));
+    target.dispatchEvent(new KeyboardEvent("keyup", {bubbles: true}));
+  }
+
+  const observingElement = document.getElementById("form");
+  const reset = document.getElementById("reset");
+
+  for (const element of observingElement.children) {
+    promise_test(async t => {
+      const {observedEvents} = setupTest(t, element, observingElement);
+
+      const target = element.firstElementChild ?? element.target ?? element;
+      await t.step_func(fire_untrusted_key_events)(target);
+      await new Promise(resolve => t.step_timeout(resolve, 0));
+
+      assert_array_equals(observedEvents, keyEvents, "Observed events");
+    }, `Untrusted key events on ${element.outerHTML}, observed from <${observingElement.localName}>`);
+
+    // Only test elements with children for trusted key events.
+    if (!element.firstElementChild && !element.target) {
+      continue;
+    }
+
+    promise_test(async t => {
+      const {observedEvents} = setupTest(t, element, observingElement);
+
+      const target = element.firstElementChild ?? element.target;
+
+      reset.focus();
+      assert_not_equals(document.activeElement, target, "Reset current focus");
+      target.focus();
+      assert_equals(document.activeElement, element.firstElementChild ?? element, "Focus the target element");
+
+      await t.step_func(fire_trusted_key_events)(target);
+      await new Promise(resolve => t.step_timeout(resolve, 0));
+
+      assert_array_equals(observedEvents, keyEvents, "Observed events");
+    }, `Trusted key events on ${element.outerHTML}, observed from <${observingElement.localName}>`);
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative-expected.txt
@@ -1,0 +1,285 @@
+     Text
+Span
+Text  Span                                            Text
+
+PASS Trusted click on <input>, observed from <input>
+PASS Trusted click on <input>, observed from <body>
+PASS Dispatch new MouseEvent() on <input>, observed from <input>
+PASS Dispatch new MouseEvent() on <input>, observed from <body>
+PASS Dispatch new PointerEvent() on <input>, observed from <input>
+PASS Dispatch new PointerEvent() on <input>, observed from <body>
+PASS click() on <input>, observed from <input>
+PASS click() on <input>, observed from <body>
+FAIL Trusted click on <select disabled=""></select>, observed from <select> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <select disabled=""></select>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <select disabled=""></select>, observed from <select>
+PASS Dispatch new MouseEvent() on <select disabled=""></select>, observed from <body>
+PASS Dispatch new PointerEvent() on <select disabled=""></select>, observed from <select>
+PASS Dispatch new PointerEvent() on <select disabled=""></select>, observed from <body>
+PASS click() on <select disabled=""></select>, observed from <select>
+PASS click() on <select disabled=""></select>, observed from <body>
+FAIL Trusted click on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <select> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <select>
+PASS Dispatch new MouseEvent() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <body>
+PASS Dispatch new PointerEvent() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <select>
+PASS Dispatch new PointerEvent() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <body>
+PASS click() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <select>
+PASS click() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <body>
+FAIL Trusted click on <fieldset disabled="">Text</fieldset>, observed from <fieldset> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <fieldset disabled="">Text</fieldset>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <fieldset disabled="">Text</fieldset>, observed from <fieldset>
+PASS Dispatch new MouseEvent() on <fieldset disabled="">Text</fieldset>, observed from <body>
+PASS Dispatch new PointerEvent() on <fieldset disabled="">Text</fieldset>, observed from <fieldset>
+PASS Dispatch new PointerEvent() on <fieldset disabled="">Text</fieldset>, observed from <body>
+PASS click() on <fieldset disabled="">Text</fieldset>, observed from <fieldset>
+PASS click() on <fieldset disabled="">Text</fieldset>, observed from <body>
+FAIL Trusted click on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span> assert_array_equals: mousedown.composedPath lengths differ, expected array ["HTMLSpanElement"] length 1, got ["HTMLSpanElement", "HTMLFieldSetElement", "HTMLDivElement", "HTMLBodyElement", "HTMLHtmlElement", "HTMLDocument", "Window"] length 7
+FAIL Trusted click on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>
+PASS Dispatch new MouseEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset>
+PASS Dispatch new MouseEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body>
+PASS Dispatch new PointerEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>
+PASS Dispatch new PointerEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset>
+PASS Dispatch new PointerEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body>
+PASS click() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>
+PASS click() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset>
+PASS click() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body>
+FAIL Trusted click on <button disabled="">Text</button>, observed from <button> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <button disabled="">Text</button>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <button disabled="">Text</button>, observed from <button>
+PASS Dispatch new MouseEvent() on <button disabled="">Text</button>, observed from <body>
+PASS Dispatch new PointerEvent() on <button disabled="">Text</button>, observed from <button>
+PASS Dispatch new PointerEvent() on <button disabled="">Text</button>, observed from <body>
+PASS click() on <button disabled="">Text</button>, observed from <button>
+PASS click() on <button disabled="">Text</button>, observed from <body>
+FAIL Trusted click on <button disabled=""><span class="target">Span</span></button>, observed from <span> assert_array_equals: mousedown.composedPath lengths differ, expected array ["HTMLSpanElement"] length 1, got ["HTMLSpanElement", "HTMLButtonElement", "HTMLDivElement", "HTMLBodyElement", "HTMLHtmlElement", "HTMLDocument", "Window"] length 7
+FAIL Trusted click on <button disabled=""><span class="target">Span</span></button>, observed from <button> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <button disabled=""><span class="target">Span</span></button>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <span>
+PASS Dispatch new MouseEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <button>
+PASS Dispatch new MouseEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <body>
+PASS Dispatch new PointerEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <span>
+PASS Dispatch new PointerEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <button>
+PASS Dispatch new PointerEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <body>
+PASS click() on <button disabled=""><span class="target">Span</span></button>, observed from <span>
+PASS click() on <button disabled=""><span class="target">Span</span></button>, observed from <button>
+PASS click() on <button disabled=""><span class="target">Span</span></button>, observed from <body>
+FAIL Trusted click on <textarea disabled=""></textarea>, observed from <textarea> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <textarea disabled=""></textarea>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <textarea disabled=""></textarea>, observed from <textarea>
+PASS Dispatch new MouseEvent() on <textarea disabled=""></textarea>, observed from <body>
+PASS Dispatch new PointerEvent() on <textarea disabled=""></textarea>, observed from <textarea>
+PASS Dispatch new PointerEvent() on <textarea disabled=""></textarea>, observed from <body>
+PASS click() on <textarea disabled=""></textarea>, observed from <textarea>
+PASS click() on <textarea disabled=""></textarea>, observed from <body>
+FAIL Trusted click on <input disabled="" type="button">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="button">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="button">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="button">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="button">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="button">, observed from <body>
+PASS click() on <input disabled="" type="button">, observed from <input>
+PASS click() on <input disabled="" type="button">, observed from <body>
+FAIL Trusted click on <input disabled="" type="checkbox">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="checkbox">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="checkbox">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="checkbox">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="checkbox">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="checkbox">, observed from <body>
+PASS click() on <input disabled="" type="checkbox">, observed from <input>
+PASS click() on <input disabled="" type="checkbox">, observed from <body>
+FAIL Trusted click on <input disabled="" type="color" value="#000000">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="color" value="#000000">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="color" value="#000000">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="color" value="#000000">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="color" value="#000000">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="color" value="#000000">, observed from <body>
+PASS click() on <input disabled="" type="color" value="#000000">, observed from <input>
+PASS click() on <input disabled="" type="color" value="#000000">, observed from <body>
+FAIL Trusted click on <input disabled="" type="date">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="date">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="date">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="date">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="date">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="date">, observed from <body>
+PASS click() on <input disabled="" type="date">, observed from <input>
+PASS click() on <input disabled="" type="date">, observed from <body>
+FAIL Trusted click on <input disabled="" type="datetime-local">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="datetime-local">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="datetime-local">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="datetime-local">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="datetime-local">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="datetime-local">, observed from <body>
+PASS click() on <input disabled="" type="datetime-local">, observed from <input>
+PASS click() on <input disabled="" type="datetime-local">, observed from <body>
+FAIL Trusted click on <input disabled="" type="email">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="email">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <input disabled="" type="email">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="email">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="email">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="email">, observed from <body>
+PASS click() on <input disabled="" type="email">, observed from <input>
+PASS click() on <input disabled="" type="email">, observed from <body>
+FAIL Trusted click on <input disabled="" type="file">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="file">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="file">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="file">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="file">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="file">, observed from <body>
+PASS click() on <input disabled="" type="file">, observed from <input>
+PASS click() on <input disabled="" type="file">, observed from <body>
+FAIL Trusted click on <input disabled="" type="image">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="image">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="image">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="image">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="image">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="image">, observed from <body>
+PASS click() on <input disabled="" type="image">, observed from <input>
+PASS click() on <input disabled="" type="image">, observed from <body>
+FAIL Trusted click on <input disabled="" type="month">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="month">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="month">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="month">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="month">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="month">, observed from <body>
+PASS click() on <input disabled="" type="month">, observed from <input>
+PASS click() on <input disabled="" type="month">, observed from <body>
+FAIL Trusted click on <input disabled="" type="number">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="number">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <input disabled="" type="number">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="number">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="number">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="number">, observed from <body>
+PASS click() on <input disabled="" type="number">, observed from <input>
+PASS click() on <input disabled="" type="number">, observed from <body>
+FAIL Trusted click on <input disabled="" type="password">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="password">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <input disabled="" type="password">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="password">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="password">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="password">, observed from <body>
+PASS click() on <input disabled="" type="password">, observed from <input>
+PASS click() on <input disabled="" type="password">, observed from <body>
+FAIL Trusted click on <input disabled="" type="radio">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="radio">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="radio">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="radio">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="radio">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="radio">, observed from <body>
+PASS click() on <input disabled="" type="radio">, observed from <input>
+PASS click() on <input disabled="" type="radio">, observed from <body>
+FAIL Trusted click on <input disabled="" type="range" value="0">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="range" value="0">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="range" value="0">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="range" value="0">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="range" value="0">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="range" value="0">, observed from <body>
+PASS click() on <input disabled="" type="range" value="0">, observed from <input>
+PASS click() on <input disabled="" type="range" value="0">, observed from <body>
+FAIL Trusted click on <input disabled="" type="range" value="50">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="range" value="50">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <input disabled="" type="range" value="50">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="range" value="50">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="range" value="50">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="range" value="50">, observed from <body>
+PASS click() on <input disabled="" type="range" value="50">, observed from <input>
+PASS click() on <input disabled="" type="range" value="50">, observed from <body>
+FAIL Trusted click on <input disabled="" type="reset">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="reset">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="reset">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="reset">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="reset">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="reset">, observed from <body>
+PASS click() on <input disabled="" type="reset">, observed from <input>
+PASS click() on <input disabled="" type="reset">, observed from <body>
+FAIL Trusted click on <input disabled="" type="search">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="search">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <input disabled="" type="search">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="search">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="search">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="search">, observed from <body>
+PASS click() on <input disabled="" type="search">, observed from <input>
+PASS click() on <input disabled="" type="search">, observed from <body>
+FAIL Trusted click on <input disabled="" type="submit">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="submit">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="submit">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="submit">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="submit">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="submit">, observed from <body>
+PASS click() on <input disabled="" type="submit">, observed from <input>
+PASS click() on <input disabled="" type="submit">, observed from <body>
+FAIL Trusted click on <input disabled="" type="tel">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="tel">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <input disabled="" type="tel">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="tel">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="tel">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="tel">, observed from <body>
+PASS click() on <input disabled="" type="tel">, observed from <input>
+PASS click() on <input disabled="" type="tel">, observed from <body>
+FAIL Trusted click on <input disabled="" type="text">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="text">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <input disabled="" type="text">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="text">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="text">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="text">, observed from <body>
+PASS click() on <input disabled="" type="text">, observed from <input>
+PASS click() on <input disabled="" type="text">, observed from <body>
+FAIL Trusted click on <input disabled="" type="time">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="time">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="time">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="time">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="time">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="time">, observed from <body>
+PASS click() on <input disabled="" type="time">, observed from <input>
+PASS click() on <input disabled="" type="time">, observed from <body>
+FAIL Trusted click on <input disabled="" type="url">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="url">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7
+PASS Dispatch new MouseEvent() on <input disabled="" type="url">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="url">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="url">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="url">, observed from <body>
+PASS click() on <input disabled="" type="url">, observed from <input>
+PASS click() on <input disabled="" type="url">, observed from <body>
+FAIL Trusted click on <input disabled="" type="week">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="week">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="week">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="week">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="week">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="week">, observed from <body>
+PASS click() on <input disabled="" type="week">, observed from <input>
+PASS click() on <input disabled="" type="week">, observed from <body>
+FAIL Trusted click on <my-control disabled="">Text</my-control>, observed from <my-control> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <my-control disabled="">Text</my-control>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <my-control disabled="">Text</my-control>, observed from <my-control>
+PASS Dispatch new MouseEvent() on <my-control disabled="">Text</my-control>, observed from <body>
+PASS Dispatch new PointerEvent() on <my-control disabled="">Text</my-control>, observed from <my-control>
+PASS Dispatch new PointerEvent() on <my-control disabled="">Text</my-control>, observed from <body>
+PASS click() on <my-control disabled="">Text</my-control>, observed from <my-control>
+PASS click() on <my-control disabled="">Text</my-control>, observed from <body>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<meta charset="utf8">
+<meta name="timeout" content="long">
+<title>Event propagation on disabled form elements</title>
+<link rel="author" href="mailto:krosylight@mozilla.com">
+<link rel="help" href="https://github.com/whatwg/html/issues/2368">
+<link rel="help" href="https://github.com/whatwg/html/issues/5886">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+
+<div id="cases">
+  <input> <!-- Sanity check with non-disabled control -->
+  <select disabled></select>
+  <select disabled>
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>
+  <fieldset disabled>Text</fieldset>
+  <fieldset disabled><span class="target">Span</span></fieldset>
+  <button disabled>Text</button>
+  <button disabled><span class="target">Span</span></button>
+  <textarea disabled></textarea>
+  <input disabled type="button">
+  <input disabled type="checkbox">
+  <input disabled type="color" value="#000000">
+  <input disabled type="date">
+  <input disabled type="datetime-local">
+  <input disabled type="email">
+  <input disabled type="file">
+  <input disabled type="image">
+  <input disabled type="month">
+  <input disabled type="number">
+  <input disabled type="password">
+  <input disabled type="radio">
+  <!-- Native click will click the bar -->
+  <input disabled type="range" value="0">
+  <!-- Native click will click the slider -->
+  <input disabled type="range" value="50">
+  <input disabled type="reset">
+  <input disabled type="search">
+  <input disabled type="submit">
+  <input disabled type="tel">
+  <input disabled type="text">
+  <input disabled type="time">
+  <input disabled type="url">
+  <input disabled type="week">
+  <my-control disabled>Text</my-control>
+</div>
+
+<script>
+  customElements.define('my-control', class extends HTMLElement {
+    static get formAssociated() { return true; }
+    get disabled() { return this.hasAttribute("disabled"); }
+  });
+
+  /**
+   * @param {Element} element
+   */
+  function getEventFiringTarget(element) {
+    return element.querySelector(".target") || element;
+  }
+
+  const allEvents = ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"];
+
+  /**
+   * @param {*} t
+   * @param {Element} element
+   * @param {Element} observingElement
+   */
+  function setupTest(t, element, observingElement) {
+    /** @type {{type: string, composedPath: Node[]}[]} */
+    const observedEvents = [];
+    const controller = new AbortController();
+    const { signal } = controller;
+    const listenerFn = t.step_func(event => {
+      observedEvents.push({
+        type: event.type,
+        target: event.target,
+        isTrusted: event.isTrusted,
+        composedPath: event.composedPath().map(n => n.constructor.name),
+      });
+    });
+    for (const event of allEvents) {
+      observingElement.addEventListener(event, listenerFn, { signal });
+    }
+    t.add_cleanup(() => controller.abort());
+
+    const target = getEventFiringTarget(element);
+    return { target, observedEvents };
+  }
+
+  /**
+   * @param {Element} target
+   * @param {*} observedEvent
+   */
+  function shouldNotBubble(target, observedEvent) {
+    return (
+      target.disabled &&
+      observedEvent.isTrusted &&
+      ["mousedown", "mouseup", "click"].includes(observedEvent.type)
+    );
+  }
+
+  /**
+   * @param {Event} event
+   */
+  function getExpectedComposedPath(event) {
+    let target = event.target;
+    const result = [];
+    while (target) {
+      if (shouldNotBubble(target, event)) {
+        return result;
+      }
+      result.push(target.constructor.name);
+      target = target.parentNode;
+    }
+    result.push("Window");
+    return result;
+  }
+
+  /**
+  * @param {object} options
+  * @param {Element & { disabled: boolean }} options.element
+  * @param {Element} options.observingElement
+  * @param {string[]} options.expectedEvents
+  * @param {(target: Element) => (Promise<void> | void)} options.clickerFn
+  * @param {string} options.title
+  */
+  function promise_event_test({ element, observingElement, expectedEvents, nonDisabledExpectedEvents, clickerFn, title }) {
+    promise_test(async t => {
+      const { target, observedEvents } = setupTest(t, element, observingElement);
+
+      await t.step_func(clickerFn)(target);
+      await new Promise(resolve => t.step_timeout(resolve, 0));
+
+      const expected = element.disabled ? expectedEvents : nonDisabledExpectedEvents;
+      assert_array_equals(observedEvents.map(e => e.type), expected, "Observed events");
+
+      for (const observed of observedEvents) {
+        assert_equals(observed.target, target, `${observed.type}.target`)
+        assert_array_equals(
+          observed.composedPath,
+          getExpectedComposedPath(observed),
+          `${observed.type}.composedPath`
+        );
+      }
+
+    }, `${title} on ${element.outerHTML}, observed from <${observingElement.localName}>`);
+  }
+
+  /**
+   * @param {object} options
+   * @param {Element & { disabled: boolean }} options.element
+   * @param {string[]} options.expectedEvents
+   * @param {(target: Element) => (Promise<void> | void)} options.clickerFn
+   * @param {string} options.title
+   */
+  function promise_event_test_hierarchy({ element, expectedEvents, nonDisabledExpectedEvents, clickerFn, title }) {
+    const targets = [element, document.body];
+    if (element.querySelector(".target")) {
+      targets.unshift(element.querySelector(".target"));
+    }
+    for (const observingElement of targets) {
+      promise_event_test({ element, observingElement, expectedEvents, nonDisabledExpectedEvents, clickerFn, title });
+    }
+  }
+
+  function trusted_click(target) {
+    // To workaround type=file clicking issue
+    // https://github.com/w3c/webdriver/issues/1666
+    return new test_driver.Actions()
+      .pointerMove(0, 0, { origin: target })
+      .pointerDown()
+      .pointerUp()
+      .send();
+  }
+
+  const mouseEvents = ["mousemove", "mousedown", "mouseup", "click"];
+  const pointerEvents = ["pointermove", "pointerdown", "pointerup"];
+
+  // Events except mousedown/up/click
+  const allowedEvents = ["pointermove", "mousemove", "pointerdown", "pointerup"];
+
+  const elements = document.getElementById("cases").children;
+  for (const element of elements) {
+    // Observe on a child element of the control, if exists
+    const target = element.querySelector(".target");
+    if (target) {
+      promise_event_test({
+        element,
+        observingElement: target,
+        expectedEvents: allEvents,
+        nonDisabledExpectedEvents: allEvents,
+        clickerFn: trusted_click,
+        title: "Trusted click"
+      });
+    }
+
+    // Observe on the control itself
+    promise_event_test({
+      element,
+      observingElement: element,
+      expectedEvents: allowedEvents,
+      nonDisabledExpectedEvents: allEvents,
+      clickerFn: trusted_click,
+      title: "Trusted click"
+    });
+
+    // Observe on document.body
+    promise_event_test({
+      element,
+      observingElement: document.body,
+      expectedEvents: allowedEvents,
+      nonDisabledExpectedEvents: allEvents,
+      clickerFn: trusted_click,
+      title: "Trusted click"
+    });
+
+    const eventFirePair = [
+      [MouseEvent, mouseEvents],
+      [PointerEvent, pointerEvents]
+    ];
+
+    for (const [eventInterface, events] of eventFirePair) {
+      promise_event_test_hierarchy({
+        element,
+        expectedEvents: events,
+        nonDisabledExpectedEvents: events,
+        clickerFn: target => {
+          for (const event of events) {
+            target.dispatchEvent(new eventInterface(event, { bubbles: true }))
+          }
+        },
+        title: `Dispatch new ${eventInterface.name}()`
+      })
+    }
+
+    promise_event_test_hierarchy({
+      element,
+      expectedEvents: getEventFiringTarget(element) === element ? [] : ["click"],
+      nonDisabledExpectedEvents: ["click"],
+      clickerFn: target => target.click(),
+      title: `click()`
+    })
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/fieldset-event-propagation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/fieldset-event-propagation.tentative-expected.txt
@@ -1,0 +1,7 @@
+
+hello world
+hello world
+
+FAIL Disabled fieldset elements should not prevent click event propagation. assert_true: The fieldset element should receive a click event. expected true got false
+FAIL Disabled fieldset elements should not block click events. assert_true: The parent of the fieldset should receive a click event. expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/fieldset-event-propagation.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/fieldset-event-propagation.tentative.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-disabled">
+<link rel=help href="https://github.com/whatwg/html/issues/5886#issuecomment-1460425364">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+
+<div id=target1parent>
+  <fieldset disabled id=target1fieldset>
+    <div id=target1child>hello world</div>
+  </fieldset>
+</div>
+
+<div id=target2parent>
+  <fieldset disabled id=target2fieldset>hello world</div>
+</div>
+
+<script>
+promise_test(async () => {
+  let target1parentClicked = false;
+  let target1childClicked = false;
+  let target1fieldsetClicked = false;
+  target1parent.onclick = () => target1parentClicked = true;
+  target1child.onclick = () => target1childClicked = true;
+  target1fieldset.onclick = () => target1fieldsetClicked = true;
+
+  await test_driver.click(target1child);
+
+  assert_true(target1parentClicked, 'The parent of the fieldset should receive a click event.');
+  assert_true(target1childClicked, 'The child of the fieldset should receive a click event.');
+  assert_true(target1fieldsetClicked, 'The fieldset element should receive a click event.');
+}, 'Disabled fieldset elements should not prevent click event propagation.');
+
+promise_test(async () => {
+  let target2parentClicked = false;
+  let target2fieldsetClicked = false;
+  target2parent.onclick = () => target2parentClicked = true;
+  target2fieldset.onclick = () => target2fieldsetClicked = true;
+
+  await test_driver.click(target2fieldset);
+
+  assert_true(target2parentClicked, 'The parent of the fieldset should receive a click event.');
+  assert_true(target2fieldsetClicked, 'The fieldset element should receive a click event.');
+}, 'Disabled fieldset elements should not block click events.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/w3c-import.log
@@ -14,4 +14,8 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabledElement.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/fieldset-event-propagation.tentative.html

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative-expected.txt
@@ -1,0 +1,285 @@
+     Text
+Span
+Text  Span                                           Text
+
+FAIL Trusted click on <input>, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+FAIL Trusted click on <input>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input>, observed from <input>
+PASS Dispatch new MouseEvent() on <input>, observed from <body>
+PASS Dispatch new PointerEvent() on <input>, observed from <input>
+PASS Dispatch new PointerEvent() on <input>, observed from <body>
+PASS click() on <input>, observed from <input>
+PASS click() on <input>, observed from <body>
+FAIL Trusted click on <select disabled=""></select>, observed from <select> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <select disabled=""></select>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <select disabled=""></select>, observed from <select>
+PASS Dispatch new MouseEvent() on <select disabled=""></select>, observed from <body>
+PASS Dispatch new PointerEvent() on <select disabled=""></select>, observed from <select>
+PASS Dispatch new PointerEvent() on <select disabled=""></select>, observed from <body>
+PASS click() on <select disabled=""></select>, observed from <select>
+PASS click() on <select disabled=""></select>, observed from <body>
+FAIL Trusted click on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <select> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <select>
+PASS Dispatch new MouseEvent() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <body>
+PASS Dispatch new PointerEvent() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <select>
+PASS Dispatch new PointerEvent() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <body>
+PASS click() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <select>
+PASS click() on <select disabled="">
+    <!-- <option> can't be clicked as it doesn't have its own painting area -->
+    <option>foo</option>
+  </select>, observed from <body>
+FAIL Trusted click on <fieldset disabled="">Text</fieldset>, observed from <fieldset> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <fieldset disabled="">Text</fieldset>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <fieldset disabled="">Text</fieldset>, observed from <fieldset>
+PASS Dispatch new MouseEvent() on <fieldset disabled="">Text</fieldset>, observed from <body>
+PASS Dispatch new PointerEvent() on <fieldset disabled="">Text</fieldset>, observed from <fieldset>
+PASS Dispatch new PointerEvent() on <fieldset disabled="">Text</fieldset>, observed from <body>
+PASS click() on <fieldset disabled="">Text</fieldset>, observed from <fieldset>
+PASS click() on <fieldset disabled="">Text</fieldset>, observed from <body>
+FAIL Trusted click on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+FAIL Trusted click on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>
+PASS Dispatch new MouseEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset>
+PASS Dispatch new MouseEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body>
+PASS Dispatch new PointerEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>
+PASS Dispatch new PointerEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset>
+PASS Dispatch new PointerEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body>
+PASS click() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>
+PASS click() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset>
+PASS click() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body>
+FAIL Trusted click on <button disabled="">Text</button>, observed from <button> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <button disabled="">Text</button>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <button disabled="">Text</button>, observed from <button>
+PASS Dispatch new MouseEvent() on <button disabled="">Text</button>, observed from <body>
+PASS Dispatch new PointerEvent() on <button disabled="">Text</button>, observed from <button>
+PASS Dispatch new PointerEvent() on <button disabled="">Text</button>, observed from <body>
+PASS click() on <button disabled="">Text</button>, observed from <button>
+PASS click() on <button disabled="">Text</button>, observed from <body>
+FAIL Trusted click on <button disabled=""><span class="target">Span</span></button>, observed from <span> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click"] length 7, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+FAIL Trusted click on <button disabled=""><span class="target">Span</span></button>, observed from <button> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <button disabled=""><span class="target">Span</span></button>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <span>
+PASS Dispatch new MouseEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <button>
+PASS Dispatch new MouseEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <body>
+PASS Dispatch new PointerEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <span>
+PASS Dispatch new PointerEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <button>
+PASS Dispatch new PointerEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <body>
+PASS click() on <button disabled=""><span class="target">Span</span></button>, observed from <span>
+PASS click() on <button disabled=""><span class="target">Span</span></button>, observed from <button>
+PASS click() on <button disabled=""><span class="target">Span</span></button>, observed from <body>
+FAIL Trusted click on <textarea disabled=""></textarea>, observed from <textarea> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <textarea disabled=""></textarea>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <textarea disabled=""></textarea>, observed from <textarea>
+PASS Dispatch new MouseEvent() on <textarea disabled=""></textarea>, observed from <body>
+PASS Dispatch new PointerEvent() on <textarea disabled=""></textarea>, observed from <textarea>
+PASS Dispatch new PointerEvent() on <textarea disabled=""></textarea>, observed from <body>
+PASS click() on <textarea disabled=""></textarea>, observed from <textarea>
+PASS click() on <textarea disabled=""></textarea>, observed from <body>
+FAIL Trusted click on <input disabled="" type="button">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="button">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="button">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="button">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="button">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="button">, observed from <body>
+PASS click() on <input disabled="" type="button">, observed from <input>
+PASS click() on <input disabled="" type="button">, observed from <body>
+FAIL Trusted click on <input disabled="" type="checkbox">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="checkbox">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="checkbox">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="checkbox">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="checkbox">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="checkbox">, observed from <body>
+PASS click() on <input disabled="" type="checkbox">, observed from <input>
+PASS click() on <input disabled="" type="checkbox">, observed from <body>
+FAIL Trusted click on <input disabled="" type="color" value="#000000">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="color" value="#000000">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="color" value="#000000">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="color" value="#000000">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="color" value="#000000">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="color" value="#000000">, observed from <body>
+PASS click() on <input disabled="" type="color" value="#000000">, observed from <input>
+PASS click() on <input disabled="" type="color" value="#000000">, observed from <body>
+FAIL Trusted click on <input disabled="" type="date">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="date">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="date">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="date">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="date">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="date">, observed from <body>
+PASS click() on <input disabled="" type="date">, observed from <input>
+PASS click() on <input disabled="" type="date">, observed from <body>
+FAIL Trusted click on <input disabled="" type="datetime-local">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="datetime-local">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="datetime-local">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="datetime-local">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="datetime-local">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="datetime-local">, observed from <body>
+PASS click() on <input disabled="" type="datetime-local">, observed from <input>
+PASS click() on <input disabled="" type="datetime-local">, observed from <body>
+FAIL Trusted click on <input disabled="" type="email">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="email">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="email">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="email">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="email">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="email">, observed from <body>
+PASS click() on <input disabled="" type="email">, observed from <input>
+PASS click() on <input disabled="" type="email">, observed from <body>
+FAIL Trusted click on <input disabled="" type="file">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="file">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="file">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="file">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="file">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="file">, observed from <body>
+PASS click() on <input disabled="" type="file">, observed from <input>
+PASS click() on <input disabled="" type="file">, observed from <body>
+FAIL Trusted click on <input disabled="" type="image">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="image">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="image">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="image">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="image">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="image">, observed from <body>
+PASS click() on <input disabled="" type="image">, observed from <input>
+PASS click() on <input disabled="" type="image">, observed from <body>
+FAIL Trusted click on <input disabled="" type="month">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="month">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="month">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="month">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="month">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="month">, observed from <body>
+PASS click() on <input disabled="" type="month">, observed from <input>
+PASS click() on <input disabled="" type="month">, observed from <body>
+FAIL Trusted click on <input disabled="" type="number">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="number">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="number">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="number">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="number">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="number">, observed from <body>
+PASS click() on <input disabled="" type="number">, observed from <input>
+PASS click() on <input disabled="" type="number">, observed from <body>
+FAIL Trusted click on <input disabled="" type="password">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="password">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="password">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="password">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="password">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="password">, observed from <body>
+PASS click() on <input disabled="" type="password">, observed from <input>
+PASS click() on <input disabled="" type="password">, observed from <body>
+FAIL Trusted click on <input disabled="" type="radio">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="radio">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="radio">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="radio">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="radio">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="radio">, observed from <body>
+PASS click() on <input disabled="" type="radio">, observed from <input>
+PASS click() on <input disabled="" type="radio">, observed from <body>
+FAIL Trusted click on <input disabled="" type="range" value="0">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="range" value="0">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="range" value="0">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="range" value="0">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="range" value="0">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="range" value="0">, observed from <body>
+PASS click() on <input disabled="" type="range" value="0">, observed from <input>
+PASS click() on <input disabled="" type="range" value="0">, observed from <body>
+FAIL Trusted click on <input disabled="" type="range" value="50">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="range" value="50">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="range" value="50">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="range" value="50">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="range" value="50">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="range" value="50">, observed from <body>
+PASS click() on <input disabled="" type="range" value="50">, observed from <input>
+PASS click() on <input disabled="" type="range" value="50">, observed from <body>
+FAIL Trusted click on <input disabled="" type="reset">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="reset">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="reset">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="reset">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="reset">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="reset">, observed from <body>
+PASS click() on <input disabled="" type="reset">, observed from <input>
+PASS click() on <input disabled="" type="reset">, observed from <body>
+FAIL Trusted click on <input disabled="" type="search">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="search">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="search">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="search">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="search">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="search">, observed from <body>
+PASS click() on <input disabled="" type="search">, observed from <input>
+PASS click() on <input disabled="" type="search">, observed from <body>
+FAIL Trusted click on <input disabled="" type="submit">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="submit">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <input disabled="" type="submit">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="submit">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="submit">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="submit">, observed from <body>
+PASS click() on <input disabled="" type="submit">, observed from <input>
+PASS click() on <input disabled="" type="submit">, observed from <body>
+FAIL Trusted click on <input disabled="" type="tel">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="tel">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="tel">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="tel">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="tel">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="tel">, observed from <body>
+PASS click() on <input disabled="" type="tel">, observed from <input>
+PASS click() on <input disabled="" type="tel">, observed from <body>
+FAIL Trusted click on <input disabled="" type="text">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="text">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="text">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="text">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="text">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="text">, observed from <body>
+PASS click() on <input disabled="" type="text">, observed from <input>
+PASS click() on <input disabled="" type="text">, observed from <body>
+FAIL Trusted click on <input disabled="" type="time">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="time">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="time">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="time">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="time">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="time">, observed from <body>
+PASS click() on <input disabled="" type="time">, observed from <input>
+PASS click() on <input disabled="" type="time">, observed from <body>
+FAIL Trusted click on <input disabled="" type="url">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="url">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="url">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="url">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="url">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="url">, observed from <body>
+PASS click() on <input disabled="" type="url">, observed from <input>
+PASS click() on <input disabled="" type="url">, observed from <body>
+FAIL Trusted click on <input disabled="" type="week">, observed from <input> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <input disabled="" type="week">, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got ["pointermove", "mousemove", "pointerdown", "mousedown", "pointerup", "mouseup", "click", "pointermove", "mousemove"] length 9
+PASS Dispatch new MouseEvent() on <input disabled="" type="week">, observed from <input>
+PASS Dispatch new MouseEvent() on <input disabled="" type="week">, observed from <body>
+PASS Dispatch new PointerEvent() on <input disabled="" type="week">, observed from <input>
+PASS Dispatch new PointerEvent() on <input disabled="" type="week">, observed from <body>
+PASS click() on <input disabled="" type="week">, observed from <input>
+PASS click() on <input disabled="" type="week">, observed from <body>
+FAIL Trusted click on <my-control disabled="">Text</my-control>, observed from <my-control> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+FAIL Trusted click on <my-control disabled="">Text</my-control>, observed from <body> assert_array_equals: Observed events lengths differ, expected array ["pointermove", "mousemove", "pointerdown", "pointerup"] length 4, got [] length 0
+PASS Dispatch new MouseEvent() on <my-control disabled="">Text</my-control>, observed from <my-control>
+PASS Dispatch new MouseEvent() on <my-control disabled="">Text</my-control>, observed from <body>
+PASS Dispatch new PointerEvent() on <my-control disabled="">Text</my-control>, observed from <my-control>
+PASS Dispatch new PointerEvent() on <my-control disabled="">Text</my-control>, observed from <body>
+PASS click() on <my-control disabled="">Text</my-control>, observed from <my-control>
+PASS click() on <my-control disabled="">Text</my-control>, observed from <body>
+

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -3917,6 +3917,12 @@
     "imported/w3c/web-platform-tests/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-percentage.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/not-in-shadow-tree.html": [
         "slow"
     ],


### PR DESCRIPTION
#### 16077001ce94726ac524c57372dcc1f4c7c6c772
<pre>
Re-import html/semantics/disabled-elements WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=254779">https://bugs.webkit.org/show_bug.cgi?id=254779</a>
rdar://107445944

Reviewed by Ryosuke Niwa.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/35f6bf623496fda2d7146162b5e9c472ea952110">https://github.com/web-platform-tests/wpt/commit/35f6bf623496fda2d7146162b5e9c472ea952110</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/fieldset-event-propagation.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/fieldset-event-propagation.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/disabled-elements/w3c-import.log:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled.tentative-expected.txt: Added.
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/262383@main">https://commits.webkit.org/262383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5691155027396fd891e7a57e54df20b9be8a6fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1462 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/2278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1472 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/2278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1396 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1245 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/2125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/1258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1280 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1252 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/346 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1352 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->