### PR TITLE
[iOS] Rakuten cellular data activation portal is sometimes clipped when presented in a web sheet

### DIFF
--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -45,6 +45,7 @@
 #import "PageClient.h"
 #import "PaymentAuthorizationViewController.h"
 #import "PrintInfo.h"
+#import "ProvisionalPageProxy.h"
 #import "RemoteLayerTreeHost.h"
 #import "RemoteLayerTreeNode.h"
 #import "RemoteLayerTreeTransaction.h"
@@ -294,6 +295,9 @@ void WebPageProxy::setViewportConfigurationViewLayoutSize(const WebCore::FloatSi
     m_viewportConfigurationViewLayoutSize = size;
     m_viewportConfigurationLayoutSizeScaleFactor = scaleFactor;
     m_viewportConfigurationMinimumEffectiveDeviceWidth = minimumEffectiveDeviceWidth;
+
+    if (m_provisionalPage)
+        m_provisionalPage->send(Messages::WebPage::SetViewportConfigurationViewLayoutSize(size, scaleFactor, minimumEffectiveDeviceWidth));
 
     if (hasRunningProcess())
         m_process->send(Messages::WebPage::SetViewportConfigurationViewLayoutSize(size, scaleFactor, minimumEffectiveDeviceWidth), m_webPageID);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -59,6 +59,7 @@
 #import <wtf/HashMap.h>
 #import <wtf/HashSet.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/RunLoop.h>
 #import <wtf/Vector.h>
 #import <wtf/text/StringConcatenateNumbers.h>
 #import <wtf/text/StringHash.h>
@@ -8534,6 +8535,57 @@ TEST(ProcessSwap, ContentModeInCaseOfPSONThenCoopProcessSwap)
     Util::run(&done);
     done = false;
 }
+
+TEST(ProcessSwap, ChangeViewSizeDuringNavigationActionPolicyDecision)
+{
+    auto processPoolConfiguration = psonProcessPoolConfiguration();
+    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [webViewConfiguration setProcessPool:processPool.get()];
+
+    auto handler = adoptNS([PSONScheme new]);
+    [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
+
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
+    auto navigationDelegate = adoptNS([PSONNavigationDelegate new]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/source.html"]]];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    navigationDelegate->decidePolicyForNavigationAction = [webView](WKNavigationAction *, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        decisionHandler(WKNavigationActionPolicyAllow);
+
+        constexpr auto estimatedDelayForWebProcessLaunch = 5_ms;
+        RunLoop::main().dispatchAfter(estimatedDelayForWebProcessLaunch, [webView] {
+            [webView setFrame:CGRectMake(0, 0, 320, 568)];
+        });
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.apple.com/destination.html"]]];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    NSArray<NSNumber *> *result = [webView objectByEvaluatingJavaScript:@"(() => {"
+        "const container = document.createElement('div');"
+        "container.style.width = '100vw';"
+        "container.style.height = '100vh';"
+        "container.style.backgroundColor = 'tomato';"
+        "document.body.appendChild(container);"
+        "document.body.offsetTop;"
+        "const bounds = container.getBoundingClientRect();"
+        "return [bounds.width, bounds.height];"
+        "})();"];
+
+    auto containerWidth = result.firstObject.doubleValue;
+    EXPECT_GT(containerWidth, 0);
+
+    auto containerHeight = result.lastObject.doubleValue;
+    EXPECT_GT(containerHeight, 0);
+}
+
 #endif // PLATFORM(IOS_FAMILY)
 
 // The WebProcess cache cannot be enabled on devices with too little RAM so we need to disable


### PR DESCRIPTION
#### b59d14452d4ba35b25178124996ce560ea32d139
<pre>
[iOS] Rakuten cellular data activation portal is sometimes clipped when presented in a web sheet
<a href="https://bugs.webkit.org/show_bug.cgi?id=254846">https://bugs.webkit.org/show_bug.cgi?id=254846</a>
rdar://107301827

Reviewed by Chris Dumez.

When activating a Rakuten cellular plan on Apple Watch via the Watch app on iOS 16.4, the web view
can end up in a state where both `vw` and `vh` units are always 0. This causes main, scrollable
container element with `height: 100vh;` on the page to become much, much shorter than intended,
which makes interacting with the activation portal difficult.

Some more important context: in the Watch app, the web view starts out at size `(0, 0)`, and is
resized to fill the entire window only after the first navigation is complete. Rakuten&apos;s portal
redirects cross-origin from a landing page, such that this size adjustment races against the second
cross-origin navigation (which initiates a process swap).

While the immediate cause of this is still unknown, the root cause is that during a process swap
(in this particular case, from &lt;login.account.rakuten.com&gt; to &lt;entitlement.devicem.rm-n.jp&gt;), it&apos;s
possible for UIKit to call `-setFrame:` with the first non-empty frame after the new web process has
been launched and `WebPageCreationParameters` are created, but before the process swap actually
finishes. This causes:

1. A viewport size of `(0, 0)` to be sent to the newly created page via `WebPageCreationParameters`.
2. The newly updated, non-zero viewport size to be sent to the *old* page, via an IPC message.

As such, the new webpage is stuck in a state where it thinks the viewport size is still `(0, 0)`. To
fix this, we simply propagate the new viewport layout size to a provisional page upon process swap.

Test: ProcessSwap.ChangeViewSizeDuringNavigationActionPolicyDecision

* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::setViewportConfigurationViewLayoutSize):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:

Canonical link: <a href="https://commits.webkit.org/262453@main">https://commits.webkit.org/262453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d22a69e62c7d6e7040a46f7198d0683ecb2deef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2478 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1651 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1575 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2314 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1421 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/1404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1519 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/166 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->