### PR TITLE
Check rendererCanHaveTrimmedMargin before calling box->hasTrimmedMargin

### DIFF
--- a/LayoutTests/css3/flexbox/flex-item-margin-top-no-crash-expected.html
+++ b/LayoutTests/css3/flexbox/flex-item-margin-top-no-crash-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.flexbox {
+    display: flex;
+}
+.flex-item {
+    width: 50px;
+    height: 50px;
+    margin-top: 10px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+    <div class="flexbox">
+        <div id="flex-item" class="flex-item"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/css3/flexbox/flex-item-margin-top-no-crash.html
+++ b/LayoutTests/css3/flexbox/flex-item-margin-top-no-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.flexbox {
+    display: flex;
+}
+.flex-item {
+    width: 50px;
+    height: 50px;
+    margin-top: 10px;
+    background-color: green;
+}
+</style>
+</head>
+<body>
+    <div class="flexbox">
+        <div id="flex-item" class="flex-item"></div>
+    </div>
+<script>
+    // This should not crash/trigger an assert
+    window.getComputedStyle(document.getElementById("flex-item")).marginTop;
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2291,24 +2291,27 @@ static bool isFlexItem(const RenderObject* renderer)
     return false;
 }
 
-static bool rendererContainingBlockHasMarginTrim(const RenderBox& renderer, std::optional<MarginTrimType> marginTrimType)
+static bool rendererCanHaveTrimmedMargin(const RenderBox& renderer, std::optional<MarginTrimType> marginTrimType)
 {
+    // A renderer will have a specific margin marked as trimmed by setting its rare data bit if:
+    // 1.) The layout system the box is in has this logic (setting the rare data bit for this 
+    // specific margin) implemented
+    // 2.) The block container/flexbox/grid has this margin specified in its margin-trim style
+    // If marginTrimType is empty we will check if any of the supported margins are in the style
     auto* containingBlock = renderer.containingBlock();
     if (!containingBlock || containingBlock->isRenderView())
         return false;
 
     // containingBlock->isBlockContainer() can return true even if the item is in a RenderFlexibleBox
     // (e.g. buttons) so we should explicitly check that the item is not a flex item to catch block containers here
-    if (!renderer.isFlexItem() && (containingBlock->isRenderGrid() || containingBlock->isBlockContainer())) {
-        ASSERT_NOT_IMPLEMENTED_YET();
+    if (!renderer.isFlexItem() && (containingBlock->isRenderGrid() || containingBlock->isBlockContainer()))
         return false;
-    }
 
     if (containingBlock->isFlexibleBox()) {
-        ASSERT(!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart || marginTrimType.value() == MarginTrimType::InlineEnd);
-        return marginTrimType ? containingBlock->style().marginTrim().contains(marginTrimType.value()) : !containingBlock->style().marginTrim().containsAny({ MarginTrimType::BlockStart, MarginTrimType::InlineEnd });
+        if (!marginTrimType)
+            return containingBlock->style().marginTrim().containsAny({ MarginTrimType::BlockStart, MarginTrimType::InlineEnd });
+        return containingBlock->style().marginTrim().contains(marginTrimType.value());
     }
-    ASSERT_NOT_REACHED();
     return false;
 }
 
@@ -2342,12 +2345,12 @@ static bool isLayoutDependent(CSSPropertyID propertyID, const RenderStyle* style
             return false;
         return !(style && style->marginTop().isFixed() && style->marginRight().isFixed()
             && style->marginBottom().isFixed() && style->marginLeft().isFixed())
-            || (isFlexItem(renderer) && rendererContainingBlockHasMarginTrim(downcast<RenderBox>(*renderer), { }));
+            || (rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), { }));
     }
     case CSSPropertyMarginTop:
-        return paddingOrMarginIsRendererDependent<&RenderStyle::marginTop>(style, renderer) || (isFlexItem(renderer) && rendererContainingBlockHasMarginTrim(downcast<RenderBox>(*renderer), MarginTrimType::BlockStart));
+        return paddingOrMarginIsRendererDependent<&RenderStyle::marginTop>(style, renderer) || (isFlexItem(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::BlockStart));
     case CSSPropertyMarginRight:
-        return paddingOrMarginIsRendererDependent<&RenderStyle::marginRight>(style, renderer) || (isFlexItem(renderer) && rendererContainingBlockHasMarginTrim(downcast<RenderBox>(*renderer), MarginTrimType::InlineEnd));
+        return paddingOrMarginIsRendererDependent<&RenderStyle::marginRight>(style, renderer) || (isFlexItem(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::InlineEnd));
     case CSSPropertyMarginBottom:
         return paddingOrMarginIsRendererDependent<&RenderStyle::marginBottom>(style, renderer);
     case CSSPropertyMarginLeft:
