### PR TITLE
Add console logging message to missing or late showNotification calls in service worker

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1323,6 +1323,10 @@ imported/w3c/web-platform-tests/notifications/idlharness.https.any.serviceworker
 imported/w3c/web-platform-tests/notifications/idlharness.https.any.worker.html [ Skip ]
 http/tests/workers/service/getnotifications-stop.html [ Skip ]
 http/tests/workers/service/getnotifications.html [ Skip ]
+http/wpt/service-workers/push-console-messages-no-showNotification.https.html [ Skip ]
+http/wpt/service-workers/push-console-messages-showNotification-async.https.html [ Skip ]
+http/wpt/service-workers/push-console-messages-showNotification-late.https.html [ Skip ]
+http/wpt/service-workers/push-console-messages-showNotification-sync.https.html [ Skip ]
 
 http/tests/media/fairplay [ Skip ]
 

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https-expected.txt
@@ -1,0 +1,6 @@
+Received ServiceWorker Console Message: doTest: {"type":"PUSHEVENT","message":"NO-SHOWNOTIFICATION"}
+Received ServiceWorker Console Message: doPush: NO-SHOWNOTIFICATION
+Received ServiceWorker Console Message: Push event ended without showing any notification may trigger removal of the push subscription.
+
+PASS push without showNotification call
+

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https.html
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https.html
@@ -1,0 +1,16 @@
+<!-- webkit-test-runner [ NotificationEventEnabled=true ] -->
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="push-console-messages.js"></script>
+</head>
+<body>
+<script>
+promise_test(test => {
+    const scope = "/WebKit/service-workers/push-console-messages.https.html?no";
+    return doTest(test, scope, "NO-SHOWNOTIFICATION");
+}, "push without showNotification call");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-async.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-async.https-expected.txt
@@ -1,0 +1,5 @@
+Received ServiceWorker Console Message: doTest: {"type":"PUSHEVENT","message":"SHOWNOTIFICATION-ASYNC"}
+Received ServiceWorker Console Message: doPush: SHOWNOTIFICATION-ASYNC
+
+PASS push with async showNotification call
+

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-async.https.html
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-async.https.html
@@ -1,0 +1,16 @@
+<!-- webkit-test-runner [ NotificationEventEnabled=true ] -->
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="push-console-messages.js"></script>
+</head>
+<body>
+<script>
+promise_test(test => {
+    const scope = "/WebKit/service-workers/push-console-messages.https.html-async";
+    return doTest(test, scope, "SHOWNOTIFICATION-ASYNC");
+}, "push with async showNotification call");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https-expected.txt
@@ -1,0 +1,7 @@
+Received ServiceWorker Console Message: doTest: {"type":"PUSHEVENT","message":"SHOWNOTIFICATION-LATE"}
+Received ServiceWorker Console Message: doPush: SHOWNOTIFICATION-LATE
+Received ServiceWorker Console Message: Push event ended without showing any notification may trigger removal of the push subscription.
+Received ServiceWorker Console Message: showNotification was called outside of any push event lifetime. PushEvent.waitUntil can be used to extend the push event lifetime as necessary.
+
+PASS push with late showNotification call
+

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https.html
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https.html
@@ -1,0 +1,16 @@
+<!-- webkit-test-runner [ NotificationEventEnabled=true ] -->
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="push-console-messages.js"></script>
+</head>
+<body>
+<script>
+promise_test(test => {
+    const scope = "/WebKit/service-workers/push-console-messages.https.html-late";
+    return doTest(test, scope, "SHOWNOTIFICATION-LATE");
+}, "push with late showNotification call");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-sync.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-sync.https-expected.txt
@@ -1,0 +1,5 @@
+Received ServiceWorker Console Message: doTest: {"type":"PUSHEVENT","message":"SHOWNOTIFICATION-SYNC"}
+Received ServiceWorker Console Message: doPush: SHOWNOTIFICATION-SYNC
+
+PASS push with sync showNotification call
+

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-sync.https.html
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-sync.https.html
@@ -1,0 +1,16 @@
+<!-- webkit-test-runner [ NotificationEventEnabled=true ] -->
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="push-console-messages.js"></script>
+</head>
+<body>
+<script>
+promise_test(test => {
+    const scope = "/WebKit/service-workers/push-console-messages.https.html-sync";
+    return doTest(test, scope, "SHOWNOTIFICATION-SYNC");
+}, "push with sync showNotification call");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-worker.js
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-worker.js
@@ -1,0 +1,70 @@
+async function doPush(event)
+{
+    const data = event.data.text();
+    self.internals.logReportedConsoleMessage("doPush: " + data);
+
+    const registration = self.registration;
+
+    try {
+        if (data === "NO-SHOWNOTIFICATION") {
+            if (self.testCallback)
+                self.testCallback("PASS");
+            return;
+        }
+        if (data === "SHOWNOTIFICATION-ASYNC") {
+            await new Promise(resolve => setTimeout(resolve, 10));
+            registration.showNotification(data);
+            if (self.testCallback)
+                self.testCallback("PASS");
+            return;
+        }
+        if (data === "SHOWNOTIFICATION-SYNC") {
+            registration.showNotification(data);
+            if (self.testCallback)
+                self.testCallback("PASS");
+            return;
+        }
+        if (data === "SHOWNOTIFICATION-LATE") {
+            setTimeout(() => {
+                try {
+                    registration.showNotification(data);
+                    if (self.testCallback)
+                        self.testCallback("PASS");
+                } catch (e) {
+                    if (self.testCallback)
+                        self.testCallback("FAIL: " + e);
+                }
+            }, 0);
+            return;
+        }
+        if (self.testCallback)
+            self.testCallback("FAIL");
+    } catch (e) {
+        if (self.testCallback)
+            self.testCallback("FAIL: " + e);
+    }
+}
+
+async function doTest(event)
+{
+    if (event.data.type !== "PUSHEVENT") {
+        event.source.postMessage("FAIL: received unexpected message from client");
+        return;
+    }
+
+    if (!self.internals) {
+        event.source.postMessage("FAIL: need internals");
+        return;
+    }
+    self.internals.enableConsoleMessageReporting();
+    self.internals.logReportedConsoleMessage("doTest: " + JSON.stringify(event.data));
+
+    const promise = new Promise(resolve => self.testCallback = resolve);
+    promise.then(value => event.source.postMessage(value));
+    event.waitUntil(promise);
+
+    event.waitUntil(self.internals.schedulePushEvent(event.data.message));
+}
+
+self.addEventListener("message", e => e.waitUntil(doTest(e)));
+self.addEventListener("push", e => e.waitUntil(doPush(e)));

