### PR TITLE
[MotionMark] Live version of 4 tests just show a 403 Access Denied page

### DIFF
--- a/Websites/browserbench.org/MotionMark1.2/resources/debug-runner/tests.js
+++ b/Websites/browserbench.org/MotionMark1.2/resources/debug-runner/tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -183,7 +183,7 @@ Suites.push(new Suite("HTML suite",
             name: "CSS bouncing filter circles"
         },
         {
-            url: "bouncing-particles/bouncing-css-images.html?particleWidth=80&particleHeight=80&imageSrc=../resources/yin-yang.svg",
+            url: "bouncing-particles/bouncing-css-images.html?particleWidth=80&particleHeight=80",
             name: "CSS bouncing SVG images"
         },
         {
@@ -199,7 +199,7 @@ Suites.push(new Suite("HTML suite",
             name: "DOM particles, SVG masks"
         },
         {
-            url: "dom/compositing-transforms.html?particleWidth=50&particleHeight=50&filters=yes&imageSrc=../resources/yin-yang.svg",
+            url: "dom/compositing-transforms.html?particleWidth=50&particleHeight=50&filters=yes",
             name: "Composited Transforms"
         }
     ]
@@ -216,11 +216,11 @@ Suites.push(new Suite("Canvas suite",
             name: "canvas bouncing gradient circles"
         },
         {
-            url: "bouncing-particles/bouncing-canvas-images.html?particleWidth=80&particleHeight=80&imageSrc=../resources/yin-yang.svg",
+            url: "bouncing-particles/bouncing-canvas-images.html?particleWidth=80&particleHeight=80",
             name: "canvas bouncing SVG images"
         },
         {
-            url: "bouncing-particles/bouncing-canvas-images.html?particleWidth=80&particleHeight=80&imageSrc=../resources/yin-yang.png",
+            url: "bouncing-particles/bouncing-canvas-images.html?particleWidth=80&particleHeight=80",
             name: "canvas bouncing PNG images"
         },
         {
@@ -253,11 +253,11 @@ Suites.push(new Suite("SVG suite",
             name: "SVG bouncing gradient circles"
         },
         {
-            url: "bouncing-particles/bouncing-svg-images.html?particleWidth=80&particleHeight=80&imageSrc=../resources/yin-yang.svg",
+            url: "bouncing-particles/bouncing-svg-images.html?particleWidth=80&particleHeight=80",
             name: "SVG bouncing SVG images"
         },
         {
-            url: "bouncing-particles/bouncing-svg-images.html?particleWidth=80&particleHeight=80&imageSrc=../resources/yin-yang.png",
+            url: "bouncing-particles/bouncing-svg-images.html?particleWidth=80&particleHeight=80",
             name: "SVG bouncing PNG images"
         },
     ]

--- a/Websites/browserbench.org/MotionMark1.2/tests/bouncing-particles/resources/bouncing-canvas-images.js
+++ b/Websites/browserbench.org/MotionMark1.2/tests/bouncing-particles/resources/bouncing-canvas-images.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,7 +49,7 @@ BouncingCanvasImagesStage = Utilities.createSubclass(BouncingCanvasParticlesStag
     initialize: function(benchmark, options)
     {
         BouncingCanvasParticlesStage.prototype.initialize.call(this, benchmark, options);
-        var imageSrc = options["imageSrc"] || "resources/yin-yang.svg";
+        var imageSrc = options["imageSrc"] || "../resources/yin-yang.svg";
         this.imageElement = document.querySelector(".hidden[src=\"" + imageSrc + "\"]");
     },
 

--- a/Websites/browserbench.org/MotionMark1.2/tests/bouncing-particles/resources/bouncing-svg-images.js
+++ b/Websites/browserbench.org/MotionMark1.2/tests/bouncing-particles/resources/bouncing-svg-images.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,7 +45,7 @@ BouncingSvgImagesStage = Utilities.createSubclass(BouncingSvgParticlesStage,
     initialize: function(benchmark, options)
     {
         BouncingSvgParticlesStage.prototype.initialize.call(this, benchmark, options);
-        this.imageSrc = options["imageSrc"] || "resources/yin-yang.svg";
+        this.imageSrc = options["imageSrc"] || "../resources/yin-yang.svg";
     },
 
     createParticle: function()


### PR DESCRIPTION
#### 7e8331b4cad9e69af27575d0ada29e950e33f059
<pre>
[MotionMark] Live version of 4 tests just show a 403 Access Denied page
<a href="https://bugs.webkit.org/show_bug.cgi?id=254782">https://bugs.webkit.org/show_bug.cgi?id=254782</a>
rdar://107208247

Reviewed by Alexey Proskuryakov.

Apparently, the firewall that the live MotionMark site is behind doesn&apos;t like it when paths that include
the &quot;../&quot; string are part of query parameters in URLs. Luckily, MotionMark is already set up to do the right
thing when the query parameter is omitted, so this patch just deletes those query parameters and uses the
test-specific logic to fall back to the correct string anyway.

* Websites/browserbench.org/MotionMark1.2/resources/debug-runner/tests.js:
* Websites/browserbench.org/MotionMark1.2/tests/bouncing-particles/resources/bouncing-canvas-images.js:
(BouncingCanvasParticlesStage.call.initialize):
* Websites/browserbench.org/MotionMark1.2/tests/bouncing-particles/resources/bouncing-svg-images.js:
(BouncingSvgParticlesStage.call.initialize):

Canonical link: <a href="https://commits.webkit.org/262382@main">https://commits.webkit.org/262382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb4340e38acfbed8277808edb71994ff7e7fb5df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1461 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/2277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1472 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/1471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/2277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1395 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/2124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/1257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1276 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/1471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/345 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1351 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->