### PR TITLE
Prefer uncheckedArgument over argument where possible for callFrame

### DIFF
--- a/Source/JavaScriptCore/API/APICallbackFunction.h
+++ b/Source/JavaScriptCore/API/APICallbackFunction.h
@@ -48,10 +48,10 @@ EncodedJSValue APICallbackFunction::callImpl(JSGlobalObject* globalObject, CallF
     JSObjectRef functionRef = toRef(callFrame->jsCallee());
     JSObjectRef thisObjRef = toRef(jsCast<JSObject*>(callFrame->thisValue().toThis(globalObject, ECMAMode::sloppy())));
 
-    int argumentCount = static_cast<int>(callFrame->argumentCount());
+    size_t argumentCount = callFrame->argumentCount();
     Vector<JSValueRef, 16> arguments;
     arguments.reserveInitialCapacity(argumentCount);
-    for (int i = 0; i < argumentCount; i++)
+    for (size_t i = 0; i < argumentCount; i++)
         arguments.uncheckedAppend(toRef(globalObject, callFrame->uncheckedArgument(i)));
 
     JSValueRef exception = nullptr;

--- a/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
@@ -176,7 +176,7 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
             value = callFrame->thisValue();
         else
             value = callFrame->argument(argument - 1);
-        
+
         if (!entry->m_expectedValues.argument(argument).validateOSREntryValue(value, FlushedJSValue)) {
             dataLogLnIf(Options::verboseOSR(),
                 "    OSR failed because argument ", argument, " is ", value,

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -111,12 +111,9 @@ JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain,
         vm.didEnterVM = true;
     });
 
-    if (!callFrame->argumentCount())
-        return jsUndefined();
-
     JSValue program = callFrame->argument(0);
     if (!program.isString())
-        return program;
+        return program; // Includes undefined if program is undefined
 
     auto* programString = asString(program);
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1358,7 +1358,8 @@ static EncodedJSValue printInternal(JSGlobalObject* globalObject, CallFrame* cal
         }
     }
 
