### PR TITLE
[GPU Process] To encode a CGImage, copy its pixels to a SharedMemory

### DIFF
--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -60,6 +60,7 @@ extern "C" {
     M(IPCMessages) \
     M(ITPDebug) \
     M(IconDatabase) \
+    M(Images) \
     M(ImageAnalysis) \
     M(IncrementalPDF) \
     M(IncrementalPDFVerbose) \

--- a/Source/WebKit/Shared/ShareableBitmap.h
+++ b/Source/WebKit/Shared/ShareableBitmap.h
@@ -52,6 +52,9 @@ public:
         , CGBitmapInfo
 #endif
     );
+#if USE(CG)
+    ShareableBitmapConfiguration(WebCore::NativeImage&);
+#endif
 
     WebCore::IntSize size() const { return m_size; }
     const WebCore::DestinationColorSpace& colorSpace() const { return m_colorSpace ? *m_colorSpace : WebCore::DestinationColorSpace::SRGB(); }
@@ -121,6 +124,12 @@ public:
 
     // Create a shareable bitmap from an already existing shared memory block.
     static RefPtr<ShareableBitmap> create(const ShareableBitmapConfiguration&, Ref<SharedMemory>&&);
+
+    // Create a shareable bitmap from a NativeImage.
+#if USE(CG)
+    static RefPtr<ShareableBitmap> createFromImagePixels(WebCore::NativeImage&);
+#endif
+    static RefPtr<ShareableBitmap> createFromImageDraw(WebCore::NativeImage&);
 
     // Create a shareable bitmap from a handle.
     static RefPtr<ShareableBitmap> create(const ShareableBitmapHandle&, SharedMemory::Protection = SharedMemory::Protection::ReadWrite);


### PR DESCRIPTION
#### c50a18ba16263493f64ba1ce8c88d759ac769636
<pre>
[GPU Process] To encode a CGImage, copy its pixels to a SharedMemory
<a href="https://bugs.webkit.org/show_bug.cgi?id=254794">https://bugs.webkit.org/show_bug.cgi?id=254794</a>
rdar://106794138

Reviewed by Simon Fraser.

Use CGImageGetDataProvider() to get the CGImage bytes. Copy these bytes to the
SharedMemory. Encode some of the CGImage properties so the decoded CGImage matches
the encoded one. These properties are BytesPerPixel, BytesPerRow and BitmapInfo

Make sure WebProcess can create a PlatformImage out of the ShareableBitmap before
sending the pixels to GPUProcess. Otherwise fall back to the old code path and
draw the image to a BitmapContext backed by the SharedMemory.

* Source/WebKit/Platform/Logging.h:
* Source/WebKit/Shared/ShareableBitmap.cpp:
(WebKit::ShareableBitmap::create):
(WebKit::ShareableBitmap::createFromImageDraw):
* Source/WebKit/Shared/ShareableBitmap.h:
* Source/WebKit/Shared/cg/ShareableBitmapCG.cpp:
(WebKit::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
(WebKit::ShareableBitmap::createFromImagePixels):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::createShareableBitmapFromNativeImage):
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):

Canonical link: <a href="https://commits.webkit.org/262607@main">https://commits.webkit.org/262607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90583d20ebaaaa6468f1e91105f01a1b4f9152d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2956 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/2095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2102 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2050 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2806 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1867 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1850 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1865 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1813 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/502 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1973 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->