### PR TITLE
Non-unified build fixes, April 1st 2023 edition

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
@@ -31,6 +31,7 @@
 #include "AirCCallSpecial.h"
 #include "AirCode.h"
 #include "B3CCallValue.h"
+#include "B3Procedure.h"
 
 namespace JSC { namespace B3 { namespace Air {
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -32,6 +32,7 @@
 #include "JSWebAssemblyStruct.h"
 #include "WasmFormat.h"
 #include "WasmTypeDefinitionInlines.h"
+#include "WebAssemblyFunctionBase.h"
 #include <wtf/CommaPrinter.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/StringPrintStream.h>

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -33,7 +33,7 @@
 #include "AXIsolatedObject.h"
 #endif
 #include "AXObjectCache.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "LocalFrameView.h"
 #include "LogInitialization.h"
 #include "Logging.h"

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -30,6 +30,7 @@
 #include "AXTreeStore.h"
 #include "HTMLInputElement.h"
 #include "RenderObject.h"
+#include "TextIterator.h"
 
 namespace WebCore {
 
@@ -171,7 +172,7 @@ std::optional<BoundaryPoint> AXTextMarker::boundaryPoint() const
     int offset = characterOffset.startIndex + characterOffset.offset;
     WeakPtr node = characterOffset.node;
     ASSERT(node);
-    if (AccessibilityObject::replacedNodeNeedsCharacter(node.get()) || node->hasTagName(brTag))
+    if (AccessibilityObject::replacedNodeNeedsCharacter(node.get()) || node->hasTagName(HTMLNames::brTag))
         node = nodeAndOffsetForReplacedNode(*node, offset, characterOffset.offset);
     if (!node)
         return std::nullopt;

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -31,6 +31,7 @@
 
 namespace WebCore {
 
+class CSSValue;
 class StyleProperties;
 
 struct CSSCounterStyleDescriptors {

--- a/Source/WebCore/css/CSSCounterValue.cpp
+++ b/Source/WebCore/css/CSSCounterValue.cpp
@@ -27,7 +27,7 @@
 #include "CSSCounterValue.h"
 
 #include "CSSMarkup.h"
-#include "CSSValueKeywords.h"
+#include "CSSPrimitiveValue.h"
 #include <wtf/PointerComparison.h> 
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -32,6 +32,7 @@
 
 #include "CommonAtomStrings.h"
 #include "DeprecatedGlobalSettings.h"
+#include "Document.h"
 #include <memory>
 #include <wtf/OptionSet.h>
 #include <wtf/SetForScope.h>

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -31,6 +31,7 @@
 #include "CSSSupportsParser.h"
 
 #include "CSSParserImpl.h"
+#include "CSSPropertyParserHelpers.h"
 #include "CSSSelectorParser.h"
 #include "StyleRule.h"
 

--- a/Source/WebCore/dom/DragEvent.cpp
+++ b/Source/WebCore/dom/DragEvent.cpp
@@ -27,6 +27,7 @@
 #include "DragEvent.h"
 
 #include "DataTransfer.h"
+#include "Node.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/RejectedPromiseTracker.h
+++ b/Source/WebCore/dom/RejectedPromiseTracker.h
@@ -28,6 +28,7 @@
 
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/WeakGCMap.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -49,6 +49,7 @@
 #include "LocalFrameView.h"
 #include "Page.h"
 #include "PlatformLocale.h"
+#include "RenderElement.h"
 #include "ScriptDisallowedScope.h"
 #include "Settings.h"
 #include "ShadowPseudoIds.h"

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -42,6 +42,7 @@
 #include "DocumentInlines.h"
 #include "Editor.h"
 #include "ElementInlines.h"
+#include "EventLoop.h"
 #include "EventNames.h"
 #include "FileChooser.h"
 #include "FileInputType.h"

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -49,6 +49,7 @@
 #include "Logging.h"
 #include "OESDrawBuffersIndexed.h"
 #include "OESTextureFloatLinear.h"
+#include "OffscreenCanvas.h"
 #include "RenderBox.h"
 #include "WebCodecsVideoFrame.h"
 #include "WebCoreOpaqueRootInlines.h"

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -36,6 +36,7 @@
 #include "FrameLoader.h"
 #include "HTTPHeaderValues.h"
 #include "ImageDecoder.h"
+#include "LocalFrame.h"
 #include "MIMETypeRegistry.h"
 #include "MemoryCache.h"
 #include "SecurityPolicy.h"

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -26,7 +26,9 @@
 #include "config.h"
 #include "DOMWindow.h"
 
+#include "Document.h"
 #include "HTTPParsers.h"
+#include "SecurityOrigin.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>
 

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -26,8 +26,12 @@
 #include "config.h"
 #include "RemoteDOMWindow.h"
 
+#include "LocalDOMWindow.h"
+#include "MessagePort.h"
 #include "RemoteFrame.h"
 #include "RemoteFrameClient.h"
+#include "SecurityOrigin.h"
+#include "SerializedScriptValue.h"
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(MEDIA_SOURCE)
 
+#include "PlatformTimeRanges.h"
+
 namespace WebCore {
 
 bool MediaSourcePrivate::hasFutureTime(const MediaTime& currentTime, const MediaTime& duration, const PlatformTimeRanges& ranges) const

--- a/Source/WebCore/style/StyleFontSizeFunctions.h
+++ b/Source/WebCore/style/StyleFontSizeFunctions.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class Document;
 class RenderStyle;
 class FontMetrics;
+struct FontSizeAdjust;
 
 namespace Style {
 


### PR DESCRIPTION
#### 64453e226bbd56f49b248f0f8816a72e5547e456
<pre>
Non-unified build fixes, April 1st 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=254870">https://bugs.webkit.org/show_bug.cgi?id=254870</a>

Unreviewed non-unified build fixes.

* Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp: Add missing
  B3Procedure.h header inclusion.
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp: Add missing
  WebAssemblyFunctionBase.h header inclusion.
* Source/WebCore/accessibility/AXLogger.cpp: Replace inclusion of
  Document.h with DocumentInlines.h, which also includes the former.
* Source/WebCore/accessibility/AXTextMarker.cpp: Add missing inclusion
  of the TextIterator.h header.
(WebCore::AXTextMarker::boundaryPoint const): Add HTMLNames:: prefix to
usage of HTMLNames::brTag.
* Source/WebCore/css/CSSCounterStyleDescriptors.h: Add missing forward
  declaration for CSSValue type.
* Source/WebCore/css/CSSCounterValue.cpp: Replace inclusion of
  CSSValueKeywords.h with CSSPrimitiveValue.h, which is the correct one
  in this case.
* Source/WebCore/css/parser/CSSSelectorParser.cpp: Add missing
  Document.h header inclusion.
* Source/WebCore/css/parser/CSSSupportsParser.cpp: Add missing
  CSSPropertyParserHelpers.h header inclusion.
* Source/WebCore/dom/DragEvent.cpp: Add missing Node.h header inclusion.
* Source/WebCore/dom/RejectedPromiseTracker.h: Add missing
  wtf/CheckedRef.h header inclusion.
* Source/WebCore/html/BaseDateAndTimeInputType.cpp: Add missing
  RenderElement.h header inclusion.
* Source/WebCore/html/HTMLInputElement.cpp: Add missing EventLoop.h
  header inclusion.
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp: Add missing
  OffscreenCanvas.h header inclusion.
* Source/WebCore/loader/cache/CachedResourceRequest.cpp: Add missing
  LocalFrame.h header inclusion.
* Source/WebCore/page/DOMWindow.cpp: Add missing Document.h and
  SecurityOrigin.h header inclusions.
* Source/WebCore/page/RemoteDOMWindow.cpp: Add missing LocalDOMWindow.h,
  MessagePort.h, SecurityOrigin.h, and SerializedScriptValue.h header
  inclusions.
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp: Add missing
  PlatformTimeRanges.h header inclusion.
* Source/WebCore/style/StyleFontSizeFunctions.h: Add missing forward
  declaration for the FontSizeAdjust type.

Canonical link: <a href="https://commits.webkit.org/262491@main">https://commits.webkit.org/262491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c9635cf751c9294cd8fc1acdd56b3cc9a991953

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2551 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1531 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2387 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1455 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1373 "3 flakes 143 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1384 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1488 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2548 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1564 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1357 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1686 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1462 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/372 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1587 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1727 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/174 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/488 "Passed tests") | 
<!--EWS-Status-Bubble-End-->