### PR TITLE
Cherry-pick 256843.11@webkit-2022.12-embargoed (7d616c4d06eb). rdar://107499625

### DIFF
--- a/LayoutTests/fast/css/style-update-timer-crash-expected.txt
+++ b/LayoutTests/fast/css/style-update-timer-crash-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: ReferenceError: Can't find variable: svgID
+PASS if no crash.

--- a/LayoutTests/fast/css/style-update-timer-crash.html
+++ b/LayoutTests/fast/css/style-update-timer-crash.html
@@ -1,0 +1,46 @@
+<style>
+    *:last-child,*:placeholder-shown { -webkit-clip-path: url(#fontFaceID);}
+    *:empty { -webkit-border-after: #D1C78D; }
+</style>
+
+<script>
+
+function test() {
+    if (window.testRunner)
+        testRunner.dumpAsText()
+    var divElement = document.createElement("div");
+    meterID.addEventListener("DOMNodeRemoved", domNodeRemovedCallback);
+    var insertedElement = animateTransformID.insertAdjacentElement("afterbegin", marqueeID);
+    var screenCTM = symbolID.getScreenCTM();
+    svgID.outerHTML = "A";
+    GCController.collect();
+    document.body.innerHTML = 'PASS if no crash.';
+}
+
+function domNodeRemovedCallback() {
+    svgID.prepend(animateMotionID);
+    range = iframeID.contentDocument.createRange();
+    range.selectNodeContents(animateTransformID);
+    range.surroundContents(document.createElement("meter"));
+}
+</script>
+
+<head>
+</head>
+<body onload="test()">
+<meter id="meterID">
+<marquee id="marqueeID">
+</marquee>
+</meter>
+<svg id="svgID">
+<symbol id="symbolID">
+<font-face id="fontFaceID">
+    <animateTransform id="animateTransformID">
+        <animateMotion id="animateMotionID">
+        </animateMotion>
+    </animateTransform>
+</font-face>
+</svg>
+<iframe id="iframeID">
+</iframe>
+</body>

--- a/LayoutTests/fast/dom/element-clearing-display-contents-on-node-removal-expected.txt
+++ b/LayoutTests/fast/dom/element-clearing-display-contents-on-node-removal-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/dom/element-clearing-display-contents-on-node-removal.html
+++ b/LayoutTests/fast/dom/element-clearing-display-contents-on-node-removal.html
@@ -1,0 +1,33 @@
+<style>
+  p~div { display: contents; }
+  span { padding-block-end: 1em; float: left; }
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function gc() {
+  if (window.GCController)
+    return GCController.collect();
+}
+function runTest() {
+  video.addEventListener("DOMNodeRemovedFromDocument", () => { });
+  range = window.document.caretRangeFromPoint();
+  range.setEnd(video, 1);
+  range.extractContents();
+  document.getElementById("span").innerText="This test passes if it doesn't crash.";
+}
+</script>
+<body id="body" onload="gc()">
+  <span id="span"></span>
+  <p></p>
+  <div>
+    foo
+    <a href="x"></a>
+  </div>
+  <video id="video" src="foo.png">
+    <kbd></kbd>
+    <details ontoggle="runTest()" open="">
+  </video>
+</body>

--- a/LayoutTests/fast/frames/disconnected-frame-set-to-eager-crash-expected.txt
+++ b/LayoutTests/fast/frames/disconnected-frame-set-to-eager-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/frames/disconnected-frame-set-to-eager-crash.html
+++ b/LayoutTests/fast/frames/disconnected-frame-set-to-eager-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<iframe id="iframe" loading="lazy"></iframe>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    let iframe = document.getElementById("iframe");
+    iframe.remove();
+    iframe.setAttribute("loading", "eager");
+    document.body.appendChild(iframe);
+    iframe.remove();
+    requestAnimationFrame(() => {
+        document.body.innerHTML = "PASS if no crash.";
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+</script>

--- a/LayoutTests/mathml/mathml-mover-layout-crash-expected.txt
+++ b/LayoutTests/mathml/mathml-mover-layout-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/mathml/mathml-mover-layout-crash.html
+++ b/LayoutTests/mathml/mathml-mover-layout-crash.html
@@ -1,0 +1,22 @@
+<style>
+.mtableStyleClass { list-style: url('foo') inside; position: absolute; }
+</style>
+<script>
+function test() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    mtrID.replaceWith("foo");
+    document.body.offsetTop;
+    document.body.innerHTML = 'PASS if no crash.';
+}
+</script>
+
+<body onload=test()>
+    <math display="inline">
+        <mover>
+            <mtable class="mtableStyleClass">
+                <mtr id="mtrID"></mtr>
+            </mtable>
+        </mover>
+    </math>
+</body>

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
@@ -12,7 +12,7 @@ PASS Appending and removing children to mpadded
 PASS Appending and removing children to mphantom
 FAIL Appending and removing children to mroot assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 4.4375
 PASS Appending and removing children to mrow
-FAIL Appending and removing children to ms assert_approx_equals: block position (child 0) expected -19705 +/- 1 but got -19723
+FAIL Appending and removing children to ms assert_approx_equals: block position (child 0) expected -39053 +/- 1 but got -39071
 PASS Appending and removing children to mspace
 FAIL Appending and removing children to msqrt assert_approx_equals: inline size expected 13 +/- 1 but got 16
 PASS Appending and removing children to mstyle
@@ -20,8 +20,8 @@ FAIL Appending and removing children to msub assert_approx_equals: block positio
 FAIL Appending and removing children to msubsup assert_approx_equals: block position (child 0) expected 0 +/- 1 but got 2.5
 FAIL Appending and removing children to msup assert_approx_equals: inline size expected 10.890625 +/- 1 but got 0
 PASS Appending and removing children to mtable
-FAIL Appending and removing children to mtext assert_approx_equals: block position (child 0) expected -5093074 +/- 1 but got -5093092
-FAIL Appending and removing children to munder assert_approx_equals: block position (child 0) expected 0 +/- 1 but got 2
+FAIL Appending and removing children to mtext assert_approx_equals: block position (child 0) expected -10046162 +/- 1 but got -10046180
+FAIL Appending and removing children to munder assert_approx_equals: block size expected 22 +/- 1 but got 24
 FAIL Appending and removing children to munderover assert_approx_equals: inline size expected 0 +/- 1 but got 10
 PASS Appending and removing children to semantics
 maction:

--- a/Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp
@@ -105,7 +105,8 @@ WebXRRigidTransform::WebXRRigidTransform(const TransformationMatrix& transform)
     }
 
     TransformationMatrix::Decomposed4Type decomp = { };
-    transform.decompose4(decomp);
+    if (!transform.decompose4(decomp))
+        return;
 
     m_position = DOMPointReadOnly::create(decomp.translateX, decomp.translateY, decomp.translateZ, 1.0f);
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2275,9 +2275,8 @@ bool KeyframeEffect::computeTransformedExtentViaTransformList(const FloatRect& r
 
             if (operation->type() == TransformOperation::Type::Matrix || operation->type() == TransformOperation::Type::Matrix3D) {
                 TransformationMatrix::Decomposed2Type toDecomp;
-                transform.decompose2(toDecomp);
                 // Any rotation prevents us from using a simple start/end rect union.
-                if (toDecomp.angle)
+                if (!transform.decompose2(toDecomp) || toDecomp.angle)
                     return false;
             }
 
@@ -2300,9 +2299,8 @@ bool KeyframeEffect::computeTransformedExtentViaMatrix(const FloatRect& renderer
         return false;
 
     TransformationMatrix::Decomposed2Type fromDecomp;
-    transform.decompose2(fromDecomp);
     // Any rotation prevents us from using a simple start/end rect union.
-    if (fromDecomp.angle)
+    if (!transform.decompose2(fromDecomp) || fromDecomp.angle)
         return false;
 
     bounds = LayoutRect(transform.mapRect(bounds));

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -4007,7 +4007,8 @@ void GraphicsLayerCA::updateRootRelativeScale()
         if (transform.isIdentityOrTranslation())
             return 1;
         TransformationMatrix::Decomposed2Type decomposeData;
-        transform.decompose2(decomposeData);
+        if (!transform.decompose2(decomposeData))
+            return 1;
         return std::max(std::abs(decomposeData.scaleX), std::abs(decomposeData.scaleY));
     };
 

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp
@@ -108,7 +108,10 @@ Ref<TransformOperation> RotateTransformOperation::blend(const TransformOperation
     
     // Extract the result as a quaternion
     TransformationMatrix::Decomposed4Type decomp;
-    toT.decompose4(decomp);
+    if (!toT.decompose4(decomp)) {
+        const RotateTransformOperation* usedOperation = context.progress > 0.5 ? this : fromOp;
+        return RotateTransformOperation::create(usedOperation->x(), usedOperation->y(), usedOperation->z(), usedOperation->angle(), TransformOperation::Type::Rotate3D);
+    }
     
     // Convert that to Axis/Angle form
     double x = -decomp.quaternionX;

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -389,7 +389,8 @@ static bool decompose4(const TransformationMatrix::Matrix4& mat, TransformationM
         // rightHandSide by the inverse. (This is the easiest way, not
         // necessarily the best.)
         TransformationMatrix::Matrix4 inversePerspectiveMatrix, transposedInversePerspectiveMatrix;
-        inverse(perspectiveMatrix, inversePerspectiveMatrix);
+        if (!inverse(perspectiveMatrix, inversePerspectiveMatrix))
+            return false;
         transposeMatrix4(inversePerspectiveMatrix, transposedInversePerspectiveMatrix);
 
         Vector4 perspectivePoint;

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -329,10 +329,10 @@ public:
         }
     };
     
-    bool decompose2(Decomposed2Type&) const;
+    bool decompose2(Decomposed2Type&) const WARN_UNUSED_RETURN;
     void recompose2(const Decomposed2Type&);
 
-    bool decompose4(Decomposed4Type&) const;
+    bool decompose4(Decomposed4Type&) const WARN_UNUSED_RETURN;
     void recompose4(const Decomposed4Type&);
 
     WEBCORE_EXPORT void blend(const TransformationMatrix& from, double progress, CompositeOperation = CompositeOperation::Replace);

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
@@ -290,6 +290,11 @@ void RenderMathMLUnderOver::layoutBlock(bool relayoutChildren, LayoutUnit pageLo
 {
     ASSERT(needsLayout());
 
+    for (auto& box : childrenOfType<RenderBox>(*this)) {
+        if (box.isOutOfFlowPositioned())
+            box.containingBlock()->insertPositionedObject(box);
+    }
+
     if (!relayoutChildren && simplifiedLayout())
         return;
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -865,6 +865,8 @@ void Scope::invalidateMatchedDeclarationsCache()
 
 void Scope::pendingUpdateTimerFired()
 {
+    auto protectedShadowRoot = RefPtr { m_shadowRoot };
+    auto protectedDocument = Ref { m_document };
     flushPendingUpdate();
 }
 


### PR DESCRIPTION
#### 6b3a0ebbfaefa2ce656f28af49b1d079279671a6
<pre>
Cherry-pick 256843.11@webkit-2022.12-embargoed (7d616c4d06eb). rdar://107499625

    Add crash test for disconnected frame switching to eager
    <a href="https://bugs.webkit.org/show_bug.cgi?id=245377">https://bugs.webkit.org/show_bug.cgi?id=245377</a>

    Reviewed by Ryosuke Niwa.

    Add crash test for disconnected frame switching to eager.

    * LayoutTests/fast/frames/disconnected-frame-set-to-eager-crash-expected.txt: Added.
    * LayoutTests/fast/frames/disconnected-frame-set-to-eager-crash.html: Added.

    Canonical link: <a href="https://commits.webkit.org/256843.11@webkit-2022.12-embargoed">https://commits.webkit.org/256843.11@webkit-2022.12-embargoed</a>

Canonical link: <a href="https://commits.webkit.org/262475@main">https://commits.webkit.org/262475@main</a>
</pre>
----------------------------------------------------------------------
#### 79423597243d8278d721a864d3e22d80bc38a9da
<pre>
Cherry-pick 256843.10@webkit-2022.12-embargoed (b7f9b7f4679b). rdar://107499606

    Add test for element&apos;s display contents change on sibling removal
    <a href="https://bugs.webkit.org/show_bug.cgi?id=248772">https://bugs.webkit.org/show_bug.cgi?id=248772</a>

    Reviewed by Tim Nguyen.

    This was already fixed with #248776, but add the test for completeness.

    * LayoutTests/fast/dom/element-clearing-display-contents-on-node-removal-expected.txt: Added.
    * LayoutTests/fast/dom/element-clearing-display-contents-on-node-removal.html: Added.

    Canonical link: <a href="https://commits.webkit.org/256843.10@webkit-2022.12-embargoed">https://commits.webkit.org/256843.10@webkit-2022.12-embargoed</a>

Canonical link: <a href="https://commits.webkit.org/262474@main">https://commits.webkit.org/262474@main</a>
</pre>
----------------------------------------------------------------------
#### 03ee49b03ed6a90fe8b8bef3d74b254386d8488d
<pre>
Cherry-pick 259548.153@safari-7615-branch (c49d1e6e50a4). rdar://107499581

    Hold reference to shadowRoot and document when timer is triggered
    <a href="https://bugs.webkit.org/show_bug.cgi?id=252091">https://bugs.webkit.org/show_bug.cgi?id=252091</a>
    rdar://105115603

    Reviewed by Ryosuke Niwa.

    This change fixes the issue where a Style::Scope can get deallocated
    when the timer is fired, leading to a use-after-free. The fix holds onto
    the shadowRoot and document in question, both of which own the
    Style::Scope object.

    * LayoutTests/fast/css/style-update-timer-crash-expected.txt: Added.
    * LayoutTests/fast/css/style-update-timer-crash.html: Added.
    * Source/WebCore/style/StyleScope.cpp:
    (WebCore::Style::Scope::pendingUpdateTimerFired):

    Canonical link: <a href="https://commits.webkit.org/259548.153@safari-7615-branch">https://commits.webkit.org/259548.153@safari-7615-branch</a>

Canonical link: <a href="https://commits.webkit.org/262473@main">https://commits.webkit.org/262473@main</a>
</pre>
----------------------------------------------------------------------
#### c839c78f8d13517130966a615158e807b0552140
<pre>
Cherry-pick 259548.74@safari-7615-branch (25cddfa82335). rdar://107499427

    Fix layout for positioned children for RenderMathMLUnderOver
    rdar://105071050

    Reviewed by Alan Baradlay.

    Before this change, the layout method in RenderMathMLUnderOver (&lt;mover&gt;) never
    added positioned elements to the map for their container, which meant if
    the positioned children are dirty, their layout will never be triggered.
    This change fixes that by looking at direct children of
    RenderMathMLUnderOver and adding them to their container&apos;s positioned
    elements map, so that their layout happens as expected.

    * LayoutTests/mathml/mathml-mover-layout-crash-expected.txt: Added.
    * LayoutTests/mathml/mathml-mover-layout-crash.html: Added.
    * Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp:
    (WebCore::RenderMathMLUnderOver::layoutBlock):
    * LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt:
    * LayoutTests/platform/mac-wk2/TestExpectations:

    Canonical link: <a href="https://commits.webkit.org/259548.74@safari-7615-branch">https://commits.webkit.org/259548.74@safari-7615-branch</a>

Canonical link: <a href="https://commits.webkit.org/262472@main">https://commits.webkit.org/262472@main</a>
</pre>
----------------------------------------------------------------------
#### 4b5765425bc9d69907b47f0d75b3aa7097f52a61
<pre>
Cherry-pick 259548.70@safari-7615-branch (4f0cd71e42b8). rdar://107499416

    Fix use of uninitialized memory in TransformationMatrix decompose()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=247835">https://bugs.webkit.org/show_bug.cgi?id=247835</a>
    &lt;rdar://102263762&gt;

    Reviewed by Dean Jackson.

    Fixes decompose4 to check for a failing return value from inverse, and early returns, rather
    than continuing with the output matrix uninitialized.

    Also adds WARN_UNUSED_RETURN to decompose2/4 to ensure that all callers handle this case.

    * Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp:
    (WebCore::m_rawTransform):
    * Source/WebCore/animation/KeyframeEffect.cpp:
    (WebCore::KeyframeEffect::computeTransformedExtentViaTransformList const):
    (WebCore::KeyframeEffect::computeTransformedExtentViaMatrix const):
    * Source/WebCore/platform/graphics/transforms/RotateTransformOperation.cpp:
    (WebCore::RotateTransformOperation::blend):
    * Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
    (WebCore::decompose4):
    * Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:

    Canonical link: <a href="https://commits.webkit.org/259548.70@safari-7615-branch">https://commits.webkit.org/259548.70@safari-7615-branch</a>

Canonical link: <a href="https://commits.webkit.org/262471@main">https://commits.webkit.org/262471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bfbf46b133de01deb0d4a6ff532bcd29b9001a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1711 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1491 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2342 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1339 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2503 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1341 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1431 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/402 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1542 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->