### PR TITLE
[GStreamer] test fast/mediastream/getDisplayMedia-size.html fails

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1669,9 +1669,9 @@ webkit.org/b/79203 fast/mediastream/RTCPeerConnection-stats.html [ Timeout Crash
 webkit.org/b/79203 webkit.org/b/186678 fast/mediastream/MediaStream-video-element-track-stop.html [ Timeout Failure Crash ]
 webkit.org/b/230415 fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html [ Timeout ]
 webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Timeout Failure Pass ]
-webkit.org/b/233731 fast/mediastream/getDisplayMedia-size.html [ Failure ]
-fast/mediastream/mediastreamtrack-configurationchange.html [ Failure ]
-fast/mediastream/getDisplayMedia-displaySurface.html [ Failure ]
+
+# This ends up calling WKPageTriggerMockMicrophoneConfigurationChange which is specific to GPUProcess.
+fast/mediastream/mediastreamtrack-configurationchange.html [ Skip ]
 
 fast/mediastream/MediaDevices-addEventListener.html [ DumpJSConsoleLogInStdErr ]
 

--- a/LayoutTests/platform/glib/fast/mediastream/getDisplayMedia-size-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/getDisplayMedia-size-expected.txt
@@ -1,0 +1,7 @@
+
+
+PASS Ensure getDisplayMedia size can be reduced with applyConstraints
+PASS Ensure getDisplayMedia size can be increased with applyConstraints
+PASS original source should stay at a small size
+PASS original source should stay at a big size
+

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h
@@ -40,9 +40,9 @@ private:
     bool canResizeVideoFrames() const final { return true; }
 };
 
-class MockDisplayCaptureSourceGStreamer final : public RealtimeMediaSource, RealtimeMediaSource::VideoFrameObserver {
+class MockDisplayCaptureSourceGStreamer : public RealtimeVideoCaptureSource, RealtimeMediaSource::VideoFrameObserver {
 public:
-    static CaptureSourceOrError create(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*);
+    static CaptureSourceOrError create(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier);
 
     void requestToEnd(Observer&) final;
     bool isProducingData() const final { return m_source->isProducingData(); }
@@ -52,8 +52,10 @@ protected:
     // RealtimeMediaSource::VideoFrameObserver
     void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) final;
 
+    void generatePresets() override { };
+
 private:
-    MockDisplayCaptureSourceGStreamer(const CaptureDevice&, Ref<MockRealtimeVideoSourceGStreamer>&&, MediaDeviceHashSalts&&);
+    MockDisplayCaptureSourceGStreamer(const CaptureDevice&, Ref<MockRealtimeVideoSourceGStreamer>&&, MediaDeviceHashSalts&&, PageIdentifier);
     ~MockDisplayCaptureSourceGStreamer();
 
     void startProducingData() final { m_source->start(); }
@@ -62,7 +64,7 @@ private:
     bool isCaptureSource() const final { return true; }
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;
-    CaptureDevice::DeviceType deviceType() const { return m_deviceType; }
+    CaptureDevice::DeviceType deviceType() const final { return m_deviceType; }
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const final { return "MockDisplayCaptureSourceGStreamer"; }

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -189,8 +189,7 @@ public:
 #if PLATFORM(MAC)
             return DisplayCaptureSourceCocoa::create(UniqueRef<DisplayCaptureSourceCocoa::Capturer>(makeUniqueRef<MockDisplayCapturer>(device, pageIdentifier)), device, WTFMove(hashSalts), constraints, pageIdentifier);
 #elif USE(GSTREAMER)
-            UNUSED_PARAM(pageIdentifier);
-            return MockDisplayCaptureSourceGStreamer::create(device, WTFMove(hashSalts), constraints);
+            return MockDisplayCaptureSourceGStreamer::create(device, WTFMove(hashSalts), constraints, pageIdentifier);
 #else
             return MockRealtimeVideoSource::create(String { device.persistentId() }, AtomString { device.label() }, WTFMove(hashSalts), constraints, pageIdentifier);
 #endif

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -70,6 +70,8 @@ protected:
     IntSize captureSize() const;
 
 private:
+    friend class MockDisplayCaptureSourceGStreamer;
+
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;
 


### PR DESCRIPTION
#### e5975bd98661d2dc24e807170ca625bacbbc498b
<pre>
[GStreamer] test fast/mediastream/getDisplayMedia-size.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=233731">https://bugs.webkit.org/show_bug.cgi?id=233731</a>

Reviewed by Xabier Rodriguez-Calvar.

The main fix here is to wrap the MockDisplayCaptureSourceGStreamer in a RealtimeVideoSource, same
logic as the MockRealtimeVideoSourceGStreamer.

This patch also fixes fast/mediastream/getDisplayMedia-displaySurface.html by adjusting the source
settings displaySurface, depending on which surface we&apos;re behaving as. The non-mock GStreamer
DisplayCapture source will need to set this setting too, but that&apos;s going to be addressed in a
follow-up patch.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp:
(WebCore::MockDisplayCaptureSourceGStreamer::create):
(WebCore::MockDisplayCaptureSourceGStreamer::MockDisplayCaptureSourceGStreamer):
(WebCore::MockDisplayCaptureSourceGStreamer::settings):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h:
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:

Canonical link: <a href="https://commits.webkit.org/262825@main">https://commits.webkit.org/262825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/902e215111e1428f2e2f87cf6902bf8972179c9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2602 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1577 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2450 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1429 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1539 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1515 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2623 "run-api-tests-without-change (failure)") | 
| | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1540 "5 failures") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1400 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1505 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/669 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->