### PR TITLE
AcceleratedSurfaceDMABuf: use a renderbuffer for fbo color attachment

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
@@ -61,11 +61,13 @@ public:
 private:
     AcceleratedSurfaceDMABuf(WebPage&, Client&);
 
-    unsigned m_texture { 0 };
     unsigned m_fbo { 0 };
     unsigned m_depthStencilBuffer { 0 };
-    EGLImage m_backImage { nullptr };
-    EGLImage m_frontImage { nullptr };
+
+    struct {
+        EGLImage image { nullptr };
+        unsigned colorBuffer { 0 };
+    } m_back, m_front;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### c4da3d5152bddf041e19a90c67d99d77ea92beee
<pre>
AcceleratedSurfaceDMABuf: use a renderbuffer for fbo color attachment
<a href="https://bugs.webkit.org/show_bug.cgi?id=254862">https://bugs.webkit.org/show_bug.cgi?id=254862</a>

Reviewed by Carlos Garcia Campos.

Don&apos;t generate and provide a texture as the color attachment for the custom
framebuffer, use a renderbuffer instead. Instead of a single renderbuffer used
as the color attachment for the framebuffer, with the EGLImage-based storage
being swapped out for each frame, separate renderbuffers are used so that just
the color attachment on the framebuffer changes.

A is-framebuffer-complete check is also done after the framebuffer is set up,
printing out a warning about the incompleteness. This provides the textual
information for why subsequently nothing will be rendered.

* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didCreateGLContext):
(WebKit::AcceleratedSurfaceDMABuf::willDestroyGLContext):
(WebKit::AcceleratedSurfaceDMABuf::clientResize):
(WebKit::AcceleratedSurfaceDMABuf::willRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/262505@main">https://commits.webkit.org/262505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d55b3037ca7e29096584685ae701dca415e06d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2681 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1877 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1851 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1771 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2520 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1485 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1613 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2683 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1566 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/1568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1706 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/181 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->