### PR TITLE
Add null check in WebCore::toNSDictionary

### DIFF
--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -92,8 +92,10 @@ static RetainPtr<NSObject> toNSObject(const AttributedString::AttributeValue& va
 static RetainPtr<NSDictionary> toNSDictionary(const HashMap<String, AttributedString::AttributeValue>& map)
 {
     auto result = adoptNS([[NSMutableDictionary alloc] initWithCapacity:map.size()]);
-    for (auto& pair : map)
-        [result setObject:toNSObject(pair.value).get() forKey:(NSString *)pair.key];
+    for (auto& pair : map) {
+        if (auto nsObject = toNSObject(pair.value))
+            [result setObject:nsObject.get() forKey:(NSString *)pair.key];
+    }
     return result;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm
@@ -76,3 +76,30 @@ TEST(NSAttributedStringWebKitAdditions, DirectoriesNotCreated)
     EXPECT_TRUE(cookieDirectoryExists());
 }
 #endif
+
+TEST(NSAttributedStringWebKitAdditions, FontDataURL)
+{
+    NSURL *fontURL = [[NSBundle mainBundle] URLForResource:@"Ahem" withExtension:@"ttf" subdirectory:@"TestWebKitAPI.resources"];
+    NSData *fontData = [NSData dataWithContentsOfURL:fontURL];
+    NSString *fontBase64 = [fontData base64EncodedStringWithOptions:0];
+
+    NSString *html = [NSString stringWithFormat:@""
+        "<html>"
+        "<head>"
+        "<style>"
+        "@font-face { font-family: exampleFont; src: url(data:font/opentype;base64,%@); }"
+        "div { font-family: exampleFont; }"
+        "</style>"
+        "</head>"
+        "<body><div>hello!</div></body>"
+        "</html>", fontBase64];
+
+    __block bool done = false;
+    [NSAttributedString loadFromHTMLWithString:html options:@{ } completionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *attributes, NSError *error) {
+        [attributedString enumerateAttributesInRange:NSMakeRange(0, attributedString.length) options:0 usingBlock:^(NSDictionary *attributes, NSRange attributeRange, BOOL *stop) {
+            EXPECT_FALSE(attributes[NSFontAttributeName]);
+        }];
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}


### PR DESCRIPTION
#### 4d5195db6f803dbdd779175730954660a9bb96a6
<pre>
Add null check in WebCore::toNSDictionary
<a href="https://bugs.webkit.org/show_bug.cgi?id=254876">https://bugs.webkit.org/show_bug.cgi?id=254876</a>
rdar://107516455

Unreviewed.

Sometimes, such as decoding an NSFont that is from a web font,
we get a null NSObject.  Rather than trying to add it to the
NSDictionary of attributes and throwing an ObjC exception, null
check the object before trying.

* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::toNSDictionary):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/262490@main">https://commits.webkit.org/262490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58990c982851a42ae258427abfeda89898243b4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1751 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1671 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2415 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1516 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1549 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1467 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/1485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1613 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/173 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->