### PR TITLE
Add a few more always-allowed classes for _WKRemoteObjectRegistry decoder

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -781,6 +781,7 @@ static const HashSet<CFTypeRef> alwaysAllowedClasses()
         (__bridge CFTypeRef)NSMutableArray.class,
         (__bridge CFTypeRef)NSDictionary.class,
         (__bridge CFTypeRef)NSMutableDictionary.class,
+        (__bridge CFTypeRef)NSNull.class,
         (__bridge CFTypeRef)NSString.class,
         (__bridge CFTypeRef)NSMutableString.class,
         (__bridge CFTypeRef)NSSet.class,
@@ -792,6 +793,7 @@ static const HashSet<CFTypeRef> alwaysAllowedClasses()
         (__bridge CFTypeRef)NSBlockInvocation.class,
         (__bridge CFTypeRef)NSHTTPURLResponse.class,
         (__bridge CFTypeRef)NSURLResponse.class,
+        (__bridge CFTypeRef)NSUUID.class,
     } };
     return classes.get();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.h
@@ -52,7 +52,7 @@
 - (void)takeLong:(long)value completionHandler:(void (^)(long value))completionHandler;
 - (void)takeDictionary:(NSDictionary *)value completionHandler:(void (^)(NSDictionary *value))completionHandler;
 - (void)doNotCallCompletionHandler:(void (^)())completionHandler;
-- (void)sendRequest:(NSURLRequest *)request response:(NSURLResponse *)response challenge:(NSURLAuthenticationChallenge *)challenge error:(NSError *)error completionHandler:(void (^)(NSURLRequest *, NSURLResponse *, NSURLAuthenticationChallenge *, NSError *))completionHandler;
+- (void)sendRequest:(NSURLRequest *)request response:(NSURLResponse *)response challenge:(NSURLAuthenticationChallenge *)challenge error:(NSError *)error nsNull:(id)nsNull uuid:(id)uuid completionHandler:(void (^)(NSURLRequest *, NSURLResponse *, NSURLAuthenticationChallenge *, NSError *, id, id))completionHandler;
 - (void)callUIProcessMethodWithReplyBlock;
 - (void)sendError:(NSError *)error completionHandler:(void (^)(NSError *))completionHandler;
 - (void)sendAwakener:(TestAwakener *)awakener completionHandler:(void (^)(TestAwakener *))completionHandler;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.mm
@@ -146,11 +146,14 @@ TEST(RemoteObjectRegistry, Basic)
         NSURLCredential *credential = [NSURLCredential credentialWithUser:@"testUser" password:@"testPassword" persistence:NSURLCredentialPersistenceForSession];
         id<NSURLAuthenticationChallengeSender> sender = nil;
         auto challenge = adoptNS([[NSURLAuthenticationChallenge alloc] initWithProtectionSpace:protectionSpace.get() proposedCredential:credential previousFailureCount:42 failureResponse:response.get() error:error sender:sender]);
-        [object sendRequest:request response:response.get() challenge:challenge.get() error:error completionHandler:^(NSURLRequest *deserializedRequest, NSURLResponse *deserializedResponse, NSURLAuthenticationChallenge *deserializedChallenge, NSError *deserializedError) {
+        NSUUID *uuid = [NSUUID UUID];
+        [object sendRequest:request response:response.get() challenge:challenge.get() error:error nsNull:[NSNull null] uuid:uuid completionHandler:^(NSURLRequest *deserializedRequest, NSURLResponse *deserializedResponse, NSURLAuthenticationChallenge *deserializedChallenge, NSError *deserializedError, id nsNull, id deserializedUUID) {
             EXPECT_WK_STREQ(deserializedRequest.URL.absoluteString, "https://webkit.org/");
             EXPECT_WK_STREQ([(NSHTTPURLResponse *)deserializedResponse allHeaderFields][@"testFieldName"], "testFieldValue");
             EXPECT_WK_STREQ(deserializedChallenge.protectionSpace.realm, "testRealm");
             EXPECT_WK_STREQ(deserializedError.domain, "testDomain");
+            EXPECT_WK_STREQ(NSStringFromClass([nsNull class]), @"NSNull");
+            EXPECT_WK_STREQ(uuid.UUIDString, [deserializedUUID UUIDString]);
             isDone = true;
         }];
         TestWebKitAPI::Util::run(&isDone);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistryPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistryPlugIn.mm
@@ -113,9 +113,9 @@
 {
 }
 
-- (void)sendRequest:(NSURLRequest *)request response:(NSURLResponse *)response challenge:(NSURLAuthenticationChallenge *)challenge error:(NSError *)error completionHandler:(void (^)(NSURLRequest *, NSURLResponse *, NSURLAuthenticationChallenge *, NSError *))completionHandler
+- (void)sendRequest:(NSURLRequest *)request response:(NSURLResponse *)response challenge:(NSURLAuthenticationChallenge *)challenge error:(NSError *)error nsNull:(id)nsNull uuid:(id)uuid completionHandler:(void (^)(NSURLRequest *, NSURLResponse *, NSURLAuthenticationChallenge *, NSError *, id, id))completionHandler
 {
-    completionHandler(request, response, challenge, error);
+    completionHandler(request, response, challenge, error, nsNull, uuid);
 }
 
 - (void)sendError:(NSError *)error completionHandler:(void (^)(NSError *))completionHandler


### PR DESCRIPTION
#### ce23986d53debfc74fec2e8dc9c1838a88c9b12a
<pre>
Add a few more always-allowed classes for _WKRemoteObjectRegistry decoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=254875">https://bugs.webkit.org/show_bug.cgi?id=254875</a>
rdar://107519277

Unreviewed.

* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(alwaysAllowedClasses):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistryPlugIn.mm:
(-[RemoteObjectRegistryPlugIn sendRequest:response:challenge:error:nsNull:uuid:completionHandler:]):
(-[RemoteObjectRegistryPlugIn sendRequest:response:challenge:error:completionHandler:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/262489@main">https://commits.webkit.org/262489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4f8197c6ccb8a2211cdd3aa8dc8b59427928356

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2578 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1750 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1497 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1494 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1515 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1379 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1466 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/1484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1612 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/172 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->