### PR TITLE
Remove and replace respondsToSelector calls where they are not needed

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -204,12 +204,6 @@ static AtomString initTypeForRequest(AVContentKeyRequest* request)
     if ([request.identifier isKindOfClass:NSString.class] && [request.identifier hasPrefix:@"skd://"])
         return CDMPrivateFairPlayStreaming::skdName();
 
-    if (![request respondsToSelector:@selector(options)]) {
-        // AVContentKeyRequest.options was added in 10.14.4; if we are running on a previous version
-        // we don't have support for 'cenc' anyway, so just assume 'sinf'.
-        return CDMPrivateFairPlayStreaming::sinfName();
-    }
-
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     auto nsInitType = (NSString*)[request.options valueForKey:InitializationDataTypeKey];
 ALLOW_NEW_API_WITHOUT_GUARDS_END

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -362,14 +362,12 @@ void MediaPlayerPrivateMediaSourceAVFObjC::playInternal(std::optional<MonotonicT
         return;
 
 #if HAVE(AVSAMPLEBUFFERRENDERSYNCHRONIZER_RATEATHOSTTIME)
-    ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    if (hostTime && [m_synchronizer respondsToSelector:@selector(setRate:time:atHostTime:)]) {
+    if (hostTime) {
         auto cmHostTime = PAL::CMClockMakeHostTimeFromSystemUnits(hostTime->toMachAbsoluteTime());
         ALWAYS_LOG(LOGIDENTIFIER, "setting rate to ", m_rate, " at host time ", PAL::CMTimeGetSeconds(cmHostTime));
         [m_synchronizer setRate:m_rate time:PAL::kCMTimeInvalid atHostTime:cmHostTime];
     } else
         [m_synchronizer setRate:m_rate];
-    ALLOW_NEW_API_WITHOUT_GUARDS_END
 #else
     UNUSED_PARAM(hostTime);
     [m_synchronizer setRate:m_rate];
@@ -388,14 +386,12 @@ void MediaPlayerPrivateMediaSourceAVFObjC::pauseInternal(std::optional<Monotonic
     m_playing = false;
 
 #if HAVE(AVSAMPLEBUFFERRENDERSYNCHRONIZER_RATEATHOSTTIME)
-    ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    if (hostTime && [m_synchronizer respondsToSelector:@selector(setRate:time:atHostTime:)]) {
+    if (hostTime) {
         auto cmHostTime = PAL::CMClockMakeHostTimeFromSystemUnits(hostTime->toMachAbsoluteTime());
         ALWAYS_LOG(LOGIDENTIFIER, "setting rate to 0 at host time ", PAL::CMTimeGetSeconds(cmHostTime));
         [m_synchronizer setRate:0 time:PAL::kCMTimeInvalid atHostTime:cmHostTime];
     } else
         [m_synchronizer setRate:0];
-    ALLOW_NEW_API_WITHOUT_GUARDS_END
 #else
     UNUSED_PARAM(hostTime);
     [m_synchronizer setRate:0];

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -362,8 +362,10 @@ void WebCoreAVFResourceLoader::responseReceived(const ResourceResponse& response
         // When the property is YES, AVAssetResourceLoader will request small data ranges over and over again
         // during the playback. For DataURLResourceMediaLoader, that means it needs to decode the URL repeatedly,
         // which is very inefficient for long URLs.
+        ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
         if (!m_dataURLMediaLoader && [contentInfo respondsToSelector:@selector(setEntireLengthAvailableOnDemand:)])
             [contentInfo setEntireLengthAvailableOnDemand:YES];
+        ALLOW_NEW_API_WITHOUT_GUARDS_END
 
         if (![m_avRequest dataRequest]) {
             [m_avRequest finishLoading];

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -124,10 +124,8 @@ Cookie::Cookie(NSHTTPCookie *cookie)
     , commentURL { cookie.commentURL }
     , ports { portVectorFromList(cookie.portList) }
 {
-    ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    if ([cookie respondsToSelector:@selector(sameSitePolicy)])
-        sameSite = coreSameSitePolicy(cookie.sameSitePolicy);
-    ALLOW_NEW_API_WITHOUT_GUARDS_END
+
+    sameSite = coreSameSitePolicy(cookie.sameSitePolicy);
 }
 
 Cookie::operator NSHTTPCookie * _Nullable () const

--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -193,7 +193,7 @@ static TextRecognitionResult makeTextRecognitionResult(VKCImageAnalysisTranslati
             continue;
         }
 
-        if ([paragraph respondsToSelector:@selector(isPassthrough)] && [paragraph isPassthrough])
+        if (paragraph.isPassthrough)
             continue;
 
         auto quad = floatQuad(paragraph.quad);

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -445,8 +445,8 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem 
         return;
     }
 
-    auto sharingServicePicker = adoptNS([[NSSharingServicePicker alloc] initWithItems:items.get()]);
-    if ([sharingServicePicker respondsToSelector:@selector(standardShareMenuItem)]) {
+    if (@available(macOS 13.0, *)) {
+        auto sharingServicePicker = adoptNS([[NSSharingServicePicker alloc] initWithItems:items.get()]);
         NSMenuItem *shareMenuItem = [sharingServicePicker standardShareMenuItem];
         [shareMenuItem setRepresentedObject:sharingServicePicker.get()];
         shareMenuItem.identifier = _WKMenuItemIdentifierShareMenu;

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -9604,7 +9604,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
 
     auto translationViewController = adoptNS([PAL::allocLTUITranslationViewControllerInstance() init]);
     [translationViewController setText:adoptNS([[NSAttributedString alloc] initWithString:info.text]).get()];
-    if (info.mode == WebCore::TranslationContextMenuMode::Editable && [translationViewController respondsToSelector:@selector(setReplacementHandler:)]) {
+    if (info.mode == WebCore::TranslationContextMenuMode::Editable) {
         [translationViewController setIsSourceEditable:YES];
         [translationViewController setReplacementHandler:[weakSelf = WeakObjCPtr<WebView>(self)](NSAttributedString *string) {
             auto strongSelf = weakSelf.get();


### PR DESCRIPTION
#### b2b3135556efb10487323ca202705c4e204a4f67
<pre>
Remove and replace respondsToSelector calls where they are not needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=252901">https://bugs.webkit.org/show_bug.cgi?id=252901</a>

Reviewed by NOBODY (OOPS!).

In some cases, we know they exist because of the headers containing them.
Others are just a case of @available being a better fit.

* Source/WebCore/bridge/objc/objc_instance.mm:(setValueOfUndefinedField):
  Remove check because comment states the check is unneeded.
  (getValueOfUndefinedField): Ditto.

* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
  (initTypeForRequest): Remove check because AVContentKeyRequest.options
  was added in 10.14.4, and earliest supported macOS is macOS 11.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
  (getSupportedTypes): Remove check because setRate:time:atHostTime:
  is now a public API.

* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
  (responseReceived): Fix compiilation by adding guard checks.

* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:(Cookie): Remove
  check because sameSitePolicy is now public API.

* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:(makeTextRecognitionResult):
  Remove check because isPassthrough is explicitly defined in the
  interface definition in the header.

* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:(getShareMenuItem):
  Replace selector check with API version because standardShareMenuItem
  is definitely a Ventura addition.

* Source/WebKitLegacy/mac/WebView/WebView.mm:(nsTextAlignmentFromRenderStyle):
  Remove check because the modern counterpart does not check either,
  meaning this is safe to remove.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebf77cfe8ee2827fd337c504b740dd5fcae33f8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2558 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1757 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1536 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2394 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1377 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1495 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2552 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1360 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1467 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1594 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->