### PR TITLE
Prevent mixing of ObjectIdentifier::generate and generateThreadSafe at compile time.

### DIFF
--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -34,7 +34,7 @@ class CallFrame;
 class JSGlobalObject;
 
 enum MicrotaskIdentifierType { };
-using MicrotaskIdentifier = ObjectIdentifier<MicrotaskIdentifierType>;
+using MicrotaskIdentifier = ObjectIdentifier<MicrotaskIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 class Microtask : public RefCounted<Microtask> {
 public:

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -286,7 +286,7 @@ private:
 };
 
 enum VMIdentifierType { };
-using VMIdentifier = ObjectIdentifier<VMIdentifierType>;
+using VMIdentifier = ObjectIdentifier<VMIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 class VM : public ThreadSafeRefCounted<VM>, public DoublyLinkedListNode<VM> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(VM);

--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -119,8 +119,8 @@ template<> struct CrossThreadCopierBase<false, false, WTF::ASCIILiteral> {
     }
 };
 
-template<typename T> struct CrossThreadCopierBase<false, false, ObjectIdentifier<T>> {
-    typedef ObjectIdentifier<T> Type;
+template<typename T, typename U> struct CrossThreadCopierBase<false, false, ObjectIdentifier<T, U>> {
+    typedef ObjectIdentifier<T, U> Type;
     static Type copy(const Type& source)
     {
         return source;

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -63,6 +63,8 @@ class WallTime;
 struct AnyThreadsAccessTraits;
 struct FastMalloc;
 struct MainThreadAccessTraits;
+struct ObjectIdentifierMainThreadAccessTraits;
+struct ObjectIdentifierThreadSafeAccessTraits;
 
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 struct VectorBufferMalloc;
@@ -81,7 +83,7 @@ template<typename> class Function;
 template<typename, typename = AnyThreadsAccessTraits> class LazyNeverDestroyed;
 template<typename T, typename Traits = typename T::MarkableTraits> class Markable;
 template<typename, typename = AnyThreadsAccessTraits> class NeverDestroyed;
-template<typename> class ObjectIdentifier;
+template<typename, typename = ObjectIdentifierMainThreadAccessTraits> class ObjectIdentifier;
 template<typename> class OptionSet;
 template<typename> class Packed;
 template<typename T, size_t = alignof(T)> class PackedAlignedPtr;

--- a/Source/WTF/wtf/ObjectIdentifier.cpp
+++ b/Source/WTF/wtf/ObjectIdentifier.cpp
@@ -26,16 +26,18 @@
 #include "config.h"
 #include "ObjectIdentifier.h"
 
+#include "MainThread.h"
 
 namespace WTF {
 
-uint64_t ObjectIdentifierBase::generateIdentifierInternal()
+uint64_t ObjectIdentifierMainThreadAccessTraits::generateIdentifierInternal()
 {
+    ASSERT(isMainThread());
     static uint64_t current = 0;
     return ++current;
 }
 
-uint64_t ObjectIdentifierBase::generateThreadSafeIdentifierInternal()
+uint64_t ObjectIdentifierThreadSafeAccessTraits::generateThreadSafeIdentifierInternal()
 {
     static LazyNeverDestroyed<std::atomic<uint64_t>> current;
     static std::once_flag initializeCurrentIdentifier;

--- a/Source/WebCore/Modules/cache/DOMCacheIdentifier.h
+++ b/Source/WebCore/Modules/cache/DOMCacheIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum DOMCacheIdentifierType { };
-using DOMCacheIdentifier = ObjectIdentifier<DOMCacheIdentifierType>;
+using DOMCacheIdentifier = ObjectIdentifier<DOMCacheIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 }

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandleIdentifier.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandleIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum FileSystemHandleIdentifierType { };
-using FileSystemHandleIdentifier = ObjectIdentifier<FileSystemHandleIdentifierType>;
+using FileSystemHandleIdentifier = ObjectIdentifier<FileSystemHandleIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandleIdentifier.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandleIdentifier.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 enum FileSystemSyncAccessHandleIdentifierType { };
-using FileSystemSyncAccessHandleIdentifier = ObjectIdentifier<FileSystemSyncAccessHandleIdentifierType>;
+using FileSystemSyncAccessHandleIdentifier = ObjectIdentifier<FileSystemSyncAccessHandleIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnectionCallbackIdentifier.h
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnectionCallbackIdentifier.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 enum WorkerFileSystemStorageConnectionCallbackIdentifierType { };
-using WorkerFileSystemStorageConnectionCallbackIdentifier = ObjectIdentifier<WorkerFileSystemStorageConnectionCallbackIdentifierType>;
+using WorkerFileSystemStorageConnectionCallbackIdentifier = ObjectIdentifier<WorkerFileSystemStorageConnectionCallbackIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -96,7 +96,7 @@ NetworkSendQueue RTCDataChannel::createMessageQueue(ScriptExecutionContext& cont
 RTCDataChannel::RTCDataChannel(ScriptExecutionContext& context, std::unique_ptr<RTCDataChannelHandler>&& handler, String&& label, RTCDataChannelInit&& options)
     : ActiveDOMObject(&context)
     , m_handler(WTFMove(handler))
-    , m_identifier(RTCDataChannelIdentifier { Process::identifier(), ObjectIdentifier<RTCDataChannelLocalIdentifierType>::generateThreadSafe() })
+    , m_identifier(RTCDataChannelIdentifier { Process::identifier(), RTCDataChannelLocalIdentifier::generateThreadSafe() })
     , m_contextIdentifier(context.isDocument() ? ScriptExecutionContextIdentifier { } : context.identifier())
     , m_label(WTFMove(label))
     , m_options(WTFMove(options))

--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserverIdentifier.h
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserverIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum MainThreadPermissionObserverIdentifierType { };
-using MainThreadPermissionObserverIdentifier = ObjectIdentifier<MainThreadPermissionObserverIdentifierType>;
+using MainThreadPermissionObserverIdentifier = ObjectIdentifier<MainThreadPermissionObserverIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/web-locks/WebLockIdentifier.h
+++ b/Source/WebCore/Modules/web-locks/WebLockIdentifier.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 enum WebLockIdentifierType { };
-using WebLockIdentifier = ProcessQualified<ObjectIdentifier<WebLockIdentifierType>>;
+using WebLockIdentifier = ProcessQualified<ObjectIdentifier<WebLockIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>>;
 
 } // namespace
 

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h
@@ -52,7 +52,7 @@ class WebSocketChannel;
 class WebSocketChannelInspector;
 class WebSocketChannelClient;
 
-using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel>;
+using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 class ThreadableWebSocketChannel {
     WTF_MAKE_NONCOPYABLE(ThreadableWebSocketChannel);

--- a/Source/WebCore/Modules/websockets/WebSocketChannelInspector.h
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelInspector.h
@@ -39,7 +39,7 @@ class ResourceResponse;
 class WebSocketChannel;
 class WebSocketChannelInspector;
 
-using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel>;
+using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 class WEBCORE_EXPORT WebSocketChannelInspector {
 public:

--- a/Source/WebCore/Modules/websockets/WebSocketIdentifier.h
+++ b/Source/WebCore/Modules/websockets/WebSocketIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum WebSocketIdentifierType { };
-using WebSocketIdentifier = ObjectIdentifier<WebSocketIdentifierType>;
+using WebSocketIdentifier = ObjectIdentifier<WebSocketIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/BroadcastChannelIdentifier.h
+++ b/Source/WebCore/dom/BroadcastChannelIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum BroadcastChannelIdentifierType { };
-using BroadcastChannelIdentifier = ObjectIdentifier<BroadcastChannelIdentifierType>;
+using BroadcastChannelIdentifier = ObjectIdentifier<BroadcastChannelIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/MessageChannel.cpp
+++ b/Source/WebCore/dom/MessageChannel.cpp
@@ -35,8 +35,8 @@ namespace WebCore {
 
 static std::pair<Ref<MessagePort>, Ref<MessagePort>> generateMessagePorts(ScriptExecutionContext& context)
 {
-    MessagePortIdentifier id1 = { Process::identifier(), PortIdentifier::generate() };
-    MessagePortIdentifier id2 = { Process::identifier(), PortIdentifier::generate() };
+    MessagePortIdentifier id1 = { Process::identifier(), PortIdentifier::generateThreadSafe() };
+    MessagePortIdentifier id2 = { Process::identifier(), PortIdentifier::generateThreadSafe() };
 
     return { MessagePort::create(context, id1, id2), MessagePort::create(context, id2, id1) };
 }

--- a/Source/WebCore/dom/PortIdentifier.h
+++ b/Source/WebCore/dom/PortIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum PortIdentifierType { };
-using PortIdentifier = ObjectIdentifier<PortIdentifierType>;
+using PortIdentifier = ObjectIdentifier<PortIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -322,7 +322,7 @@ public:
     WEBCORE_EXPORT HasResourceAccess canAccessResource(ResourceType) const;
 
     enum NotificationCallbackIdentifierType { };
-    using NotificationCallbackIdentifier = ObjectIdentifier<NotificationCallbackIdentifierType>;
+    using NotificationCallbackIdentifier = ObjectIdentifier<NotificationCallbackIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
     WEBCORE_EXPORT NotificationCallbackIdentifier addNotificationCallback(CompletionHandler<void()>&&);
     WEBCORE_EXPORT CompletionHandler<void()> takeNotificationCallback(NotificationCallbackIdentifier);

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -106,7 +106,7 @@ struct Styleable;
 class WebGLProgram;
 #endif
 
-using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel>;
+using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 enum class StorageType : uint8_t;
 
 struct ComputedEffectTiming;

--- a/Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.h
+++ b/Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.h
@@ -34,7 +34,7 @@ class ResourceRequest;
 class ResourceResponse;
 class WebSocketChannel;
 struct WebSocketFrame;
-using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel>;
+using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 class WEBCORE_EXPORT LegacyWebSocketInspectorInstrumentation {
 public:

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -692,7 +692,7 @@ void InspectorNetworkAgent::didLoadResourceFromMemoryCache(DocumentLoader* loade
     if (!loader)
         return;
 
-    auto identifier = ResourceLoaderIdentifier::generate();
+    auto identifier = ResourceLoaderIdentifier::generateThreadSafe();
     String requestId = IdentifiersFactory::requestId(identifier.toUInt64());
     Protocol::Network::LoaderId loaderId = loaderIdentifier(loader);
     Protocol::Network::FrameId frameId = frameIdentifier(loader);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -802,7 +802,7 @@ bool DocumentLoader::tryLoadingSubstituteData()
         return false;
 
     DOCUMENTLOADER_RELEASE_LOG("startLoadingMainResource: Returning substitute data");
-    m_identifierForLoadWithoutResourceLoader = ResourceLoaderIdentifier::generate();
+    m_identifierForLoadWithoutResourceLoader = ResourceLoaderIdentifier::generateThreadSafe();
     frameLoader()->notifier().assignIdentifierToInitialRequest(m_identifierForLoadWithoutResourceLoader, this, m_request);
     frameLoader()->notifier().dispatchWillSendRequest(this, m_identifierForLoadWithoutResourceLoader, m_request, ResourceResponse(), nullptr);
 
@@ -2250,7 +2250,7 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
 #endif
 
     if (!mainResourceLoader()) {
-        m_identifierForLoadWithoutResourceLoader = ResourceLoaderIdentifier::generate();
+        m_identifierForLoadWithoutResourceLoader = ResourceLoaderIdentifier::generateThreadSafe();
         frameLoader()->notifier().assignIdentifierToInitialRequest(m_identifierForLoadWithoutResourceLoader, this, mainResourceRequest.resourceRequest());
         frameLoader()->notifier().dispatchWillSendRequest(this, m_identifierForLoadWithoutResourceLoader, mainResourceRequest.resourceRequest(), ResourceResponse(), nullptr);
     }

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -616,7 +616,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     RefPtr<SharedBuffer> data;
     ResourceError error;
     ResourceResponse response;
-    auto identifier = makeObjectIdentifier<ResourceLoader>(std::numeric_limits<uint64_t>::max());
+    auto identifier = makeObjectIdentifier<ResourceLoader, WTF::ObjectIdentifierThreadSafeAccessTraits>(std::numeric_limits<uint64_t>::max());
     if (auto* frame = m_document.frame()) {
         if (!MixedContentChecker::canRunInsecureContent(*frame, m_document.securityOrigin(), requestURL))
             return;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3807,7 +3807,7 @@ void FrameLoader::requestFromDelegate(ResourceRequest& request, ResourceLoaderId
 {
     ASSERT(!request.isNull());
 
-    identifier = ResourceLoaderIdentifier::generate();
+    identifier = ResourceLoaderIdentifier::generateThreadSafe();
     notifier().assignIdentifierToInitialRequest(identifier, m_documentLoader.get(), request);
 
     ResourceRequest newRequest(request);

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -210,7 +210,7 @@ void PingLoader::sendViolationReport(LocalFrame& frame, const URL& reportURL, Re
 
 void PingLoader::startPingLoad(LocalFrame& frame, ResourceRequest& request, HTTPHeaderMap&& originalRequestHeaders, ShouldFollowRedirects shouldFollowRedirects, ContentSecurityPolicyImposition policyCheck, ReferrerPolicy referrerPolicy, std::optional<ViolationReportType> violationReportType)
 {
-    auto identifier = ResourceLoaderIdentifier::generate();
+    auto identifier = ResourceLoaderIdentifier::generateThreadSafe();
     // FIXME: Why activeDocumentLoader? I would have expected documentLoader().
     // It seems like the PingLoader should be associated with the current
     // Document in the Frame, but the activeDocumentLoader will be associated

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -382,7 +382,7 @@ void ResourceLoader::willSendRequestInternal(ResourceRequest&& request, const Re
     // We need a resource identifier for all requests, even if FrameLoader is never going to see it (such as with CORS preflight requests).
     bool createdResourceIdentifier = false;
     if (!m_identifier) {
-        m_identifier = ResourceLoaderIdentifier::generate();
+        m_identifier = ResourceLoaderIdentifier::generateThreadSafe();
         createdResourceIdentifier = true;
     }
 

--- a/Source/WebCore/loader/ResourceLoaderIdentifier.h
+++ b/Source/WebCore/loader/ResourceLoaderIdentifier.h
@@ -31,6 +31,6 @@ namespace WebCore {
 
 class ResourceLoader;
 
-using ResourceLoaderIdentifier = ObjectIdentifier<ResourceLoader>;
+using ResourceLoaderIdentifier = ObjectIdentifier<ResourceLoader, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore

--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -113,7 +113,7 @@ WorkerThreadableLoader::MainThreadBridge::MainThreadBridge(ThreadableLoaderClien
     : m_workerClientWrapper(&workerClientWrapper)
     , m_loaderProxy(loaderProxy)
     , m_taskMode(taskMode.isolatedCopy())
-    , m_workerRequestIdentifier { ResourceLoaderIdentifier::generate() }
+    , m_workerRequestIdentifier { ResourceLoaderIdentifier::generateThreadSafe() }
     , m_contextIdentifier(contextIdentifier)
 {
     auto* securityOrigin = globalScope.securityOrigin();

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
@@ -437,7 +437,7 @@ void ApplicationCacheGroup::update(LocalFrame& frame, ApplicationCacheUpdateOpti
 
     auto request = createRequest(URL { m_manifestURL }, m_newestCache ? m_newestCache->manifestResource() : nullptr);
 
-    m_currentResourceIdentifier = ResourceLoaderIdentifier::generate();
+    m_currentResourceIdentifier = ResourceLoaderIdentifier::generateThreadSafe();
     InspectorInstrumentation::willSendRequest(m_frame.get(), m_currentResourceIdentifier, m_frame->loader().documentLoader(), request, ResourceResponse { }, nullptr, nullptr);
 
     m_manifestLoader = ApplicationCacheResourceLoader::create(ApplicationCacheResource::Type::Manifest, documentLoader.cachedResourceLoader(), WTFMove(request), [this] (auto&& resourceOrError) {
@@ -898,7 +898,7 @@ void ApplicationCacheGroup::startLoadingEntry()
 
     auto request = createRequest(URL { firstPendingEntryURL }, m_newestCache ? m_newestCache->resourceForURL(firstPendingEntryURL) : nullptr);
 
-    m_currentResourceIdentifier = ResourceLoaderIdentifier::generate();
+    m_currentResourceIdentifier = ResourceLoaderIdentifier::generateThreadSafe();
     InspectorInstrumentation::willSendRequest(m_frame.get(), m_currentResourceIdentifier, m_frame->loader().documentLoader(), request, ResourceResponse { }, nullptr, nullptr);
 
     auto& documentLoader = *m_frame->loader().documentLoader();

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -257,7 +257,7 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
         ASSERT(m_originalRequest);
         CachedResourceHandle<CachedResource> protectedThis(this);
 
-        auto identifier = ResourceLoaderIdentifier::generate();
+        auto identifier = ResourceLoaderIdentifier::generateThreadSafe();
         InspectorInstrumentation::willSendRequestOfType(&frame, identifier, frameLoader.activeDocumentLoader(), request, InspectorInstrumentation::LoadType::Beacon);
 
         platformStrategies()->loaderStrategy()->startPingLoad(frame, request, m_originalRequest->httpHeaderFields(), m_options, m_options.contentSecurityPolicyImposition, [this, protectedThis = WTFMove(protectedThis), protectedFrame = Ref { frame }, identifier] (const ResourceError& error, const ResourceResponse& response) {

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -37,7 +37,7 @@ class LocalFrame;
 class SecurityOrigin;
 
 enum OpaqueOriginIdentifierType { };
-using OpaqueOriginIdentifier = ObjectIdentifier<OpaqueOriginIdentifierType>;
+using OpaqueOriginIdentifier = ObjectIdentifier<OpaqueOriginIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 class SecurityOriginData {
 public:

--- a/Source/WebCore/platform/graphics/RenderingResourceIdentifier.h
+++ b/Source/WebCore/platform/graphics/RenderingResourceIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum RenderingResourceIdentifierType { };
-using RenderingResourceIdentifier = ObjectIdentifier<RenderingResourceIdentifierType>;
+using RenderingResourceIdentifier = ObjectIdentifier<RenderingResourceIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.h
+++ b/Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.h
@@ -37,7 +37,7 @@
 namespace WebCore {
 
 enum DisplayConfigurationClientIdentifierType { };
-using DisplayConfigurationClientIdentifier = ObjectIdentifier<DisplayConfigurationClientIdentifierType>;
+using DisplayConfigurationClientIdentifier = ObjectIdentifier<DisplayConfigurationClientIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 class DisplayConfigurationMonitor {
 public:

--- a/Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h
@@ -29,6 +29,6 @@
 namespace WebCore {
 
 enum RTCDataChannelLocalIdentifierType { };
-using RTCDataChannelLocalIdentifier = ObjectIdentifier<RTCDataChannelLocalIdentifierType>;
+using RTCDataChannelLocalIdentifier = ObjectIdentifier<RTCDataChannelLocalIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebCore {
 
 enum LibWebRTCSocketIdentifierType { };
-using LibWebRTCSocketIdentifier = ObjectIdentifier<LibWebRTCSocketIdentifierType>;
+using LibWebRTCSocketIdentifier = ObjectIdentifier<LibWebRTCSocketIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2933,7 +2933,7 @@ uint64_t Internals::messagePortIdentifier(const MessagePort& port) const
 
 bool Internals::isMessagePortAlive(uint64_t messagePortIdentifier) const
 {
-    MessagePortIdentifier portIdentifier { Process::identifier(), makeObjectIdentifier<PortIdentifierType>(messagePortIdentifier) };
+    MessagePortIdentifier portIdentifier { Process::identifier(), makeObjectIdentifier<PortIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>(messagePortIdentifier) };
     return MessagePort::isMessagePortAliveForTesting(portIdentifier);
 }
 

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -230,7 +230,7 @@ void setMockGamepadButtonValue(unsigned gamepadIndex, unsigned buttonIndex, doub
 void setupNewlyCreatedServiceWorker(uint64_t serviceWorkerIdentifier)
 {
 #if ENABLE(SERVICE_WORKER)
-    auto identifier = makeObjectIdentifier<ServiceWorkerIdentifierType>(serviceWorkerIdentifier);
+    auto identifier = makeObjectIdentifier<ServiceWorkerIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>(serviceWorkerIdentifier);
     SWContextManager::singleton().postTaskToServiceWorker(identifier, [identifier] (ServiceWorkerGlobalScope& globalScope) {
         auto* script = globalScope.script();
         if (!script)

--- a/Source/WebCore/workers/service/ServiceWorkerClients.h
+++ b/Source/WebCore/workers/service/ServiceWorkerClients.h
@@ -56,7 +56,7 @@ public:
     void claim(ScriptExecutionContext&, Ref<DeferredPromise>&&);
 
     enum PromiseIdentifierType { };
-    using PromiseIdentifier = ObjectIdentifier<PromiseIdentifierType>;
+    using PromiseIdentifier = ObjectIdentifier<PromiseIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
     PromiseIdentifier addPendingPromise(Ref<DeferredPromise>&&);
     RefPtr<DeferredPromise> takePendingPromise(PromiseIdentifier);

--- a/Source/WebCore/workers/service/ServiceWorkerIdentifier.h
+++ b/Source/WebCore/workers/service/ServiceWorkerIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 enum ServiceWorkerIdentifierType { };
-using ServiceWorkerIdentifier = ObjectIdentifier<ServiceWorkerIdentifierType>;
+using ServiceWorkerIdentifier = ObjectIdentifier<ServiceWorkerIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebCore
 

--- a/Source/WebCore/workers/service/ServiceWorkerTypes.h
+++ b/Source/WebCore/workers/service/ServiceWorkerTypes.h
@@ -67,10 +67,10 @@ enum class ServiceWorkerClientFrameType : uint8_t {
 enum class ShouldNotifyWhenResolved : bool { No, Yes };
 
 enum ServiceWorkerRegistrationIdentifierType { };
-using ServiceWorkerRegistrationIdentifier = ObjectIdentifier<ServiceWorkerRegistrationIdentifierType>;
+using ServiceWorkerRegistrationIdentifier = ObjectIdentifier<ServiceWorkerRegistrationIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 enum ServiceWorkerJobIdentifierType { };
-using ServiceWorkerJobIdentifier = ObjectIdentifier<ServiceWorkerJobIdentifierType>;
+using ServiceWorkerJobIdentifier = ObjectIdentifier<ServiceWorkerJobIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 enum SWServerToContextConnectionIdentifierType { };
 using SWServerToContextConnectionIdentifier = ObjectIdentifier<SWServerToContextConnectionIdentifierType>;

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -391,8 +391,8 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
             continue;
         }
 
-        auto workerIdentifier = ServiceWorkerIdentifier::generate();
-        auto registrationIdentifier = ServiceWorkerRegistrationIdentifier::generate();
+        auto workerIdentifier = ServiceWorkerIdentifier::generateThreadSafe();
+        auto registrationIdentifier = ServiceWorkerRegistrationIdentifier::generateThreadSafe();
         auto serviceWorkerData = ServiceWorkerData { workerIdentifier, registrationIdentifier, scriptURL, ServiceWorkerState::Activated, *workerType };
         auto registration = ServiceWorkerRegistrationData { WTFMove(*key), registrationIdentifier, WTFMove(scopeURL), *updateViaCache, lastUpdateCheckTime, std::nullopt, std::nullopt, WTFMove(serviceWorkerData) };
         auto contextData = ServiceWorkerContextData { std::nullopt, WTFMove(registration), workerIdentifier, WTFMove(script), WTFMove(*certificateInfo), WTFMove(*contentSecurityPolicy), WTFMove(*coep), WTFMove(referrerPolicy), WTFMove(scriptURL), *workerType, true, LastNavigationWasAppInitiated::Yes, WTFMove(scriptResourceMap), std::nullopt, WTFMove(*navigationPreloadState) };

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -821,7 +821,7 @@ void SWServer::removeClientServiceWorkerRegistration(Connection& connection, Ser
 
 void SWServer::updateWorker(const ServiceWorkerJobDataIdentifier& jobDataIdentifier, const std::optional<ProcessIdentifier>& requestingProcessIdentifier, SWServerRegistration& registration, const URL& url, const ScriptBuffer& script, const CertificateInfo& certificateInfo, const ContentSecurityPolicyResponseHeaders& contentSecurityPolicy, const CrossOriginEmbedderPolicy& coep, const String& referrerPolicy, WorkerType type, MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>&& scriptResourceMap, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier)
 {
-    tryInstallContextData(requestingProcessIdentifier, ServiceWorkerContextData { jobDataIdentifier, registration.data(), ServiceWorkerIdentifier::generate(), script, certificateInfo, contentSecurityPolicy, coep, referrerPolicy, url, type, false, clientIsAppInitiatedForRegistrableDomain(RegistrableDomain(url)), WTFMove(scriptResourceMap), serviceWorkerPageIdentifier, { } });
+    tryInstallContextData(requestingProcessIdentifier, ServiceWorkerContextData { jobDataIdentifier, registration.data(), ServiceWorkerIdentifier::generateThreadSafe(), script, certificateInfo, contentSecurityPolicy, coep, referrerPolicy, url, type, false, clientIsAppInitiatedForRegistrableDomain(RegistrableDomain(url)), WTFMove(scriptResourceMap), serviceWorkerPageIdentifier, { } });
 }
 
 LastNavigationWasAppInitiated SWServer::clientIsAppInitiatedForRegistrableDomain(const RegistrableDomain& domain)
@@ -1449,7 +1449,7 @@ void SWServer::softUpdate(SWServerRegistration& registration)
     if (!newestWorker)
         return;
 
-    ServiceWorkerJobData jobData(Process::identifier(), ServiceWorkerIdentifier::generate());
+    ServiceWorkerJobData jobData(Process::identifier(), ServiceWorkerIdentifier::generateThreadSafe());
     jobData.scriptURL = registration.scriptURL();
     jobData.topOrigin = registration.key().topOrigin();
     jobData.scopeURL = registration.scopeURLWithoutFragment();

--- a/Source/WebCore/workers/service/server/SWServerRegistration.cpp
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 
 static ServiceWorkerRegistrationIdentifier generateServiceWorkerRegistrationIdentifier()
 {
-    return ServiceWorkerRegistrationIdentifier::generate();
+    return ServiceWorkerRegistrationIdentifier::generateThreadSafe();
 }
 
 SWServerRegistration::SWServerRegistration(SWServer& server, const ServiceWorkerRegistrationKey& key, ServiceWorkerUpdateViaCache updateViaCache, const URL& scopeURL, const URL& scriptURL, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, NavigationPreloadState&& navigationPreloadState)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -234,13 +234,13 @@ void NetworkConnectionToWebProcess::didReceiveMessage(IPC::Connection& connectio
     if (decoder.messageReceiverName() == Messages::NetworkResourceLoader::messageReceiverName()) {
         RELEASE_ASSERT(RunLoop::isMain());
         RELEASE_ASSERT(decoder.destinationID());
-        if (auto* loader = m_networkResourceLoaders.get(makeObjectIdentifier<WebCore::ResourceLoader>(decoder.destinationID())))
+        if (auto* loader = m_networkResourceLoaders.get(makeObjectIdentifier<WebCore::ResourceLoader, WTF::ObjectIdentifierThreadSafeAccessTraits>(decoder.destinationID())))
             loader->didReceiveNetworkResourceLoaderMessage(connection, decoder);
         return;
     }
 
     if (decoder.messageReceiverName() == Messages::NetworkSocketChannel::messageReceiverName()) {
-        if (auto* channel = m_networkSocketChannels.get(makeObjectIdentifier<WebSocketIdentifierType>(decoder.destinationID())))
+        if (auto* channel = m_networkSocketChannels.get(makeObjectIdentifier<WebSocketIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>(decoder.destinationID())))
             channel->didReceiveMessage(connection, decoder);
         return;
     }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1730,14 +1730,14 @@ static String escapeForJSON(const String& s)
     return makeStringByReplacingAll(makeStringByReplacingAll(s, '\\', "\\\\"_s), '"', "\\\""_s);
 }
 
-template<typename IdentifierType>
-static String escapeIDForJSON(const std::optional<ObjectIdentifier<IdentifierType>>& value)
+template<typename IdentifierType, typename ThreadSafety>
+static String escapeIDForJSON(const std::optional<ObjectIdentifier<IdentifierType, ThreadSafety>>& value)
 {
     return value ? String::number(value->toUInt64()) : String("None"_s);
 }
 
-template<typename IdentifierType>
-static String escapeIDForJSON(const std::optional<ProcessQualified<ObjectIdentifier<IdentifierType>>>& value)
+template<typename IdentifierType, typename ThreadSafety>
+static String escapeIDForJSON(const std::optional<ProcessQualified<ObjectIdentifier<IdentifierType, ThreadSafety>>>& value)
 {
     return value ? String::number(value->object().toUInt64()) : String("None"_s);
 }

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCaches.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCaches.cpp
@@ -324,7 +324,7 @@ void Caches::open(const String& name, CacheIdentifierCallback&& callback)
 
     makeDirty();
 
-    auto cacheIdentifier = WebCore::DOMCacheIdentifier::generate();
+    auto cacheIdentifier = WebCore::DOMCacheIdentifier::generateThreadSafe();
     m_caches.append(Cache { *this, cacheIdentifier, Cache::State::Open, String { name }, createVersion4UUIDString() });
 
     writeCachesToDisk([callback = WTFMove(callback), cacheIdentifier](std::optional<Error>&& error) mutable {
@@ -472,7 +472,7 @@ void Caches::readCachesFromDisk(WTF::Function<void(Expected<Vector<Cache>, Error
             return;
         }
         callback(WTF::map(WTFMove(result.value()), [this] (auto&& pair) {
-            return Cache { *this, WebCore::DOMCacheIdentifier::generate(), Cache::State::Uninitialized, WTFMove(pair.first), WTFMove(pair.second) };
+            return Cache { *this, WebCore::DOMCacheIdentifier::generateThreadSafe(), Cache::State::Uninitialized, WTFMove(pair.first), WTFMove(pair.second) };
         }));
     });
 }

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -300,7 +300,7 @@ HashMap<IPC::Connection::UniqueID, Connection*>& Connection::connectionMap()
 }
 
 Connection::Connection(Identifier identifier, bool isServer)
-    : m_uniqueID(UniqueID::generate())
+    : m_uniqueID(UniqueID::generateThreadSafe())
     , m_isServer(isServer)
     , m_connectionQueue(WorkQueue::create("com.apple.IPC.ReceiveQueue"))
 {
@@ -1166,7 +1166,7 @@ void Connection::dispatchMessage(Decoder& decoder)
     assertIsCurrent(dispatcher());
     RELEASE_ASSERT(m_client);
     if (decoder.messageReceiverName() == ReceiverName::AsyncReply) {
-        auto handler = takeAsyncReplyHandler(makeObjectIdentifier<AsyncReplyIDType>(decoder.destinationID()));
+        auto handler = takeAsyncReplyHandler(makeObjectIdentifier<AsyncReplyIDType, WTF::ObjectIdentifierThreadSafeAccessTraits>(decoder.destinationID()));
         if (!handler) {
             markCurrentlyDispatchedMessageAsInvalid();
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -37,7 +37,7 @@ enum class SendSyncOption : uint8_t;
 struct AsyncReplyIDType;
 struct ConnectionAsyncReplyHandler;
 template<typename> struct ConnectionSendSyncResult;
-using AsyncReplyID = ObjectIdentifier<AsyncReplyIDType>;
+using AsyncReplyID = ObjectIdentifier<AsyncReplyIDType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 class MessageSender {
 public:
@@ -47,8 +47,8 @@ public:
     template<typename T> inline bool send(T&& message, OptionSet<SendOption>);
     template<typename T> inline bool send(T&& message, uint64_t destinationID);
     template<typename T> inline bool send(T&& message, uint64_t destinationID, OptionSet<SendOption>);
-    template<typename T, typename U> inline bool send(T&& message, ObjectIdentifier<U> destinationID);
-    template<typename T, typename U> inline bool send(T&& message, ObjectIdentifier<U> destinationID, OptionSet<SendOption>);
+    template<typename T, typename U, typename V> inline bool send(T&& message, ObjectIdentifier<U, V> destinationID);
+    template<typename T, typename U, typename V> inline bool send(T&& message, ObjectIdentifier<U, V> destinationID, OptionSet<SendOption>);
 
     template<typename T> using SendSyncResult = ConnectionSendSyncResult<T>;
     template<typename T> inline SendSyncResult<T> sendSync(T&& message);
@@ -57,17 +57,17 @@ public:
     template<typename T> inline SendSyncResult<T> sendSync(T&& message, uint64_t destinationID);
     template<typename T> inline SendSyncResult<T> sendSync(T&& message, uint64_t destinationID, Timeout);
     template<typename T> inline SendSyncResult<T> sendSync(T&& message, uint64_t destinationID, Timeout, OptionSet<SendSyncOption>);
-    template<typename T, typename U> inline SendSyncResult<T> sendSync(T&& message, ObjectIdentifier<U> destinationID);
-    template<typename T, typename U> inline SendSyncResult<T> sendSync(T&& message, ObjectIdentifier<U> destinationID, Timeout);
-    template<typename T, typename U> inline SendSyncResult<T> sendSync(T&& message, ObjectIdentifier<U> destinationID, Timeout, OptionSet<SendSyncOption>);
+    template<typename T, typename U, typename V> inline SendSyncResult<T> sendSync(T&& message, ObjectIdentifier<U, V> destinationID);
+    template<typename T, typename U, typename V> inline SendSyncResult<T> sendSync(T&& message, ObjectIdentifier<U, V> destinationID, Timeout);
+    template<typename T, typename U, typename V> inline SendSyncResult<T> sendSync(T&& message, ObjectIdentifier<U, V> destinationID, Timeout, OptionSet<SendSyncOption>);
 
     using AsyncReplyID = IPC::AsyncReplyID;
     template<typename T, typename C> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler);
     template<typename T, typename C> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, OptionSet<SendOption>);
     template<typename T, typename C> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID);
     template<typename T, typename C> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption>);
-    template<typename T, typename C, typename U> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U> destinationID);
-    template<typename T, typename C, typename U> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U> destinationID, OptionSet<SendOption>);
+    template<typename T, typename C, typename U, typename V> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U, V> destinationID);
+    template<typename T, typename C, typename U, typename V> inline AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U, V> destinationID, OptionSet<SendOption>);
 
     virtual bool sendMessage(UniqueRef<Encoder>&&, OptionSet<SendOption>);
 

--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -73,12 +73,12 @@ template<typename MessageType> inline bool MessageSender::send(MessageType&& mes
     return send(std::forward<MessageType>(message), destinationID, { });
 }
 
-template<typename MessageType, typename U> inline bool MessageSender::send(MessageType&& message, ObjectIdentifier<U> destinationID)
+template<typename MessageType, typename U, typename V> inline bool MessageSender::send(MessageType&& message, ObjectIdentifier<U, V> destinationID)
 {
     return send(std::forward<MessageType>(message), destinationID.toUInt64(), { });
 }
 
-template<typename MessageType, typename U> inline bool MessageSender::send(MessageType&& message, ObjectIdentifier<U> destinationID, OptionSet<SendOption> options)
+template<typename MessageType, typename U, typename V> inline bool MessageSender::send(MessageType&& message, ObjectIdentifier<U, V> destinationID, OptionSet<SendOption> options)
 {
     return send(std::forward<MessageType>(message), destinationID.toUInt64(), options);
 }
@@ -98,12 +98,12 @@ template<typename MessageType> inline auto MessageSender::sendSync(MessageType&&
     return sendSync(std::forward<MessageType>(message), messageSenderDestinationID(), timeout, options);
 }
 
-template<typename MessageType, typename U> inline auto MessageSender::sendSync(MessageType&& message, ObjectIdentifier<U> destinationID) -> SendSyncResult<MessageType>
+template<typename MessageType, typename U, typename V> inline auto MessageSender::sendSync(MessageType&& message, ObjectIdentifier<U, V> destinationID) -> SendSyncResult<MessageType>
 {
     return sendSync(std::forward<MessageType>(message), destinationID.toUInt64(), Timeout::infinity(), { });
 }
 
-template<typename MessageType, typename U> inline auto MessageSender::sendSync(MessageType&& message, ObjectIdentifier<U> destinationID, Timeout timeout, OptionSet<SendSyncOption> options) -> SendSyncResult<MessageType>
+template<typename MessageType, typename U, typename V> inline auto MessageSender::sendSync(MessageType&& message, ObjectIdentifier<U, V> destinationID, Timeout timeout, OptionSet<SendSyncOption> options) -> SendSyncResult<MessageType>
 {
     return sendSync(std::forward<MessageType>(message), destinationID.toUInt64(), timeout, options);
 }
@@ -123,12 +123,12 @@ template<typename MessageType, typename C> inline AsyncReplyID MessageSender::se
     return sendWithAsyncReply(std::forward<MessageType>(message), std::forward<C>(completionHandler), destinationID, { });
 }
 
-template<typename MessageType, typename C, typename U> inline AsyncReplyID MessageSender::sendWithAsyncReply(MessageType&& message, C&& completionHandler, ObjectIdentifier<U> destinationID)
+template<typename MessageType, typename C, typename U, typename V> inline AsyncReplyID MessageSender::sendWithAsyncReply(MessageType&& message, C&& completionHandler, ObjectIdentifier<U, V> destinationID)
 {
     return sendWithAsyncReply(std::forward<MessageType>(message), std::forward<C>(completionHandler), destinationID.toUInt64(), { });
 }
 
-template<typename MessageType, typename C, typename U> inline AsyncReplyID MessageSender::sendWithAsyncReply(MessageType&& message, C&& completionHandler, ObjectIdentifier<U> destinationID, OptionSet<SendOption> options)
+template<typename MessageType, typename C, typename U, typename V> inline AsyncReplyID MessageSender::sendWithAsyncReply(MessageType&& message, C&& completionHandler, ObjectIdentifier<U, V> destinationID, OptionSet<SendOption> options)
 {
     return sendWithAsyncReply(std::forward<MessageType>(message), std::forward<C>(completionHandler), destinationID.toUInt64(), options);
 }

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -74,18 +74,18 @@ public:
     void open(Connection::Client&, SerialFunctionDispatcher& = RunLoop::current());
     void invalidate();
 
-    template<typename T, typename U> bool send(T&& message, ObjectIdentifier<U> destinationID, Timeout);
+    template<typename T, typename U, typename V> bool send(T&& message, ObjectIdentifier<U, V> destinationID, Timeout);
 
     using AsyncReplyID = Connection::AsyncReplyID;
-    template<typename T, typename C, typename U>
-    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U> destinationID, Timeout);
+    template<typename T, typename C, typename U, typename V>
+    AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U, V> destinationID, Timeout);
 
     template<typename T> using SendSyncResult = Connection::SendSyncResult<T>;
-    template<typename T, typename U>
-    SendSyncResult<T> sendSync(T&& message, ObjectIdentifier<U> destinationID, Timeout);
+    template<typename T, typename U, typename V>
+    SendSyncResult<T> sendSync(T&& message, ObjectIdentifier<U, V> destinationID, Timeout);
 
-    template<typename T, typename U>
-    bool waitForAndDispatchImmediately(ObjectIdentifier<U> destinationID, Timeout, OptionSet<WaitForOption> = { });
+    template<typename T, typename U, typename V>
+    bool waitForAndDispatchImmediately(ObjectIdentifier<U, V> destinationID, Timeout, OptionSet<WaitForOption> = { });
 
     StreamClientConnectionBuffer& bufferForTesting();
     Connection& connectionForTesting();
@@ -125,8 +125,8 @@ private:
     friend class WebKit::IPCTestingAPI::JSIPCStreamClientConnection;
 };
 
-template<typename T, typename U>
-bool StreamClientConnection::send(T&& message, ObjectIdentifier<U> destinationID, Timeout timeout)
+template<typename T, typename U, typename V>
+bool StreamClientConnection::send(T&& message, ObjectIdentifier<U, V> destinationID, Timeout timeout)
 {
     static_assert(!T::isSync, "Message is sync!");
     if (!trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout))
@@ -144,8 +144,8 @@ bool StreamClientConnection::send(T&& message, ObjectIdentifier<U> destinationID
     return true;
 }
 
-template<typename T, typename C, typename U>
-StreamClientConnection::AsyncReplyID StreamClientConnection::sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U> destinationID, Timeout timeout)
+template<typename T, typename C, typename U, typename V>
+StreamClientConnection::AsyncReplyID StreamClientConnection::sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifier<U, V> destinationID, Timeout timeout)
 {
     static_assert(!T::isSync, "Message is sync!");
     if (!trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout))
@@ -193,8 +193,8 @@ bool StreamClientConnection::trySendStream(Span<uint8_t>& span, T& message, Addi
     return false;
 }
 
-template<typename T, typename U>
-StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& message, ObjectIdentifier<U> destinationID, Timeout timeout)
+template<typename T, typename U, typename V>
+StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& message, ObjectIdentifier<U, V> destinationID, Timeout timeout)
 {
     static_assert(T::isSync, "Message is not sync!");
     if (!trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout))
@@ -211,8 +211,8 @@ StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& m
     return m_connection->sendSync(WTFMove(message), destinationID.toUInt64(), timeout);
 }
 
-template<typename T, typename U>
-bool StreamClientConnection::waitForAndDispatchImmediately(ObjectIdentifier<U> destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
+template<typename T, typename U, typename V>
+bool StreamClientConnection::waitForAndDispatchImmediately(ObjectIdentifier<U, V> destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
 {
     return m_connection->waitForAndDispatchImmediately<T>(destinationID, timeout, waitForOptions);
 }

--- a/Source/WebKit/Shared/StorageAreaIdentifier.h
+++ b/Source/WebKit/Shared/StorageAreaIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 struct StorageAreaIdentifierType;
-using StorageAreaIdentifier = ObjectIdentifier<StorageAreaIdentifierType>;
+using StorageAreaIdentifier = ObjectIdentifier<StorageAreaIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 }

--- a/Source/WebKit/Shared/WebsiteData/QuotaIncreaseRequestIdentifier.h
+++ b/Source/WebKit/Shared/WebsiteData/QuotaIncreaseRequestIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum QuotaIncreaseRequestIdentifierType { };
-using QuotaIncreaseRequestIdentifier = ObjectIdentifier<QuotaIncreaseRequestIdentifierType>;
+using QuotaIncreaseRequestIdentifier = ObjectIdentifier<QuotaIncreaseRequestIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -274,7 +274,7 @@ using PlatformLayerIdentifier = ProcessQualified<ObjectIdentifier<PlatformLayerI
 using PlaybackTargetClientContextIdentifier = ObjectIdentifier<PlaybackTargetClientContextIdentifierType>;
 using PointerID = int32_t;
 using PolicyCheckIdentifier = ProcessQualified<ObjectIdentifier<PolicyCheckIdentifierType>>;
-using ResourceLoaderIdentifier = ObjectIdentifier<ResourceLoader>;
+using ResourceLoaderIdentifier = ObjectIdentifier<ResourceLoader, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 using ScrollingNodeID = uint64_t;
 using UserMediaRequestIdentifier = ObjectIdentifier<UserMediaRequestIdentifierType>;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/DisplayListRecorderFlushIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/DisplayListRecorderFlushIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum DisplayListRecorderFlushIdentifierType { };
-using DisplayListRecorderFlushIdentifier = ObjectIdentifier<DisplayListRecorderFlushIdentifierType>;
+using DisplayListRecorderFlushIdentifier = ObjectIdentifier<DisplayListRecorderFlushIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderFlushIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderFlushIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum DisplayListRecorderFlushIdentifierType { };
-using DisplayListRecorderFlushIdentifier = ObjectIdentifier<DisplayListRecorderFlushIdentifierType>;
+using DisplayListRecorderFlushIdentifier = ObjectIdentifier<DisplayListRecorderFlushIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -314,7 +314,7 @@ bool RemoteImageBufferProxy::flushDrawingContextAsync()
     if (!m_needsFlush)
         return hasPendingFlush();
 
-    m_sentFlushIdentifier = DisplayListRecorderFlushIdentifier::generate();
+    m_sentFlushIdentifier = DisplayListRecorderFlushIdentifier::generateThreadSafe();
     LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " flushDrawingContextAsync - flush " << m_sentFlushIdentifier);
     m_remoteDisplayList.flushContext(m_sentFlushIdentifier);
     m_remoteRenderingBackendProxy->addPendingFlush(m_flushState, m_sentFlushIdentifier);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteSerializedImageBufferIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteSerializedImageBufferIdentifier.h
@@ -33,7 +33,7 @@
 namespace WebKit {
 
 enum RemoteSerializedImageBufferIdentifierType { };
-using RemoteSerializedImageBufferIdentifier = ObjectIdentifier<RemoteSerializedImageBufferIdentifierType>;
+using RemoteSerializedImageBufferIdentifier = ObjectIdentifier<RemoteSerializedImageBufferIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 using RemoteSerializedImageBufferReadReference = ObjectIdentifierReadReference<RemoteSerializedImageBufferIdentifier>;
 using RemoteSerializedImageBufferWriteReference = ObjectIdentifierWriteReference<RemoteSerializedImageBufferIdentifier>;
 using RemoteSerializedImageBufferReference = ObjectIdentifierReference<RemoteSerializedImageBufferIdentifier>;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h
@@ -33,7 +33,7 @@
 namespace WebKit {
 
 enum RemoteVideoFrameIdentifierType { };
-using RemoteVideoFrameIdentifier = ObjectIdentifier<RemoteVideoFrameIdentifierType>;
+using RemoteVideoFrameIdentifier = ObjectIdentifier<RemoteVideoFrameIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 using RemoteVideoFrameReadReference = ObjectIdentifierReadReference<RemoteVideoFrameIdentifier>;
 using RemoteVideoFrameWriteReference = ObjectIdentifierWriteReference<RemoteVideoFrameIdentifier>;
 using RemoteVideoFrameReference = ObjectIdentifierReference<RemoteVideoFrameIdentifier>;

--- a/Source/WebKit/WebProcess/GPU/webrtc/VideoDecoderIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/VideoDecoderIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum VideoDecoderIdentifierType { };
-using VideoDecoderIdentifier = ObjectIdentifier<VideoDecoderIdentifierType>;
+using VideoDecoderIdentifier = ObjectIdentifier<VideoDecoderIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/webrtc/VideoEncoderIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/VideoEncoderIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum VideoEncoderIdentifierType { };
-using VideoEncoderIdentifier = ObjectIdentifier<VideoEncoderIdentifierType>;
+using VideoEncoderIdentifier = ObjectIdentifier<VideoEncoderIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -97,7 +97,7 @@ NetworkProcessConnection::~NetworkProcessConnection()
 void NetworkProcessConnection::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (decoder.messageReceiverName() == Messages::WebResourceLoader::messageReceiverName()) {
-        if (auto* webResourceLoader = WebProcess::singleton().webLoaderStrategy().webResourceLoaderForIdentifier(makeObjectIdentifier<WebCore::ResourceLoader>(decoder.destinationID())))
+        if (auto* webResourceLoader = WebProcess::singleton().webLoaderStrategy().webResourceLoaderForIdentifier(makeObjectIdentifier<WebCore::ResourceLoader, WTF::ObjectIdentifierThreadSafeAccessTraits>(decoder.destinationID())))
             webResourceLoader->didReceiveWebResourceLoaderMessage(connection, decoder);
         return;
     }
@@ -136,7 +136,7 @@ void NetworkProcessConnection::didReceiveMessage(IPC::Connection& connection, IP
     if (decoder.messageReceiverName() == Messages::WebRTCResolver::messageReceiverName()) {
         auto& network = WebProcess::singleton().libWebRTCNetwork();
         if (network.isActive())
-            network.resolver(makeObjectIdentifier<LibWebRTCResolverIdentifierType>(decoder.destinationID())).didReceiveMessage(connection, decoder);
+            network.resolver(makeObjectIdentifier<LibWebRTCResolverIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>(decoder.destinationID())).didReceiveMessage(connection, decoder);
         else
             RELEASE_LOG_ERROR(WebRTC, "Received WebRTCResolver message while libWebRTCNetwork is not active");
         return;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -816,7 +816,7 @@ void WebLoaderStrategy::startPingLoad(LocalFrame& frame, ResourceRequest& reques
     }
 
     NetworkResourceLoadParameters loadParameters;
-    loadParameters.identifier = WebCore::ResourceLoaderIdentifier::generate();
+    loadParameters.identifier = WebCore::ResourceLoaderIdentifier::generateThreadSafe();
     loadParameters.webPageProxyID = webPage->webPageProxyIdentifier();
     loadParameters.webPageID = webPage->identifier();
     loadParameters.webFrameID = webFrame->frameID();
@@ -906,7 +906,7 @@ void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage
         if (!webPageUserAgent.isEmpty())
             parameters.request.setHTTPUserAgent(webPageUserAgent);
     }
-    parameters.identifier = WebCore::ResourceLoaderIdentifier::generate();
+    parameters.identifier = WebCore::ResourceLoaderIdentifier::generateThreadSafe();
     parameters.webPageProxyID = webPage.webPageProxyIdentifier();
     parameters.webPageID = webPage.identifier();
     parameters.webFrameID = webFrame.frameID();

--- a/Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp
@@ -46,7 +46,7 @@ void WebSocketChannelManager::networkProcessCrashed()
 
 void WebSocketChannelManager::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
-    auto iterator = m_channels.find(makeObjectIdentifier<WebCore::WebSocketIdentifierType>(decoder.destinationID()));
+    auto iterator = m_channels.find(makeObjectIdentifier<WebCore::WebSocketIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>(decoder.destinationID()));
     if (iterator != m_channels.end())
         iterator->value->didReceiveMessage(connection, decoder);
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
@@ -48,7 +48,7 @@ class LibWebRTCSocketFactory;
 class LibWebRTCResolver final : public rtc::AsyncResolverInterface {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    LibWebRTCResolver() : m_identifier(LibWebRTCResolverIdentifier::generate()) { }
+    LibWebRTCResolver() : m_identifier(LibWebRTCResolverIdentifier::generateThreadSafe()) { }
 
     bool isResolving() const { return m_isResolving; }
     LibWebRTCResolverIdentifier identifier() const { return m_identifier; }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolverIdentifier.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolverIdentifier.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 enum LibWebRTCResolverIdentifierType { };
-using LibWebRTCResolverIdentifier = ObjectIdentifier<LibWebRTCResolverIdentifierType>;
+using LibWebRTCResolverIdentifier = ObjectIdentifier<LibWebRTCResolverIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp
@@ -42,7 +42,7 @@ namespace WebKit {
 
 LibWebRTCSocket::LibWebRTCSocket(LibWebRTCSocketFactory& factory, const void* socketGroup, Type type, const rtc::SocketAddress& localAddress, const rtc::SocketAddress& remoteAddress)
     : m_factory(factory)
-    , m_identifier(WebCore::LibWebRTCSocketIdentifier::generate())
+    , m_identifier(WebCore::LibWebRTCSocketIdentifier::generateThreadSafe())
     , m_type(type)
     , m_localAddress(localAddress)
     , m_remoteAddress(remoteAddress)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -1981,7 +1981,7 @@ void WebFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<void(Exp
 
     NetworkResourceLoadParameters parameters;
     parameters.request = ResourceRequest(url);
-    parameters.identifier = WebCore::ResourceLoaderIdentifier::generate();
+    parameters.identifier = WebCore::ResourceLoaderIdentifier::generateThreadSafe();
     parameters.webPageProxyID = webPage->webPageProxyIdentifier();
     parameters.webPageID = webPage->identifier();
     parameters.webFrameID = m_frame->frameID();

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -59,7 +59,7 @@ class SocketStreamHandle;
 class SocketStreamError;
 class WebSocketChannelClient;
 class WebSocketChannel;
-using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel>;
+using WebSocketChannelIdentifier = ObjectIdentifier<WebSocketChannel, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 class WebSocketChannel final : public RefCounted<WebSocketChannel>, public SocketStreamHandleClient, public ThreadableWebSocketChannel, public FileReaderLoaderClient
 {


### PR DESCRIPTION
#### 1641f98f8e4856012de8e5c4a0de69143d2026a7
<pre>
Prevent mixing of ObjectIdentifier::generate and generateThreadSafe at compile time.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254873">https://bugs.webkit.org/show_bug.cgi?id=254873</a>

Reviewed by Chris Dumez.

This introduces an extra parameter for ObjectIdentifier type to specify whether they want
thread safe or main-run loop only (the default) usage.

generate and generateThreadSafe use separate counter variables, so mixing usage will cause
collisions.

This also introduces an assertion that non-threadsafe usage only happens on the main run loop. This is strictly
more restrictive than necessary (races between unrelated types wouldn&apos;t cause meaningful collisions), but is the
only way we can add useful checking to prevent unsafe usage of the non-threadsafe variant.

Functional changes:

Changing some DOMCacheIdentifier callsites to use generateThreadSafe.
This previously had mixed usage, but appeared to be using them in separate contexts, so the collision wouldn&apos;t
have had runtime problems.

Uses generateThreadSafe for linear/radial gradient callsites of RenderingResourceIdentifier. This is to match
the rest of the callsites for RenderingResourceIdentifier.

Uses thread safe for Connection::UniqueID. These can be allocated from multiple threads, so need to use threadsafe.

ResourceLoaderIdentifier, LibWebRTCSocketIdentifier, LibWebRTCResolverIdentifier, PortIdentifier, DisplayListRecorderFlushIdentifier, ServerWorkerRegisrationIdentifier and ServiceWorkerIdentifier all moved to use threadsafe
since they can run on (multiple) worker threads.

* Source/JavaScriptCore/runtime/Microtask.h:
* Source/JavaScriptCore/runtime/VM.h:
* Source/WTF/wtf/CrossThreadCopier.h:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/ObjectIdentifier.cpp:
(WTF::ObjectIdentifierMainThreadAccessTraits::generateIdentifierInternal):
(WTF::ObjectIdentifierThreadSafeAccessTraits::generateThreadSafeIdentifierInternal):
(WTF::ObjectIdentifierBase::generateIdentifierInternal): Deleted.
(WTF::ObjectIdentifierBase::generateThreadSafeIdentifierInternal): Deleted.
* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::ObjectIdentifier::generate):
(WTF::ObjectIdentifier::generateThreadSafe):
(WTF::makeObjectIdentifier):
(WTF::add):
(WTF::ObjectIdentifierHash::hash):
(WTF::ObjectIdentifierHash::equal):
(WTF::operator&lt;&lt;):
(WTF::StringTypeAdapter&lt;ObjectIdentifier&lt;T&gt;&gt;::StringTypeAdapter): Deleted.
(WTF::StringTypeAdapter&lt;ObjectIdentifier&lt;T&gt;&gt;::length const): Deleted.
(WTF::StringTypeAdapter&lt;ObjectIdentifier&lt;T&gt;&gt;::is8Bit const): Deleted.
(WTF::StringTypeAdapter&lt;ObjectIdentifier&lt;T&gt;&gt;::writeTo const): Deleted.
* Source/WebCore/Modules/cache/DOMCacheIdentifier.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemHandleIdentifier.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandleIdentifier.h:
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnectionCallbackIdentifier.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::RTCDataChannel):
* Source/WebCore/Modules/permissions/MainThreadPermissionObserverIdentifier.h:
* Source/WebCore/Modules/web-locks/WebLockIdentifier.h:
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.h:
* Source/WebCore/Modules/websockets/WebSocketChannelInspector.h:
* Source/WebCore/Modules/websockets/WebSocketIdentifier.h:
* Source/WebCore/dom/BroadcastChannelIdentifier.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/inspector/InspectorInstrumentation.h:
* Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::didLoadResourceFromMemoryCache):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::tryLoadingSubstituteData):
(WebCore::DocumentLoader::loadMainResource):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::loadRequest):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::requestFromDelegate):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::startPingLoad):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::willSendRequestInternal):
* Source/WebCore/loader/ResourceLoaderIdentifier.h:
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::MainThreadBridge::MainThreadBridge):
* Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp:
(WebCore::ApplicationCacheGroup::update):
(WebCore::ApplicationCacheGroup::startLoadingEntry):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::load):
* Source/WebCore/page/SecurityOriginData.h:
* Source/WebCore/platform/graphics/RenderingResourceIdentifier.h:
* Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.h:
* Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h:
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp:
(WebCore::RenderSVGResourceLinearGradient::buildGradient const):
* Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp:
(WebCore::RenderSVGResourceRadialGradient::buildGradient const):
* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
(WebCoreTestSupport::setupNewlyCreatedServiceWorker):
* Source/WebCore/workers/service/ServiceWorkerClients.h:
* Source/WebCore/workers/service/ServiceWorkerIdentifier.h:
* Source/WebCore/workers/service/ServiceWorkerTypes.h:
* Source/WebCore/workers/service/server/RegistrationDatabase.cpp:
(WebCore::RegistrationDatabase::importRecords):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::updateWorker):
(WebCore::SWServer::softUpdate):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::didReceiveMessage):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::escapeIDForJSON):
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineCaches.cpp:
(WebKit::CacheStorage::Caches::open):
(WebKit::CacheStorage::Caches::readCachesFromDisk):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::Connection):
(IPC::Connection::dispatchMessage):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithAsyncReply):
(IPC::Connection::send):
(IPC::Connection::sendSync):
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::waitForAsyncReplyAndDispatchImmediately):
* Source/WebKit/Platform/IPC/MessageSender.h:
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::send):
(IPC::MessageSender::sendSync):
(IPC::MessageSender::sendWithAsyncReply):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::sendWithAsyncReply):
(IPC::StreamClientConnection::sendSync):
(IPC::StreamClientConnection::waitForAndDispatchImmediately):
* Source/WebKit/Shared/StorageAreaIdentifier.h:
* Source/WebKit/Shared/WebsiteData/QuotaIncreaseRequestIdentifier.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteSerializedImageBufferIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h:
* Source/WebKit/WebProcess/GPU/webrtc/VideoDecoderIdentifier.h:
* Source/WebKit/WebProcess/GPU/webrtc/VideoEncoderIdentifier.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::didReceiveMessage):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::startPingLoad):
(WebKit::WebLoaderStrategy::preconnectTo):
* Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp:
(WebKit::WebSocketChannelManager::didReceiveMessage):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.cpp:
(WebKit::LibWebRTCSocket::LibWebRTCSocket):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::sendH2Ping):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:
* Source/WebCore/dom/MessageChannel.cpp:
(WebCore::generateMessagePorts):
* Source/WebCore/dom/PortIdentifier.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isMessagePortAlive const):
* Source/WebKit/WebProcess/GPU/graphics/DisplayListRecorderFlushIdentifier.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderFlushIdentifier.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::flushDrawingContextAsync):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::didReceiveMessage):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolverIdentifier.h:

Canonical link: <a href="https://commits.webkit.org/262749@main">https://commits.webkit.org/262749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c7e6c3e2514e656b51acf7b09bb082644054395

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2417 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3678 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2459 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2149 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3487 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2038 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2022 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2269 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2192 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3358 "261 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2317 "Built successfully and passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2216 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2004 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2490 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2168 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/561 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/612 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2159 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2542 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2331 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/673 "Passed tests") | 
<!--EWS-Status-Bubble-End-->