### PR TITLE
Add length check to avoid calling operationEqualIgnoringASCIICaseNonNull.

### DIFF
--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2014 Yusuke Suzuki <utatane.tea@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -3422,6 +3422,13 @@ void SelectorCodeGenerator::generateElementAttributeValueExactMatching(Assembler
 
         LocalRegister valueStringImpl(m_registerAllocator);
         m_assembler.loadPtr(Assembler::Address(currentAttributeAddress, Attribute::valueMemoryOffset()), valueStringImpl);
+        {
+            LocalRegister valueLength(m_registerAllocator);
+            LocalRegister expectedValueLength(m_registerAllocator);
+            m_assembler.load32(Assembler::Address(expectedValueRegister, StringImpl::lengthMemoryOffset()), expectedValueLength);
+            m_assembler.load32(Assembler::Address(valueStringImpl, StringImpl::lengthMemoryOffset()), valueLength);
+            failureCases.append(m_assembler.branch32(Assembler::NotEqual, valueLength, expectedValueLength));
+        }
 
         FunctionCall functionCall(m_assembler, m_registerAllocator, m_stackAllocator, m_functionCalls);
         functionCall.setFunctionAddress(operationEqualIgnoringASCIICaseNonNull);
@@ -3436,6 +3443,14 @@ void SelectorCodeGenerator::generateElementAttributeValueExactMatching(Assembler
         m_assembler.loadPtr(Assembler::Address(currentAttributeAddress, Attribute::valueMemoryOffset()), valueStringImpl);
 
         Assembler::Jump skipCaseInsensitiveComparison = m_assembler.branchPtr(Assembler::Equal, valueStringImpl, expectedValueRegister);
+        {
+            LocalRegister valueLength(m_registerAllocator);
+            LocalRegister expectedValueLength(m_registerAllocator);
+            m_assembler.load32(Assembler::Address(expectedValueRegister, StringImpl::lengthMemoryOffset()), expectedValueLength);
+            m_assembler.load32(Assembler::Address(valueStringImpl, StringImpl::lengthMemoryOffset()), valueLength);
+            failureCases.append(m_assembler.branch32(Assembler::NotEqual, valueLength, expectedValueLength));
+        }
+
         FunctionCall functionCall(m_assembler, m_registerAllocator, m_stackAllocator, m_functionCalls);
         functionCall.setFunctionAddress(operationEqualIgnoringASCIICaseNonNull);
         functionCall.setTwoArguments(valueStringImpl, expectedValueRegister);


### PR DESCRIPTION
#### f8e7504cdb77506a8060bc4ff8c8d679b1ebfa0d
<pre>
Add length check to avoid calling operationEqualIgnoringASCIICaseNonNull.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254878">https://bugs.webkit.org/show_bug.cgi?id=254878</a>
rdar://107521383

Reviewed by NOBODY (OOPS!).

* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementAttributeValueExactMatching):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8e7504cdb77506a8060bc4ff8c8d679b1ebfa0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1754 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1560 "115 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1674 "Passed tests") | [💥 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9193 "An unexpected error occured. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2419 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1481 "7 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1399 "2 flakes 135 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1499 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1523 "5 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2581 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1519 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1383 "Exiting early after 60 failures. 4484 tests run. 1 flakes 60 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1488 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1470 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->