### PR TITLE
Cherry-pick 256843.9@webkit-2022.12-embargoed (4c3dcd480f7e). rdar://107475307

### DIFF
--- a/JSTests/stress/arguments-elimination-should-happen-only-when-stack-slot-is-available-at-replacement-site.js
+++ b/JSTests/stress/arguments-elimination-should-happen-only-when-stack-slot-is-available-at-replacement-site.js
@@ -1,0 +1,19 @@
+//@ runDefault("--jitPolicyScale=0")
+function empty() {}
+
+function bar2(...a0) {
+  return a0;
+}
+
+function foo() {
+  let xs = bar2(undefined);
+  '' == 1 && 0;
+  return empty(...xs, undefined);
+}
+function main () {
+    for (let i = 0; i < 1_000_000; i++) {
+      let a = foo();
+      Array.isArray(a);
+    }
+}
+main();

--- a/LayoutTests/fast/css/content/content-on-focus-change-expected.txt
+++ b/LayoutTests/fast/css/content/content-on-focus-change-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/content/content-on-focus-change.html
+++ b/LayoutTests/fast/css/content/content-on-focus-change.html
@@ -1,0 +1,21 @@
+<style>
+.class2:focus-within { display: contents; }
+</style>
+<script>
+if(window.testRunner)
+    testRunner.dumpAsText();
+
+function main() {
+    input.setSelectionRange(0,31,"forward");
+}
+function f1() {
+    var input = document.getElementById("input");
+    document.execCommand("justifyRight",false,null);
+    a.text = "This test passes if it doesn't crash.";
+    input.type = "checkbox";
+}
+</script>
+<body onload="main()">
+<a id="a" onfocusin="f1()">
+<span class="class2">
+<input id="input">

--- a/LayoutTests/fast/css/display-contents-slot-to-none-expected.txt
+++ b/LayoutTests/fast/css/display-contents-slot-to-none-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/display-contents-slot-to-none.html
+++ b/LayoutTests/fast/css/display-contents-slot-to-none.html
@@ -1,0 +1,28 @@
+<style>
+#remove_this {
+  display: contents;
+}
+</style>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+
+function gc() {
+ for(var i=0;i<100;i++) {
+   a = new Uint8Array(1024*1024);
+ }
+}
+function main() {
+  slot.setAttribute("hidden","");
+  dialog.show();
+  remove_this.style.left = "10px";
+  document.body.offsetHeight;
+  remove_this.remove();
+  gc();
+}
+</script>
+<body onload="main()">
+<slot id=slot>
+  <span id=remove_this><dialog id=dialog></dialog><span></span></span>
+</slot>
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/layers/normal-flow-dialog-remove-layer-crash-expected.html
+++ b/LayoutTests/fast/layers/normal-flow-dialog-remove-layer-crash-expected.html
@@ -1,0 +1,1 @@
+Pass if no crash.

--- a/LayoutTests/fast/layers/normal-flow-dialog-remove-layer-crash.html
+++ b/LayoutTests/fast/layers/normal-flow-dialog-remove-layer-crash.html
@@ -1,0 +1,30 @@
+<style>
+  div {
+    overflow: hidden;
+  }
+  dialog {
+    overflow: hidden;
+    position: static;
+    display: inline;
+    float: left;
+  }
+  head {
+    display: inline;
+  }
+</style>
+<script>
+  if (window.testRunner)
+    testRunner.waitUntilDone();
+  onload = () => {
+    document.head.append(dialog);
+    setTimeout(() => {
+      dialog.showModal();
+      document.styleSheets[0].disabled = true;
+      testRunner.notifyDone();
+    }, 0);
+  };
+</script>
+<body>
+<dialog id="dialog"><div></div></dialog>
+Pass if no crash.
+</body>

--- a/LayoutTests/fast/multicol/nested-columns-out-of-flow-crash-expected.txt
+++ b/LayoutTests/fast/multicol/nested-columns-out-of-flow-crash-expected.txt
@@ -1,0 +1,1 @@
+Pass if no crash.

--- a/LayoutTests/fast/multicol/nested-columns-out-of-flow-crash.html
+++ b/LayoutTests/fast/multicol/nested-columns-out-of-flow-crash.html
@@ -1,0 +1,12 @@
+<div style="column-count: 2">
+  <div style="position: relative">
+    <div style="column-count: 2">
+      <div style="position: absolute"></div>
+    </div>
+  </div>
+</div>
+Pass if no crash.
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -33,11 +33,9 @@
 #include "DFGArgumentsUtilities.h"
 #include "DFGBlockMapInlines.h"
 #include "DFGClobberize.h"