--- a/LayoutTests/http/wpt/service-workers/push-console-messages.js
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages.js
@@ -1,0 +1,28 @@
+async function doTest(test, scope, message)
+{
+    var registration = await navigator.serviceWorker.getRegistration(scope);
+    if (registration && registration.scope === scope)
+        await registration.unregister();
+
+    var registration = await navigator.serviceWorker.register("push-console-messages-worker.js", { scope : scope });
+    activeWorker = registration.active;
+    assert_equals(registration.active, null);
+
+    activeWorker = registration.installing;
+    await new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve();
+        });
+    });
+    const promise = new Promise((resolve, reject) => {
+        navigator.serviceWorker.addEventListener("message", (event) => {
+            resolve(event.data);
+        });
+        setTimeout(() => reject("did not get message early enough"), 5000);
+    });
+
+    activeWorker.postMessage({type:"PUSHEVENT", message});
+    assert_equals(await promise, "PASS");
+    await new Promise(resolve => setTimeout(resolve, 100));
+}

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -1913,6 +1913,10 @@ webkit.org/b/228165 http/wpt/webrtc/transfer-datachannel-service-worker.https.ht
 webkit.org/b/232570 [ Debug ] http/wpt/push-api/pushEvent.any.serviceworker.html [ Pass Failure ]
 webkit.org/b/232570 [ Debug ] http/wpt/push-api/pushManager.any.html [ Pass Failure ]
 webkit.org/b/232570 [ Debug ] http/wpt/push-api/pushManager.any.serviceworker.html [ Pass Failure ]
