### PR TITLE
Move HashCountedSet to WeakHashCountedSet in StyleGeneratedImage

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -240,8 +240,9 @@ HashSet<Element*> CanvasBase::cssCanvasClients() const
         if (!is<StyleCanvasImage>(observer))
             continue;
 
-        for (auto& client : downcast<StyleCanvasImage>(observer).clients().values()) {
-            if (auto element = client->element())
+        for (auto entry : downcast<StyleCanvasImage>(observer).clients()) {
+            auto& client = entry.key;
+            if (auto element = client.element())
                 cssCanvasClients.add(element);
         }
     }

--- a/Source/WebCore/rendering/style/StyleCanvasImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.cpp
@@ -76,7 +76,7 @@ RefPtr<Image> StyleCanvasImage::image(const RenderElement* renderer, const Float
     if (!renderer)
         return &Image::nullImage();
 
-    ASSERT(clients().contains(const_cast<RenderElement*>(renderer)));
+    ASSERT(clients().contains(const_cast<RenderElement&>(*renderer)));
     auto* element = this->element(renderer->document());
     if (!element || !element->buffer())
         return nullptr;
@@ -117,8 +117,10 @@ void StyleCanvasImage::canvasChanged(CanvasBase& canvasBase, const std::optional
         return;
 
     auto imageChangeRect = enclosingIntRect(changedRect.value());
-    for (auto& client : clients().values())
-        client->imageChanged(static_cast<WrappedImagePtr>(this), &imageChangeRect);
+    for (auto entry : clients()) {
+        auto& client = entry.key;
+        client.imageChanged(static_cast<WrappedImagePtr>(this), &imageChangeRect);
+    }
 }
 
 void StyleCanvasImage::canvasResized(CanvasBase& canvasBase)
@@ -126,8 +128,10 @@ void StyleCanvasImage::canvasResized(CanvasBase& canvasBase)
     ASSERT_UNUSED(canvasBase, is<HTMLCanvasElement>(canvasBase));
     ASSERT_UNUSED(canvasBase, m_element == &downcast<HTMLCanvasElement>(canvasBase));
 
-    for (auto& client : clients().values())
-        client->imageChanged(static_cast<WrappedImagePtr>(this));
+    for (auto entry : clients()) {
+        auto& client = entry.key;
+        client.imageChanged(static_cast<WrappedImagePtr>(this));
+    }
 }
 
 void StyleCanvasImage::canvasDestroyed(CanvasBase& canvasBase)

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
@@ -184,8 +184,10 @@ void StyleCrossfadeImage::imageChanged(CachedImage*, const IntRect*)
 {
     if (!m_inputImagesAreReady)
         return;
-    for (auto& client : clients().values())
-        client->imageChanged(this);
+    for (auto entry : clients()) {
+        auto& client = entry.key;
+        client.imageChanged(static_cast<WrappedImagePtr>(this));
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -162,8 +162,10 @@ void StyleFilterImage::imageChanged(CachedImage*, const IntRect*)
     if (!m_inputImageIsReady)
         return;
 
-    for (auto& client : clients().values())
-        client->imageChanged(static_cast<WrappedImagePtr>(this));
+    for (auto entry : clients()) {
+        auto& client = entry.key;
+        client.imageChanged(static_cast<WrappedImagePtr>(this));
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleGeneratedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGeneratedImage.cpp
@@ -138,29 +138,29 @@ void StyleGeneratedImage::computeIntrinsicDimensions(const RenderElement* render
 
 void StyleGeneratedImage::addClient(RenderElement& renderer)
 {
-    if (m_clients.isEmpty())
+    if (m_clients.isEmptyIgnoringNullReferences())
         ref();
 
-    m_clients.add(&renderer);
+    m_clients.add(renderer);
 
     this->didAddClient(renderer);
 }
 
 void StyleGeneratedImage::removeClient(RenderElement& renderer)
 {
-    ASSERT(m_clients.contains(&renderer));
-    if (!m_clients.remove(&renderer))
+    ASSERT(m_clients.contains(renderer));
+    if (!m_clients.remove(renderer))
         return;
 
     this->didRemoveClient(renderer);
 
-    if (m_clients.isEmpty())
+    if (m_clients.isEmptyIgnoringNullReferences())
         deref();
 }
 
 bool StyleGeneratedImage::hasClient(RenderElement& renderer) const
 {
-    return m_clients.contains(&renderer);
+    return m_clients.contains(renderer);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleGeneratedImage.h
+++ b/Source/WebCore/rendering/style/StyleGeneratedImage.h
@@ -26,8 +26,8 @@
 #include "FloatSize.h"
 #include "FloatSizeHash.h"
 #include "StyleImage.h"
-#include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
+#include <wtf/WeakHashCountedSet.h>
 
 namespace WebCore {
 
@@ -42,7 +42,7 @@ struct ResourceLoaderOptions;
 
 class StyleGeneratedImage : public StyleImage {
 public:
-    const HashCountedSet<RenderElement*>& clients() const { return m_clients; }
+    const WeakHashCountedSet<RenderElement>& clients() const { return m_clients; }
 
 protected:
     explicit StyleGeneratedImage(StyleImage::Type, bool fixedSize);
@@ -76,7 +76,7 @@ protected:
 
     FloatSize m_containerSize;
     bool m_fixedSize;
-    HashCountedSet<RenderElement*> m_clients;
+    WeakHashCountedSet<RenderElement> m_clients;
     HashMap<FloatSize, std::unique_ptr<CachedGeneratedImage>> m_images;
 };
 

--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -189,7 +189,7 @@ RefPtr<Image> StyleGradientImage::image(const RenderElement* renderer, const Flo
 
     bool cacheable = m_knownCacheableBarringFilter && !renderer->style().hasAppleColorFilter();
     if (cacheable) {
-        if (!clients().contains(const_cast<RenderElement*>(renderer)))
+        if (!clients().contains(const_cast<RenderElement&>(*renderer)))
             return nullptr;
         if (auto* result = const_cast<StyleGradientImage&>(*this).cachedImageForSize(size))
             return result;


### PR DESCRIPTION
#### 4bfd15d8cdc7d90dc7674237addf934a3d5c7be4
<pre>
Move HashCountedSet to WeakHashCountedSet in StyleGeneratedImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=254835">https://bugs.webkit.org/show_bug.cgi?id=254835</a>
rdar://107480319

Reviewed by Chris Dumez.

Generated images should use a Weak container to keep track of
RenderElements so that we don&apos;t trigger UAF issues.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore:: const):
* Source/WebCore/rendering/style/StyleCanvasImage.cpp:
(WebCore::StyleCanvasImage::image const):
(WebCore::StyleCanvasImage::canvasChanged):
(WebCore::StyleCanvasImage::canvasResized):
* Source/WebCore/rendering/style/StyleCrossfadeImage.cpp:
(WebCore::StyleCrossfadeImage::imageChanged):
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::imageChanged):
* Source/WebCore/rendering/style/StyleGeneratedImage.cpp:
(WebCore::StyleGeneratedImage::addClient):
(WebCore::StyleGeneratedImage::removeClient):
(WebCore::StyleGeneratedImage::hasClient const):
* Source/WebCore/rendering/style/StyleGeneratedImage.h:
(WebCore::StyleGeneratedImage::clients const):
(WebCore::StyleGeneratedImage:: const): Deleted.
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::StyleGradientImage::image const):

Canonical link: <a href="https://commits.webkit.org/262469@main">https://commits.webkit.org/262469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d854e6580eba9ff8a07a7d6b8031cdf0a38c334f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1463 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2297 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1313 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1406 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2468 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1295 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1383 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/399 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1504 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->