-#include "DFGCombinedLiveness.h"
 #include "DFGForAllKills.h"
 #include "DFGGraph.h"
 #include "DFGInsertionSet.h"
-#include "DFGLivenessAnalysisPhase.h"
 #include "DFGOSRAvailabilityAnalysisPhase.h"
 #include "DFGPhase.h"
 #include "JSCInlines.h"
@@ -74,7 +72,13 @@ public:
         identifyCandidates();
         if (m_candidates.isEmpty())
             return false;
-        
+
+        removeInvalidCandidates();
+        if (m_candidates.isEmpty())
+            return false;
+
+        collectAvailability();
+
         eliminateCandidatesThatEscape();
         if (m_candidates.isEmpty())
             return false;
@@ -97,7 +101,7 @@ private:
                 switch (node->op()) {
                 case CreateDirectArguments:
                 case CreateClonedArguments:
-                    m_candidates.add(node);
+                    m_candidates.add(node, AvailabilityMap { });
                     break;
 
                 case CreateRest:
@@ -107,7 +111,7 @@ private:
                         // this allocation when we're not watching the watchpoint because it could entail calling
                         // indexed accessors (and probably more crazy things) on out of bound accesses to the
                         // rest parameter. It's also much easier to reason about this way.
-                        m_candidates.add(node);
+                        m_candidates.add(node, AvailabilityMap { });
                     }
                     break;
 
@@ -118,7 +122,7 @@ private:
                         // been changed).
                         if (node->child1().useKind() == ArrayUse) {
                             if ((node->child1()->op() == CreateRest || node->child1()->op() == NewArrayBuffer) && m_candidates.contains(node->child1().node()))
-                                m_candidates.add(node);
+                                m_candidates.add(node, AvailabilityMap { });
                         }
                     }
                     break;
@@ -140,14 +144,14 @@ private:
                         if (!isOK)
                             break;
 
-                        m_candidates.add(node);
+                        m_candidates.add(node, AvailabilityMap { });
                     }
                     break;
                 }
 
                 case NewArrayBuffer: {
                     if (m_graph.isWatchingHavingABadTimeWatchpoint(node) && !hasAnyArrayStorage(node->indexingMode()))
-                        m_candidates.add(node);
+                        m_candidates.add(node, AvailabilityMap { });
                     break;
                 }
                     
@@ -166,8 +170,35 @@ private:
             }
         }
         
-        if (DFGArgumentsEliminationPhaseInternal::verbose)
-            dataLog("Candidates: ", listDump(m_candidates), "\n");
+        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "Candidates: ", listDump(m_candidates.keys()));
+    }
+
+    // Do this analysis after we found we have some candidates to avoid doing fixed-point analysis on FTL graph which does not have candidates.
+    void collectAvailability()
+    {
+        performOSRAvailabilityAnalysis(m_graph);
+
+        for (BasicBlock* block : m_graph.blocksInPreOrder()) {
+            LocalOSRAvailabilityCalculator calculator(m_graph);
+            calculator.beginBlock(block);
+            for (Node* node : *block) {
+                switch (node->op()) {
+                case CreateDirectArguments:
+                case CreateClonedArguments:
+                case CreateRest: {
+                    auto iterator = m_candidates.find(node);
+                    if (iterator != m_candidates.end())
+                        iterator->value = calculator.m_availability;
+                    break;
+                }
+                default:
+                    break;
+                }
+                if (node->isPseudoTerminal())
+                    break;
+                calculator.executeNode(node);
+            }
+        }
     }
 
     bool isStillValidCandidate(Node* candidate)
@@ -202,7 +233,7 @@ private:
             changed = false;
             Vector<Node*, 1> toRemove;
 
-            for (Node* candidate : m_candidates) {
+            for (auto& [candidate, availability] : m_candidates) {
                 if (!isStillValidCandidate(candidate))
                     toRemove.append(candidate);
             }
@@ -219,8 +250,8 @@ private:
     void transitivelyRemoveCandidate(Node* node, Node* source = nullptr)
     {
         bool removed = m_candidates.remove(node);
-        if (removed && DFGArgumentsEliminationPhaseInternal::verbose && source)
-            dataLog("eliminating candidate: ", node, " because it escapes from: ", source, "\n");
+        if (removed && source)
+            dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", node, " because it escapes from: ", source);
 
         if (removed)
             removeInvalidCandidates();
@@ -287,8 +318,6 @@ private:
             }
         };
 