+http/wpt/service-workers/push-console-messages-no-showNotification.https.html [ Pass ]
+http/wpt/service-workers/push-console-messages-showNotification-async.https.html [ Pass ]
+http/wpt/service-workers/push-console-messages-showNotification-late.https.html [ Pass ]
+http/wpt/service-workers/push-console-messages-showNotification-sync.https.html [ Pass ]
 
 webkit.org/b/215398 [ Release ] imported/w3c/web-platform-tests/css/css-images/idlharness.html [ Pass Timeout ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1680,6 +1680,10 @@ webkit.org/b/253343 [ Ventura+ ] http/tests/workers/service/shownotification-all
 [ Ventura+ ] imported/w3c/web-platform-tests/notifications/idlharness.https.any.worker.html [ Pass ]
 [ Ventura+ ] http/tests/workers/service/getnotifications-stop.html [ Pass ]
 [ Ventura+ ] http/tests/workers/service/getnotifications.html [ Pass ]
+[ Ventura+ ] http/wpt/service-workers/push-console-messages-no-showNotification.https.html [ Pass ]
+[ Ventura+ ] http/wpt/service-workers/push-console-messages-showNotification-async.https.html [ Pass ]
+[ Ventura+ ] http/wpt/service-workers/push-console-messages-showNotification-late.https.html [ Pass ]
+[ Ventura+ ] http/wpt/service-workers/push-console-messages-showNotification-sync.https.html [ Pass ]
 
 webkit.org/b/242164 [ Debug ] imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html [ Failure ]
 

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -208,6 +208,16 @@ void ServiceWorkerInternals::setAsInspected(bool isInspected)
     SWContextManager::singleton().setAsInspected(m_identifier, isInspected);
 }
 
+void ServiceWorkerInternals::enableConsoleMessageReporting(ScriptExecutionContext& context)
+{
+    downcast<ServiceWorkerGlobalScope>(context).enableConsoleMessageReporting();
+}
+
+void ServiceWorkerInternals:: logReportedConsoleMessage(ScriptExecutionContext& context, const String& value)
+{
+    downcast<ServiceWorkerGlobalScope>(context).addConsoleMessage(MessageSource::Storage, MessageLevel::Info, value, 0);
+}
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/testing/ServiceWorkerInternals.h
+++ b/Source/WebCore/testing/ServiceWorkerInternals.h
@@ -75,6 +75,8 @@ public:
 
     String serviceWorkerClientInternalIdentifier(const ServiceWorkerClient&);
     void setAsInspected(bool);
+    void enableConsoleMessageReporting(ScriptExecutionContext&);
+    void logReportedConsoleMessage(ScriptExecutionContext&, const String&);
 
 private:
     ServiceWorkerInternals(ServiceWorkerGlobalScope&, ServiceWorkerIdentifier);

--- a/Source/WebCore/testing/ServiceWorkerInternals.idl
+++ b/Source/WebCore/testing/ServiceWorkerInternals.idl
@@ -54,4 +54,6 @@
     DOMString serviceWorkerClientInternalIdentifier(ServiceWorkerClient client);
 
     undefined setAsInspected(boolean isInspected);
+    [CallWith=CurrentScriptExecutionContext] undefined enableConsoleMessageReporting();
+    [CallWith=CurrentScriptExecutionContext] undefined logReportedConsoleMessage(DOMString value);
 };

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -176,13 +176,14 @@ protected:
     void applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders&);
     void updateSourceProviderBuffers(const ScriptBuffer& mainScript, const HashMap<URL, ScriptBuffer>& importedScripts);
 
+    void addConsoleMessage(MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier) override;
+
 private:
     void logExceptionToConsole(const String& errorMessage, const String& sourceURL, int lineNumber, int columnNumber, RefPtr<Inspector::ScriptCallStack>&&) final;
 
     // The following addMessage and addConsoleMessage functions are deprecated.
     // Callers should try to create the ConsoleMessage themselves.
     void addMessage(MessageSource, MessageLevel, const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber, RefPtr<Inspector::ScriptCallStack>&&, JSC::JSGlobalObject*, unsigned long requestIdentifier) final;
