### PR TITLE
Use generateThreadSafe for RenderingResourceIdentifier.

### DIFF
--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.h
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class DecomposedGlyphs final : public RenderingResource {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static WEBCORE_EXPORT Ref<DecomposedGlyphs> create(const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
+    static WEBCORE_EXPORT Ref<DecomposedGlyphs> create(const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode, RenderingResourceIdentifier = RenderingResourceIdentifier::generateThreadSafe());
     static WEBCORE_EXPORT Ref<DecomposedGlyphs> create(PositionedGlyphs&&, RenderingResourceIdentifier);
 
     const PositionedGlyphs& positionedGlyphs() const { return m_positionedGlyphs; }

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -181,7 +181,7 @@ RenderingResourceIdentifier Font::renderingResourceIdentifier() const
 RenderingResourceIdentifier Font::Attributes::ensureRenderingResourceIdentifier() const
 {
     if (!renderingResourceIdentifier)
-        renderingResourceIdentifier = RenderingResourceIdentifier::generate();
+        renderingResourceIdentifier = RenderingResourceIdentifier::generateThreadSafe();
     return *renderingResourceIdentifier;
 }
 

--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -64,7 +64,7 @@ public:
     FontCustomPlatformData(CTFontDescriptorRef fontDescriptor, FontPlatformData::CreationData&& creationData)
         : fontDescriptor(fontDescriptor)
         , creationData(WTFMove(creationData))
-        , m_renderingResourceIdentifier(RenderingResourceIdentifier::generate())
+        , m_renderingResourceIdentifier(RenderingResourceIdentifier::generateThreadSafe())
     {
     }
 #else

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -222,7 +222,7 @@ public:
     WEBCORE_EXPORT virtual String debugDescription() const;
 
 protected:
-    WEBCORE_EXPORT ImageBuffer(const ImageBufferBackend::Parameters&, const ImageBufferBackend::Info&, std::unique_ptr<ImageBufferBackend>&& = nullptr, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
+    WEBCORE_EXPORT ImageBuffer(const ImageBufferBackend::Parameters&, const ImageBufferBackend::Info&, std::unique_ptr<ImageBufferBackend>&& = nullptr, RenderingResourceIdentifier = RenderingResourceIdentifier::generateThreadSafe());
 
     WEBCORE_EXPORT virtual RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread();
     WEBCORE_EXPORT virtual std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer();

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -40,7 +40,7 @@ class GraphicsContext;
 class NativeImage final : public RenderingResource {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
+    static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generateThreadSafe());
 
     WEBCORE_EXPORT void setPlatformImage(PlatformImagePtr&&);
     const PlatformImagePtr& platformImage() const { return m_platformImage; }

--- a/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 FontCustomPlatformData::FontCustomPlatformData(const String& name, FontPlatformData::CreationData&& creationData)
     : name(name)
     , creationData(WTFMove(creationData))
-    , m_renderingResourceIdentifier(RenderingResourceIdentifier::generate())
+    , m_renderingResourceIdentifier(RenderingResourceIdentifier::generateThreadSafe())
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -72,7 +72,7 @@ public:
     std::unique_ptr<WebCore::SerializedImageBuffer> sinkIntoSerializedImageBuffer() final;
 
 private:
-    RemoteImageBufferProxy(const WebCore::ImageBufferBackend::Parameters&, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&, std::unique_ptr<WebCore::ImageBufferBackend>&& = nullptr, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generate());
+    RemoteImageBufferProxy(const WebCore::ImageBufferBackend::Parameters&, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&, std::unique_ptr<WebCore::ImageBufferBackend>&& = nullptr, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generateThreadSafe());
 
     bool hasPendingFlush() const;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
@@ -54,7 +54,7 @@ TEST(DisplayListTests, ReplayWithMissingResource)
     auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
     GraphicsContextCG context { cgContext.get() };
 
-    auto imageBufferIdentifier = RenderingResourceIdentifier::generate();
+    auto imageBufferIdentifier = RenderingResourceIdentifier::generateThreadSafe();
 
     DisplayList list;
 


### PR DESCRIPTION
#### 30500262a0f1c8420030cc2f72e928301668b6ba
<pre>
Use generateThreadSafe for RenderingResourceIdentifier.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254796">https://bugs.webkit.org/show_bug.cgi?id=254796</a>
&lt;rdar://105752952&gt;

Reviewed by Simon Fraser.

We can allocate ImageBuffers from a worker thread, so we need to use the thread safe allocator
for all RenderingResourceIdentifiers.

* Source/WebCore/platform/graphics/DecomposedGlyphs.h:
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::renderingResourceIdentifier const):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262486@main">https://commits.webkit.org/262486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcfb7b618a1f43ba0640885dc1a2e23972b84e14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1546 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1485 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1466 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1503 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1508 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1368 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/410 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1601 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->