### PR TITLE
Small interaction regions need to be guarded with occlusion regions.

### DIFF
--- a/LayoutTests/interaction-region/input-type-file-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-file-region-expected.txt
@@ -12,6 +12,8 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
+        (occlusion (1,-8) width=84 height=38)
+        (borderRadius 0.00),
         (interaction (1,2) width=84 height=18)
         (borderRadius 9.00)])
       )

--- a/LayoutTests/interaction-region/tiny-regions-expected.txt
+++ b/LayoutTests/interaction-region/tiny-regions-expected.txt
@@ -1,4 +1,3 @@
-
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -12,10 +11,12 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (occlusion (48,-8) width=37 height=36)
+        (occlusion (-10,0) width=30 height=30)
         (borderRadius 0.00),
-        (interaction (58,2) width=17 height=16)
-        (borderRadius 8.00)])
+        (interaction (0,10) width=10 height=10)
+        (borderRadius 8.00),
+        (occlusion (0,20) width=10 height=10)
+        (borderRadius 0.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/tiny-regions.html
+++ b/LayoutTests/interaction-region/tiny-regions.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+
+    .occlusion {
+        z-index: 1;
+        width: 10px;
+        height: 10px;
+        background-color: blue;
+    }
+    .interaction {
+        width: 10px;
+        height: 10px;
+        background-color: green;
+
+        cursor: pointer;
+    }
+</style>
+<body>
+<div class="interaction"></div>
+<div class="interaction" onclick="click()"></div>
+<div class="occlusion"></div>
+
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -400,8 +400,12 @@ std::optional<InteractionRegion> InteractionRegionOverlay::activeRegion() const
         }
     }
     
-    if (hitRegion)
+    if (hitRegion) {
+        if (hitRegion->type == InteractionRegion::Type::Occlusion)
+            return std::nullopt;
+        
         hitRegion->rectInLayerCoordinates = hitRectInOverlayCoordinates;
+    }
 
     return hitRegion;
 #else

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3690,10 +3690,14 @@ void RenderLayerBacking::paintDebugOverlays(const GraphicsLayer* graphicsLayer, 
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     if (DebugPageOverlays::shouldPaintOverlayIntoLayerForRegionType(renderer().page(), DebugPageOverlays::RegionType::InteractionRegion)) {
-        context.setStrokeColor(Color::green);
         context.setStrokeThickness(1);
 
         for (const auto& region : eventRegion.interactionRegions()) {
+            if (region.type == InteractionRegion::Type::Occlusion)
+                context.setStrokeColor(Color::red);
+            else
+                context.setStrokeColor(Color::green);
+            
             auto rect = region.rectInLayerCoordinates;
             Path path;
             path.addRoundedRect(rect, { region.borderRadius, region.borderRadius });


### PR DESCRIPTION
#### e69ef3dfd95259622b14db520960c37959feeafd
<pre>
Small interaction regions need to be guarded with occlusion regions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254785">https://bugs.webkit.org/show_bug.cgi?id=254785</a>
rdar://105092716

Reviewed by Tim Horton.

Also add some additional debug information to draw occlusion regions
in red.

* LayoutTests/interaction-region/input-type-file-region-expected.txt:
* LayoutTests/interaction-region/input-type-range-region-expected.txt:
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::drawRect):
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::guardSmallIntetactionRegions):
(WebCore::EventRegionContext::copyInteractionRegionsToEventRegion):
* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::paintDebugOverlays):

Canonical link: <a href="https://commits.webkit.org/262655@main">https://commits.webkit.org/262655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5aea908663f10df05fc68d479c38daf21ebf9b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2163 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3086 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/2205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2241 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2941 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1916 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1964 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1982 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1926 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/535 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2099 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->