-    void addConsoleMessage(MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier) final;
 
     bool isWorkerGlobalScope() const final { return true; }
 

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -93,6 +93,11 @@ public:
     void recordUserGesture();
     void setIsProcessingUserGestureForTesting(bool value) { m_isProcessingUserGesture = value; }
 
+    bool didFirePushEventRecently() const;
+
+    WEBCORE_EXPORT void addConsoleMessage(MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier) final;
+    void enableConsoleMessageReporting() { m_consoleMessageReportingEnabled = true; }
+
 private:
     ServiceWorkerGlobalScope(ServiceWorkerContextData&&, ServiceWorkerData&&, const WorkerParameters&, Ref<SecurityOrigin>&&, ServiceWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<NotificationClient>&&);
     void notifyServiceWorkerPageOfCreationIfNecessary();
@@ -117,6 +122,8 @@ private:
     bool m_isProcessingUserGesture { false };
     Timer m_userGestureTimer;
     RefPtr<PushEvent> m_pushEvent;
+    MonotonicTime m_lastPushEventTime;
+    bool m_consoleMessageReportingEnabled { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -86,6 +86,8 @@ public:
         virtual void deref() const = 0;
         virtual void stop() = 0;
 
+        virtual void reportConsoleMessage(ServiceWorkerIdentifier, MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier) = 0;
+
         bool isClosed() const { return m_isClosed; }
 
     protected:

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -246,6 +246,9 @@ void ServiceWorkerThread::queueTaskToFirePushEvent(std::optional<Vector<uint8_t>
             }
 
             bool showedNotification = !serviceWorkerGlobalScope->hasPendingSilentPushEvent();
+            serviceWorkerGlobalScope->setHasPendingSilentPushEvent(false);
+            if (!showedNotification)
+                serviceWorkerGlobalScope->addConsoleMessage(MessageSource::Storage, MessageLevel::Error, "Push event ended without showing any notification may trigger removal of the push subscription."_s, 0);
             bool success = !hasRejectedAnyPromise && showedNotification;
 
             RELEASE_LOG_ERROR_IF(!success, ServiceWorker, "ServiceWorkerThread::queueTaskToFirePushEvent failed to process push event (rejectedPromise = %d, showedNotification = %d)", hasRejectedAnyPromise, showedNotification);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -257,6 +257,15 @@ void WebSWServerToContextConnection::openWindow(WebCore::ServiceWorkerIdentifier
     m_connection.networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::OpenWindowFromServiceWorker { m_connection.sessionID(), url.string(), worker->origin().clientOrigin }, WTFMove(innerCallback));
 }
 
+void WebSWServerToContextConnection::reportConsoleMessage(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, MessageSource source, MessageLevel level, const String& message, unsigned long requestIdentifier)
+{
+    auto* server = this->server();
+    auto* worker = server ? server->workerByID(serviceWorkerIdentifier) : nullptr;
+    if (!worker)
+        return;
+    m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::ReportConsoleMessage { m_connection.sessionID(), worker->scriptURL(), worker->origin().clientOrigin, source, level, message, requestIdentifier }, 0);
+}
+
 void WebSWServerToContextConnection::matchAllCompleted(uint64_t requestIdentifier, const Vector<ServiceWorkerClientData>& clientsData)
 {
     send(Messages::WebSWContextManagerConnection::MatchAllCompleted { requestIdentifier, clientsData });

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -109,6 +109,7 @@ private:
     void connectionIsNoLongerNeeded() final;
     void terminateDueToUnresponsiveness() final;
     void openWindow(WebCore::ServiceWorkerIdentifier, const URL&, OpenWindowCallback&&) final;
+    void reportConsoleMessage(WebCore::ServiceWorkerIdentifier, MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier);
 
     void connectionClosed();
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
@@ -43,6 +43,7 @@ messages -> WebSWServerToContextConnection NotRefCounted {
     SetAsInspected(WebCore::ServiceWorkerIdentifier identifier, bool isInspected)
 
     OpenWindow(WebCore::ServiceWorkerIdentifier identifier, URL url) -> (Expected<std::optional<WebCore::ServiceWorkerClientData>, WebCore::ExceptionData> newClientData)
+    ReportConsoleMessage(WebCore::ServiceWorkerIdentifier identifier, enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String message, unsigned long requestIdentifier);
 }
 
 #endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -141,6 +141,13 @@ private:
         [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() openWindow:nsURL fromServiceWorkerOrigin:wrapper(apiOrigin.get()) completionHandler:completionHandler.get()];
     }
 
