### PR TITLE
Avoid CPU time under AnimationEffect::getBasicTiming() when no animation event listeners are registered

### DIFF
--- a/Source/WebCore/animation/DeclarativeAnimation.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimation.cpp
@@ -68,7 +68,7 @@ void DeclarativeAnimation::tick()
     bool wasRelevant = isRelevant();
     
     WebAnimation::tick();
-    invalidateDOMEvents();
+    invalidateDOMEvents(shouldFireDOMEvents());
 
     // If a declarative animation transitions from a non-idle state to an idle state, it means it was
     // canceled using the Web Animations API and it should be disassociated from its owner element.
@@ -204,14 +204,18 @@ void DeclarativeAnimation::setTimeline(RefPtr<AnimationTimeline>&& newTimeline)
 void DeclarativeAnimation::cancel()
 {
     auto cancelationTime = 0_s;
-    if (auto* animationEffect = effect()) {
-        if (auto activeTime = animationEffect->getBasicTiming().activeTime)
-            cancelationTime = *activeTime;
+
+    auto shouldFireEvents = shouldFireDOMEvents();
+    if (shouldFireEvents != ShouldFireEvents::No) {
+        if (auto* animationEffect = effect()) {
+            if (auto activeTime = animationEffect->getBasicTiming().activeTime)
+                cancelationTime = *activeTime;
+        }
     }
 
     WebAnimation::cancel();
 
-    invalidateDOMEvents(cancelationTime);
+    invalidateDOMEvents(shouldFireEvents, cancelationTime);
 }
 
 void DeclarativeAnimation::cancelFromStyle()
@@ -254,7 +258,24 @@ Seconds DeclarativeAnimation::effectTimeAtEnd() const
     return 0_s;
 }
 
-void DeclarativeAnimation::invalidateDOMEvents(Seconds elapsedTime)
+auto DeclarativeAnimation::shouldFireDOMEvents() const -> ShouldFireEvents
+{
+    if (!m_owningElement)
+        return ShouldFireEvents::No;
+
+    auto& document = m_owningElement->document();
+    if (is<CSSAnimation>(*this)) {
+        if (document.hasListenerType(Document::CSS_ANIMATION_LISTENER))
+            return ShouldFireEvents::YesForCSSAnimation;
+        return ShouldFireEvents::No;
+    }
+    ASSERT(is<CSSTransition>(*this));
+    if (document.hasListenerType(Document::CSS_TRANSITION_LISTENER))
+        return ShouldFireEvents::YesForCSSTransition;
+    return ShouldFireEvents::No;
+}
+
+void DeclarativeAnimation::invalidateDOMEvents(ShouldFireEvents shouldFireEvents, Seconds elapsedTime)
 {
     if (!m_owningElement)
         return;
@@ -293,62 +314,63 @@ void DeclarativeAnimation::invalidateDOMEvents(Seconds elapsedTime)
     bool isBefore = currentPhase == AnimationEffectPhase::Before;
     bool isIdle = currentPhase == AnimationEffectPhase::Idle;
 
-    if (is<CSSAnimation>(*this)) {
-        if (m_owningElement->document().hasListenerType(Document::CSS_ANIMATION_LISTENER)) {
-            // https://drafts.csswg.org/css-animations-2/#events
-            if ((wasIdle || wasBefore) && isActive)
-                enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
-            else if ((wasIdle || wasBefore) && isAfter) {
-                enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
-                enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());
-            } else if (wasActive && isBefore)
-                enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
-            else if (wasActive && isActive && m_previousIteration != iteration) {
-                auto iterationBoundary = iteration;
-                if (m_previousIteration > iteration)
-                    iterationBoundary++;
-                auto elapsedTime = animationEffect ? animationEffect->iterationDuration() * (iterationBoundary - animationEffect->iterationStart()) : 0_s;
-                enqueueDOMEvent(eventNames().animationiterationEvent, elapsedTime, effectTimeAtIteration(iteration));
-            } else if (wasActive && isAfter)
-                enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());
-            else if (wasAfter && isActive)
-                enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd, effectTimeAtStart());
-            else if (wasAfter && isBefore) {
-                enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd, effectTimeAtStart());
-                enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
-            } else if ((!wasIdle && !wasAfter) && isIdle)
-                enqueueDOMEvent(eventNames().animationcancelEvent, elapsedTime, elapsedTime);
-        }
-    } else if (is<CSSTransition>(*this)) {
-        if (m_owningElement->document().hasListenerType(Document::CSS_TRANSITION_LISTENER)) {
-            // https://drafts.csswg.org/css-transitions-2/#transition-events
-            if (wasIdle && (isPending || isBefore))
-                enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());
-            else if (wasIdle && isActive) {
-                auto scheduledEffectTime = effectTimeAtStart();
-                enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, scheduledEffectTime);
-                enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, scheduledEffectTime);
-            } else if (wasIdle && isAfter) {
-                enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());
-                enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
-                enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
-            } else if ((m_wasPending || wasBefore) && isActive)
-                enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
-            else if ((m_wasPending || wasBefore) && isAfter) {
-                enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
-                enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
-            } else if (wasActive && isAfter)
-                enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
-            else if (wasActive && isBefore)
-                enqueueDOMEvent(eventNames().transitionendEvent, intervalStart, effectTimeAtEnd());
-            else if (wasAfter && isActive)
-                enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd, effectTimeAtStart());
-            else if (wasAfter && isBefore) {
-                enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd, effectTimeAtStart());
-                enqueueDOMEvent(eventNames().transitionendEvent, intervalStart, effectTimeAtEnd());
-            } else if ((!wasIdle && !wasAfter) && isIdle)
-                enqueueDOMEvent(eventNames().transitioncancelEvent, elapsedTime, elapsedTime);
-        }
+    switch (shouldFireEvents) {
+    case ShouldFireEvents::YesForCSSAnimation:
+        // https://drafts.csswg.org/css-animations-2/#events
+        if ((wasIdle || wasBefore) && isActive)
+            enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
+        else if ((wasIdle || wasBefore) && isAfter) {
+            enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());
+        } else if (wasActive && isBefore)
+            enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
+        else if (wasActive && isActive && m_previousIteration != iteration) {
+            auto iterationBoundary = iteration;
+            if (m_previousIteration > iteration)
+                iterationBoundary++;
+            auto elapsedTime = animationEffect ? animationEffect->iterationDuration() * (iterationBoundary - animationEffect->iterationStart()) : 0_s;
+            enqueueDOMEvent(eventNames().animationiterationEvent, elapsedTime, effectTimeAtIteration(iteration));
+        } else if (wasActive && isAfter)
+            enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());
+        else if (wasAfter && isActive)
+            enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd, effectTimeAtStart());
+        else if (wasAfter && isBefore) {
+            enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
+        } else if ((!wasIdle && !wasAfter) && isIdle)
+            enqueueDOMEvent(eventNames().animationcancelEvent, elapsedTime, elapsedTime);
+        break;
+    case ShouldFireEvents::YesForCSSTransition:
+        // https://drafts.csswg.org/css-transitions-2/#transition-events
+        if (wasIdle && (isPending || isBefore))
+            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());
+        else if (wasIdle && isActive) {
+            auto scheduledEffectTime = effectTimeAtStart();
+            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, scheduledEffectTime);
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, scheduledEffectTime);
+        } else if (wasIdle && isAfter) {
+            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
+        } else if ((m_wasPending || wasBefore) && isActive)
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
+        else if ((m_wasPending || wasBefore) && isAfter) {
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
+        } else if (wasActive && isAfter)
+            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
+        else if (wasActive && isBefore)
+            enqueueDOMEvent(eventNames().transitionendEvent, intervalStart, effectTimeAtEnd());
+        else if (wasAfter && isActive)
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd, effectTimeAtStart());
+        else if (wasAfter && isBefore) {
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().transitionendEvent, intervalStart, effectTimeAtEnd());
+        } else if ((!wasIdle && !wasAfter) && isIdle)
+            enqueueDOMEvent(eventNames().transitioncancelEvent, elapsedTime, elapsedTime);
+        break;
+    case ShouldFireEvents::No:
+        break;
     }
 
     m_wasPending = isPending;

