### PR TITLE
Fix some minor warnings from cppcheck in WTF

### DIFF
--- a/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
@@ -59,7 +59,7 @@ public:
     void randomValues(void* buffer, size_t length);
 
 private:
-    inline void addRandomData(unsigned char *data, int length);
+    inline void addRandomData(const unsigned char *data, int length);
     void stir() WTF_REQUIRES_LOCK(m_lock);
     void stirIfNeeded() WTF_REQUIRES_LOCK(m_lock);
     inline uint8_t getByte();
@@ -83,7 +83,7 @@ ARC4RandomNumberGenerator::ARC4RandomNumberGenerator()
 {
 }
 
-void ARC4RandomNumberGenerator::addRandomData(unsigned char* data, int length)
+void ARC4RandomNumberGenerator::addRandomData(const unsigned char* data, int length)
 {
     m_stream.i--;
     for (int n = 0; n < 256; n++) {

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -73,7 +73,7 @@ template<typename NumberType> HexNumberBuffer hex(NumberType number, HexConversi
 
 template<> class StringTypeAdapter<HexNumberBuffer> {
 public:
-    StringTypeAdapter(const HexNumberBuffer& buffer)
+    explicit StringTypeAdapter(const HexNumberBuffer& buffer)
         : m_buffer { buffer }
     {
     }

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -404,8 +404,7 @@ RefPtr<JSON::Value> buildValue(const CodeUnit* start, const CodeUnit* end, const
                 return nullptr;
             }
         }
-        if (token != Token::ArrayEnd)
-            return nullptr;
+        ASSERT(token == Token::ArrayEnd);
         result = WTFMove(array);
         break;
     }
@@ -445,8 +444,7 @@ RefPtr<JSON::Value> buildValue(const CodeUnit* start, const CodeUnit* end, const
                 return nullptr;
             }
         }
-        if (token != Token::ObjectEnd)
-            return nullptr;
+        ASSERT(token == Token::ObjectEnd);
         result = WTFMove(object);
         break;
     }

--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -49,12 +49,8 @@ static uint32_t greatestCommonDivisor(uint32_t a, uint32_t b)
     ASSERT(b);
 
     // Euclid's Algorithm
-    uint32_t temp = 0;
-    while (b) {
-        temp = b;
-        b = a % b;
-        a = temp;
-    }
+    while (b)
+        b = std::exchange(a, b) % b;
 
     ASSERT(a);
     return a;

