### PR TITLE
[WGSL] Serialize variables without type declarations

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTTypeName.h
+++ b/Source/WebGPU/WGSL/AST/ASTTypeName.h
@@ -29,6 +29,8 @@
 #include "ASTIdentifier.h"
 
 namespace WGSL {
+class EntryPointRewriter;
+class RewriteGlobalVariables;
 class TypeChecker;
 struct Type;
 
@@ -38,6 +40,8 @@ class Structure;
 class TypeName : public Node, public RefCounted<TypeName> {
     WTF_MAKE_FAST_ALLOCATED;
     friend TypeChecker;
+    friend EntryPointRewriter;
+    friend RewriteGlobalVariables;
 
 public:
     using Ref = WTF::Ref<TypeName>;

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -369,6 +369,7 @@ void TypeChecker::visit(AST::CallExpression& call)
             }
             typeError(call.span(), "no matching overload for initializer ", targetName, typeArgumentsStream.toString(), "(", valueArgumentsStream.toString(), ")");
         }
+        target.m_resolvedType = result;
         return;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -34,14 +34,13 @@
 
 namespace TestWGSLAPI {
 
-inline Expected<String, WGSL::Error> translate(const String& wgsl, const String& entryPointName)
+inline Expected<String, WGSL::FailedCheck> translate(const String& wgsl, const String& entryPointName)
 {
-    WGSL::ShaderModule shaderModule(wgsl, { 8 });
-    auto maybeError = WGSL::parse(shaderModule);
-    if (maybeError.has_value())
+    auto result = WGSL::staticCheck(wgsl, std::nullopt, { 8 });
+    if (auto* maybeError = std::get_if<WGSL::FailedCheck>(&result))
         return makeUnexpected(*maybeError);
 
-    auto preparedResults = WGSL::prepare(shaderModule, entryPointName, { });
+    auto preparedResults = WGSL::prepare(std::get<WGSL::SuccessfulCheck>(result).ast, entryPointName, { });
 
     return { WTFMove(preparedResults.msl) };
 }


### PR DESCRIPTION
#### cf77c5fc66ee77ed1ae01584fb410b2445fd5a31
<pre>
[WGSL] Serialize variables without type declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=254808">https://bugs.webkit.org/show_bug.cgi?id=254808</a>
rdar://107469795

Reviewed by Myles C. Maxfield.

So far, the compiler just rejected programs that contained variables without
explicit type annotations (e.g. let x = 1), since at first we didn&apos;t have a
type checker, and consequently couldn&apos;t infer the type. Refactor the codegen
to use the inferred types instead of the AST types in most scenarios. The only
exceptions are references, which still aren&apos;t supported in the type checker.
This also requires adding type information for some of the nodes created at
runtime. For now, I&apos;m manually adding this information to the nodes when creating
them, but later this could be done through a nicer API.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):

Canonical link: <a href="https://commits.webkit.org/262528@main">https://commits.webkit.org/262528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4605faabcfee54877e4e5091df3806e131a1463f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2710 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1905 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1669 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1799 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2551 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1509 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1640 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1623 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2716 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1484 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/440 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1733 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->