### PR TITLE
[margin-trim] Trigger layout on margin-trim style change.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-style-change-triggers-layout-block-start-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-style-change-triggers-layout-block-start-expected.txt
@@ -1,0 +1,4 @@
+
+PASS flexbox > item 1
+PASS flexbox > item 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-style-change-triggers-layout-block-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-style-change-triggers-layout-block-start.html
@@ -31,7 +31,7 @@ item {
 </flexbox>
 </div>
 <script>
-// Force the first layout to trim margins, set margin-trim to none, 
+// Force the first layout to trim margins, set margin-trim to none,
 // force a second layout, and then check to see if the margins were added back
 document.body.offsetHeight;
 document.querySelector("flexbox").style["margin-trim"] = "none";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-block-start-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-block-start-dynamic-expected.txt
@@ -1,8 +1,0 @@
-
-FAIL flexbox > item 1 assert_equals:
-<item data-expected-margin-top="10" data-offset-y="18"></item>
-offsetTop expected 18 but got 8
-FAIL flexbox > item 2 assert_equals:
-<item data-expected-margin-top="10" data-offset-y="78"></item>
-offsetTop expected 78 but got 68
-

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-end-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-block-end: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-end-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-end-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-block-end: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-end.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<link rel="match" href="flex-column-style-change-triggers-layout-block-end-ref.html">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+.initial-margin-trim {
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block-end: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox class="initial-margin-trim" id="to-no-margin-trim">
+        <item></item>
+    </flexbox>
+    <flexbox id="to-margin-trim">
+        <item></item>
+    </flexbox>
+</body>
+<script>
+document.body.offsetHeight;
+document.getElementById("to-no-margin-trim").style["margin-trim"] = "none";
+document.getElementById("to-margin-trim").style["margin-trim"] = "block-end";
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-start-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-start-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-block-start: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-start-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-start-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-block-start: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-start.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-column-style-change-triggers-layout-block-start-ref.html">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+.initial-margin-trim {
+    margin-trim: block-start;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block-start: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox class="initial-margin-trim" id="to-no-margin-trim">
+        <item></item>
+    </flexbox>
+    <flexbox id="to-margin-trim">
+        <item></item>
+    </flexbox>
+</body>
+<script>
+document.body.offsetHeight;
+document.getElementById("to-no-margin-trim").style["margin-trim"] = "none";
+document.getElementById("to-margin-trim").style["margin-trim"] = "block-start";
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-column-style-change-triggers-layout-block-ref.html">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    flex-direction: column;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+.initial-margin-trim {
+    margin-trim: block;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-block: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox class="initial-margin-trim" id="to-no-margin-trim">
+        <item></item>
+    </flexbox>
+    <flexbox id="to-margin-trim">
+        <item></item>
+    </flexbox>
+</body>
+<script>
+document.body.offsetHeight;
+document.getElementById("to-no-margin-trim").style["margin-trim"] = "none";
+document.getElementById("to-margin-trim").style["margin-trim"] = "block";
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-end-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-inline-end: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-end-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-end-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-inline-end: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-end.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<link rel="match" href="flex-row-style-change-triggers-layout-inline-end-ref.html">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+.initial-margin-trim {
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox id="to-no-margin-trim" class="initial-margin-trim">
+        <item></item>
+    </flexbox>
+    <flexbox id="to-margin-trim">
+        <item></item>
+    </flexbox>
+</body>
+<script>
+document.body.offsetHeight;
+document.getElementById("to-no-margin-trim").style["margin-trim"] = "none";
+document.getElementById("to-margin-trim").style["margin-trim"] = "inline-end";
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-inline: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-inline: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-start-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-start-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-inline-start: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-start-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-start-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+}
+.margin {
+    margin-inline-start: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox>
+        <item class="margin"></item>
+    </flexbox>
+    <flexbox>
+        <item></item>
+    </flexbox>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-start.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-row-style-change-triggers-layout-inline-start-ref.html">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+.initial-margin-trim {
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline-start: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox class="initial-margin-trim" id="to-no-margin-trim">
+        <item></item>
+    </flexbox>
+    <flexbox id="to-margin-trim">
+        <item></item>
+    </flexbox>
+</body>
+<script>
+document.body.offsetHeight;
+document.getElementById("to-no-margin-trim").style["margin-trim"] = "none";
+document.getElementById("to-margin-trim").style["margin-trim"] = "inline-start";
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-flex">
+<link rel="match" href="flex-row-style-change-triggers-layout-inline-ref.html">
+<meta name="assert" content="Flex items react to change in their flexbox's margin-trim value">
+<style>
+flexbox {
+    display: flex;
+    width: min-content;
+    flex-wrap: wrap;
+    border: 1px solid black;
+}
+.initial-margin-trim {
+    margin-trim: inline;
+}
+item {
+    display: block;
+    background-color: green;
+    width: 50px;
+    height: 50px;
+    margin-inline: 10px;
+}
+</style>
+</head>
+<body>
+    <flexbox class="initial-margin-trim" id="to-no-margin-trim">
+        <item></item>
+    </flexbox>
+    <flexbox id="to-margin-trim">
+        <item></item>
+    </flexbox>
+</body>
+<script>
+document.body.offsetHeight;
+document.getElementById("to-no-margin-trim").style["margin-trim"] = "none";
+document.getElementById("to-margin-trim").style["margin-trim"] = "inline";
+</script>
+</html>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -831,6 +831,9 @@ static bool rareDataChangeRequiresLayout(const StyleRareNonInheritedData& first,
     if (first.containIntrinsicWidth != second.containIntrinsicWidth || first.containIntrinsicHeight != second.containIntrinsicHeight)
         return true;
 
+    if (first.marginTrim != second.marginTrim)
+        return true;
+
     return false;
 }
 


### PR DESCRIPTION
#### 226684b758a062ec07c68f2de73a6687844fbaf1
<pre>
[margin-trim] Trigger layout on margin-trim style change.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254300">https://bugs.webkit.org/show_bug.cgi?id=254300</a>
rdar://107108810

Reviewed by Tim Nguyen.

When the value of the margin-trim property changes on a box, it
should trigger layout again so that the children can be relaid out
properly. This patch takes the first step and has rareDataChangeRequiresLayout
return true when the box&apos;s old margin-trim value is not the same as
the new one. The 3 container types in which margin-trim is applicable to
(flex, grid, and block) may need to have their styleDidChange function
adjusted to actually relayout their children properly, but that will be
done in a separate patch for each layout type.

However, we can verify that this change works by attempting to trigger
this logic for flexboxes. This is because when a flexbox goes through
layout again, it will set the main axis margins for each of its children
inside RenderFlexibleBox::prepareOrderIteratorAndMargins before it goes
through and lays them out. Since the main axis margins for each child
will be step at the beginning of flex layout each time it happens, the
trimming logic will also apply each time. The cross axis margins will
need to be handled and verified separately once the change is made to
RenderFlexibleBox::styleDidChange.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-style-change-triggers-layout-block-start-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-column-style-change-triggers-layout-block-start.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-block-start-dynamic.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/flexbox-row-block-start-dynamic-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-end-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-end-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-end.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-start-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-start-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block-start.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-column-style-change-triggers-layout-block.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-end-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-end-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-end.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-start-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-start-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-start.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareDataChangeRequiresLayout):

Canonical link: <a href="https://commits.webkit.org/262423@main">https://commits.webkit.org/262423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9174d1710283768d7c936223cf410a05ce68a566

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2291 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1239 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1373 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2138 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1227 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1270 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1293 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2361 "8 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1190 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1264 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/373 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1365 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->