### PR TITLE
[Win] WebInspector: enable "inspector-resource:" scheme for remote inspector

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/win/RemoteWebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/RemoteWebInspectorUIProxyWin.cpp
@@ -104,7 +104,6 @@ LRESULT RemoteWebInspectorUIProxy::onClose()
 WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
 {
     RefPtr<WebPreferences> preferences = WebPreferences::create(String(), "WebKit2."_s, "WebKit2."_s);
-    preferences->setAllowFileAccessFromFileURLs(true);
 
 #if ENABLE(DEVELOPER_MODE)
     preferences->setDeveloperExtrasEnabled(true);
@@ -129,7 +128,11 @@ WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
     RECT r;
     ::GetClientRect(m_frontendHandle, &r);
     m_webView = WebView::create(r, pageConfiguration, m_frontendHandle);
-    return m_webView->page();
+
+    auto inspectorPage = m_webView->page();
+    inspectorPage->setURLSchemeHandlerForScheme(InspectorResourceURLSchemeHandler::create(), "inspector-resource"_s);
+
+    return inspectorPage;
 }
 
 void RemoteWebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&& saveDatas, bool /* forceSaveAs */)


### PR DESCRIPTION
#### d795f7f4b71b6662187a863f24529844bef4f698
<pre>
[Win] WebInspector: enable &quot;inspector-resource:&quot; scheme for remote inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=254803">https://bugs.webkit.org/show_bug.cgi?id=254803</a>

Reviewed by Fujii Hironori.

Remote Inspector is unable to load the resources specified in the &quot;inspector-resoure://&quot; scheme.

The fix for stand-alone Web Inspector was introduced in Bug 223619.
<a href="https://bugs.webkit.org/show_bug.cgi?id=223619">https://bugs.webkit.org/show_bug.cgi?id=223619</a>
235682@main

This change should be enabled for the Remote Inspector as well.

* Source/WebKit/UIProcess/Inspector/win/RemoteWebInspectorUIProxyWin.cpp:
(WebKit::RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow):

Canonical link: <a href="https://commits.webkit.org/262462@main">https://commits.webkit.org/262462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5033715740a918a8766d732660906fec1c60d36e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2359 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1266 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1392 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2198 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1308 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2390 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1214 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1294 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/393 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1403 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->