### PR TITLE
Update HTMLFastPathParser::scanTagName() to return an ElementName

### DIFF
--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -1048,6 +1048,8 @@ sub printElementNameHeaderFile
     print F "} // namespace ElementNames\n";
     print F "\n";
     print F "ElementName findElementName(Namespace, const String&);\n";
+    print F "ElementName findHTMLElementName(Span<const LChar>);\n";
+    print F "ElementName findHTMLElementName(Span<const UChar>);\n";
     print F "TagName tagNameForElement(ElementName);\n";
     print F "ElementName elementNameForTag(Namespace, TagName);\n";
     print F "const QualifiedName& qualifiedNameForElement(ElementName);\n";
@@ -1169,6 +1171,16 @@ sub printElementNameCppFile
     print F "    if (name.is8Bit())\n";
     print F "        return findElementFromBuffer(ns, makeSpan(name.characters8(), name.length()));\n";
     print F "    return findElementFromBuffer(ns, makeSpan(name.characters16(), name.length()));\n";
+    print F "}\n";
+    print F "\n";
+    print F "ElementName findHTMLElementName(Span<const LChar> buffer)\n";
+    print F "{\n";
+    print F "    return findHTMLElement(buffer);\n";
+    print F "}\n";
+    print F "\n";
+    print F "ElementName findHTMLElementName(Span<const UChar> buffer)\n";
+    print F "{\n";
+    print F "    return findHTMLElement(buffer);\n";
     print F "}\n";
     print F "\n";
     print F "const QualifiedName& qualifiedNameForElement(ElementName elementName)\n";

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -103,36 +103,6 @@ template<class Char> static bool operator==(Span<const Char> span, ASCIILiteral 
     return WTF::equal(span.data(), s.characters8(), span.size());
 }
 
-#if ASSERT_ENABLED
-static constexpr bool onlyContainsLowercaseASCIILetters(ASCIILiteral s)
-{
-    for (size_t i = 0; i < s.length(); ++i) {
-        if (!isASCIILower(s[i]))
-            return false;
-    }
-    return true;
-}
-#endif // ASSERT_ENABLED
-
-// A hash function that is just good enough to distinguish the supported tagNames. It needs to be
-// adapted as soon as we have colliding tagNames. The implementation was chosen to map to a dense
-// integer range to allow for compact switch jump-tables. If adding support for a new tag results
-// in a collision, then pick a new function that minimizes the number of operations and results
-// in a dense integer range.
-static constexpr uint32_t tagNameHash(ASCIILiteral s)
-{
-    // The fast-path parser only scans for letters in tagNames.
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(onlyContainsLowercaseASCIILetters(s));
-    // This function is called with null-termined string, which should be used in the hash
-    // implementation, hence the -2.
-    return (s[0] + 17 * s[s.length() - 1]) & 63;
-}
-
-template<class Char> static constexpr uint32_t tagNameHash(Span<const Char> s)
-{
-    return (s[0] + 17 * s[s.size() - 1]) & 63;
-}
-
 template<typename CharacterType> static inline bool isQuoteCharacter(CharacterType c)
 {
     return c == '"' || c == '\'';
@@ -334,7 +304,7 @@ private:
         };
 
         struct A : ContainerTag<HTMLAnchorElement, PermittedParents::FlowContent> {
-            static constexpr ASCIILiteral tagName = "a"_s;
+            static constexpr ElementName tagName = ElementName::HTML_a;
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -347,7 +317,7 @@ private:
         };
 
         struct AWithPhrasingContent : ContainsPhrasingContentTag<HTMLAnchorElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ASCIILiteral tagName = "a"_s;
+            static constexpr ElementName tagName = ElementName::HTML_a;
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -360,7 +330,7 @@ private:
         };
 
         struct B : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ASCIILiteral tagName = "b"_s;
+            static constexpr ElementName tagName = ElementName::HTML_b;
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -369,19 +339,19 @@ private:
         };
 
         struct Br : VoidTag<HTMLBRElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ASCIILiteral tagName = "br"_s;
+            static constexpr ElementName tagName = ElementName::HTML_br;
         };
 
         struct Button : ContainsPhrasingContentTag<HTMLButtonElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ASCIILiteral tagName = "button"_s;