@@ -3279,13 +3282,15 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             return CSSPrimitiveValue::create(CSSValueAuto);
         return CSSPrimitiveValue::createCustomIdent(style.specifiedLocale());
     case CSSPropertyMarginTop: {
-        if (auto* box = dynamicDowncast<RenderBox>(renderer); box && box->isFlexItem() && box->hasTrimmedMargin(PhysicalDirection::Top))
+        if (auto* box = dynamicDowncast<RenderBox>(renderer); box
+            && rendererCanHaveTrimmedMargin(*box, MarginTrimType::BlockStart) 
+            && box->hasTrimmedMargin(PhysicalDirection::Top))
             return zoomAdjustedPixelValue(box->marginTop(), style);
         return zoomAdjustedPaddingOrMarginPixelValue<&RenderStyle::marginTop, &RenderBoxModelObject::marginTop>(style, renderer);
     }
     case CSSPropertyMarginRight: {
         if (auto* box = dynamicDowncast<RenderBox>(renderer); box && box->isFlexItem() 
-            && rendererContainingBlockHasMarginTrim(*box, MarginTrimType::InlineEnd)
+            && rendererCanHaveTrimmedMargin(*box, MarginTrimType::InlineEnd)
             && box->hasTrimmedMargin(PhysicalDirection::Right))
             return zoomAdjustedPixelValue(box->marginRight(), style);
         Length marginRight = style.marginRight();

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1454,12 +1454,19 @@ bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) c
     if (!isInFlow())
         return false;
 #if ASSERT_ENABLED
+    // We should assert here if this function is called with a layout system and
+    // MarginTrimType combination that is not supported yet (i.e. the layout system
+    // does not set the margin trim rare data bit for that margin)
+
     // containingBlock->isBlockContainer() can return true even if the item is in a RenderFlexibleBox
     // (e.g. buttons) so we should explicitly check that the item is not a flex item to catch block containers here
-    if (auto* containingBlock = this->containingBlock(); containingBlock && !containingBlock->isFlexibleBox() &&  (containingBlock->isBlockContainer() || containingBlock->isRenderGrid())) {
+    auto* containingBlock = this->containingBlock(); 
+    if (containingBlock && !containingBlock->isFlexibleBox() && (containingBlock->isBlockContainer() || containingBlock->isRenderGrid())) {
         ASSERT_NOT_IMPLEMENTED_YET();
         return false;
     }
+    if (containingBlock && containingBlock->isFlexibleBox())
+        ASSERT(!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart || marginTrimType.value() == MarginTrimType::InlineEnd);
 #endif
     if (!hasRareData())
         return false;


### PR DESCRIPTION
#### beefa0360c1e5611074acc823e60878b9be936db
<pre>
Check rendererCanHaveTrimmedMargin before calling box-&gt;hasTrimmedMargin
<a href="https://bugs.webkit.org/show_bug.cgi?id=254859">https://bugs.webkit.org/show_bug.cgi?id=254859</a>
rdar://problem/107502795

Reviewed by Alan Baradlay.

In this example we will trigger ASSERT(!needsLayout()) inside of
RenderBox::hasTrimmedMargin. This is because computing the margin on
the item is not layout dependent (isLayoutDependent returns false)
and we end up calling into box-&gt;hasTrimmedMargin before layout has
occurred.

&lt;style&gt;
.flexbox {
    display: flex;
}
.flex-item {
    width: 50px;
    height: 50px;
    margin-top: 10px;
    background-color: green;
}
&lt;/style&gt;
&lt;body&gt;
    &lt;div class=&quot;flexbox&quot;&gt;
        &lt;div id=&quot;flex-item&quot; class=&quot;flex-item&quot;&gt;&lt;/div&gt;
    &lt;/div&gt;
&lt;script&gt;
    window.getComputedStyle(document.getElementById(&quot;flex-item&quot;)).marginTop;
&lt;/script&gt;
&lt;/body&gt;

Before calling hasTrimmedMargin we should check for the same conditions
that would make isLayoutDependent return true. To accomplish this, I
renamed rendererContainingBlockHasMarginTrim to rendererCanHaveTrimmedMargin
and removed the asserts that were in there. These asserts were
unnecessary because they were the same ones being checked inside of
hasTrimmedMargin. Now we can use this helper function inside of
isLayoutDependent and to guard the call to hasTrimmedMargin. Another
benefit of this is that as we iterate on the computed values for
trimmed margins in different layout contexts we can just change this
one function rather than sprinkling the same checks around each of
the margin types.

* LayoutTests/css3/flexbox/flex-item-margin-top-no-crash-expected.html: Added.
* LayoutTests/css3/flexbox/flex-item-margin-top-no-crash.html: Added.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::rendererCanHaveTrimmedMargin):
(WebCore::isLayoutDependent):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
(WebCore::rendererContainingBlockHasMarginTrim): Deleted.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hasTrimmedMargin const):

Canonical link: <a href="https://commits.webkit.org/262679@main">https://commits.webkit.org/262679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89083d42cb1490260918245f9cf827245fea99c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2255 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2188 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/2365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2002 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2998 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1958 "Build was cancelled. Recent messages:OS: Monterey (12.6), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1859 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2047 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2013 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3162 "268 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1822 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1975 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/552 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2151 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->