+    void reportServiceWorkerConsoleMessage(const URL&, const WebCore::SecurityOriginData&, MessageSource, MessageLevel, const String& message, unsigned long)
+    {
+        if (![m_delegate.get() respondsToSelector:@selector(websiteDataStore:reportServiceWorkerConsoleMessage:)])
+            return;
+        [m_delegate.getAutoreleased() websiteDataStore:m_dataStore.getAutoreleased() reportServiceWorkerConsoleMessage:message];
+    }
+
     bool showNotification(const WebCore::NotificationData& data) final
     {
         if (!m_hasShowNotificationSelector || !m_delegate || !m_dataStore)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
@@ -51,6 +51,7 @@ WK_API_AVAILABLE(macos(10.15), ios(13.0))
 - (void)requestStorageSpace:(NSURL *)mainFrameURL frameOrigin:(NSURL *)frameURL quota:(NSUInteger)quota currentSize:(NSUInteger)currentSize spaceRequired:(NSUInteger)spaceRequired decisionHandler:(void (^)(unsigned long long quota))decisionHandler;
 - (void)didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore openWindow:(NSURL *)url fromServiceWorkerOrigin:(WKSecurityOrigin *)serviceWorkerOrigin completionHandler:(void (^)(WKWebView *newWebView))completionHandler;
+- (void)websiteDataStore:(WKWebsiteDataStore *)dataStore reportServiceWorkerConsoleMessage:(NSString *)message;
 - (NSDictionary<NSString *, NSNumber *> *)notificationPermissionsForWebsiteDataStore:(WKWebsiteDataStore *)dataStore;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore showNotification:(_WKNotificationData *)notificationData;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore workerOrigin:(WKSecurityOrigin *)workerOrigin updatedAppBadge:(NSNumber *)badge;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1916,6 +1916,12 @@ void NetworkProcessProxy::openWindowFromServiceWorker(PAL::SessionID sessionID, 
     callback(std::nullopt);
 }
 
+void NetworkProcessProxy::reportConsoleMessage(PAL::SessionID sessionID, const URL& scriptURL, const WebCore::SecurityOriginData& clientOrigin, MessageSource source, MessageLevel level, const String& message, unsigned long requestIdentifier)
+{
+    if (auto* store = websiteDataStoreFromSessionID(sessionID))
+        store->reportServiceWorkerConsoleMessage(scriptURL, clientOrigin, source, level, message, requestIdentifier);
+}
+
 void NetworkProcessProxy::navigateServiceWorkerClient(WebCore::FrameIdentifier frameIdentifier, WebCore::ScriptExecutionContextIdentifier documentIdentifier, const URL& url, CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)>&& callback)
 {
     auto process = WebProcessProxy::processForIdentifier(documentIdentifier.processIdentifier());

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -385,6 +385,7 @@ private:
     void establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWorkerType, WebCore::RegistrableDomain&&, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PAL::SessionID, CompletionHandler<void(WebCore::ProcessIdentifier)>&&);
     void registerRemoteWorkerClientProcess(RemoteWorkerType, WebCore::ProcessIdentifier clientProcessIdentifier, WebCore::ProcessIdentifier remoteWorkerProcessIdentifier);
     void unregisterRemoteWorkerClientProcess(RemoteWorkerType, WebCore::ProcessIdentifier clientProcessIdentifier, WebCore::ProcessIdentifier remoteWorkerProcessIdentifier);