-        removeInvalidCandidates();
-        
         for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
             for (Node* node : *block) {
                 switch (node->op()) {
@@ -362,7 +391,7 @@ private:
                 case TailCallVarargsInlinedCaller:
                     escape(node->child1(), node);
                     escape(node->child2(), node);
-                    if (node->callVarargsData()->firstVarArgOffset && (node->child3()->op() == NewArrayWithSpread || node->child3()->op() == Spread || node->child1()->op() == NewArrayBuffer))
+                    if (node->callVarargsData()->firstVarArgOffset && (node->child3()->op() == NewArrayWithSpread || node->child3()->op() == Spread || node->child3()->op() == NewArrayBuffer))
                         escape(node->child3(), node);
                     break;
 
@@ -463,187 +492,241 @@ private:
             }
         }
 
-        if (DFGArgumentsEliminationPhaseInternal::verbose)
-            dataLog("After escape analysis: ", listDump(m_candidates), "\n");
+        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "After escape analysis: ", listDump(m_candidates.keys()));
     }
 
-    // Anywhere that a candidate is live (in bytecode or in DFG), check if there is a chance of
-    // interference between the stack area that the arguments object copies from and the arguments
-    // object's payload. Conservatively this means that the stack region doesn't get stored to.
     void eliminateCandidatesThatInterfere()
     {
-        performLivenessAnalysis(m_graph);
-        performOSRAvailabilityAnalysis(m_graph);
-        m_graph.initializeNodeOwners();
-        CombinedLiveness combinedLiveness(m_graph);
-        
-        BlockMap<Operands<bool>> clobberedByBlock(m_graph);
-        for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
-            Operands<bool>& clobberedByThisBlock = clobberedByBlock[block];
-            clobberedByThisBlock = Operands<bool>(OperandsLike, m_graph.block(0)->variablesAtHead);
-            for (Node* node : *block) {
-                clobberize(
-                    m_graph, node, NoOpClobberize(),
-                    [&] (AbstractHeap heap) {
-                        if (heap.kind() != Stack) {
-                            ASSERT(!heap.overlaps(Stack));
-                            return;
-                        }
-                        ASSERT(!heap.payload().isTop());
-                        Operand operand = heap.operand();
-                        // The register may not point to an argument or local, for example if we are looking at SetArgumentCountIncludingThis.
-                        if (!operand.isHeader())
-                            clobberedByThisBlock.operand(operand) = true;
-                    },
-                    NoOpClobberize());
-            }
-        }
-        
-        using InlineCallFrames = HashSet<InlineCallFrame*, WTF::DefaultHash<InlineCallFrame*>, WTF::NullableHashTraits<InlineCallFrame*>>;
-        using InlineCallFramesForCanditates = HashMap<Node*, InlineCallFrames>;
-        InlineCallFramesForCanditates inlineCallFramesForCandidate;
-        auto forEachDependentNode = recursableLambda([&](auto self, Node* node, const auto& functor) -> void {
-            functor(node);
+        auto forEachDependentNode = recursableLambda([&](auto self, Node* node, const auto& functor) -> IterationStatus {
+            if (functor(node) == IterationStatus::Done)
+                return IterationStatus::Done;
 
-            if (node->op() == Spread) {
-                self(node->child1().node(), functor);
-                return;
-            }
+            if (node->op() == Spread)
+                return self(node->child1().node(), functor);
 
             if (node->op() == NewArrayWithSpread) {
                 BitVector* bitVector = node->bitVector();
                 for (unsigned i = node->numChildren(); i--; ) {
-                    if (bitVector->get(i))
-                        self(m_graph.varArgChild(node, i).node(), functor);
+                    if (bitVector->get(i)) {
+                        if (self(m_graph.varArgChild(node, i).node(), functor) == IterationStatus::Done)
+                            return IterationStatus::Done;
+                    }
                 }
-                return;
             }
-        });
-        for (Node* candidate : m_candidates) {
-            auto& set = inlineCallFramesForCandidate.add(candidate, InlineCallFrames()).iterator->value;
-            forEachDependentNode(candidate, [&](Node* dependent) {
-                set.add(dependent->origin.semantic.inlineCallFrame());
-            });
-        }
 
-        for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
+            return IterationStatus::Continue;
+        });
+
+        auto computeInterference = [&](Node* candidate, const AvailabilityMap& availability) {
+            bool interfere = false;
+            forEachDependentNode(candidate, [&](Node* dependent) -> IterationStatus {
+                if (dependent->op() != CreateRest && dependent->op() != CreateDirectArguments && dependent->op() != CreateClonedArguments)
+                    return IterationStatus::Continue;
+
+                auto iterator = m_candidates.find(dependent);
+                if (iterator == m_candidates.end())
+                    return IterationStatus::Continue;
+
+                InlineCallFrame* inlineCallFrame = dependent->origin.semantic.inlineCallFrame();
+                if (inlineCallFrame) {
+                    if (inlineCallFrame->isVarargs()) {
+                        VirtualRegister reg(inlineCallFrame->stackOffset + CallFrameSlot::argumentCountIncludingThis);
+                        if (availability.m_locals.operand(reg) != iterator->value.m_locals.operand(reg)) {
+                            interfere = true;
+                            return IterationStatus::Done;
+                        }
+                    }
+
+                    if (inlineCallFrame->isClosureCall) {
+                        VirtualRegister reg(inlineCallFrame->stackOffset + CallFrameSlot::callee);
+                        if (availability.m_locals.operand(reg) != iterator->value.m_locals.operand(reg)) {
+                            interfere = true;
+                            return IterationStatus::Done;
+                        }
+                    }
+
+                    for (unsigned i = 0; i < static_cast<unsigned>(inlineCallFrame->argumentCountIncludingThis - 1); ++i) {
+                        VirtualRegister reg = VirtualRegister(inlineCallFrame->stackOffset) + CallFrame::argumentOffset(i);
+                        if (availability.m_locals.operand(reg) != iterator->value.m_locals.operand(reg)) {
+                            interfere = true;
+                            return IterationStatus::Done;
+                        }
+                    }
+                } else {
+                    // We don't include the ArgumentCount or Callee in this case because we can be
+                    // damn sure that this won't be clobbered.
+                    for (unsigned i = 1; i < static_cast<unsigned>(codeBlock()->numParameters()); ++i) {
+                        if (availability.m_locals.argument(i) != iterator->value.m_locals.argument(i)) {
+                            interfere = true;
+                            return IterationStatus::Done;
+                        }
+                    }
+                }
+                return IterationStatus::Continue;
+            });
+            return interfere;
+        };
+
+        for (BasicBlock* block : m_graph.blocksInPreOrder()) {
             // Stop if we've already removed all candidates.
             if (m_candidates.isEmpty())
                 return;
-            
-            // Ignore blocks that don't write to the stack.
-            bool writesToStack = false;
-            for (unsigned i = clobberedByBlock[block].size(); i--;) {
-                if (clobberedByBlock[block][i]) {
-                    writesToStack = true;
+
+            LocalOSRAvailabilityCalculator calculator(m_graph);
+            calculator.beginBlock(block);
+            for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
+                Node* node = block->at(nodeIndex);
+
+                switch (node->op()) {
+                case GetFromArguments: {
+                    Node* candidate = node->child1().node();
+                    if (!m_candidates.contains(candidate))
+                        break;
+
+                    DFG_ASSERT(m_graph, node, node->child1()->op() == CreateDirectArguments, node->child1()->op());
+                    VirtualRegister reg = virtualRegisterForArgumentIncludingThis(node->capturedArgumentsOffset().offset() + 1) + node->origin.semantic.stackOffset();
+                    bool interfere = false;
+                    forEachDependentNode(candidate, [&](Node* dependent) -> IterationStatus {
+                        if (dependent->op() != CreateRest && dependent->op() != CreateDirectArguments && dependent->op() != CreateClonedArguments)
+                            return IterationStatus::Continue;
+
+                        auto iterator = m_candidates.find(dependent);
+                        if (iterator == m_candidates.end())
+                            return IterationStatus::Continue;
+
+                        if (iterator->value.m_locals.operand(reg) != calculator.m_availability.m_locals.operand(reg)) {
+                            interfere = true;
+                            return IterationStatus::Done;
+                        }
+
+                        return IterationStatus::Continue;
+                    });
+                    if (interfere) {
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", node);
+                        transitivelyRemoveCandidate(candidate);
+                    }
                     break;
                 }
-            }
-            if (!writesToStack)
-                continue;
-            
-            forAllKillsInBlock(
-                m_graph, combinedLiveness, block,
-                [&] (unsigned nodeIndex, Node* candidate) {
+
+                case GetByOffset: {
+                    Node* candidate = node->child2().node();
                     if (!m_candidates.contains(candidate))
-                        return;
-                    
-                    for (InlineCallFrame* inlineCallFrame : inlineCallFramesForCandidate.get(candidate)) {
-                        // Check if this block has any clobbers that affect this candidate. This is a fairly
-                        // fast check.
-                        bool isClobberedByBlock = false;
-                        Operands<bool>& clobberedByThisBlock = clobberedByBlock[block];
-                        
-                        if (inlineCallFrame) {
-                            if (inlineCallFrame->isVarargs()) {
-                                isClobberedByBlock |= clobberedByThisBlock.operand(
-                                    VirtualRegister(inlineCallFrame->stackOffset + CallFrameSlot::argumentCountIncludingThis));
-                            }
+                        break;
 
-                            if (!isClobberedByBlock || inlineCallFrame->isClosureCall) {
-                                isClobberedByBlock |= clobberedByThisBlock.operand(
-                                    VirtualRegister(inlineCallFrame->stackOffset + CallFrameSlot::callee));
-                            }
-
-                            if (!isClobberedByBlock) {
-                                for (unsigned i = 0; i < static_cast<unsigned>(inlineCallFrame->argumentCountIncludingThis - 1); ++i) {
-                                    VirtualRegister reg =
-                                        VirtualRegister(inlineCallFrame->stackOffset) +
-                                        CallFrame::argumentOffset(i);
-                                    if (clobberedByThisBlock.operand(reg)) {
-                                        isClobberedByBlock = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        } else {
-                            // We don't include the ArgumentCount or Callee in this case because we can be
-                            // damn sure that this won't be clobbered.
-                            for (unsigned i = 1; i < static_cast<unsigned>(codeBlock()->numParameters()); ++i) {
-                                if (clobberedByThisBlock.argument(i)) {
-                                    isClobberedByBlock = true;
-                                    break;
-                                }
-                            }
-                        }
-                        
-                        if (!isClobberedByBlock)
-                            continue;
-                        
-                        // Check if we can immediately eliminate this candidate. If the block has a clobber
-                        // for this arguments allocation, and we'd have to examine every node in the block,
-                        // then we can just eliminate the candidate.
-                        if (nodeIndex == block->size() && candidate->owner != block) {
-                            if (DFGArgumentsEliminationPhaseInternal::verbose)
-                                dataLog("eliminating candidate: ", candidate, " because it is clobbered by: ", block->at(nodeIndex), "\n");
-                            transitivelyRemoveCandidate(candidate);
-                            return;
-                        }
-
-                        // This loop considers all nodes up to the nodeIndex, excluding the nodeIndex.
-                        //
-                        // Note: nodeIndex here has a double meaning. Before entering this
-                        // while loop, it refers to the remaining number of nodes that have
-                        // yet to be processed. Inside the look, it refers to the index
-                        // of the current node to process (after we decrement it).
-                        //
-                        // If the remaining number of nodes is 0, we should not decrement nodeIndex.
-                        // Hence, we must only decrement nodeIndex inside the while loop instead of
-                        // in its condition statement. Note that this while loop is embedded in an
-                        // outer for loop. If we decrement nodeIndex in the condition statement, a
-                        // nodeIndex of 0 will become UINT_MAX, and the outer loop will wrongly
-                        // treat this as there being UINT_MAX remaining nodes to process.
-                        while (nodeIndex) {
-                            --nodeIndex;
-                            Node* node = block->at(nodeIndex);
-                            if (node == candidate)
-                                break;
-
-                            bool found = false;
-                            clobberize(
-                                m_graph, node, NoOpClobberize(),
-                                [&] (AbstractHeap heap) {
-                                    if (heap.kind() == Stack && !heap.payload().isTop()) {
-                                        if (argumentsInvolveStackSlot(inlineCallFrame, heap.operand()))
-                                            found = true;
-                                        return;
-                                    }
-                                    if (heap.overlaps(Stack))
-                                        found = true;
-                                },
-                                NoOpClobberize());
-
-                            if (found) {
-                                if (DFGArgumentsEliminationPhaseInternal::verbose)
-                                    dataLog("eliminating candidate: ", candidate, " because it is clobbered by ", block->at(nodeIndex), "\n");
-                                transitivelyRemoveCandidate(candidate);
-                                return;
-                            }
-                        }
+                    ASSERT(candidate->op() == CreateClonedArguments);
+                    ASSERT(node->storageAccessData().offset == clonedArgumentsLengthPropertyOffset);
+                    if (computeInterference(candidate, calculator.m_availability)) {
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", node);
+                        transitivelyRemoveCandidate(candidate);
                     }
-                });
+                    break;
+                }
+
+                case GetArrayLength: {
+                    Node* candidate = node->child1().node();
+                    if (!m_candidates.contains(candidate))
+                        break;
+
+                    if (computeInterference(candidate, calculator.m_availability)) {
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", node);
+                        transitivelyRemoveCandidate(candidate);
+                    }
+                    break;
+                }
+
+                case GetByVal: {
+                    Node* candidate = m_graph.varArgChild(node, 0).node();
+                    if (!m_candidates.contains(candidate))
+                        break;
+
+                    if (computeInterference(candidate, calculator.m_availability)) {
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", node);
+                        transitivelyRemoveCandidate(candidate);
+                    }
+                    break;
+                }
+
+                case VarargsLength: {
+                    Node* candidate = node->argumentsChild().node();
+                    if (!m_candidates.contains(candidate))
+                        break;
+
+                    if (computeInterference(candidate, calculator.m_availability)) {
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", node);
+                        transitivelyRemoveCandidate(candidate);
+                    }
+                    break;
+                }
+
+                case LoadVarargs: {
+                    Node* candidate = node->argumentsChild().node();
+                    if (!m_candidates.contains(candidate))
+                        break;
+
+                    if (computeInterference(candidate, calculator.m_availability)) {
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", node);
+                        transitivelyRemoveCandidate(candidate);
+                    }
+                    break;
+                }
+
+                case CallVarargs:
+                case ConstructVarargs:
+                case TailCallVarargs:
+                case TailCallVarargsInlinedCaller: {
+                    Node* candidate = node->child3().node();
+                    if (!m_candidates.contains(candidate))
+                        break;
+
+                    if (computeInterference(candidate, calculator.m_availability)) {
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", node);
+                        transitivelyRemoveCandidate(candidate);
+                    }
+                    break;
+                }
+
+                case CheckArrayOrEmpty:
+                case CheckArray:
+                case GetButterfly:
+                case FilterGetByStatus:
+                case FilterPutByStatus:
+                case FilterCallLinkStatus:
+                case FilterInByStatus:
+                case FilterDeleteByStatus:
+                case FilterCheckPrivateBrandStatus:
+                case FilterSetPrivateBrandStatus: {
+                    Node* candidate = node->child1().node();
+                    if (!m_candidates.contains(candidate))
+                        break;
+
+                    if (computeInterference(candidate, calculator.m_availability)) {
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", node);
+                        transitivelyRemoveCandidate(candidate);
+                    }
+                    break;
+                }
+
+                case CheckStructureOrEmpty:
+                case CheckStructure: {
+                    Node* candidate = node->child1().node();
+                    if (!m_candidates.contains(candidate))
+                        break;
+
+                    if (computeInterference(candidate, calculator.m_availability)) {
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", node);
+                        transitivelyRemoveCandidate(candidate);
+                    }
+                    break;
+                }
+
+                default:
+                    break;
+                }
+
+                calculator.executeNode(node);
+            }
         }
-        
+
         // Q: How do we handle OSR exit with a live PhantomArguments at a point where the inline call
         // frame is dead?  A: Naively we could say that PhantomArguments must escape the stack slots. But
         // that would break PutStack sinking, which in turn would break object allocation sinking, in
@@ -657,10 +740,9 @@ private:
         // since those availabilities speak of the stack before the optimizing compiler stack frame is
         // torn down.
 
-        if (DFGArgumentsEliminationPhaseInternal::verbose)
-            dataLog("After interference analysis: ", listDump(m_candidates), "\n");
+        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "After interference analysis: ", listDump(m_candidates.keys()));
     }
-    
+
     void transform()
     {
         bool modifiedCFG = false;
@@ -1309,7 +1391,7 @@ private:
         }
     }
     
-    HashSet<Node*> m_candidates;
+    HashMap<Node*, AvailabilityMap> m_candidates;
 };
 
 } // anonymous namespace

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3930,8 +3930,10 @@ void RenderLayer::establishesTopLayerWillChange()
 
 void RenderLayer::establishesTopLayerDidChange()
 {
-    if (auto* parentLayer = renderer().layerParent())
+    if (auto* parentLayer = renderer().layerParent()) {
+        setIsNormalFlowOnly(shouldBeNormalFlowOnly());
         parentLayer->addChild(*this);
+    }
 }
 
 RenderLayer* RenderLayer::enclosingFragmentedFlowAncestor() const

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -297,7 +297,8 @@ public:
         InsideInFragmentedFlow = 1,
     };
 
