### PR TITLE
REGRESSION(259969@main): Screen sharing is no longer working in public builds and causing UIProcess to crash

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.h
@@ -48,6 +48,7 @@ public:
 
     static std::optional<CaptureDevice> screenCaptureDeviceWithPersistentID(const String&);
     static void screenCaptureDevices(Vector<CaptureDevice>&);
+    WEBCORE_EXPORT static std::optional<CaptureDevice> screenCaptureDeviceForMainDisplay();
 
 private:
 

--- a/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.mm
@@ -209,6 +209,17 @@ void CGDisplayStreamScreenCaptureSource::screenCaptureDevices(Vector<CaptureDevi
     }
 }
 
+std::optional<CaptureDevice> CGDisplayStreamScreenCaptureSource::screenCaptureDeviceForMainDisplay()
+{
+    auto screenID = displayID([NSScreen mainScreen]);
+    if (!CGDisplayIDToOpenGLDisplayMask(screenID))
+        return std::nullopt;
+
+    CaptureDevice device(String::number(screenID), CaptureDevice::DeviceType::Screen, makeString("Screen 0"));
+    device.setEnabled(true);
+    return { WTFMove(device) };
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM) && PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -34,6 +34,7 @@
 #import "WebPageProxy.h"
 #import "WebProcess.h"
 #import "WebProcessPool.h"
+#import <WebCore/CGDisplayStreamScreenCaptureSource.h>
 #import <WebCore/CaptureDeviceManager.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/MockRealtimeMediaSourceCenter.h>
@@ -240,11 +241,15 @@ void DisplayCaptureSessionManager::promptForGetDisplayMedia(UserMediaPermissionR
         else
             showWindowPicker(origin, WTFMove(completionHandler));
     });
-#else
-    completionHandler(std::nullopt);
-#endif
 
+#elif PLATFORM(MAC)
+
+    // There is no picker on systems without ScreenCaptureKit, so share the main screen.
+    completionHandler(CGDisplayStreamScreenCaptureSource::screenCaptureDeviceForMainDisplay());
+
+#endif
 }
+
 } // namespace WebKit
 
 #endif // PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)


### PR DESCRIPTION
#### 3bc64a5506e3a0324da4b6c4b99e3e99f4b3a947
<pre>
REGRESSION(259969@main): Screen sharing is no longer working in public builds and causing UIProcess to crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=254155">https://bugs.webkit.org/show_bug.cgi?id=254155</a>
rdar://107265903

Reviewed by Youenn Fablet.

If the user agrees to share a screen on a version of macOS that doesn&apos;t have the
ScreenCaptureKit picker, share the main screen. This restores the behavior before
<a href="https://commits.webkit.org/259969@main.">https://commits.webkit.org/259969@main.</a>

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.mm:
(WebCore::CGDisplayStreamScreenCaptureSource::screenCaptureDeviceForMainDisplay):
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::promptForGetDisplayMedia):

Canonical link: <a href="https://commits.webkit.org/262424@main">https://commits.webkit.org/262424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ce97a2890a3c3d6dfb66e645b6a9b93d62a99ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1304 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1420 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2242 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1274 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1345 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2425 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1398 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1324 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/370 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1441 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->