+    void reportConsoleMessage(PAL::SessionID, const URL&, const WebCore::SecurityOriginData&, MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier);
 
     void terminateWebProcess(WebCore::ProcessIdentifier);
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -97,6 +97,8 @@ messages -> NetworkProcessProxy LegacyReceiver {
     OpenWindowFromServiceWorker(PAL::SessionID sessionID, String urlString, WebCore::SecurityOriginData serviceWorkerOrigin) -> (std::optional<WebCore::PageIdentifier> newPage)
     NavigateServiceWorkerClient(WebCore::FrameIdentifier frameIdentifier, WebCore::ScriptExecutionContextIdentifier documentIdentifier, URL url) -> (std::optional<WebCore::PageIdentifier> page, std::optional<WebCore::FrameIdentifier> frame)
 
+    ReportConsoleMessage(PAL::SessionID sessionID, URL scriptURL, WebCore::SecurityOriginData serviceWorkerOrigin, enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String message, unsigned long requestIdentifier)
+
     CookiesDidChange(PAL::SessionID sessionID)
 
     DeleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebKit::WebsiteDataType> websiteDataTypes, struct WebCore::ClientOrigin origin, PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier webPageProxyID) -> ()

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2337,6 +2337,11 @@ void WebsiteDataStore::openWindowFromServiceWorker(const String& urlString, cons
     m_client->openWindowFromServiceWorker(urlString, serviceWorkerOrigin, WTFMove(innerCallback));
 }
 
+void WebsiteDataStore::reportServiceWorkerConsoleMessage(const URL& scriptURL, const WebCore::SecurityOriginData& clientOrigin, MessageSource source, MessageLevel level, const String& message, unsigned long requestIdentifier)
+{
+    m_client->reportServiceWorkerConsoleMessage(scriptURL, clientOrigin, source, level, message, requestIdentifier);
+}
+
 void WebsiteDataStore::workerUpdatedAppBadge(const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge)
 {
     m_client->workerUpdatedAppBadge(origin, badge);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -426,6 +426,7 @@ public:
     void didDestroyServiceWorkerNotification(const UUID& notificationID);
 
     void openWindowFromServiceWorker(const String& urlString, const WebCore::SecurityOriginData& serviceWorkerOrigin, CompletionHandler<void(std::optional<WebCore::PageIdentifier>)>&&);
+    void reportServiceWorkerConsoleMessage(const URL&, const WebCore::SecurityOriginData&, MessageSource,  MessageLevel, const String& message, unsigned long requestIdentifier);
 
     void workerUpdatedAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t>);
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -59,6 +59,9 @@ public:
     {
         completionHandler(nullptr);
     }
+    virtual void reportServiceWorkerConsoleMessage(const URL&, const WebCore::SecurityOriginData&, MessageSource, MessageLevel, const String&, unsigned long)
+    {
+    }
 
     virtual bool showNotification(const WebCore::NotificationData&)
     {

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -546,6 +546,11 @@ void WebSWContextManagerConnection::setAsInspected(WebCore::ServiceWorkerIdentif
     m_connectionToNetworkProcess->send(Messages::WebSWServerToContextConnection::SetAsInspected { identifier, isInspected }, 0);
 }
 
+void WebSWContextManagerConnection::reportConsoleMessage(WebCore::ServiceWorkerIdentifier identifier, MessageSource source, MessageLevel level, const String& message, unsigned long requestIdentifier)
+{
+    m_connectionToNetworkProcess->send(Messages::WebSWServerToContextConnection::ReportConsoleMessage { identifier, source, level, message, requestIdentifier }, 0);
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -94,6 +94,7 @@ private:
     void setAsInspected(WebCore::ServiceWorkerIdentifier, bool) final;
     void openWindow(WebCore::ServiceWorkerIdentifier, const URL&, OpenWindowCallback&&) final;
     void stop() final;
+    void reportConsoleMessage(WebCore::ServiceWorkerIdentifier, MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier) final;
 
     // IPC messages.
     void updatePreferencesStore(WebPreferencesStore&&);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2481,6 +2481,11 @@ void TestController::downloadDidFail(WKDownloadRef, WKErrorRef error)
     m_currentInvocation->notifyDownloadDone();
 }
 
+void TestController::receivedServiceWorkerConsoleMessage(const String& message)
+{
+    m_currentInvocation->outputText(makeString("Received ServiceWorker Console Message: ", message, "\n"));
+}
+
 void TestController::downloadDidReceiveAuthenticationChallenge(WKDownloadRef, WKAuthenticationChallengeRef authenticationChallenge, const void *clientInfo)
 {
     static_cast<TestController*>(const_cast<void*>(clientInfo))->didReceiveAuthenticationChallenge(nullptr, authenticationChallenge);

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -417,6 +417,8 @@ public:
     WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> backgroundFetchState(WKStringRef);
 
+    void receivedServiceWorkerConsoleMessage(const String&);
+
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);
     WKRetainPtr<WKContextConfigurationRef> generateContextConfiguration(const TestOptions&) const;

--- a/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
@@ -95,6 +95,10 @@
     _shouldAllowBackgroundFetchPermission = shouldAllowBackgroundFetchPermission;
 }
 
