### PR TITLE
run-api-tests should have options to disable GPU process for DOM rendering and UI side compositing

### DIFF
--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -146,9 +146,13 @@ def parse_args(args):
                              help='Passes that environment variable to the tests (--additional-env-var=NAME=VALUE)'),
 
         optparse.make_option('--remote-layer-tree', action='store_true', default=False,
-                             help='Use the remote layer tree drawing model (macOS non-WebKitLegacy only)'),
+                             help='Use the remote layer tree drawing model (macOS WebKit2 only)'),
+        optparse.make_option('--no-remote-layer-tree', action='store_true', default=False,
+                             help='Disable the remote layer tree drawing model (macOS WebKit2 only)'),
         optparse.make_option('--use-gpu-process', action='store_true', default=False,
                              help='Enable GPU process DOM rendering'),
+        optparse.make_option('--no-use-gpu-process', action='store_true', default=False,
+                             help='Disable GPU process DOM rendering'),
     ]))
     option_group_definitions.append(('Upload Options', upload_options()))
 

--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -90,8 +90,12 @@ class Runner(object):
             args.append('--gtest_also_run_disabled_tests=1')
         if (port.get_option('remote_layer_tree')):
             args.append('--remote-layer-tree')
+        if (port.get_option('no_remote_layer_tree')):
+            args.append('--no-remote-layer-tree')
         if (port.get_option('use_gpu_process')):
             args.append('--use-gpu-process')
+        if (port.get_option('no_use_gpu_process')):
+            args.append('--no-use-gpu-process')
         if getattr(port, 'DEVICE_MANAGER', None):
             assert port.DEVICE_MANAGER.INITIALIZED_DEVICES
             return ['/usr/bin/xcrun', 'simctl', 'spawn', port.DEVICE_MANAGER.INITIALIZED_DEVICES[0].udid] + args

--- a/Tools/TestWebKitAPI/mac/mainMac.mm
+++ b/Tools/TestWebKitAPI/mac/mainMac.mm
@@ -44,8 +44,12 @@ void buildArgumentDefaults(int argc, char** argv, NSMutableDictionary *argumentD
         // These defaults are not propagated manually but are only consulted in the UI process.
         if (strcmp(argv[i], "--remote-layer-tree") == 0)
             argumentDefaults[@"WebKit2UseRemoteLayerTreeDrawingArea"] = @YES;
+        else if (strcmp(argv[i], "--no-remote-layer-tree") == 0)
+            argumentDefaults[@"WebKit2UseRemoteLayerTreeDrawingArea"] = @NO;
         else if (strcmp(argv[i], "--use-gpu-process") == 0)
             argumentDefaults[@"WebKit2GPUProcessForDOMRendering"] = @YES;
+        else if (strcmp(argv[i], "--no-use-gpu-process") == 0)
+            argumentDefaults[@"WebKit2GPUProcessForDOMRendering"] = @NO;
     }
 }
 


### PR DESCRIPTION
#### c7d1d1292af0187239828f28c73ddd3ef34f71ed
<pre>
run-api-tests should have options to disable GPU process for DOM rendering and UI side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=254789">https://bugs.webkit.org/show_bug.cgi?id=254789</a>

Reviewed by Simon Fraser and Jonathan Bedard.

Add --no-remote-layer-tree and --no-use-gpu-process as new options to run-api-tests.

* Tools/Scripts/run-api-tests:
* Tools/Scripts/webkitpy/api_tests/runner.py:
(Runner.command_for_port):
* Tools/TestWebKitAPI/mac/mainMac.mm:
(buildArgumentDefaults):

Canonical link: <a href="https://commits.webkit.org/262521@main">https://commits.webkit.org/262521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab1f5059ec34f6126996915dea52351ba8d1fb21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1394 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1371 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1292 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2135 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/1433 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1223 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1267 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2354 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1189 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1260 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1362 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/186 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->