### PR TITLE
[UI-side compositing] Several layout tests fail with pixel tolerances

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clip-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clip-001.html
@@ -12,7 +12,7 @@
 
   <meta name="assert" content="Test passes if a box with border-radius that clips its content to a box edge clips to the border-radius curve in the corners.">
 
-  <meta name="fuzzy" content="0-1;0-1000">
+  <meta name="fuzzy" content="0-57;0-1552">
 
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-padding.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-padding.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=110-209; totalPixels=298-934" />
+<meta name="fuzzy" content="maxDifference=86-209; totalPixels=298-934" />
 <style>
     html, body {
         margin: 0;


### PR DESCRIPTION
#### 656c0aeae78bfa54346b7a5f5ed224574dd0b78d
<pre>
[UI-side compositing] Several layout tests fail with pixel tolerances
<a href="https://bugs.webkit.org/show_bug.cgi?id=254836">https://bugs.webkit.org/show_bug.cgi?id=254836</a>
rdar://107460054

Reviewed by Simon Fraser.

Adjusts the pixel tolerances for the affected tests.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clip-001.html:
* LayoutTests/svg/compositing/outermost-svg-with-border-padding.html:

Canonical link: <a href="https://commits.webkit.org/262452@main">https://commits.webkit.org/262452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9353cb9ec1373dc2de5f8528a0ead911d0081797

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2440 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1449 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2277 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1386 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1361 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1385 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1400 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1431 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1367 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/385 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1483 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->