### PR TITLE
Remove Google Legacy ID support

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.cpp
@@ -44,9 +44,6 @@ std::optional<AuthenticationExtensionsClientInputs> AuthenticationExtensionsClie
     auto it = decodedMap.find(cbor::CBORValue("appid"));
     if (it != decodedMap.end() && it->second.isString())
         clientInputs.appid = it->second.getString();
-    it = decodedMap.find(cbor::CBORValue("googleLegacyAppidSupport"));
-    if (it != decodedMap.end() && it->second.isBool())
-        clientInputs.googleLegacyAppidSupport = it->second.getBool();
     it = decodedMap.find(cbor::CBORValue("credProps"));
     if (it != decodedMap.end() && it->second.isBool())
         clientInputs.credProps = it->second.getBool();
@@ -80,8 +77,6 @@ Vector<uint8_t> AuthenticationExtensionsClientInputs::toCBOR() const
     cbor::CBORValue::MapValue clientInputsMap;
     if (!appid.isEmpty())
         clientInputsMap[cbor::CBORValue("appid")] = cbor::CBORValue(appid);
-    if (googleLegacyAppidSupport)
-        clientInputsMap[cbor::CBORValue("googleLegacyAppidSupport")] = cbor::CBORValue(googleLegacyAppidSupport);
     if (credProps)
         clientInputsMap[cbor::CBORValue("credProps")] = cbor::CBORValue(credProps);
     if (largeBlob) {

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h
@@ -40,7 +40,6 @@ struct AuthenticationExtensionsClientInputs {
     };
 
     String appid;
-    bool googleLegacyAppidSupport;
     bool credProps; // Not serialized but probably should be. Don't re-introduce rdar://101057340 though.
     std::optional<AuthenticationExtensionsClientInputs::LargeBlobInputs> largeBlob;
 

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl
@@ -36,7 +36,6 @@
 ] dictionary AuthenticationExtensionsClientInputs {
     USVString appid;
     // For Google to turn off the legacy AppID support.
-    boolean googleLegacyAppidSupport = true;
     boolean credProps;
     AuthenticationExtensionsLargeBlobInputs largeBlob;
 };

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -85,16 +85,6 @@ static String processAppIdExtension(const SecurityOrigin& facetId, const String&
     return appId;
 }
 
-// The default behaviour for google.com is to always turn on the legacy AppID support.
-static bool processGoogleLegacyAppIdSupportExtension(const std::optional<AuthenticationExtensionsClientInputs>& extensions, const String& rpId)
-{
-    if (rpId != "google.com"_s)
-        return false;
-    if (!extensions)
-        return true;
-    return extensions->googleLegacyAppidSupport;
-}
-
 } // namespace AuthenticatorCoordinatorInternal
 
 AuthenticatorCoordinator::AuthenticatorCoordinator(std::unique_ptr<AuthenticatorCoordinatorClient>&& client)