-    for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
+    size_t count = callFrame->argumentCount();
+    for (size_t i = 0; i < count; ++i) {
         if (i)
             if (EOF == fputc(' ', out))
                 goto fail;
@@ -1401,7 +1402,7 @@ JSC_DEFINE_HOST_FUNCTION(functionAtob, (JSGlobalObject* globalObject, CallFrame*
     if (!callFrame->argumentCount())
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Missing input for atob."_s)));
 
-    JSValue jsValue = callFrame->argument(0);
+    JSValue jsValue = callFrame->uncheckedArgument(0);
     if (jsValue.isUndefined())
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Invalid character in argument for atob."_s)));
 
@@ -1428,7 +1429,7 @@ JSC_DEFINE_HOST_FUNCTION(functionBtoa, (JSGlobalObject* globalObject, CallFrame*
     if (!callFrame->argumentCount())
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Missing input for btoa."_s)));
 
-    auto* string = callFrame->argument(0).toString(globalObject);
+    auto* string = callFrame->uncheckedArgument(0).toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     String stringToEncode = string->value(globalObject);
@@ -1464,7 +1465,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDescribe, (JSGlobalObject* globalObject, CallFr
     VM& vm = globalObject->vm();
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(jsUndefined());
-    return JSValue::encode(jsString(vm, toString(callFrame->argument(0))));
+    return JSValue::encode(jsString(vm, toString(callFrame->uncheckedArgument(0))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionDescribeArray, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -1472,7 +1473,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDescribeArray, (JSGlobalObject* globalObject, C
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(jsUndefined());
     VM& vm = globalObject->vm();
-    JSObject* object = jsDynamicCast<JSObject*>(callFrame->argument(0));
+    JSObject* object = jsDynamicCast<JSObject*>(callFrame->uncheckedArgument(0));
     if (!object)
         return JSValue::encode(jsNontrivialString(vm, "<not object>"_s));
     return JSValue::encode(jsNontrivialString(vm, toString("<Butterfly: ", RawPointer(object->butterfly()), "; public length: ", object->getArrayLength(), "; vector length: ", object->getVectorLength(), ">")));
@@ -1484,11 +1485,11 @@ JSC_DEFINE_HOST_FUNCTION(functionSleepSeconds, (JSGlobalObject* globalObject, Ca
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (callFrame->argumentCount() >= 1) {
-        Seconds seconds = Seconds(callFrame->argument(0).toNumber(globalObject));
+        Seconds seconds = Seconds(callFrame->uncheckedArgument(0).toNumber(globalObject));
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
         sleep(seconds);
     }
-    
+
     return JSValue::encode(jsUndefined());
 }
 
@@ -1659,7 +1660,8 @@ JSC_DEFINE_HOST_FUNCTION(functionRun, (JSGlobalObject* globalObject, CallFrame* 
 
     JSArray* array = constructEmptyArray(realm, nullptr);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    for (unsigned i = 1; i < callFrame->argumentCount(); ++i) {
+    unsigned count = callFrame->argumentCount();
+    for (unsigned i = 1; i < count; ++i) {
         array->putDirectIndex(realm, i - 1, callFrame->uncheckedArgument(i));
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
@@ -1693,7 +1695,8 @@ JSC_DEFINE_HOST_FUNCTION(functionRunString, (JSGlobalObject* globalObject, CallF
 
     JSArray* array = constructEmptyArray(realm, nullptr);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    for (unsigned i = 1; i < callFrame->argumentCount(); ++i) {
+    unsigned count = callFrame->argumentCount();
+    for (unsigned i = 1; i < count; ++i) {
         array->putDirectIndex(realm, i - 1, callFrame->uncheckedArgument(i));
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
@@ -1784,7 +1787,7 @@ JSC_DEFINE_HOST_FUNCTION(functionReadFile, (JSGlobalObject* globalObject, CallFr
 
     bool isBinary = false;
     if (callFrame->argumentCount() > 1) {
-        String type = callFrame->argument(1).toWTFString(globalObject);
+        String type = callFrame->uncheckedArgument(1).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
         if (type != "binary"_s)
             return throwVMError(globalObject, scope, "Expected 'binary' as second argument."_s);
@@ -1878,7 +1881,8 @@ JSC_DEFINE_HOST_FUNCTION(functionCheckSyntax, (JSGlobalObject* globalObject, Cal
 #if ENABLE(SAMPLING_FLAGS)
 JSC_DEFINE_HOST_FUNCTION(functionSetSamplingFlags, (JSGlobalObject*, CallFrame* callFrame))
 {
-    for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
+    size_t count = callFrame->argumentCount();
+    for (size_t i = 0; i < count; ++i) {
         unsigned flag = static_cast<unsigned>(callFrame->uncheckedArgument(i).toNumber(globalObject));
         if ((flag >= 1) && (flag <= 32))
             SamplingFlags::setFlag(flag);
@@ -1888,7 +1892,8 @@ JSC_DEFINE_HOST_FUNCTION(functionSetSamplingFlags, (JSGlobalObject*, CallFrame* 
 
 JSC_DEFINE_HOST_FUNCTION(functionClearSamplingFlags, (JSGlobalObject*, CallFrame* callFrame))
 {
-    for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
+    size_t count = callFrame->argumentCount();
+    for (size_t i = 0; i < count; ++i) {
         unsigned flag = static_cast<unsigned>(callFrame->uncheckedArgument(i).toNumber(globalObject));
         if ((flag >= 1) && (flag <= 32))
             SamplingFlags::clearFlag(flag);
@@ -2037,8 +2042,8 @@ JSC_DEFINE_HOST_FUNCTION(functionNoDFG, (JSGlobalObject* globalObject, CallFrame
 
 JSC_DEFINE_HOST_FUNCTION(functionNoFTL, (JSGlobalObject*, CallFrame* callFrame))
 {
-    if (callFrame->argumentCount()) {
-        FunctionExecutable* executable = getExecutableForFunction(callFrame->argument(0));
+    if (callFrame->argumentCount() >= 1) {
+        FunctionExecutable* executable = getExecutableForFunction(callFrame->uncheckedArgument(0));
         if (executable)
             executable->setNeverFTLOptimize(true);
     }
@@ -2251,7 +2256,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarGlobalObjectFor, (JSGlobalObject* globalO
 
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Not enough arguments"_s)));
-    JSValue arg = callFrame->argument(0);
+    JSValue arg = callFrame->uncheckedArgument(0);
     if (arg.isObject())
         return JSValue::encode(asObject(arg)->globalObject()->globalThis());
 
@@ -2266,7 +2271,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarIsRemoteFunction, (JSGlobalObject* global
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Not enough arguments"_s)));
 
-    JSValue arg = callFrame->argument(0);
+    JSValue arg = callFrame->uncheckedArgument(0);
     return JSValue::encode(jsBoolean(isRemoteFunction(arg)));
 }
 
@@ -2400,8 +2405,8 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentSleep, (JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (callFrame->argumentCount() >= 1) {
-        Seconds seconds = Seconds::fromMilliseconds(callFrame->argument(0).toNumber(globalObject));
+    if (callFrame->argumentCount()) {
+        Seconds seconds = Seconds::fromMilliseconds(callFrame->uncheckedArgument(0).toNumber(globalObject));
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
         sleep(seconds);
     }
@@ -2499,7 +2504,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFlashHeapAccess, (JSGlobalObject* globalObject,
     
     double sleepTimeMs = 0;
     if (callFrame->argumentCount() >= 1) {
-        sleepTimeMs = callFrame->argument(0).toNumber(globalObject);
+        sleepTimeMs = callFrame->uncheckedArgument(0).toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
 
@@ -2559,8 +2564,8 @@ JSC_DEFINE_HOST_FUNCTION(functionReoptimizationRetryCount, (JSGlobalObject*, Cal
 {
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(jsUndefined());
-    
-    CodeBlock* block = getSomeBaselineCodeBlockForFunction(callFrame->argument(0));
+
+    CodeBlock* block = getSomeBaselineCodeBlockForFunction(callFrame->uncheckedArgument(0));
     if (!block)
         return JSValue::encode(jsNumber(0));
     
@@ -2574,8 +2579,8 @@ JSC_DEFINE_HOST_FUNCTION(functionTransferArrayBuffer, (JSGlobalObject* globalObj
 
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Not enough arguments"_s)));
-    
-    JSArrayBuffer* buffer = jsDynamicCast<JSArrayBuffer*>(callFrame->argument(0));
+
+    JSArrayBuffer* buffer = jsDynamicCast<JSArrayBuffer*>(callFrame->uncheckedArgument(0));
     if (!buffer)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Expected an array buffer"_s)));
     
@@ -2622,8 +2627,9 @@ JSC_DEFINE_HOST_FUNCTION(functionUndefined2, (JSGlobalObject*, CallFrame*))
 
 JSC_DEFINE_HOST_FUNCTION(functionIsInt32, (JSGlobalObject*, CallFrame* callFrame))
 {
-    for (size_t i = 0; i < callFrame->argumentCount(); ++i) {
-        if (!callFrame->argument(i).isInt32())
+    size_t count = callFrame->argumentCount();
+    for (size_t i = 0; i < count; ++i) {
+        if (!callFrame->uncheckedArgument(i).isInt32())
             return JSValue::encode(jsBoolean(false));
     }
     return JSValue::encode(jsBoolean(true));
@@ -2631,8 +2637,9 @@ JSC_DEFINE_HOST_FUNCTION(functionIsInt32, (JSGlobalObject*, CallFrame* callFrame
 
 JSC_DEFINE_HOST_FUNCTION(functionIsPureNaN, (JSGlobalObject*, CallFrame* callFrame))
 {
-    for (size_t i = 0; i < callFrame->argumentCount(); ++i) {
-        JSValue value = callFrame->argument(i);
+    size_t count = callFrame->argumentCount();
+    for (size_t i = 0; i < count; ++i) {
+        JSValue value = callFrame->uncheckedArgument(i);
         if (!value.isNumber())
             return JSValue::encode(jsBoolean(false));
         double number = value.asNumber();
@@ -2954,8 +2961,10 @@ JSC_DEFINE_HOST_FUNCTION(functionResetSuperSamplerState, (JSGlobalObject*, CallF
 JSC_DEFINE_HOST_FUNCTION(functionEnsureArrayStorage, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
-    for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
-        if (JSObject* object = jsDynamicCast<JSObject*>(callFrame->argument(i)))
+    size_t count = callFrame->argumentCount();
+    for (size_t i = 0; i < count; ++i) {
+        JSObject* object = jsDynamicCast<JSObject*>(callFrame->uncheckedArgument(i));
+        if (object)
             object->ensureArrayStorage(vm);
     }
     return JSValue::encode(jsUndefined());

--- a/Source/JavaScriptCore/runtime/ConsoleObject.cpp
+++ b/Source/JavaScriptCore/runtime/ConsoleObject.cpp
@@ -35,9 +35,6 @@ namespace JSC {
 
 static String valueOrDefaultLabelString(JSGlobalObject* globalObject, CallFrame* callFrame)
 {
-    if (callFrame->argumentCount() < 1)
-        return "default"_s;
-
     auto value = callFrame->argument(0);
     if (value.isUndefined())
         return "default"_s;

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -862,7 +862,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetYear, (JSGlobalObject* globalObject, Ca
             gregorianDateTime = *other;
     }
 
-    double year = callFrame->argument(0).toIntegerPreserveNaN(globalObject);
+    double year = callFrame->uncheckedArgument(0).toIntegerPreserveNaN(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     if (!std::isfinite(year)) {
         thisDateObj->setInternalNumber(PNaN);

--- a/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
@@ -114,10 +114,10 @@ JSC_DEFINE_HOST_FUNCTION(functionProtoFuncBind, (JSGlobalObject* globalObject, C
     JSObject* target = asObject(thisValue);
 
     JSValue boundThis = callFrame->argument(0);
-    unsigned argumentCount = callFrame->argumentCount();
-    unsigned numBoundArgs = 0;
+    size_t argsCount = callFrame->argumentCount();
+    size_t numBoundArgs = 0;
     ArgList boundArgs { };
-    if (argumentCount > 1)
+    if (argsCount > 1)
         boundArgs = ArgList(callFrame, 1);
 
     double length = PNaN;

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -51,7 +51,8 @@ JSC_DEFINE_HOST_FUNCTION(boundThisNoArgsFunctionCall, (JSGlobalObject* globalObj
                 return IterationStatus::Continue;
             });
         }
-        for (unsigned i = 0; i < callFrame->argumentCount(); ++i)
+        size_t count = callFrame->argumentCount();
+        for (size_t i = 0; i < count; ++i) 
             args.append(callFrame->uncheckedArgument(i));
         RELEASE_ASSERT(!args.hasOverflowed());
     }
@@ -84,7 +85,8 @@ JSC_DEFINE_HOST_FUNCTION(boundFunctionCall, (JSGlobalObject* globalObject, CallF
                 return IterationStatus::Continue;
             });
         }
-        for (unsigned i = 0; i < callFrame->argumentCount(); ++i)
+        size_t count = callFrame->argumentCount();
+        for (size_t i = 0; i < count; ++i)
             args.append(callFrame->uncheckedArgument(i));
         if (UNLIKELY(args.hasOverflowed())) {
             throwOutOfMemoryError(globalObject, scope);
@@ -120,7 +122,8 @@ JSC_DEFINE_HOST_FUNCTION(boundFunctionConstruct, (JSGlobalObject* globalObject, 
                 return IterationStatus::Continue;
             });
         }
-        for (unsigned i = 0; i < callFrame->argumentCount(); ++i)
+        size_t count = callFrame->argumentCount();
+        for (size_t i = 0; i < count; ++i)
             args.append(callFrame->uncheckedArgument(i));
         if (UNLIKELY(args.hasOverflowed())) {
             throwOutOfMemoryError(globalObject, scope);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -892,15 +892,16 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncCopyDataProperties, (JSGlobalObject* globalOb
     UnlinkedCodeBlock* unlinkedCodeBlock = nullptr;
     const IdentifierSet* excludedSet = nullptr;
     std::optional<IdentifierSet> newlyCreatedSet;
-    if (callFrame->argumentCount() > 1) {
+    size_t count = callFrame->argumentCount();
+    if (count > 1) {
         int32_t setIndex = callFrame->uncheckedArgument(1).asUInt32AsAnyInt();
         CodeBlock* codeBlock = getCallerCodeBlock(callFrame);
         ASSERT(codeBlock);
         unlinkedCodeBlock = codeBlock->unlinkedCodeBlock();
         excludedSet = &unlinkedCodeBlock->constantIdentifierSets()[setIndex];
-        if (callFrame->argumentCount() > 2) {
+        if (count > 2) {
             newlyCreatedSet.emplace(*excludedSet);
-            for (unsigned index = 2; index < callFrame->argumentCount(); ++index) {
+            for (size_t index = 2; index < count; ++index) {
                 // This isn't observable since ObjectPatternNode::bindValue() also performs ToPropertyKey.
                 auto propertyName = callFrame->uncheckedArgument(index).toPropertyKey(globalObject);
                 RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -99,7 +99,8 @@ JSC_DEFINE_HOST_FUNCTION(remoteFunctionCallForJSFunction, (JSGlobalObject* globa
         args.overflowCheckNotNeeded();
         return { };
     };
-    for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
+    size_t count = callFrame->argumentCount();
+    for (size_t i = 0; i < count; ++i) {
         JSValue wrappedValue = wrapArgument(globalObject, targetGlobalObject, callFrame->uncheckedArgument(i));
         RETURN_IF_EXCEPTION(scope, clearArgOverflowCheckAndReturnAbortValue());
         args.append(wrappedValue);
@@ -140,7 +141,8 @@ JSC_DEFINE_HOST_FUNCTION(remoteFunctionCallGeneric, (JSGlobalObject* globalObjec
         args.overflowCheckNotNeeded();
         return { };
     };
-    for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
+    size_t count = callFrame->argumentCount();
+    for (size_t i = 0; i < count; ++i) {
         JSValue wrappedValue = wrapArgument(globalObject, targetGlobalObject, callFrame->uncheckedArgument(i));
         RETURN_IF_EXCEPTION(scope, clearArgOverflowCheckAndReturnAbortValue());
         args.append(wrappedValue);

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -189,10 +189,10 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncHypot, (JSGlobalObject* globalObject, Call
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    unsigned argsCount = callFrame->argumentCount();
+    size_t argsCount = callFrame->argumentCount();
     Vector<double, 8> args;
     args.reserveInitialCapacity(argsCount);
-    for (unsigned i = 0; i < argsCount; ++i) {
+    for (size_t i = 0; i < argsCount; ++i) {
         double argument = callFrame->uncheckedArgument(i).toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
         args.uncheckedAppend(argument);
@@ -230,9 +230,9 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncMax, (JSGlobalObject* globalObject, CallFr
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    unsigned argsCount = callFrame->argumentCount();
+    size_t argsCount = callFrame->argumentCount();
     double result = -std::numeric_limits<double>::infinity();
-    for (unsigned k = 0; k < argsCount; ++k) {
+    for (size_t k = 0; k < argsCount; ++k) {
         double val = callFrame->uncheckedArgument(k).toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
         if (std::isnan(val)) {
@@ -247,9 +247,9 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncMin, (JSGlobalObject* globalObject, CallFr
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    unsigned argsCount = callFrame->argumentCount();
+    size_t argsCount = callFrame->argumentCount();
     double result = +std::numeric_limits<double>::infinity();
-    for (unsigned k = 0; k < argsCount; ++k) {
+    for (size_t k = 0; k < argsCount; ++k) {
         double val = callFrame->uncheckedArgument(k).toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
         if (std::isnan(val)) {

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -327,8 +327,8 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorAssign, (JSGlobalObject* globalObject,
 
     Vector<RefPtr<UniquedStringImpl>, 8> properties;
     MarkedArgumentBuffer values;
-    unsigned argsCount = callFrame->argumentCount();
-    for (unsigned i = 1; i < argsCount; ++i) {
+    size_t argsCount = callFrame->argumentCount();
+    for (size_t i = 1; i < argsCount; ++i) {
         JSValue sourceValue = callFrame->uncheckedArgument(i);
         if (sourceValue.isUndefinedOrNull())
             continue;

--- a/Source/JavaScriptCore/runtime/ProxyConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyConstructor.cpp
@@ -60,8 +60,8 @@ JSC_DEFINE_HOST_FUNCTION(makeRevocableProxy, (JSGlobalObject* globalObject, Call
     if (callFrame->argumentCount() < 2)
         return throwVMTypeError(globalObject, scope, "Proxy.revocable needs to be called with two arguments: the target and the handler"_s);
 
-    JSValue target = callFrame->argument(0);
-    JSValue handler = callFrame->argument(1);
+    JSValue target = callFrame->uncheckedArgument(0);
+    JSValue handler = callFrame->uncheckedArgument(1);
     ProxyObject* proxy = ProxyObject::create(globalObject, target, handler);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     ProxyRevoke* revoke = ProxyRevoke::create(vm, globalObject->proxyRevokeStructure(), proxy);

--- a/Source/JavaScriptCore/runtime/ReflectObject.cpp
+++ b/Source/JavaScriptCore/runtime/ReflectObject.cpp
@@ -99,7 +99,7 @@ JSC_DEFINE_HOST_FUNCTION(reflectObjectConstruct, (JSGlobalObject* globalObject, 
 
     JSValue newTarget = target;
     if (callFrame->argumentCount() >= 3) {
-        newTarget = callFrame->argument(2);
+        newTarget = callFrame->uncheckedArgument(2);
         if (!newTarget.isConstructor())
             return JSValue::encode(throwTypeError(globalObject, scope, "Reflect.construct requires the third argument be a constructor if present"_s));
     }
@@ -234,7 +234,7 @@ JSC_DEFINE_HOST_FUNCTION(reflectObjectSet, (JSGlobalObject* globalObject, CallFr
 
     JSValue receiver = target;
     if (callFrame->argumentCount() >= 4)
-        receiver = callFrame->argument(3);
+        receiver = callFrame->uncheckedArgument(3);
 
     // Do not raise any readonly errors that happen in strict mode.
     bool shouldThrowIfCantSet = false;

--- a/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
@@ -90,7 +90,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalDuration, (JSGlobalObject* globalObjec
     RETURN_IF_EXCEPTION(scope, { });
 
     ISO8601::Duration result;
-    auto count = std::min<size_t>(callFrame->argumentCount(), numberOfTemporalUnits);
+    size_t count = std::min<size_t>(callFrame->argumentCount(), numberOfTemporalUnits);
     for (size_t i = 0; i < count; i++) {
         JSValue value = callFrame->uncheckedArgument(i);
         if (value.isUndefined())

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
@@ -90,9 +90,9 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDateTime, (JSGlobalObject* global
     RETURN_IF_EXCEPTION(scope, { });
 
     ISO8601::Duration duration { };
-    auto count = std::min<size_t>(callFrame->argumentCount(), numberOfTemporalPlainDateUnits + numberOfTemporalPlainTimeUnits);
-    for (unsigned i = 0; i < count; i++) {
-        unsigned durationIndex = i >= static_cast<unsigned>(TemporalUnit::Week) ? i + 1 : i;
+    size_t count = std::min<size_t>(callFrame->argumentCount(), numberOfTemporalPlainDateUnits + numberOfTemporalPlainTimeUnits);
+    for (size_t i = 0; i < count; i++) {
+        size_t durationIndex = i >= static_cast<size_t>(TemporalUnit::Week) ? i + 1 : i;
         duration[durationIndex] = callFrame->uncheckedArgument(i).toIntegerOrInfinity(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(duration[durationIndex]))

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
@@ -90,9 +90,9 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainTime, (JSGlobalObject* globalObje
     RETURN_IF_EXCEPTION(scope, { });
 
     ISO8601::Duration duration { };
-    auto count = std::min<size_t>(callFrame->argumentCount(), numberOfTemporalPlainTimeUnits);
-    for (unsigned i = 0; i < count; i++) {
-        unsigned durationIndex = i + static_cast<unsigned>(TemporalUnit::Hour);
+    size_t count = std::min<size_t>(callFrame->argumentCount(), numberOfTemporalPlainTimeUnits);
+    for (size_t i = 0; i < count; i++) {
+        size_t durationIndex = i + static_cast<size_t>(TemporalUnit::Hour);
         duration[durationIndex] = callFrame->uncheckedArgument(i).toIntegerOrInfinity(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(duration[durationIndex]))

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
@@ -134,7 +134,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncIs, (JSGlobalObject* globa
     if (UNLIKELY(callFrame->argumentCount() < 1))
         return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
 
-    JSWebAssemblyTag* tag = jsDynamicCast<JSWebAssemblyTag*>(callFrame->argument(0));
+    JSWebAssemblyTag* tag = jsDynamicCast<JSWebAssemblyTag*>(callFrame->uncheckedArgument(0));
     if (!tag)
         return throwVMTypeError(globalObject, throwScope, "WebAssembly.Exception.is(): First argument must be a WebAssembly.Tag"_s);
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -80,8 +80,8 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyFunction, (JSGlobalObject* globalObject,
     if (signature.argumentsOrResultsIncludeV128())
         return throwVMTypeError(globalObject, scope, Wasm::errorMessageForExceptionType(Wasm::ExceptionType::TypeErrorInvalidV128Use));
 
-    for (unsigned argIndex = 0; argIndex < signature.argumentCount(); ++argIndex) {
-        uint64_t value = fromJSValue(globalObject, signature.argumentType(argIndex), callFrame->argument(argIndex));
+    for (size_t argIndex = 0; argIndex < signature.argumentCount(); ++argIndex) {
+        uint64_t value = fromJSValue(globalObject, signature.argumentType(argIndex), callFrame->uncheckedArgument(argIndex));
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
         boxedArgs.append(value);
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalPrototype.cpp
@@ -114,7 +114,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyGlobalProtoSetterFuncValue, (JSGlobalObject*
     if (global->global()->mutability() == Wasm::Mutability::Immutable)
         return JSValue::encode(throwException(globalObject, throwScope, createTypeError(globalObject, "WebAssembly.Global.prototype.value attempts to modify immutable global value"_s)));
 
-    global->global()->set(globalObject, callFrame->argument(0));
+    global->global()->set(globalObject, callFrame->uncheckedArgument(0));
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
     return JSValue::encode(jsUndefined());
 }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
@@ -94,7 +94,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncGrow, (JSGlobalObject* globalO
     uint32_t delta = toNonWrappingUint32(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
-    JSValue defaultValue = jsNull();
+    JSValue defaultValue;
     if (callFrame->argumentCount() < 2)
         defaultValue = defaultValueForReferenceType(table->table()->wasmType());
     else
@@ -140,9 +140,11 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncSet, (JSGlobalObject* globalOb
     if (index >= table->length())
         return throwVMRangeError(globalObject, throwScope, "WebAssembly.Table.prototype.set expects an integer less than the length of the table"_s);
 
-    JSValue value = callFrame->argument(1);
+    JSValue value;
     if (callFrame->argumentCount() < 2)
         value = defaultValueForReferenceType(table->table()->wasmType());
+    else
+        value = callFrame->uncheckedArgument(1);
 
     if (table->table()->asFuncrefTable()) {
         WebAssemblyFunction* wasmFunction = nullptr;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp
@@ -45,11 +45,11 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTag, (JSGlobalObject* globalObjec
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    
+
     if (callFrame->argumentCount() < 1)
         return throwVMTypeError(globalObject, scope, "WebAssembly.Tag constructor expects the tag type as the first argument."_s);
 
-    JSValue tagTypeValue = callFrame->argument(0);
+    JSValue tagTypeValue = callFrame->uncheckedArgument(0);
     JSValue signatureObject = tagTypeValue.get(globalObject, Identifier::fromString(vm, "parameters"_s));
     RETURN_IF_EXCEPTION(scope, { });
 

--- a/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
@@ -538,7 +538,7 @@ JSC_DEFINE_HOST_FUNCTION(showModalDialog, (JSGlobalObject* lexicalGlobalObjectPt
     if (UNLIKELY(callFrame.argumentCount() < 1))
         return throwVMException(&lexicalGlobalObject, scope, createNotEnoughArgumentsError(&lexicalGlobalObject));
 
-    String urlString = convert<IDLNullable<IDLDOMString>>(lexicalGlobalObject, callFrame.argument(0));
+    String urlString = convert<IDLNullable<IDLDOMString>>(lexicalGlobalObject, callFrame.uncheckedArgument(0));
     RETURN_IF_EXCEPTION(scope, { });
     String dialogFeaturesString = convert<IDLNullable<IDLDOMString>>(lexicalGlobalObject, callFrame.argument(2));
     RETURN_IF_EXCEPTION(scope, { });

--- a/Source/WebCore/bindings/js/JSPluginElementFunctions.cpp
+++ b/Source/WebCore/bindings/js/JSPluginElementFunctions.cpp
@@ -131,7 +131,7 @@ JSC_DEFINE_HOST_FUNCTION(callPlugin, (JSGlobalObject* lexicalGlobalObject, CallF
     size_t argumentCount = callFrame->argumentCount();
     MarkedArgumentBuffer argumentList;
     for (size_t i = 0; i < argumentCount; i++)
-        argumentList.append(callFrame->argument(i));
+        argumentList.append(callFrame->uncheckedArgument(i));
     ASSERT(!argumentList.hasOverflowed());
 
     auto callData = JSC::getCallData(scriptObject);

--- a/Source/WebCore/bridge/objc/objc_instance.mm
+++ b/Source/WebCore/bridge/objc/objc_instance.mm
@@ -253,15 +253,15 @@ JSC::JSValue ObjcInstance::invokeObjcMethod(JSGlobalObject* lexicalGlobalObject,
         [invocation setArgument:&jsName atIndex:2];
 
         NSMutableArray* objcArgs = [NSMutableArray array];
-        int count = callFrame->argumentCount();
-        for (int i = 0; i < count; i++) {
+        size_t count = callFrame->argumentCount();
+        for (size_t i = 0; i < count; i++) {
             ObjcValue value = convertValueToObjcValue(lexicalGlobalObject, callFrame->uncheckedArgument(i), ObjcObjectType);
             [objcArgs addObject:(__bridge id)value.objectValue];
         }
         [invocation setArgument:&objcArgs atIndex:3];
     } else {
-        unsigned count = [signature numberOfArguments];
-        for (unsigned i = 2; i < count; ++i) {
+        NSUInteger count = [signature numberOfArguments];
+        for (NSUInteger i = 2; i < count; ++i) {
             const char* type = [signature getArgumentTypeAtIndex:i];
             ObjcValueType objcValueType = objcValueTypeForType(type);
 
@@ -365,8 +365,8 @@ JSC::JSValue ObjcInstance::invokeDefaultMethod(JSGlobalObject* lexicalGlobalObje
     }
 
     NSMutableArray* objcArgs = [NSMutableArray array];
-    unsigned count = callFrame->argumentCount();
-    for (unsigned i = 0; i < count; i++) {
+    size_t count = callFrame->argumentCount();
+    for (size_t i = 0; i < count; i++) {
         ObjcValue value = convertValueToObjcValue(lexicalGlobalObject, callFrame->uncheckedArgument(i), ObjcObjectType);
         [objcArgs addObject:(__bridge id)value.objectValue];
     }


### PR DESCRIPTION
This saves us the extra work of an if-statement check.

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/387d3bf5ff14810312689aa8fe79833d96f050c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2712 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1879 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1801 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2553 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/1512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1642 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2715 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/1708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1670 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1837 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1594 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/1591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/423 "Found 35 jsc stress test failures: wasm.yaml/wasm/function-tests/double-instance.js.default-wasm, wasm.yaml/wasm/function-tests/double-instance.js.wasm-air, wasm.yaml/wasm/function-tests/double-instance.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/double-instance.js.wasm-eager, wasm.yaml/wasm/function-tests/double-instance.js.wasm-eager-jettison ...") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1735 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1883 "Built successfully") | 
| | | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->