### PR TITLE
Avoid wptserve triggering "accept incoming network connections?" prompt

### DIFF
--- a/LayoutTests/imported/w3c/resources/config.json
+++ b/LayoutTests/imported/w3c/resources/config.json
@@ -11,7 +11,7 @@
           {"url-path": "/WebKit/", "local-dir":"../../../http/wpt/"}],
  "check_subdomains": false,
  "log_level":"debug",
- "bind_address": false,
+ "bind_address": true,
  "ssl": {"type": "openssl",
          "encrypt_after_connect": false,
          "openssl": {

--- a/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
@@ -45,6 +45,7 @@ def wpt_config_json(port_obj):
         return
     config = json.loads(fs.read_text_file(config_wk_filepath))
     if port_obj.supports_localhost_aliases and not port_obj.get_option('disable_wpt_hostname_aliases'):
+        config['server_host'] = '127.0.0.1'
         config['browser_host'] = 'web-platform.test'
         config['alternate_hosts'] = {'alt': 'not-web-platform.test'}
     config['ssl']['openssl']['base_path'] = fs.join(port_obj.results_directory(), "_wpt_certs")


### PR DESCRIPTION
#### 67e2dc7878b6bc0956e9106358cac9ff6dad8f60
<pre>
Avoid wptserve triggering &quot;accept incoming network connections?&quot; prompt
<a href="https://bugs.webkit.org/show_bug.cgi?id=253164">https://bugs.webkit.org/show_bug.cgi?id=253164</a>

Reviewed by Jonathan Bedard.

This was a regression from 254273@main, which was meant to be a
glib-port-only change, but because it changed the generic WPT
config.json this affected all ports, including the Apple&apos;s macOS port
which produces such a prompt when you try and bind on all addresses.

* LayoutTests/imported/w3c/resources/config.json:
* Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py:
(wpt_config_json):

Canonical link: <a href="https://commits.webkit.org/262821@main">https://commits.webkit.org/262821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87c57b84811e428e8519d7cec6466631eccf6ab4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3172 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2027 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3067 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/2279 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1921 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2076 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2053 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3230 "9 api tests failed or timed out") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2042 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1861 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/666 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1984 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->