### PR TITLE
Add proxy setting to Slack's API, and corrected ENV names for storing Bugzilla credentials

### DIFF
--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -27,6 +27,8 @@ import {stat} from "fs";
 import path from "path";
 import util from "util";
 import {execFile, spawn} from "child_process";
+import HttpsProxyAgent from "https-proxy-agent";
+import LogLevel from "@slack/rtm-api";
 import SlackRTMAPI from "@slack/rtm-api";
 import AsyncTaskQueue from "./AsyncTaskQueue.mjs";
 import {dataLogLn, escapeForSlackText, isASCII, rootDirectoryOfWebKit} from "./Utility.mjs";
@@ -185,8 +187,8 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
             operation: this.youThereCommand.bind(this),
         });
 
-
-        this._rtm = new SlackRTMAPI.RTMClient(process.env.SLACK_TOKEN);
+        const proxy = new HttpsProxyAgent(process.env.http_proxy);
+        this._rtm = new SlackRTMAPI.RTMClient(process.env.SLACK_TOKEN, { agent: proxy, logLevel: LogLevel.DEBUG });
         this._rtm.on("message", async (event) => {
             if (event.type !== "message")
                 return;
@@ -484,8 +486,8 @@ Type \`help COMMAND\` for help on my individual commands.`,
                 env: {
                     CHANGE_LOG_NAME: "Commit Queue",
                     CHANGE_LOG_EMAIL_ADDRESS: "commit-queue@webkit.org",
-                    webkit_bugzilla_username: process.env.webkitBugzillaUsername,
-                    webkit_bugzilla_password: process.env.webkitBugzillaPassword,
+                    WEBKIT_BUGZILLA_USERNAME: process.env.webkitBugzillaUsername,
+                    WEBKIT_BUGZILLA_PASSWORD: process.env.webkitBugzillaPassword,
                 },
                 timeout: defaultTimeoutForRevert,
                 maxBuffer: 1024 * 1024 * 50,

--- a/Tools/WebKitBot/src/index.mjs
+++ b/Tools/WebKitBot/src/index.mjs
@@ -26,6 +26,8 @@
 import dotenv from "dotenv";
 import storage from "node-persist";
 import WebKitBot from "./WebKitBot.mjs";
+import HttpsProxyAgent from "https-proxy-agent";
+import LogLevel from "@slack/web-api";
 import SlackWebAPI from "@slack/web-api";
 
 dotenv.config();
@@ -35,7 +37,8 @@ async function main() {
         dir: "data",
     });
 
-    let webClient = new SlackWebAPI.WebClient(process.env.SLACK_TOKEN);
+    const proxy = new HttpsProxyAgent(process.env.http_proxy);
+    let webClient = new SlackWebAPI.WebClient(process.env.SLACK_TOKEN, {agent: proxy, logLevel: LogLevel.DEBUG});
     let auth = await webClient.auth.test();
 
     WebKitBot.main(webClient, auth);


### PR DESCRIPTION
#### b8c7f56ec505596df146066ebd0aca56bd23fd8a
<pre>
Add proxy setting to Slack&apos;s API, and corrected ENV names for storing Bugzilla credentials
<a href="https://bugs.webkit.org/show_bug.cgi?id=254839">https://bugs.webkit.org/show_bug.cgi?id=254839</a>
rdar://problem/107483623

Reviewed by Ryan Haddad.

Webkitbot requires to go through proxy server to get to Slack API.

* Tools/WebKitBot/src/WebKitBot.mjs:

Canonical link: <a href="https://commits.webkit.org/262685@main">https://commits.webkit.org/262685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93213c8c45afcb804e8968ac3e99ce4025eba64b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2265 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/2289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3192 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/2293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/2239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/2378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2347 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2286 "Failed to checkout and rebase branch from PR 12256") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/2378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3050 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/2378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/2015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2096 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2078 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2004 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/2025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2199 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/256 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->