-    void setFragmentedFlowStateIncludingDescendants(FragmentedFlowState, const RenderElement* fragmentedFlowRoot);
+    enum class SkipDescendentFragmentedFlow { No, Yes };
+    void setFragmentedFlowStateIncludingDescendants(FragmentedFlowState, const RenderElement* fragmentedFlowRoot, SkipDescendentFragmentedFlow = SkipDescendentFragmentedFlow::Yes);
 
     FragmentedFlowState fragmentedFlowState() const { return m_bitfields.fragmentedFlowState(); }
     void setFragmentedFlowState(FragmentedFlowState state) { m_bitfields.setFragmentedFlowState(state); }

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -183,6 +183,8 @@ static bool affectsRenderedSubtree(Element& element, const RenderStyle& newStyle
         return true;
     if (element.renderOrDisplayContentsStyle())
         return true;
+    if (element.displayContentsChanged())
+        return true;
     if (element.rendererIsNeeded(newStyle))
         return true;
     return false;


### PR DESCRIPTION
#### 55616cb231b6806084e5b17f82cd9612ab260394
<pre>
Cherry-pick 256843.9@webkit-2022.12-embargoed (4c3dcd480f7e). rdar://107475307

    Test display contents change on focus change
    <a href="https://bugs.webkit.org/show_bug.cgi?id=251014">https://bugs.webkit.org/show_bug.cgi?id=251014</a>

    Reviewed by Tim Nguyen.

    * LayoutTests/fast/css/content/content-on-focus-change-expected.txt: Added.
    * LayoutTests/fast/css/content/content-on-focus-change.html: Added.

    Canonical link: <a href="https://commits.webkit.org/256843.9@webkit-2022.12-embargoed">https://commits.webkit.org/256843.9@webkit-2022.12-embargoed</a>

Canonical link: <a href="https://commits.webkit.org/262446@main">https://commits.webkit.org/262446@main</a>
</pre>
----------------------------------------------------------------------
#### fa3e94b523cdb209d4db2980a7a92dfeb7cf8707
<pre>
Cherry-pick 256843.8@webkit-2022.12-embargoed (fe2f16c1dabe). rdar://107475239

    Recalculate normal flow value in RenderLayer::establishesTopLayerDidChange
    <a href="https://bugs.webkit.org/show_bug.cgi?id=251013">https://bugs.webkit.org/show_bug.cgi?id=251013</a>

    Reviewed by Tim Nguyen.

    In RenderLayer::rebuildZOrderLists the RenderView layer makes sure the layers for dialogs/top-level elements are appended after
    everything else in the positive z-order list. When removing the dialog layer, dirtyPaintOrderListsOnChildChange will be called
    and since it is not a normal only flow everything will be handled correctly through dirtyStackingContextZOrderLists.

    In the test case the behaviour is the same until dirtyPaintOrderListsOnChildChange is called on the dialog layer removal. Now that
    layer to be removed *is* a normal only flow (the element is no longer positioned and has non visible overflow, see
    RenderLayer::shouldBeNormalFlowOnly). This means the positive z-order list is unchanged and the deleted layer still part of it.
    When the test cleanup code does a final repaint, the RenderView positive z-order list is processed as normal and when trying to
    access the deleted layer the UAF happens.

    To fix this, make sure the normal flow value is correct when adding the layer in RenderLayer::establishesTopLayerDidChange.

    * LayoutTests/fast/layers/normal-flow-dialog-remove-layer-crash-expected.html: Added.
    * LayoutTests/fast/layers/normal-flow-dialog-remove-layer-crash.html: Added.
    * Source/WebCore/rendering/RenderLayer.cpp:
    (WebCore::RenderLayer::establishesTopLayerDidChange):

    Canonical link: <a href="https://commits.webkit.org/256843.8@webkit-2022.12-embargoed">https://commits.webkit.org/256843.8@webkit-2022.12-embargoed</a>

Canonical link: <a href="https://commits.webkit.org/262445@main">https://commits.webkit.org/262445@main</a>
</pre>
----------------------------------------------------------------------
#### ea15ace73a2e2643dc73085a137791fb80f4339a
<pre>
Cherry-pick 256843.7@webkit-2022.12-embargoed (3b92d70ba3ea). rdar://107475202

    Do not skip fragmented flow thread descendents
    <a href="https://bugs.webkit.org/show_bug.cgi?id=245374">https://bugs.webkit.org/show_bug.cgi?id=245374</a>
    rdar://98438399

    Reviewed by Alan Baradlay.

    Do not skip fragmented flow thread descendents in initializeFragmentedFlowStateOnInsertion
    since its children may have a different state based on the inserted fragmented
    flow thread. When a fragmented flow thread is removed there is no effect on the inner
    fragmented flow threads so that behaviour is unchenged.

    * LayoutTests/fast/multicol/nested-columns-out-of-flow-crash-expected.txt: Added.
    * LayoutTests/fast/multicol/nested-columns-out-of-flow-crash.html: Added.
    * Source/WebCore/rendering/RenderObject.cpp:
    (WebCore::RenderObject::setFragmentedFlowStateIncludingDescendants):
    (WebCore::RenderObject::initializeFragmentedFlowStateOnInsertion):
    * Source/WebCore/rendering/RenderObject.h:

    Canonical link: <a href="https://commits.webkit.org/256843.7@webkit-2022.12-embargoed">https://commits.webkit.org/256843.7@webkit-2022.12-embargoed</a>

Canonical link: <a href="https://commits.webkit.org/262444@main">https://commits.webkit.org/262444@main</a>
</pre>
----------------------------------------------------------------------
#### 8e4a125888c6042c3d36639e96653123edb30163
<pre>
Cherry-pick 259548.51@safari-7615-branch (44f75343da9e). rdar://107475121

    [be894cadcf68a52a] (REGRESSION 256601@main) ASAN_SEGV | WebCore::RenderObject::pushOntoGeometryMap; WebCore::RenderInline::pushMappingToContainer;
    <a href="https://bugs.webkit.org/show_bug.cgi?id=251788">https://bugs.webkit.org/show_bug.cgi?id=251788</a>
    rdar://104793275

    Reviewed by Alan Baradlay.

    * LayoutTests/fast/css/display-contents-slot-to-none-expected.txt: Added.
    * LayoutTests/fast/css/display-contents-slot-to-none.html: Added.
    * Source/WebCore/style/StyleTreeResolver.cpp:
    (WebCore::Style::affectsRenderedSubtree):

    We may have had display:contents before and a rendered subtree may still be affected.

    Canonical link: <a href="https://commits.webkit.org/259548.51@safari-7615-branch">https://commits.webkit.org/259548.51@safari-7615-branch</a>

Canonical link: <a href="https://commits.webkit.org/262443@main">https://commits.webkit.org/262443@main</a>
</pre>
----------------------------------------------------------------------
#### bdbb4be89a2aaff918a9aa6c2cf23660e6ef1a35
<pre>
Cherry-pick 259548.47@safari-7615-branch (0f2c12121b0a). rdar://107474791

    [JSC] FTL arguments elimination should ensure that replacement sites can access to original stack slots
    <a href="https://bugs.webkit.org/show_bug.cgi?id=251640">https://bugs.webkit.org/show_bug.cgi?id=251640</a>
    rdar://99273500

    Reviewed by Mark Lam.

    FTL arguments elimination does analysis and attempts to eliminate arguments allocation if it is not escaped.
    We emit stack access at `arguments[0]` site for example, and remove `arguments` allocations.
    But important thing is that stack slots used for the `arguments` need to be available at `arguments[0]` access site.
    Since we are using stack slots for different purpose when inlining different functions, it is possible that the given
    stack slot is no longer available when using `arguments[0]`. For example,

        function a() { return arguments; }
        function b() { do-something }

        var arg = a()
        b();
        arg[0];         // If both &quot;a&quot; and &quot;b&quot; are inlined, stack slots used for inlined &quot;a&quot; can be used for the other purpose for &quot;b&quot;
                        // As a result, it is possible that the slot is not available at `arg[0]` access point.

    We were doing stack slot interference analysis to avoid the above problem[1]. However, it was not complete solution since it is only
    checking block-local status. So if we have branch between a() and arg[0], this analysis didn&apos;t work. Attached test
    &quot;arguments-elimination-should-happen-only-when-stack-slot-is-available-at-replacement-site.js&quot; is literally doing this.

        function empty() {}

        function bar2(...a0) {
          return a0;
        }

        function foo() {
          let xs = bar2(undefined);
          &apos;&apos; == 1 &amp;&amp; 0;
          return empty(...xs, undefined);
        }

    Between bar2 and `...xs` site, we have branch due to &amp;&amp;. And at &quot;...xs&quot; site, the stack slot were no longer available.

    In this patch, we replace our existing interference analysis with the revised fix. We use OSR availability which can describe the
    state of each stack slot. For all arguments, initially, it is flushed state with a node. Then, when slot gets unavailable or overridden,
    we can see the availability change, which no longer points at the same node.
    We first do this OSR availability analysis and capture availability map of each candidates. And then, we analyze whether replacement sites
    are still seeing the same availability for arguments. And if it becomes different, we remove the candidate from optimization target. This change
    simplifies our analysis significantly, and make it procedure global (previous one was block local).

    [1]: <a href="https://commits.webkit.org/212536@main">https://commits.webkit.org/212536@main</a>

    * JSTests/stress/arguments-elimination-should-happen-only-when-stack-slot-is-available-at-replacement-site.js: Added.
    (empty):
    (bar2):
    (foo):
    (main):
    * Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp:

    Canonical link: <a href="https://commits.webkit.org/259548.47@safari-7615-branch">https://commits.webkit.org/259548.47@safari-7615-branch</a>

Canonical link: <a href="https://commits.webkit.org/262442@main">https://commits.webkit.org/262442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be16818c00df159445184f37718c2bcc87cb344b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2447 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1510 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1617 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1542 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2284 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1363 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/1304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1392 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1402 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1469 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1436 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1568 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1369 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/338 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/384 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1491 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1610 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/452 "Passed tests") | 
<!--EWS-Status-Bubble-End-->