### PR TITLE
Re-import html/semantics/popovers WPT

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -5758,6 +5758,7 @@
         "web-platform-tests/html/semantics/popovers/popover-anchor-display-ref.html",
         "web-platform-tests/html/semantics/popovers/popover-anchor-nested-display-ref.html",
         "web-platform-tests/html/semantics/popovers/popover-anchor-scroll-display-ref.html",
+        "web-platform-tests/html/semantics/popovers/popover-and-svg-ref.html",
         "web-platform-tests/html/semantics/popovers/popover-appearance-ref.html",
         "web-platform-tests/html/semantics/popovers/popover-backdrop-appearance-ref.html",
         "web-platform-tests/html/semantics/popovers/popover-dialog-appearance-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-idl-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-idl-property-expected.txt
@@ -1,4 +1,5 @@
-This is an anchor button  This button invokes the popover but isn't an anchor  button Anchored div
+This is an anchor button  This button invokes the popover but isn't an anchor
+button Anchored div
 
 FAIL popover anchorElement IDL property returns the anchor element assert_equals: expected (object) Element node <button id="b1">This is an anchor button</button> but got (undefined) undefined
 FAIL popover anchorElement is settable assert_equals: expected (object) Element node <button id="b1">This is an anchor button</button> but got (undefined) undefined

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-idl-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-idl-property.html
@@ -6,9 +6,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<button id=b1>This is an anchor button</button>
-<div popover id=p1 anchor=b1>This is a popover</div>
-<button id=b2 popovertarget=p1>This button invokes the popover but isn't an anchor</button>
+<div>
+  <button id=b1>This is an anchor button</button>
+  <div popover id=p1 anchor=b1>This is a popover</div>
+  <button id=b2 popovertarget=p1>This button invokes the popover but isn't an anchor</button>
+</div>
 
 <script>
   test(function() {
@@ -24,11 +26,13 @@
   }, "popover anchorElement is settable");
 </script>
 
-<button id=b1>button</button>
-<div id=p2>Anchored div</div>
+<div>
+  <button id=b3>button</button>
+  <div id=p2>Anchored div</div>
+</div>
 <style>
   * {margin:0;padding:0;}
-  #b1 {width: 200px;}
+  #b3 {width: 200px;}
   #p2 {
     position: absolute;
     left: anchor(right);
@@ -38,7 +42,7 @@
 <script>
   test(function() {
     assert_equals(p2.anchorElement,null);
-    const button = document.getElementById('b1');
+    const button = document.getElementById('b3');
     assert_true(!!button);
     p2.anchorElement = button;
     assert_equals(p2.getAttribute('anchor'),'','Idref should be empty after setting element');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -6,8 +6,8 @@ PASS Clicking inside a popover does not close that popover
 PASS Popovers close on pointerup, not pointerdown
 PASS Synthetic events can't close popovers
 FAIL Moving focus outside the popover should not dismiss the popover assert_equals: Focus should move to a button outside the popover expected Element node <button id="after_p1">Next control after popover1</button> but got Element node <body><button id="b1t" popovertarget="p1">Popover 1</butt...
-FAIL Clicking inside a child popover shouldn't close either popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
-FAIL Clicking inside a parent popover should close child popover promise_test: Unhandled rejection with value: object "InvalidStateError: Element has unexpected visibility state"
+PASS Clicking inside a child popover shouldn't close either popover
+PASS Clicking inside a parent popover should close child popover
 PASS Clicking on invoking element, after using it for activation, shouldn't close its popover
 PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case)
 PASS Clicking on invoking element, after using it for activation, shouldn't close its popover (nested case, not used for invocation)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html
@@ -117,7 +117,8 @@
     assert_false(popover1.matches(':open'),'pointerup (outside the popover) should trigger light dismiss');
   },'Popovers close on pointerup, not pointerdown');
 