+- (void)websiteDataStore:(WKWebsiteDataStore *)dataStore reportServiceWorkerConsoleMessage:(NSString *)message
+{
+    WTR::TestController::singleton().receivedServiceWorkerConsoleMessage(message);
+}
 
 - (void)requestBackgroundFetchPermission:(NSURL *)mainFrameURL frameOrigin:(NSURL *)frameURL  decisionHandler:(void (^)(bool isGranted))decisionHandler
 {


### PR DESCRIPTION
#### 9eb7504c1b928c5e5da74a591fc42dc5aef58f46
<pre>
Add console logging message to missing or late showNotification calls in service worker
<a href="https://bugs.webkit.org/show_bug.cgi?id=254811">https://bugs.webkit.org/show_bug.cgi?id=254811</a>
rdar://problem/107471641

Reviewed by Ben Nham.

Add console log messages in case no showNotification is called during the lifetime of the push event.
Add console log messages in case a showNotification is called slightly too late after the end of the push event.

Add test API to be able to recover these console messages for WTR and related internals API.
Covered by added test.

* LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https.html: Added.
* LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-async.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-async.https.html: Added.
* LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https.html: Added.
* LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-sync.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-sync.https.html: Added.
* LayoutTests/http/wpt/service-workers/push-console-messages-worker.js: Added.
(async doPush):
(async doTest):
* LayoutTests/http/wpt/service-workers/push-console-messages.js: Added.
(promise_test.async test):
(async doTest):
* LayoutTests/platform/glib/http/wpt/service-workers/push-console-messages-no-showNotification.https-expected.txt: Added.
* LayoutTests/platform/glib/http/wpt/service-workers/push-console-messages-showNotification-async.https-expected.txt: Added.
* LayoutTests/platform/glib/http/wpt/service-workers/push-console-messages-showNotification-late.https-expected.txt: Added.
* LayoutTests/platform/glib/http/wpt/service-workers/push-console-messages-showNotification-sync.https-expected.txt: Added.
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
(WebCore::ServiceWorkerInternals::enableConsoleMessageReporting):
(WebCore::logReportedConsoleMessage):
* Source/WebCore/testing/ServiceWorkerInternals.h:
* Source/WebCore/testing/ServiceWorkerInternals.idl:
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::dispatchPushEvent):
(WebCore::ServiceWorkerGlobalScope::didFirePushEventRecently const):
(WebCore::ServiceWorkerGlobalScope::addConsoleMessage):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
(WebCore::ServiceWorkerRegistration::showNotification):
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFirePushEvent):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::reportConsoleMessage):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::reportConsoleMessage):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::reportServiceWorkerConsoleMessage):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
(WebKit::WebsiteDataStoreClient::reportServiceWorkerConsoleMessage):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::reportConsoleMessage):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
(-[ServiceWorkerOpenWindowWebsiteDataStoreDelegate websiteDataStore:openWindow:fromServiceWorkerOrigin:completionHandler:]):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::receivedServiceWorkerConsoleMessage):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm:
(-[TestWebsiteDataStoreDelegate websiteDataStore:reportServiceWorkerConsoleMessage:]):

Canonical link: <a href="https://commits.webkit.org/262584@main">https://commits.webkit.org/262584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bd089c955cf6245b10912d383d823ef37cbde28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2032 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1799 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2717 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1641 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1788 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2889 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1800 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1735 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/479 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1891 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->