### PR TITLE
[GTK] AcceleratedSurfaceDMABuf.cpp does not build on i386

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
@@ -130,12 +130,12 @@ void AcceleratedSurfaceDMABuf::clientResize(const WebCore::IntSize& size)
     }
     UnixFileDescriptor backFD(gbm_bo_get_fd(backObject), UnixFileDescriptor::Adopt);
     Vector<EGLAttrib> attributes = {
-        EGL_WIDTH, gbm_bo_get_width(backObject),
-        EGL_HEIGHT, gbm_bo_get_height(backObject),
-        EGL_LINUX_DRM_FOURCC_EXT, gbm_bo_get_format(backObject),
+        EGL_WIDTH, static_cast<EGLAttrib>(gbm_bo_get_width(backObject)),
+        EGL_HEIGHT, static_cast<EGLAttrib>(gbm_bo_get_height(backObject)),
+        EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLAttrib>(gbm_bo_get_format(backObject)),
         EGL_DMA_BUF_PLANE0_FD_EXT, backFD.value(),
-        EGL_DMA_BUF_PLANE0_OFFSET_EXT, gbm_bo_get_offset(backObject, 0),
-        EGL_DMA_BUF_PLANE0_PITCH_EXT, gbm_bo_get_stride(backObject),
+        EGL_DMA_BUF_PLANE0_OFFSET_EXT, static_cast<EGLAttrib>(gbm_bo_get_offset(backObject, 0)),
+        EGL_DMA_BUF_PLANE0_PITCH_EXT, static_cast<EGLAttrib>(gbm_bo_get_stride(backObject)),
         EGL_NONE
     };
     m_backImage = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);


### PR DESCRIPTION
#### f8991bed5a03b036f3dde275833c10cec4bdc307
<pre>
[GTK] AcceleratedSurfaceDMABuf.cpp does not build on i386
<a href="https://bugs.webkit.org/show_bug.cgi?id=254828">https://bugs.webkit.org/show_bug.cgi?id=254828</a>

Reviewed by Adrian Perez de Castro.

* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::clientResize):

Canonical link: <a href="https://commits.webkit.org/262476@main">https://commits.webkit.org/262476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2548d949e01a9100d1c6946f4866745bbce1b32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1728 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1510 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2366 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1443 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1360 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1466 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1485 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1345 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1450 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/400 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1565 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->