### PR TITLE
Fix some performance-related warnings reported by cppcheck

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -102,7 +102,7 @@ private:
     explicit FetchBody(Ref<const ArrayBufferView>&& data) : m_data(WTFMove(data)) { }
     explicit FetchBody(Ref<FormData>&& data) : m_data(WTFMove(data)) { }
     explicit FetchBody(Ref<const URLSearchParams>&& data) : m_data(WTFMove(data)) { }
-    explicit FetchBody(Ref<ReadableStream>&& stream) : m_data(stream) { m_readableStream = WTFMove(stream); }
+    explicit FetchBody(Ref<ReadableStream>&& stream) : m_data(stream), m_readableStream(WTFMove(stream)) { }
     explicit FetchBody(FetchBodyConsumer&& consumer) : m_consumer(WTFMove(consumer)) { }
 
     void consume(FetchBodyOwner&, Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
@@ -131,8 +131,8 @@ void WebSocketDeflater::reset()
 
 WebSocketInflater::WebSocketInflater(int windowBits)
     : m_windowBits(windowBits)
+    , m_stream(makeUniqueWithoutFastMallocCheck<z_stream>())
 {
-    m_stream = makeUniqueWithoutFastMallocCheck<z_stream>();
     memset(m_stream.get(), 0, sizeof(z_stream));
 }
 

--- a/Source/WebCore/css/MediaQueryParserContext.cpp
+++ b/Source/WebCore/css/MediaQueryParserContext.cpp
@@ -33,14 +33,14 @@
 namespace WebCore {
     
 MediaQueryParserContext::MediaQueryParserContext(const CSSParserContext& context)
+    : useSystemAppearance(context.useSystemAppearance)
+    , mode(context.mode)
 {
-    useSystemAppearance = context.useSystemAppearance;
-    mode = context.mode;
 }
 
 MediaQueryParserContext::MediaQueryParserContext(const Document& document)
+    : useSystemAppearance(document.page() && document.page()->useSystemAppearance())
 {
-    useSystemAppearance = document.page() ? document.page()->useSystemAppearance() : false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserObserverWrapper.cpp
+++ b/Source/WebCore/css/parser/CSSParserObserverWrapper.cpp
@@ -55,9 +55,9 @@ void CSSParserObserverWrapper::skipCommentsBefore(const CSSParserTokenRange& ran
 {
     unsigned startIndex = range.begin() - m_firstParserToken;
     if (!leaveDirectlyBefore)
-        startIndex++;
+        ++startIndex;
     while (m_commentIterator < m_commentOffsets.end() && m_commentIterator->tokensBefore < startIndex)
-        m_commentIterator++;
+        ++m_commentIterator;
 }
 
 void CSSParserObserverWrapper::yieldCommentsBefore(const CSSParserTokenRange& range)
@@ -65,7 +65,7 @@ void CSSParserObserverWrapper::yieldCommentsBefore(const CSSParserTokenRange& ra
     unsigned startIndex = range.begin() - m_firstParserToken;
     while (m_commentIterator < m_commentOffsets.end() && m_commentIterator->tokensBefore <= startIndex) {
         m_observer.observeComment(m_commentIterator->startOffset, m_commentIterator->endOffset);
-        m_commentIterator++;
+        ++m_commentIterator;
     }
 }
 

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -105,9 +105,9 @@ CSSParserSelector::CSSParserSelector(const QualifiedName& tagQName)
 {
 }
 
-CSSParserSelector::CSSParserSelector(const CSSSelector& selector) 
+CSSParserSelector::CSSParserSelector(const CSSSelector& selector)
+    : m_selector(makeUnique<CSSSelector>(selector))
 {
-    m_selector = makeUnique<CSSSelector>(selector);
     if (auto next = selector.tagHistory())
         m_tagHistory = makeUnique<CSSParserSelector>(*next);
 }

--- a/Source/WebCore/display/css/DisplayStyle.cpp
+++ b/Source/WebCore/display/css/DisplayStyle.cpp
@@ -84,16 +84,14 @@ Style::Style(const RenderStyle& style)
 }
 
 Style::Style(const RenderStyle& style, const RenderStyle* styleForBackground)
-    : m_overflowX(style.overflowX())
+    : m_color(style.visitedDependentColorWithColorFilter(CSSPropertyColor)) // FIXME: Is currentColor resolved here?
+    , m_overflowX(style.overflowX())
     , m_overflowY(style.overflowY())
     , m_fontCascade(style.fontCascade())
     , m_whiteSpace(style.whiteSpace())
     , m_tabSize(style.tabSize())
     , m_opacity(style.opacity())
 {
-    // FIXME: Is currentColor resolved here?
-    m_color = style.visitedDependentColorWithColorFilter(CSSPropertyColor);
-
     if (styleForBackground)
         setupBackground(*styleForBackground);
 

--- a/Source/WebCore/inspector/InspectorStyleSheet.h
+++ b/Source/WebCore/inspector/InspectorStyleSheet.h
@@ -50,8 +50,8 @@ public:
     InspectorCSSId() = default;
 
     explicit InspectorCSSId(const JSON::Object& value)
+        : m_styleSheetId(value.getString("styleSheetId"_s))
     {
-        m_styleSheetId = value.getString("styleSheetId"_s);
         if (!m_styleSheetId)
             return;
 

--- a/Source/WebCore/loader/LinkPreloadResourceClients.cpp
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.cpp
@@ -32,9 +32,9 @@
 namespace WebCore {
 
 LinkPreloadResourceClient::LinkPreloadResourceClient(LinkLoader& loader, CachedResource& resource)
+    : m_loader(loader)
+    , m_resource(&resource)
 {
-    m_loader = loader;
-    m_resource = &resource;
 }
 
 void LinkPreloadResourceClient::triggerEvents(const CachedResource& resource)

--- a/Source/WebCore/page/UserContentURLPattern.cpp
+++ b/Source/WebCore/page/UserContentURLPattern.cpp
@@ -33,8 +33,8 @@
 namespace WebCore {
 
 UserContentURLPattern::UserContentURLPattern(StringView scheme, StringView host, StringView path)
+    : m_scheme(scheme.toString())
 {
-    m_scheme = scheme.toString();
     if (m_scheme.isEmpty()) {
         m_error = Error::MissingScheme;
         return;

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -103,15 +103,15 @@ static bool needsUpdateAfterChangingDisabledAdaptations(const OptionSet<Disabled
     return false;
 }
 
+// Setup a reasonable default configuration to avoid computing infinite scale/sizes.
+// Those are the original iPhone configuration.
 ViewportConfiguration::ViewportConfiguration()
-    : m_minimumLayoutSize(1024, 768)
+    : m_defaultConfiguration(ViewportConfiguration::webpageParameters())
+    , m_minimumLayoutSize(1024, 768)
     , m_viewLayoutSize(1024, 768)
     , m_canIgnoreScalingConstraints(false)
     , m_forceAlwaysUserScalable(false)
 {
-    // Setup a reasonable default configuration to avoid computing infinite scale/sizes.
-    // Those are the original iPhone configuration.
-    m_defaultConfiguration = ViewportConfiguration::webpageParameters();
     updateConfiguration();
 }
 

--- a/Source/WebCore/platform/DragImage.cpp
+++ b/Source/WebCore/platform/DragImage.cpp
@@ -256,9 +256,9 @@ DragImage::DragImage(DragImageRef dragImageRef)
 
 DragImage::DragImage(DragImage&& other)
     : m_dragImageRef { std::exchange(other.m_dragImageRef, nullptr) }
+    , m_indicatorData { WTFMove(other.m_indicatorData) }
+    , m_visiblePath { WTFMove(other.m_visiblePath) }
 {
-    m_indicatorData = other.m_indicatorData;
-    m_visiblePath = other.m_visiblePath;
 }
 
 DragImage& DragImage::operator=(DragImage&& other)
@@ -267,8 +267,8 @@ DragImage& DragImage::operator=(DragImage&& other)
         deleteDragImage(m_dragImageRef);
 
     m_dragImageRef = std::exchange(other.m_dragImageRef, nullptr);
-    m_indicatorData = other.m_indicatorData;
-    m_visiblePath = other.m_visiblePath;
+    m_indicatorData = WTFMove(other.m_indicatorData);
+    m_visiblePath = WTFMove(other.m_visiblePath);
 
     return *this;
 }

--- a/Source/WebCore/platform/ThreadSafeDataBuffer.h
+++ b/Source/WebCore/platform/ThreadSafeDataBuffer.h
@@ -37,8 +37,8 @@ class ThreadSafeDataBufferImpl : public ThreadSafeRefCounted<ThreadSafeDataBuffe
 friend class ThreadSafeDataBuffer;
 private:
     ThreadSafeDataBufferImpl(Vector<uint8_t>&& data)
+        : m_data(WTFMove(data))
     {
-        m_data = WTFMove(data);
     }
 
     ThreadSafeDataBufferImpl(const Vector<uint8_t>& data)
@@ -99,18 +99,18 @@ public:
 
 private:
     explicit ThreadSafeDataBuffer(Vector<uint8_t>&& data)
+        : m_impl(adoptRef(new ThreadSafeDataBufferImpl(WTFMove(data))))
     {
-        m_impl = adoptRef(new ThreadSafeDataBufferImpl(WTFMove(data)));
     }
 
     explicit ThreadSafeDataBuffer(const Vector<uint8_t>& data)
+        : m_impl(adoptRef(new ThreadSafeDataBufferImpl(data)))
     {
-        m_impl = adoptRef(new ThreadSafeDataBufferImpl(data));
     }
 
     explicit ThreadSafeDataBuffer(const void* data, unsigned length)
+        : m_impl(adoptRef(new ThreadSafeDataBufferImpl(data, length)))
     {
-        m_impl = adoptRef(new ThreadSafeDataBufferImpl(data, length));
     }
 
     RefPtr<ThreadSafeDataBufferImpl> m_impl;

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -182,9 +182,9 @@ private:
 
     class OutOfLineComponents : public ThreadSafeRefCounted<OutOfLineComponents> {
     public:
-        static Ref<OutOfLineComponents> create(ColorComponents<float, 4> components)
+        static Ref<OutOfLineComponents> create(ColorComponents<float, 4>&& components)
         {
-            return adoptRef(*new OutOfLineComponents(components));
+            return adoptRef(*new OutOfLineComponents(WTFMove(components)));
         }
 
         float unresolvedAlpha() const { return m_components[3]; }
@@ -193,8 +193,8 @@ private:
         ColorComponents<float, 4> resolvedComponents() const { return resolveColorComponents(m_components); }
 
     private:
-        OutOfLineComponents(ColorComponents<float, 4> components)
-            : m_components(components)
+        OutOfLineComponents(ColorComponents<float, 4>&& components)
+            : m_components(WTFMove(components))
         {
         }
 

--- a/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
@@ -118,13 +118,13 @@ class PNGImageReader {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     PNGImageReader(PNGImageDecoder* decoder)
-        : m_readOffset(0)
+        : m_png(png_create_read_struct(PNG_LIBPNG_VER_STRING, 0, decodingFailed, decodingWarning))
+        , m_info(png_create_info_struct(m_png))
+        , m_readOffset(0)
         , m_currentBufferSize(0)
         , m_decodingSizeOnly(false)
         , m_hasAlpha(false)
     {
-        m_png = png_create_read_struct(PNG_LIBPNG_VER_STRING, 0, decodingFailed, decodingWarning);
-        m_info = png_create_info_struct(m_png);
         png_set_progressive_read_fn(m_png, decoder, headerAvailable, rowAvailable, pngComplete);
 #if ENABLE(APNG)
         png_byte apngChunks[]= {"acTL\0fcTL\0fdAT\0"};

--- a/Source/WebCore/platform/ios/SelectionGeometry.cpp
+++ b/Source/WebCore/platform/ios/SelectionGeometry.cpp
@@ -136,7 +136,7 @@ void SelectionGeometry::setRect(const IntRect& rect)
     m_cachedEnclosingRect = rect;
 }
 
-TextStream& operator<<(TextStream& stream, SelectionGeometry rect)
+TextStream& operator<<(TextStream& stream, const SelectionGeometry& rect)
 {
     TextStream::GroupScope group(stream);
     stream << "selection geometry";

--- a/Source/WebCore/platform/ios/SelectionGeometry.h
+++ b/Source/WebCore/platform/ios/SelectionGeometry.h
@@ -112,7 +112,7 @@ private:
     mutable std::optional<IntRect> m_cachedEnclosingRect;
 };
 
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, SelectionGeometry);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const SelectionGeometry&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -47,9 +47,9 @@ namespace WebCore {
 namespace Style {
 
 ScopeRuleSets::ScopeRuleSets(Resolver& styleResolver)
-    : m_styleResolver(styleResolver)
+    : m_authorStyle(RuleSet::create())
+    , m_styleResolver(styleResolver)
 {
-    m_authorStyle = RuleSet::create();
 }
 
 ScopeRuleSets::~ScopeRuleSets()

--- a/Source/WebCore/svg/SVGPathByteStreamSource.cpp
+++ b/Source/WebCore/svg/SVGPathByteStreamSource.cpp
@@ -24,9 +24,9 @@
 namespace WebCore {
 
 SVGPathByteStreamSource::SVGPathByteStreamSource(const SVGPathByteStream& stream)
+    : m_streamCurrent(stream.begin())
+    , m_streamEnd(stream.end())
 {
-    m_streamCurrent = stream.begin();
-    m_streamEnd = stream.end();
 }
 
 bool SVGPathByteStreamSource::hasMoreData() const

--- a/Source/WebCore/testing/MallocStatistics.h
+++ b/Source/WebCore/testing/MallocStatistics.h
@@ -40,8 +40,8 @@ public:
 
 private:
     MallocStatistics()
+        : m_stats(WTF::fastMallocStatistics())
     {
-        m_stats = WTF::fastMallocStatistics();
     }
 
     WTF::FastMallocStatistics m_stats;

--- a/Source/WebKit/Platform/IPC/unix/UnixMessage.h
+++ b/Source/WebKit/Platform/IPC/unix/UnixMessage.h
@@ -86,9 +86,9 @@ public:
     }
 
     UnixMessage(UnixMessage&& other)
+        : m_attachments(WTFMove(other.m_attachments))
+        , m_messageInfo(WTFMove(other.m_messageInfo))
     {
-        m_attachments = WTFMove(other.m_attachments);
-        m_messageInfo = WTFMove(other.m_messageInfo);
         if (other.m_bodyOwned) {
             std::swap(m_body, other.m_body);
             std::swap(m_bodyOwned, other.m_bodyOwned);


### PR DESCRIPTION
#### 4d53eb48f4c606624a2887a6e094e6eb1f2d640a
<pre>
Fix some performance-related warnings reported by cppcheck
<a href="https://bugs.webkit.org/show_bug.cgi?id=254854">https://bugs.webkit.org/show_bug.cgi?id=254854</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/fetch/FetchBody.h:
(WebCore::FetchBody::FetchBody):
* Source/WebCore/Modules/websockets/WebSocketDeflater.cpp:
(WebCore::WebSocketInflater::WebSocketInflater):
* Source/WebCore/css/MediaQueryParserContext.cpp:
(WebCore::MediaQueryParserContext::MediaQueryParserContext):
* Source/WebCore/css/parser/CSSParserObserverWrapper.cpp:
(WebCore::CSSParserObserverWrapper::skipCommentsBefore):
(WebCore::CSSParserObserverWrapper::yieldCommentsBefore):
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::CSSParserSelector):
* Source/WebCore/display/css/DisplayStyle.cpp:
(WebCore::Display::Style::Style):
* Source/WebCore/inspector/InspectorStyleSheet.h:
(WebCore::InspectorCSSId::InspectorCSSId):
* Source/WebCore/loader/LinkPreloadResourceClients.cpp:
(WebCore::LinkPreloadResourceClient::LinkPreloadResourceClient):
* Source/WebCore/page/UserContentURLPattern.cpp:
(WebCore::UserContentURLPattern::UserContentURLPattern):
* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::ViewportConfiguration):
* Source/WebCore/platform/DragImage.cpp:
* Source/WebCore/platform/ThreadSafeDataBuffer.h:
(WebCore::ThreadSafeDataBufferImpl::ThreadSafeDataBufferImpl):
(WebCore::ThreadSafeDataBuffer::ThreadSafeDataBuffer):
* Source/WebCore/platform/graphics/Color.h:
(WebCore::Color::OutOfLineComponents::create):
(WebCore::Color::OutOfLineComponents::OutOfLineComponents):
* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp:
(WebCore::PNGImageReader::PNGImageReader):
* Source/WebCore/platform/ios/SelectionGeometry.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ios/SelectionGeometry.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::ScopeRuleSets):
* Source/WebCore/svg/SVGPathByteStreamSource.cpp:
(WebCore::SVGPathByteStreamSource::SVGPathByteStreamSource):
* Source/WebCore/testing/MallocStatistics.h:
(WebCore::MallocStatistics::MallocStatistics):
* Source/WebKit/Platform/IPC/unix/UnixMessage.h:
(IPC::UnixMessage::UnixMessage):

Canonical link: <a href="https://commits.webkit.org/262468@main">https://commits.webkit.org/262468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba4d8e3d89f2c5d67ea88ff64b1a1c5e640031aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1596 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2517 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1500 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1432 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1454 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1472 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2523 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1334 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1439 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/398 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1553 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->