### PR TITLE
Set numBoundArgs after setting boundArgs

### DIFF
--- a/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionPrototype.cpp
@@ -113,12 +113,18 @@ JSC_DEFINE_HOST_FUNCTION(functionProtoFuncBind, (JSGlobalObject* globalObject, C
         return throwVMTypeError(globalObject, scope, "|this| is not a function inside Function.prototype.bind"_s);
     JSObject* target = asObject(thisValue);
 
-    JSValue boundThis = callFrame->argument(0);
-    unsigned argumentCount = callFrame->argumentCount();
-    unsigned numBoundArgs = 0;
-    ArgList boundArgs { };
-    if (argumentCount > 1)
+    JSValue boundThis;
+    ArgList boundArgs;
+    size_t numBoundArgs;
+    if (size_t argCount = callFrame->argumentCount(); argCount > 1) {
+        boundThis = callFrame->uncheckedArgument(0);
         boundArgs = ArgList(callFrame, 1);
+        numBoundArgs = argCount - 1;
+    } else {
+        boundThis = callFrame->argument(0);
+        boundArgs = ArgList();
+        numBoundArgs = 0;
+    }
 
     double length = 0;
     JSString* name = nullptr;


### PR DESCRIPTION
#### 81d93da03d83c8e0e7d641030972ee2cf7c3c798
<pre>
Set numBoundArgs after setting boundArgs
<a href="https://bugs.webkit.org/show_bug.cgi?id=255540">https://bugs.webkit.org/show_bug.cgi?id=255540</a>

Reviewed by Yusuke Suzuki.

numBoundArgs is always zero because it is never changed
after being set to zero. It is clear from the code itself that the
number of arguments is meant to be set, but whoever programmed this part
forgot to do so.

* Source/JavaScriptCore/runtime/FunctionPrototype.cpp:
  (JSC::JSC_DEFINE_HOST_FUNCTION): Assign numBoundArgs to the size
  of the boundArgs array.

Canonical link: <a href="https://commits.webkit.org/264109@main">https://commits.webkit.org/264109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/894cab30c4aa9af3e9fa4d5ee77199cbbb976917

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4974 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3084 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4796 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3078 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2900 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3152 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4562 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3329 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2913 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3620 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3173 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/923 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1586 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3177 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3712 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3428 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1035 "Passed tests") | 
<!--EWS-Status-Bubble-End-->