### PR TITLE
image/jxl isn't added to the Accept: header when USE(JPEGXL) is enabled

### DIFF
--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -144,6 +144,15 @@ static constexpr ASCIILiteral acceptHeaderValueForAVIFImageResource()
 #endif
 }
 
+static constexpr ASCIILiteral acceptHeaderValueForJPEGXLImageResource()
+{
+#if USE(JPEGXL)
+    return "image/jxl,"_s;
+#else
+    return ""_s;
+#endif
+}
+
 static String acceptHeaderValueForAdditionalSupportedImageMIMETypes()
 {
     StringBuilder sb;
@@ -163,6 +172,7 @@ static String acceptHeaderValueForImageResource()
 {
     return String(acceptHeaderValueForWebPImageResource())
         + acceptHeaderValueForAVIFImageResource()
+        + acceptHeaderValueForJPEGXLImageResource()
         + acceptHeaderValueForAdditionalSupportedImageMIMETypes()
         + acceptHeaderValueForVideoImageResource(ImageDecoder::supportsMediaType(ImageDecoder::MediaType::Video))
         + "image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5"_s;


### PR DESCRIPTION
#### 8778787cbaef5a2237eb3cecd07ee515e59f6469
<pre>
image/jxl isn&apos;t added to the Accept: header when USE(JPEGXL) is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=254780">https://bugs.webkit.org/show_bug.cgi?id=254780</a>
rdar://107446115

Reviewed by Said Abou-Hallawa.

Just like AVIF, if an image format is enabled, it should be advertised in the Accept: header.

Because every port, AFAIK, has USE(JPEGXL) disabled, I didn&apos;t add an automated test for this.

* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::acceptHeaderValueForJPEGXLImageResource):
(WebCore::acceptHeaderValueForImageResource):

Canonical link: <a href="https://commits.webkit.org/262455@main">https://commits.webkit.org/262455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/591fc5f168acba7e7670b4b3bb6f329ee6661103

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1226 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1365 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2122 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1219 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1255 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2360 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1321 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1177 "1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1249 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/387 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1348 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->