--- a/Source/WTF/wtf/ObjectIdentifier.cpp
+++ b/Source/WTF/wtf/ObjectIdentifier.cpp
@@ -31,7 +31,7 @@ namespace WTF {
 
 uint64_t ObjectIdentifierBase::generateIdentifierInternal()
 {
-    static uint64_t current;
+    static uint64_t current = 0;
     return ++current;
 }
 

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -176,7 +176,7 @@ TextStream& operator<<(TextStream& ts, const ObjectIdentifier<T>& identifier)
 
 template<typename T> class StringTypeAdapter<ObjectIdentifier<T>> {
 public:
-    StringTypeAdapter(ObjectIdentifier<T> identifier)
+    explicit StringTypeAdapter(ObjectIdentifier<T> identifier)
         : m_identifier(identifier) { }
     unsigned length() const { return lengthOfIntegerAsString(m_identifier.toUInt64()); }
     bool is8Bit() const { return true; }

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -2231,7 +2231,7 @@ Expected<uint32_t, URLParser::IPv4PieceParsingError> URLParser::parseIPv4Piece(C
 ALWAYS_INLINE static uint64_t pow256(size_t exponent)
 {
     RELEASE_ASSERT(exponent <= 4);
-    uint64_t values[5] = {1, 256, 256 * 256, 256 * 256 * 256, 256ull * 256 * 256 * 256 };
+    static constexpr uint64_t values[5] = { 1, 256, 256 * 256, 256 * 256 * 256, 256ull * 256 * 256 * 256 };
     return values[exponent];
 }
 
@@ -2314,8 +2314,6 @@ std::optional<uint32_t> URLParser::parseIPv4PieceInsideIPv6(CodePointIterator<Ch
                 return std::nullopt;
             leadingZeros = true;
         }
-        if (!piece && *iterator == '0')
-            leadingZeros = true;
         piece = piece * 10 + *iterator - '0';
         if (piece > 255)
             return std::nullopt;

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -405,7 +405,7 @@ public:
     {
     }
 
-    VectorBuffer(size_t capacity, size_t size = 0)
+    explicit VectorBuffer(size_t capacity, size_t size = 0)
     {
         m_size = size;
         // Calling malloc(0) might take a lock and may actually do an
@@ -481,7 +481,7 @@ public:
     {
     }
 
-    VectorBuffer(size_t capacity, size_t size = 0)
+    explicit VectorBuffer(size_t capacity, size_t size = 0)
         : Base(inlineBuffer(), inlineCapacity, size)
     {
         if (capacity > inlineCapacity)

--- a/Source/WTF/wtf/dtoa.cpp
+++ b/Source/WTF/wtf/dtoa.cpp
@@ -38,7 +38,7 @@ const char* numberToString(double d, NumberToStringBuffer& buffer)
     return builder.Finalize();
 }
 
-static inline void truncateTrailingZeros(char* buffer, double_conversion::StringBuilder& builder)
+static inline void truncateTrailingZeros(const char* buffer, double_conversion::StringBuilder& builder)
 {
     size_t length = builder.position();
     size_t decimalPointPosition = 0;

--- a/Source/WTF/wtf/dtoa/fast-dtoa.cc
+++ b/Source/WTF/wtf/dtoa/fast-dtoa.cc
@@ -42,8 +42,8 @@ namespace double_conversion {
 //
 // A different range might be chosen on a different platform, to optimize digit
 // generation, but a smaller range requires more powers of ten to be cached.
-static const int kMinimalTargetExponent = -60;
-static const int kMaximalTargetExponent = -32;
+static constexpr int kMinimalTargetExponent = -60;
+static constexpr int kMaximalTargetExponent = -32;
 
 
 // Adjusts the last digit of the generated number, and screens out generated
@@ -434,8 +434,8 @@ static bool DigitGenCounted(DiyFp w,
                             int* length,
                             int* kappa) {
   ASSERT(kMinimalTargetExponent <= w.e() && w.e() <= kMaximalTargetExponent);
-  ASSERT(kMinimalTargetExponent >= -60);
-  ASSERT(kMaximalTargetExponent <= -32);
+  static_assert(kMinimalTargetExponent >= -60);
+  static_assert(kMaximalTargetExponent <= -32);
   // w is assumed to have an error less than 1 unit. Whenever w is scaled we
   // also scale its error.
   uint64_t w_error = 1;

--- a/Source/WTF/wtf/dtoa/strtod.cc
+++ b/Source/WTF/wtf/dtoa/strtod.cc
@@ -489,21 +489,17 @@ static float SanitizedDoubletof(double d) {
   // https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks
   // The behavior should be covered by IEEE 754, but some projects use this
   // flag, so work around it.
-  float max_finite = 3.4028234663852885981170418348451692544e+38;
+  constexpr float max_finite = 3.4028234663852885981170418348451692544e+38;
   // The half-way point between the max-finite and infinity value.
   // Since infinity has an even significand everything equal or greater than
   // this value should become infinity.
-  double half_max_finite_infinity =
-      3.40282356779733661637539395458142568448e+38;
+  constexpr double half_max_finite_infinity = 3.40282356779733661637539395458142568448e+38;
   if (d >= max_finite) {
-    if (d >= half_max_finite_infinity) {
+    if (d >= half_max_finite_infinity)
       return Single::Infinity();
-    } else {
-      return max_finite;
-    }
-  } else {
-    return static_cast<float>(d);
+    return max_finite;
   }
+  return static_cast<float>(d);
 }
 
 float Strtof(BufferReference<const char> buffer, int exponent) {

--- a/Source/WTF/wtf/text/StringBuilderJSON.cpp
+++ b/Source/WTF/wtf/text/StringBuilderJSON.cpp
@@ -63,7 +63,6 @@ ALWAYS_INLINE static void appendQuotedJSONStringInternal(OutputCharacterType*& o
         *output++ = lowerNibbleToLowercaseASCIIHexDigit(upper);
         *output++ = upperNibbleToLowercaseASCIIHexDigit(lower);
         *output++ = lowerNibbleToLowercaseASCIIHexDigit(lower);
-        continue;
     }
 }
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1438,7 +1438,7 @@ bool equal(const StringImpl* a, const LChar* b)
     if (!a)
         return !b;
     if (!b)
-        return !a;
+        return false;
 
     unsigned length = a->length();
 

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
@@ -81,7 +81,7 @@ static UText* uTextLatin1Clone(UText* destination, const UText* source, UBool de
     result->context = source->context;
     result->a = source->a;
     result->pFuncs = &uTextLatin1Funcs;
-    result->chunkContents = (UChar*)result->pExtra;
+    result->chunkContents = static_cast<UChar*>(result->pExtra);
     memset(const_cast<UChar*>(result->chunkContents), 0, sizeof(UChar) * UTextWithBufferInlineCapacity);
 
     return result;
@@ -228,7 +228,7 @@ UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, const LChar* strin
     text->context = string;
     text->a = length;
     text->pFuncs = &uTextLatin1Funcs;
-    text->chunkContents = (UChar*)text->pExtra;
+    text->chunkContents = static_cast<UChar*>(text->pExtra);
     memset(const_cast<UChar*>(text->chunkContents), 0, sizeof(UChar) * UTextWithBufferInlineCapacity);
 
     return text;

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -33,7 +33,7 @@
 
 namespace WTF::Unicode {
 
-bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char** targetStart, char* targetEnd)
+bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char** targetStart, const char* targetEnd)
 {
     const LChar* source;
     char* target = *targetStart;
@@ -53,7 +53,7 @@ bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char
     return true;
 }
 
-ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sourceEnd, char** targetStart, char* targetEnd, bool strict)
+ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sourceEnd, char** targetStart, const char* targetEnd, bool strict)
 {
     auto result = ConversionResult::Success;
     const UChar* source = *sourceStart;
@@ -88,7 +88,7 @@ ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sour
 }
 
 template<bool replaceInvalidSequences>
-bool convertUTF8ToUTF16Impl(const char* source, const char* sourceEnd, UChar** targetStart, UChar* targetEnd, bool* sourceAllASCII)
+bool convertUTF8ToUTF16Impl(const char* source, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
 {
     RELEASE_ASSERT(sourceEnd - source <= std::numeric_limits<int>::max());
     UBool error = false;
@@ -117,12 +117,12 @@ bool convertUTF8ToUTF16Impl(const char* source, const char* sourceEnd, UChar** t
     return true;
 }
 
-bool convertUTF8ToUTF16(const char* source, const char* sourceEnd, UChar** targetStart, UChar* targetEnd, bool* sourceAllASCII)
+bool convertUTF8ToUTF16(const char* source, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
 {
     return convertUTF8ToUTF16Impl<false>(source, sourceEnd, targetStart, targetEnd, sourceAllASCII);
 }
 
-bool convertUTF8ToUTF16ReplacingInvalidSequences(const char* source, const char* sourceEnd, UChar** targetStart, UChar* targetEnd, bool* sourceAllASCII)
+bool convertUTF8ToUTF16ReplacingInvalidSequences(const char* source, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
 {
     return convertUTF8ToUTF16Impl<true>(source, sourceEnd, targetStart, targetEnd, sourceAllASCII);
 }

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -44,10 +44,10 @@ enum class ConversionResult : uint8_t {
 // converted to the replacement character, except for an unpaired lead surrogate
 // at the end of the source, which will instead cause a SourceExhausted error.
 
-WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16(const char* sourceStart, const char* sourceEnd, UChar** targetStart, UChar* targetEnd, bool* isSourceAllASCII = nullptr);
-WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16ReplacingInvalidSequences(const char* sourceStart, const char* sourceEnd, UChar** targetStart, UChar* targetEnd, bool* isSourceAllASCII = nullptr);
-WTF_EXPORT_PRIVATE bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char** targetStart, char* targetEnd);
-WTF_EXPORT_PRIVATE ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sourceEnd, char** targetStart, char* targetEnd, bool strict = true);
+WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16(const char* sourceStart, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* isSourceAllASCII = nullptr);
+WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16ReplacingInvalidSequences(const char* sourceStart, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* isSourceAllASCII = nullptr);
+WTF_EXPORT_PRIVATE bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char** targetStart, const char* targetEnd);
+WTF_EXPORT_PRIVATE ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sourceEnd, char** targetStart, const char* targetEnd, bool strict = true);
 WTF_EXPORT_PRIVATE unsigned calculateStringHashAndLengthFromUTF8MaskingTop8Bits(const char* data, const char* dataEnd, unsigned& dataLength, unsigned& utf16Length);
 
 // Callers of these functions must check that the lengths are the same; accordingly we omit an end argument for UTF-16 and Latin-1.


### PR DESCRIPTION
#### 9dd212febdb2ba8bc9900ed5eb2789a6ae72529e
<pre>
Fix some minor warnings from cppcheck in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=254856">https://bugs.webkit.org/show_bug.cgi?id=254856</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/CryptographicallyRandomNumber.cpp:
* Source/WTF/wtf/HexNumber.h:
(WTF::StringTypeAdapter&lt;HexNumberBuffer&gt;::StringTypeAdapter):
* Source/WTF/wtf/JSONValues.cpp:
* Source/WTF/wtf/MediaTime.cpp:
(WTF::greatestCommonDivisor):
* Source/WTF/wtf/ObjectIdentifier.cpp:
(WTF::ObjectIdentifierBase::generateIdentifierInternal):
* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::StringTypeAdapter&lt;ObjectIdentifier&lt;T&gt;&gt;::StringTypeAdapter):
* Source/WTF/wtf/URLParser.cpp:
(WTF::pow256):
(WTF::URLParser::parseIPv4PieceInsideIPv6):
* Source/WTF/wtf/Vector.h:
(WTF::VectorBuffer::VectorBuffer):
* Source/WTF/wtf/dtoa.cpp:
(WTF::truncateTrailingZeros):
* Source/WTF/wtf/dtoa/fast-dtoa.cc:
* Source/WTF/wtf/dtoa/strtod.cc:
* Source/WTF/wtf/text/StringBuilderJSON.cpp:
(WTF::appendQuotedJSONStringInternal):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::equal):
* Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp:
(WTF::uTextLatin1Clone):
(WTF::openLatin1UTextProvider):
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::convertLatin1ToUTF8):
(WTF::Unicode::convertUTF16ToUTF8):
(WTF::Unicode::convertUTF8ToUTF16Impl):
(WTF::Unicode::convertUTF8ToUTF16):
(WTF::Unicode::convertUTF8ToUTF16ReplacingInvalidSequences):
* Source/WTF/wtf/unicode/UTF8Conversion.h:

Canonical link: <a href="https://commits.webkit.org/262482@main">https://commits.webkit.org/262482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a71eb857e7700459f679ed2e554df98b5611a2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2524 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1723 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1507 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2361 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1352 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1361 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1461 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2529 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1540 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1340 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1660 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1446 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/356 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/405 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1560 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1700 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/471 "Passed tests") | 
<!--EWS-Status-Bubble-End-->