+            static constexpr ElementName tagName = ElementName::HTML_button;
         };
 
         struct Div : ContainerTag<HTMLDivElement, PermittedParents::FlowContent> {
-            static constexpr ASCIILiteral tagName = "div"_s;
+            static constexpr ElementName tagName = ElementName::HTML_div;
         };
 
         struct Footer : ContainerTag<HTMLDivElement, PermittedParents::FlowContent> {
-            static constexpr ASCIILiteral tagName = "footer"_s;
+            static constexpr ElementName tagName = ElementName::HTML_footer;
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -390,7 +360,7 @@ private:
         };
 
         struct I : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ASCIILiteral tagName = "i"_s;
+            static constexpr ElementName tagName = ElementName::HTML_i;
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -399,7 +369,7 @@ private:
         };
 
         struct Input : VoidTag<HTMLInputElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ASCIILiteral tagName = "input"_s;
+            static constexpr ElementName tagName = ElementName::HTML_input;
 
             static Ref<HTMLInputElement> create(Document& document)
             {
@@ -408,15 +378,15 @@ private:
         };
 
         struct Li : ContainerTag<HTMLLIElement, PermittedParents::Special> {
-            static constexpr ASCIILiteral tagName = "li"_s;
+            static constexpr ElementName tagName = ElementName::HTML_li;
         };
 
         struct Label : ContainsPhrasingContentTag<HTMLLabelElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ASCIILiteral tagName = "label"_s;
+            static constexpr ElementName tagName = ElementName::HTML_label;
         };
 
         struct Option : ContainerTag<HTMLOptionElement, PermittedParents::Special> {
-            static constexpr ASCIILiteral tagName = "option"_s;
+            static constexpr ElementName tagName = ElementName::HTML_option;
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -426,7 +396,7 @@ private:
         };
 
         struct Ol : ContainerTag<HTMLOListElement, PermittedParents::FlowContent> {
-            static constexpr ASCIILiteral tagName = "ol"_s;
+            static constexpr ElementName tagName = ElementName::HTML_ol;
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -435,11 +405,11 @@ private:
         };
 
         struct P : ContainsPhrasingContentTag<HTMLParagraphElement, PermittedParents::FlowContent> {
-            static constexpr ASCIILiteral tagName = "p"_s;
+            static constexpr ElementName tagName = ElementName::HTML_p;
         };
 
         struct Select : ContainerTag<HTMLSelectElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ASCIILiteral tagName = "select"_s;
+            static constexpr ElementName tagName = ElementName::HTML_select;
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -448,11 +418,11 @@ private:
         };
 
         struct Span : ContainsPhrasingContentTag<HTMLSpanElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ASCIILiteral tagName = "span"_s;
+            static constexpr ElementName tagName = ElementName::HTML_span;
         };
 
         struct Strong : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ASCIILiteral tagName = "strong"_s;
+            static constexpr ElementName tagName = ElementName::HTML_strong;
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -461,7 +431,7 @@ private:
         };
 
         struct Ul : ContainerTag<HTMLUListElement, PermittedParents::FlowContent> {
-            static constexpr ASCIILiteral tagName = "ul"_s;
+            static constexpr ElementName tagName = ElementName::HTML_ul;
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -525,7 +495,7 @@ private:
     }
 
     // Scan a tagName and convert to lowercase if necessary.
-    CharSpan scanTagName()
+    ElementName scanTagName()
     {
         auto* start = m_parsingBuffer.position();
         skipWhile<isASCIILower>(m_parsingBuffer);
@@ -544,13 +514,13 @@ private:
                 m_charBuffer.append(c);
             }
             if (m_parsingBuffer.atEnd() || !isCharAfterTagNameOrAttribute(*m_parsingBuffer))
-                return didFail(HTMLFastPathResult::FailedParsingTagName, CharSpan { });
+                return didFail(HTMLFastPathResult::FailedParsingTagName, ElementName::Unknown);
             skipWhile<isHTMLSpace>(m_parsingBuffer);
-            return CharSpan { m_charBuffer.data(), m_charBuffer.size() };
+            return findHTMLElementName({ m_charBuffer.data(), m_charBuffer.size() });
         }
-        CharSpan result { start, static_cast<size_t>(m_parsingBuffer.position() - start) };
+        auto tagName = findHTMLElementName({ start, static_cast<size_t>(m_parsingBuffer.position() - start) });
         skipWhile<isHTMLSpace>(m_parsingBuffer);
-        return result;
+        return tagName;
     }
 
     CharSpan scanAttributeName()