-  promise_test(async () => {
+  promise_test(async (t) => {
+    t.add_cleanup(() => popover1.hidePopover());
     assert_false(popover1.matches(':open'));
     popover1.showPopover();
     assert_true(popover1.matches(':open'));
@@ -132,17 +133,16 @@
     await testOne('pointerdown');
     await testOne('mouseup');
     await testOne('mousedown');
-    popover1.hidePopover();
   },'Synthetic events can\'t close popovers');
 
-  promise_test(async () => {
+  promise_test(async (t) => {
+    t.add_cleanup(() => popover1.hidePopover());
     popover1.showPopover();
     await clickOn(inside1After);
     assert_true(popover1.matches(':open'));
     await sendTab();
     assert_equals(document.activeElement,afterp1,'Focus should move to a button outside the popover');
     assert_true(popover1.matches(':open'));
-    popover1.hidePopover();
   },'Moving focus outside the popover should not dismiss the popover');
 
   promise_test(async () => {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom-expected.txt
@@ -6,4 +6,5 @@ PASS Popovers located inside shadow DOM can still be shown
 PASS anchor references do not cross shadow boundaries
 FAIL anchor references use the flat tree not the DOM tree assert_true: expected true got false
 FAIL The popover stack is preserved across shadow-inclusive ancestors assert_true: popover1 not open expected true got false
+FAIL Popover ancestor relationships are within a root, not within the document assert_true: popover1 not open expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom.html
@@ -5,6 +5,7 @@
 <link rel=help href="https://html.spec.whatwg.org/multipage/popover.html">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/declarative-shadow-dom-polyfill.js"></script>
 <script src="resources/popover-utils.js"></script>
 
 <script>
@@ -166,4 +167,38 @@
     assert_false(popover2.matches(':open'));
     assert_false(isElementVisible(popover2));
   }, "The popover stack is preserved across shadow-inclusive ancestors");
+</script>
+
+
+<div id=test5>
+  <template shadowrootmode=open>
+    <button popovertarget=p1>Test 5 Popover 1</button>
+    <div popover id=p1>Popover 1
+      <p>This should not get hidden when popover2 opens.</p>
+      <button popovertarget=p2>Click</button>
+    </div>
+    <div popover id=p2>Popover 2
+      <p>This should not hide popover1.</p>
+    </div>
+  </template>
+</div>
+<script>
+  promise_test(async function() {
+    polyfill_declarative_shadow_dom(test5);
+    const [popover1,popover2] = getPopoverReferences('test5');
+    popover1.showPopover();
+    popover2.showPopover();
+    // Both 1 and 2 should be open at this point.
+    assert_true(popover1.matches(':open'), 'popover1 not open');
+    assert_true(isElementVisible(popover1));
+    assert_true(popover2.matches(':open'), 'popover2 not open');
+    assert_true(isElementVisible(popover2));
+    // This should hide both of them.
+    popover1.hidePopover();
+    await waitForRender();
+    assert_false(popover1.matches(':open'));
+    assert_false(isElementVisible(popover1));
+    assert_false(popover2.matches(':open'));
+    assert_false(isElementVisible(popover2));
+  }, "Popover ancestor relationships are within a root, not within the document");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled-expected.txt
@@ -1,5 +1,5 @@
 form
-popover
+helloother button
 
 PASS Disabled popover*target buttons should not affect the popover heirarchy.
 FAIL Disabling popover*target buttons when popovers are open should still cause all popovers to be closed when the formerly outer popover is closed. assert_false: The inner popover should be closed when the hierarchy is broken. expected false got true
@@ -7,4 +7,6 @@ FAIL Disabling popover*target buttons when popovers are open should still cause 
 FAIL Setting the form attribute on popover*target buttons when popovers are open should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
 FAIL Changing the input type on a popover*target button when popovers are open should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
 FAIL Disconnecting popover*target buttons when popovers are open should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
+FAIL Changing the popovertarget attribute to break the chain should close all popovers. assert_false: The inner popover be should be closed when the hierarchy is broken. expected false got true
+PASS Modifying popovertarget on a button which doesn't break the chain shouldn't close any popovers.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled.html
@@ -124,3 +124,53 @@ test(() => {
     'The outer popover be should be closed when the hierarchy is broken.');
 }, 'Disconnecting popover*target buttons when popovers are open should close all popovers.');
 </script>
+
+<div id=outerpopover7 popover=auto>
+  <button id=togglebutton7 popovertarget=innerpopover7>toggle popover</button>
+</div>
+<div id=innerpopover7 popover=auto>popover</div>
+<script>
+test(() => {
+  outerpopover7.showPopover();
+  innerpopover7.showPopover();
+  assert_true(innerpopover7.matches(':open'),
+    'The inner popover should be able to open successfully.');
+  assert_true(outerpopover7.matches(':open'),
+    'The outer popover should stay open when opening the inner one.');
+
+  togglebutton7.setAttribute('popovertarget', 'otherpopover7');
+  assert_false(innerpopover7.matches(':open'),
+    'The inner popover be should be closed when the hierarchy is broken.');
+  assert_false(outerpopover7.matches(':open'),
+    'The outer popover be should be closed when the hierarchy is broken.');
+}, 'Changing the popovertarget attribute to break the chain should close all popovers.');
+</script>
+
+<div id=outerpopover8 popover=auto>
+  <div id=middlepopover8 popover=auto>
+    <div id=innerpopover8 popover=auto>hello</div>
+  </div>
+</div>
+<div id=otherpopover8 popover=auto>other popover</div>
+<button id=togglebutton8 popovertarget=middlepopover8>other button</div>
+<script>
+test(() => {
+  outerpopover8.showPopover();
+  middlepopover8.showPopover();
+  innerpopover8.showPopover();
+  assert_true(innerpopover8.matches(':open'),
+    'The inner popover should be able to open successfully.');
+  assert_true(middlepopover8.matches(':open'),
+    'The middle popover should stay open when opening the inner one.');
+  assert_true(outerpopover8.matches(':open'),
+    'The outer popover should stay open when opening the inner one.');
+
+  togglebutton8.setAttribute('popovertarget', 'otherpopover8');
+  assert_true(innerpopover8.matches(':open'),
+    'The inner popover should remain open.');
+  assert_true(middlepopover8.matches(':open'),
+    'The middle popover should remain open.');
+  assert_true(outerpopover8.matches(':open'),
+    'The outer popover should remain open.');
+}, `Modifying popovertarget on a button which doesn't break the chain shouldn't close any popovers.`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log
@@ -32,6 +32,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-scroll-display-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-scroll-display-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-scroll-display.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-and-svg.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-appearance-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-appearance-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-appearance.html


### PR DESCRIPTION
#### 8610b1f543e2d24265f9a02d40b953e9e3db4b99
<pre>
Re-import html/semantics/popovers WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=254810">https://bugs.webkit.org/show_bug.cgi?id=254810</a>

Reviewed by Tim Nguyen.

Based on <a href="https://github.com/web-platform-tests/wpt/commit/8f71659306c53f3cabad054ed02ac7c4d14de693">https://github.com/web-platform-tests/wpt/commit/8f71659306c53f3cabad054ed02ac7c4d14de693</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-idl-property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-idl-property.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-target-element-disabled.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/262428@main">https://commits.webkit.org/262428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ca3c41b8c6e3ecfd3a71cdf33a0f2fd1fa4e475

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1293 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1413 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1475 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1349 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1267 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1334 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2414 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1387 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1315 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/376 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1429 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->