@@ -164,7 +154,6 @@ void AuthenticatorCoordinator::create(const Document& document, const PublicKeyC
 
     AuthenticationExtensionsClientInputs extensionInputs = {
         String(),
-        processGoogleLegacyAppIdSupportExtension(options.extensions, *options.rp.id),
         false,
         std::nullopt
     };

--- a/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
@@ -102,9 +102,8 @@ std::optional<Vector<uint8_t>> convertToU2fRegisterCommand(const Vector<uint8_t>
     if (!isConvertibleToU2fRegisterCommand(request))
         return std::nullopt;
 
-    auto appId = processGoogleLegacyAppIdSupportExtension(request.extensions);
     ASSERT(request.rp.id);
-    return constructU2fRegisterCommand(produceRpIdHash(!appId ? *request.rp.id : appId), clientDataHash);
+    return constructU2fRegisterCommand(produceRpIdHash(*request.rp.id), clientDataHash);
 }
 
 std::optional<Vector<uint8_t>> convertToU2fCheckOnlySignCommand(const Vector<uint8_t>& clientDataHash, const PublicKeyCredentialCreationOptions& request, const PublicKeyCredentialDescriptor& keyHandle)
@@ -130,19 +129,6 @@ std::optional<Vector<uint8_t>> convertToU2fSignCommand(const Vector<uint8_t>& cl
 Vector<uint8_t> constructBogusU2fRegistrationCommand()
 {
     return constructU2fRegisterCommand(convertBytesToVector(kBogusAppParam, sizeof(kBogusAppParam)), convertBytesToVector(kBogusChallenge, sizeof(kBogusChallenge)));
-}
-
-String processGoogleLegacyAppIdSupportExtension(const std::optional<AuthenticationExtensionsClientInputs>& extensions)
-{
-    if (!extensions) {
-        // AuthenticatorCoordinator::create should always set it.
-        ASSERT_NOT_REACHED();
-        return String();
-    }
-
-    if (!extensions->googleLegacyAppidSupport)
-        return String();
-    return "https://www.gstatic.com/securitykey/origins.json"_s;
 }
 
 } // namespace fido

--- a/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.h
+++ b/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.h
@@ -68,9 +68,6 @@ WEBCORE_EXPORT std::optional<Vector<uint8_t>> convertToU2fSignCommand(const Vect
 
 WEBCORE_EXPORT Vector<uint8_t> constructBogusU2fRegistrationCommand();
 
-// Returns "https://www.gstatic.com/securitykey/origins.json" as an AppID when googleLegacyAppidSupport is true.
-WEBCORE_EXPORT String processGoogleLegacyAppIdSupportExtension(const std::optional<WebCore::AuthenticationExtensionsClientInputs>&);
-
 } // namespace fido
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
@@ -135,10 +135,9 @@ typedef NS_ENUM(NSInteger, ASCSecurityKeyPublicKeyCredentialKind) {
 
 @interface ASCWebAuthenticationExtensionsClientInputs : NSObject <NSCopying, NSSecureCoding>
 
-- (instancetype)initWithAppID:(NSString * _Nullable)appID isGoogleLegacyAppIDSupport:(BOOL)isGoogleLegacyAppIDSupport NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithAppID:(NSString * _Nullable)appID NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, nullable, copy) NSString *appID;
-@property (nonatomic) BOOL isGoogleLegacyAppIDSupport;
 
 @end
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -988,7 +988,6 @@ struct WebCore::WebLockManagerSnapshot {
 
 [LegacyPopulateFromEmptyConstructor] struct WebCore::AuthenticationExtensionsClientInputs {
     String appid;
-    bool googleLegacyAppidSupport;
     std::optional<WebCore::AuthenticationExtensionsClientInputs::LargeBlobInputs> largeBlob;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h
@@ -35,7 +35,6 @@ WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 @interface _WKAuthenticationExtensionsClientInputs : NSObject
 
 @property (nullable, nonatomic, copy) NSString *appid;
-@property (nonatomic) BOOL googleLegacyAppidSupport;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -903,7 +903,6 @@ static WebCore::AuthenticationExtensionsClientInputs authenticationExtensionsCli
 {
     WebCore::AuthenticationExtensionsClientInputs result;
     result.appid = extensions.appid;
-    result.googleLegacyAppidSupport = extensions.googleLegacyAppidSupport;
 
     return result;
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -152,19 +152,6 @@ static AuthenticatorManager::TransportSet collectTransports(const Vector<PublicK
     return result;
 }
 
-// Only roaming authenticators are supported for Google legacy AppID support.
-static void processGoogleLegacyAppIdSupportExtension(const std::optional<AuthenticationExtensionsClientInputs>& extensions, AuthenticatorManager::TransportSet& transports)
-{
-    if (!extensions) {
-        // AuthenticatorCoordinator::create should always set it.
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    if (!extensions->googleLegacyAppidSupport)
-        return;
-    transports.remove(AuthenticatorTransport::Internal);
-}
-
 static String getRpId(const std::variant<PublicKeyCredentialCreationOptions, PublicKeyCredentialRequestOptions>& options)
 {
     if (std::holds_alternative<PublicKeyCredentialCreationOptions>(options)) {
@@ -544,7 +531,6 @@ auto AuthenticatorManager::getTransports() const -> TransportSet
     TransportSet transports;
     WTF::switchOn(m_pendingRequestData.options, [&](const PublicKeyCredentialCreationOptions& options) {
         transports = collectTransports(options.authenticatorSelection);
-        processGoogleLegacyAppIdSupportExtension(options.extensions, transports);
     }, [&](const PublicKeyCredentialRequestOptions& options) {
         transports = collectTransports(options.allowCredentials, options.authenticatorAttachment);
     });

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -182,8 +182,8 @@ static inline RetainPtr<ASCPublicKeyCredentialDescriptor> toASCDescriptor(Public
 
 static inline RetainPtr<ASCWebAuthenticationExtensionsClientInputs> toASCExtensions(const AuthenticationExtensionsClientInputs& extensions)
 {
-    if ([allocASCWebAuthenticationExtensionsClientInputsInstance() respondsToSelector:@selector(initWithAppID:isGoogleLegacyAppIDSupport:)])
-        return adoptNS([allocASCWebAuthenticationExtensionsClientInputsInstance() initWithAppID:extensions.appid isGoogleLegacyAppIDSupport:extensions.googleLegacyAppidSupport]);
+    if ([allocASCWebAuthenticationExtensionsClientInputsInstance() respondsToSelector:@selector(initWithAppID:)])
+        return adoptNS([allocASCWebAuthenticationExtensionsClientInputsInstance() initWithAppID:extensions.appid]);
 
     return nil;
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -92,8 +92,6 @@ CtapAuthenticator::CtapAuthenticator(std::unique_ptr<CtapDriver>&& driver, Authe
 void CtapAuthenticator::makeCredential()
 {
     ASSERT(!m_isDowngraded);
-    if (processGoogleLegacyAppIdSupportExtension())
-        return;
     Vector<uint8_t> cborCmd;
     auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
     auto internalUVAvailability = m_info.options().userVerificationAvailability();
@@ -390,20 +388,6 @@ bool CtapAuthenticator::tryDowngrade()
     driver().setProtocol(ProtocolVersion::kU2f);
     observer()->downgrade(this, U2fAuthenticator::create(releaseDriver()));
     return true;
-}
-
-// Only U2F protocol is supported for Google legacy AppID support.
-bool CtapAuthenticator::processGoogleLegacyAppIdSupportExtension()
-{
-    auto& extensions = std::get<PublicKeyCredentialCreationOptions>(requestData().options).extensions;
-    if (!extensions) {
-        // AuthenticatorCoordinator::create should always set it.
-        ASSERT_NOT_REACHED();
-        return false;
-    }
-    if (extensions->googleLegacyAppidSupport)
-        tryDowngrade();
-    return extensions->googleLegacyAppidSupport;
 }
 
 Vector<AuthenticatorTransport> CtapAuthenticator::transports() const

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -68,7 +68,6 @@ private:
     bool tryRestartPin(const fido::CtapDeviceResponseCode&);
 
     bool tryDowngrade();
-    bool processGoogleLegacyAppIdSupportExtension();
 
     Vector<WebCore::AuthenticatorTransport> transports() const;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -157,9 +157,8 @@ void U2fAuthenticator::continueRegisterCommandAfterResponseReceived(ApduResponse
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR: {
         auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
-        auto appId = processGoogleLegacyAppIdSupportExtension(options.extensions);
         ASSERT(options.rp.id);
-        auto response = readU2fRegisterResponse(!appId ? *options.rp.id : appId, apduResponse.data(), AuthenticatorAttachment::CrossPlatform, { driver().transport() }, options.attestation);
+        auto response = readU2fRegisterResponse(*options.rp.id, apduResponse.data(), AuthenticatorAttachment::CrossPlatform, { driver().transport() }, options.attestation);
         if (!response) {
             receiveRespond(ExceptionData { UnknownError, "Couldn't parse the U2F register response."_s });
             return;

--- a/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
@@ -60,7 +60,6 @@ PublicKeyCredentialCreationOptions constructMakeCredentialRequest()
     params.alg = COSE::ES256;
 
     AuthenticationExtensionsClientInputs extensions;
-    extensions.googleLegacyAppidSupport = false;
 
     PublicKeyCredentialCreationOptions options;
     options.rp = WTFMove(rp);
@@ -68,13 +67,6 @@ PublicKeyCredentialCreationOptions constructMakeCredentialRequest()
     options.pubKeyCredParams.append(WTFMove(params));
     options.extensions = WTFMove(extensions);
 
-    return options;
-}
-
-PublicKeyCredentialCreationOptions constructMakeCredentialRequestWithGoogleLegacyAppidSupport()
-{
-    auto options = constructMakeCredentialRequest();
-    options.extensions->googleLegacyAppidSupport = true;
     return options;
 }
 
@@ -94,17 +86,6 @@ TEST(U2fCommandConstructorTest, TestConvertCtapMakeCredentialToU2fRegister)
     const auto u2fRegisterCommand = convertToU2fRegisterCommand(convertBytesToVector(TestData::kClientDataHash, sizeof(TestData::kClientDataHash)), makeCredentialParam);
     ASSERT_TRUE(u2fRegisterCommand);
     EXPECT_EQ(*u2fRegisterCommand, convertBytesToVector(TestData::kU2fRegisterCommandApdu, sizeof(TestData::kU2fRegisterCommandApdu)));
-}
-
-TEST(U2fCommandConstructorTest, TestConvertCtapMakeCredentialToU2fRegisterWithGoogleLegacyAppidSupport)
-{
-    const auto makeCredentialParam = constructMakeCredentialRequestWithGoogleLegacyAppidSupport();
-
-    EXPECT_TRUE(isConvertibleToU2fRegisterCommand(makeCredentialParam));
-
-    const auto u2fRegisterCommand = convertToU2fRegisterCommand(convertBytesToVector(TestData::kClientDataHash, sizeof(TestData::kClientDataHash)), makeCredentialParam);
-    ASSERT_TRUE(u2fRegisterCommand);
-    EXPECT_EQ(*u2fRegisterCommand, convertBytesToVector(TestData::kU2fRegisterCommandApduWithGoogleLegacyAppidSupport, sizeof(TestData::kU2fRegisterCommandApduWithGoogleLegacyAppidSupport)));
 }
 
 TEST(U2fCommandConstructorTest, TestConvertCtapMakeCredentialToU2fCheckOnlySign)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1512,7 +1512,6 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
     EXPECT_EQ(result.authenticatorSelection, std::nullopt);
     EXPECT_EQ(result.attestation, AttestationConveyancePreference::None);
     EXPECT_TRUE(result.extensions->appid.isNull());
-    EXPECT_EQ(result.extensions->googleLegacyAppidSupport, false);
 }
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
@@ -1859,7 +1858,6 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMinimun)
     EXPECT_EQ(result.allowCredentials.size(), 0lu);
     EXPECT_EQ(result.userVerification, UserVerificationRequirement::Preferred);
     EXPECT_TRUE(result.extensions->appid.isNull());
-    EXPECT_EQ(result.extensions->googleLegacyAppidSupport, false);
 }
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximumDefault)


### PR DESCRIPTION
#### 08da3c918e1b3f9eca9d75effe7bee1637ae9330
<pre>
Remove Google Legacy ID support
<a href="https://bugs.webkit.org/show_bug.cgi?id=254848">https://bugs.webkit.org/show_bug.cgi?id=254848</a>
rdar://107068173

Reviewed by J Pascoe.

Remove support for GoogleLegacyAppID

* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.cpp:
(WebCore::AuthenticationExtensionsClientInputs::fromCBOR):
(WebCore::AuthenticationExtensionsClientInputs::toCBOR const):
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h:
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl:
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
(WebCore::AuthenticatorCoordinatorInternal::processGoogleLegacyAppIdSupportExtension): Deleted.
* Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp:
(fido::convertToU2fRegisterCommand):
(fido::processGoogleLegacyAppIdSupportExtension): Deleted.
* Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.h:
* Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(authenticationExtensionsClientInputs):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::getTransports const):
(WebKit::WebCore::processGoogleLegacyAppIdSupportExtension): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::toASCExtensions):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::processGoogleLegacyAppIdSupportExtension): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::continueRegisterCommandAfterResponseReceived):
* Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp:
(TestWebKitAPI::constructMakeCredentialRequest):
(TestWebKitAPI::constructMakeCredentialRequestWithGoogleLegacyAppidSupport): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262524@main">https://commits.webkit.org/262524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1f436d1c7cc1cec9965a16036e500239bcafced

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2473 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1695 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1469 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2310 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1320 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1417 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1434 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2483 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1302 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1401 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/439 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1515 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->