@@ -845,16 +815,16 @@ private:
 
     template<class... Tags> RefPtr<Element> parseSpecificElements()
     {
-        CharSpan tagName = scanTagName();
+        auto tagName = scanTagName();
         return parseSpecificElements<Tags...>(tagName);
     }
 
-    template<void* = nullptr> RefPtr<Element> parseSpecificElements(CharSpan)
+    template<void* = nullptr> RefPtr<Element> parseSpecificElements(ElementName)
     {
         return didFail(HTMLFastPathResult::FailedParsingSpecificElements, nullptr);
     }
 
-    template<class Tag, class... OtherTags> RefPtr<Element> parseSpecificElements(CharSpan tagName)
+    template<class Tag, class... OtherTags> RefPtr<Element> parseSpecificElements(ElementName tagName)
     {
         if (tagName == Tag::tagName)
             return parseElementAfterTagName<Tag>();
@@ -864,8 +834,6 @@ private:
     template<bool nonPhrasingContent> RefPtr<Element> parseElement()
     {
         auto tagName = scanTagName();
-        if (tagName.empty())
-            return didFail(HTMLFastPathResult::FailedParsingElement, nullptr);
 
         // HTML has complicated rules around auto-closing tags and re-parenting
         // DOM nodes. We avoid complications with auto-closing rules by disallowing
@@ -877,16 +845,13 @@ private:
         //
         // If this switch has duplicate cases, then `tagNameHash()` needs to be
         // updated.
-        switch (tagNameHash(tagName)) {
+        switch (tagName) {
 #define TAG_CASE(TagName, TagClassName)                                                  \
-        case tagNameHash(TagInfo::TagClassName::tagName):                                \
+        case ElementName::HTML_ ## TagName:                                              \
             if (std::is_same_v<typename TagInfo::A, typename TagInfo::TagClassName>)     \
-                goto caseA;                                                             \
-            if constexpr (nonPhrasingContent ? TagInfo::TagClassName::allowedInFlowContent() : TagInfo::TagClassName::allowedInPhrasingOrFlowContent()) { \
-                /* See comment in parse() for details on why equality is checked here */ \
-                if (tagName == TagInfo::TagClassName::tagName)                           \
-                    return parseElementAfterTagName<typename TagInfo::TagClassName>();   \
-            }                                                                            \
+                goto caseA;                                                              \
+            if constexpr (nonPhrasingContent ? TagInfo::TagClassName::allowedInFlowContent() : TagInfo::TagClassName::allowedInPhrasingOrFlowContent()) \
+                return parseElementAfterTagName<typename TagInfo::TagClassName>();   \
             break;
 
         FOR_EACH_SUPPORTED_TAG(TAG_CASE)
@@ -895,7 +860,7 @@ private:
             caseA:
             // <a> tags must not be nested, because HTML parsing would auto-close
             // the outer one when encountering a nested one.
-            if (tagName == TagInfo::A::tagName && !m_insideOfTagA) {
+            if (!m_insideOfTagA) {
                 return nonPhrasingContent
                     ? parseElementAfterTagName<typename TagInfo::A>()
                     : parseElementAfterTagName<typename TagInfo::AWithPhrasingContent>();


### PR DESCRIPTION
#### 8e6de7844cbbe195f4f71cec376dba02c6ad2fd2
<pre>
Update HTMLFastPathParser::scanTagName() to return an ElementName
<a href="https://bugs.webkit.org/show_bug.cgi?id=254857">https://bugs.webkit.org/show_bug.cgi?id=254857</a>

Reviewed by Darin Adler.

Update HTMLFastPathParser::scanTagName() to return an ElementName enum instead
of a Span&lt;Character&gt;. This simplifies the logic in the HTML fast parser and is
slightly more efficient.

* Source/WebCore/dom/make_names.pl:
(printElementNameHeaderFile):
(printElementNameCppFile):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanTagName):
(WebCore::HTMLFastPathParser::parseSpecificElements):
(WebCore::HTMLFastPathParser::parseElement):
(WebCore::onlyContainsLowercaseASCIILetters): Deleted.
(WebCore::tagNameHash): Deleted.

Canonical link: <a href="https://commits.webkit.org/262484@main">https://commits.webkit.org/262484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f6983c7cbeb67ee11cc6ae4bbf10ae9d142837c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2539 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1738 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1520 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2376 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1452 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1476 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1494 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2541 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1353 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1459 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/408 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1575 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->