### PR TITLE
REGRESSION (262337@main) swipe-back-with-passive-wheel-listener.html fails

### DIFF
--- a/LayoutTests/swipe/resources/swipe-test.js
+++ b/LayoutTests/swipe/resources/swipe-test.js
@@ -46,6 +46,8 @@ async function startSlowSwipeGesture()
     if (!window.eventSender)
         return;
 
+    log("startSlowSwipeGesture");
+
     await UIHelper.ensurePresentationUpdate();
 
     // Similar to uiController.beginBackSwipe(), but with a gap between events to allow

--- a/LayoutTests/swipe/swipe-back-with-active-wheel-listener-expected.txt
+++ b/LayoutTests/swipe/swipe-back-with-active-wheel-listener-expected.txt
@@ -1,4 +1,5 @@
 Swipe target
+startSlowSwipeGesture
 didBeginSwipe
 completeSwipeGesture
 willEndSwipe

--- a/LayoutTests/swipe/swipe-back-with-passive-wheel-listener-expected.txt
+++ b/LayoutTests/swipe/swipe-back-with-passive-wheel-listener-expected.txt
@@ -1,5 +1,5 @@
 Swipe target
-startSwipeGesture
+startSlowSwipeGesture
 didBeginSwipe
 completeSwipeGesture
 willEndSwipe

--- a/LayoutTests/swipe/wheel-prevent-default-prevents-swipe-back-expected.txt
+++ b/LayoutTests/swipe/wheel-prevent-default-prevents-swipe-back-expected.txt
@@ -1,3 +1,4 @@
 Swipe target
+startSlowSwipeGesture
 completeSwipeGesture
 


### PR DESCRIPTION
#### fe6383eb455a364c711d2cc11f89543747a9b454
<pre>
REGRESSION (262337@main) swipe-back-with-passive-wheel-listener.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=254795">https://bugs.webkit.org/show_bug.cgi?id=254795</a>
rdar://107456894

Reviewed by Ryosuke Niwa.

262337@main failed to update the result for swipe-back-with-passive-wheel-listener.html,
which no longer logs `startSwipeGesture`. Add a log to `startSlowSwipeGesture()` to make
it match `startSwipeGesture()`, and update baselines accordingly.

* LayoutTests/swipe/resources/swipe-test.js:
(async startSlowSwipeGesture):
* LayoutTests/swipe/swipe-back-with-active-wheel-listener-expected.txt:
* LayoutTests/swipe/swipe-back-with-passive-wheel-listener-expected.txt:
* LayoutTests/swipe/wheel-prevent-default-prevents-swipe-back-expected.txt:

Canonical link: <a href="https://commits.webkit.org/262404@main">https://commits.webkit.org/262404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/849b2d8b6a8ae284f3ffbdd5110e6aac28497b73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2321 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1250 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1379 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1233 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1288 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2373 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1197 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1277 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/364 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1383 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->