--- a/Source/WebCore/animation/DeclarativeAnimation.h
+++ b/Source/WebCore/animation/DeclarativeAnimation.h
@@ -77,7 +77,10 @@ protected:
     void initialize(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     virtual void syncPropertiesWithBackingAnimation();
     virtual Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) = 0;
-    void invalidateDOMEvents(Seconds elapsedTime = 0_s);
+
+    enum class ShouldFireEvents : uint8_t { No, YesForCSSAnimation, YesForCSSTransition };
+    ShouldFireEvents shouldFireDOMEvents() const;
+    void invalidateDOMEvents(ShouldFireEvents, Seconds elapsedTime = 0_s);
 
 private:
     void disassociateFromOwningElement();


### PR DESCRIPTION
#### 2700abd1cd65088c94c06be6e3d711dbee1561a5
<pre>
Avoid CPU time under AnimationEffect::getBasicTiming() when no animation event listeners are registered
<a href="https://bugs.webkit.org/show_bug.cgi?id=254792">https://bugs.webkit.org/show_bug.cgi?id=254792</a>

Reviewed by Antoine Quint.

Avoid CPU time under AnimationEffect::getBasicTiming() when no animation event
listeners are registered:

Sample Count, Samples %, Normalized CPU %, Symbol
45, 0.0%, 0.0%, WebCore::AnimationEffect::getBasicTiming(std::__1::optional&lt;WTF::Seconds&gt;) const (in WebCore)
25, 0.0%, 0.0%,     WebCore::DeclarativeAnimation::cancelFromStyle() (in WebCore)
8, 0.0%, 0.0%,     WebCore::WebAnimation::updateRelevance() (in WebCore)
5, 0.0%, 0.0%,     WebCore::Styleable::cancelDeclarativeAnimations() const (in WebCore)

* Source/WebCore/animation/DeclarativeAnimation.cpp:
(WebCore::DeclarativeAnimation::tick):
(WebCore::DeclarativeAnimation::cancel):
(WebCore::DeclarativeAnimation::shouldFireDOMEvents const):
(WebCore::DeclarativeAnimation::invalidateDOMEvents):
* Source/WebCore/animation/DeclarativeAnimation.h:

Canonical link: <a href="https://commits.webkit.org/262390@main">https://commits.webkit.org/262390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1a31d94e9b41a0100fe59b26040d54ad80c3267

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2300 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1244 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1376 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1417 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2146 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1231 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1277 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1303 "6 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2370 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1336 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1274 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1372 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/154 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->