### PR TITLE
Add fast abort case for StringCommon's equalCommon()

### DIFF
--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -298,17 +298,18 @@ ALWAYS_INLINE bool equal(const UChar* a, const LChar* b, unsigned length) { retu
 template<typename StringClassA, typename StringClassB>
 ALWAYS_INLINE bool equalCommon(const StringClassA& a, const StringClassB& b, unsigned length)
 {
+    if (!length)
+        return true;
+
     if (a.is8Bit()) {
         if (b.is8Bit())
-            return equal(a.characters8(), b.characters8(), length);
-
-        return equal(a.characters8(), b.characters16(), length);
+            return *a.characters8() == *b.characters8() && equal(a.characters8() + 1, b.characters8() + 1, length - 1);
+        return *a.characters8() == *b.characters16() && equal(a.characters8() + 1, b.characters16() + 1, length - 1);
     }
 
     if (b.is8Bit())
-        return equal(a.characters16(), b.characters8(), length);
-
-    return equal(a.characters16(), b.characters16(), length);
+        return *a.characters16() == *b.characters8() && equal(a.characters16() + 1, b.characters8() + 1, length - 1);
+    return *a.characters16() == *b.characters16() && equal(a.characters16() + 1, b.characters16() + 1, length - 1);
 }
 
 template<typename StringClassA, typename StringClassB>


### PR DESCRIPTION
#### b63c1155dfa7bf35b055845ce270ac08d0244517
<pre>
Add fast abort case for StringCommon&apos;s equalCommon()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254819">https://bugs.webkit.org/show_bug.cgi?id=254819</a>

Reviewed by Mark Lam and Geoffrey Garen.

* Source/WTF/wtf/text/StringCommon.h:
(WTF::equalCommon):

Canonical link: <a href="https://commits.webkit.org/262467@main">https://commits.webkit.org/262467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c043940abacf3674e7a0c96400440b1e251b308

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1312 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1432 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2253 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1288 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1277 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1356 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2439 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1438 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1253 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1528 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1339 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/323 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/395 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1453 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1569 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/436 "Passed tests") | 
<!--EWS-Status-Bubble-End-->