### PR TITLE
Make priority hints tests more stable

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6296,6 +6296,4 @@ imported/w3c/web-platform-tests/css/css-ruby/ruby-whitespace-002.html [ ImageOnl
 imported/w3c/web-platform-tests/css/css-ruby/ruby-with-floats-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-ruby/ruby-with-floats-003.html [ ImageOnlyFailure ]
 
-webkit.org/b/254259 http/tests/priority-hints/fetch-api-priority.html [ Failure Pass ]
-
 webkit.org/b/242658 http/tests/media/user-gesture-preserved-across-xmlhttprequest.html [ Slow Pass Failure ]

--- a/LayoutTests/http/tests/priority-hints/link-preload-dynamic-insertion.html
+++ b/LayoutTests/http/tests/priority-hints/link-preload-dynamic-insertion.html
@@ -98,7 +98,7 @@
       link.as = test.as;
       if (test.fetchPriority) link.fetchPriority = test.fetchPriority;
 
-      const url = new URL(`../resources/${test.resource}?${iteration++}`, location);
+      const url = new URL(`../resources/${test.resource}?lpdi${iteration++}`, location);
       link.href = url;
       link.onload = t.step_func(() => { checkResourcePriority(url, test.expected_priority, test.description); t.done(); });
       document.head.appendChild(link);

--- a/LayoutTests/http/tests/priority-hints/link-preload-initial-load.html
+++ b/LayoutTests/http/tests/priority-hints/link-preload-initial-load.html
@@ -6,51 +6,51 @@
 <script>
 const priority_tests = [
   {
-    url: new URL('../resources/dummy.css', location), expected_priority: "ResourceLoadPriorityMedium",
+    url: new URL('../resources/dummy.css?lpil', location), expected_priority: "ResourceLoadPriorityMedium",
     description: 'low fetchpriority on <link rel=preload as=style> must be fetched with medium resource load priority'
   },
   {
-    url: new URL('../resources/dummy.css?1', location), expected_priority: "ResourceLoadPriorityHigh",
+    url: new URL('../resources/dummy.css?lpil1', location), expected_priority: "ResourceLoadPriorityHigh",
     description: 'missing fetchpriority on <link rel=preload as=style> must have no effect on resource load priority'
   },
   {
-    url: new URL('../resources/dummy.css?2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    url: new URL('../resources/dummy.css?lpil2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
     description: 'high fetchpriority on <link rel=preload as=style> must be fetched with very high resource load priority'
   },
   {
-    url: new URL('../resources/dummy.js', location), expected_priority: "ResourceLoadPriorityMedium",
+    url: new URL('../resources/dummy.js?lpil', location), expected_priority: "ResourceLoadPriorityMedium",
     description: 'low fetchpriority on <link rel=preload as=script> must be fetched with medium resource load priority'
   },
   {
-    url: new URL('../resources/dummy.js?1', location), expected_priority: "ResourceLoadPriorityHigh",
+    url: new URL('../resources/dummy.js?lpil1', location), expected_priority: "ResourceLoadPriorityHigh",
     description: 'missing fetchpriority on <link rel=preload as=script> must have no effect on resource load priority'
   },
   {
-    url: new URL('../resources/dummy.js?2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    url: new URL('../resources/dummy.js?lpil2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
     description: 'high fetchpriority on <link rel=preload as=script> must be fetched with very high resource load priority'
   },
   {
-    url: new URL('../resources/dummy.txt', location), expected_priority: "ResourceLoadPriorityLow",
+    url: new URL('../resources/dummy.txt?lpil', location), expected_priority: "ResourceLoadPriorityLow",
     description: 'low fetchpriority on <link rel=preload as=fetch> must be fetched with low resource load priority'
   },
   {
-    url: new URL('../resources/dummy.txt?1', location), expected_priority: "ResourceLoadPriorityMedium",
+    url: new URL('../resources/dummy.txt?lpil1', location), expected_priority: "ResourceLoadPriorityMedium",
     description: 'missing fetchpriority on <link rel=preload as=fetch> must have no effect on resource load priority'
   },
   {
-    url: new URL('../resources/dummy.txt?2', location), expected_priority: "ResourceLoadPriorityHigh",
+    url: new URL('../resources/dummy.txt?lpil2', location), expected_priority: "ResourceLoadPriorityHigh",
     description: 'high fetchpriority on <link rel=preload as=fetch> must be fetched with high resource load priority'
   },
   {
-    url: new URL('../resources/square.png', location), expected_priority: "ResourceLoadPriorityVeryLow",
+    url: new URL('../resources/square.png?lpil', location), expected_priority: "ResourceLoadPriorityVeryLow",
     description: 'low fetchpriority on <link rel=preload as=image> must be fetched with very low resource load priority'
   },
   {
-    url: new URL('../resources/square.png?1', location), expected_priority: "ResourceLoadPriorityLow",
+    url: new URL('../resources/square.png?lpil1', location), expected_priority: "ResourceLoadPriorityLow",
     description: 'missing fetchpriority on <link rel=preload as=image> must have no effect on resource load priority'
   },
   {
-    url: new URL('../resources/square.png?2', location), expected_priority: "ResourceLoadPriorityMedium",
+    url: new URL('../resources/square.png?lpil2', location), expected_priority: "ResourceLoadPriorityMedium",
     description: 'high fetchpriority on <link rel=preload as=image> must be fetched with medium resource load priority'
   }
 ];
@@ -58,24 +58,24 @@ const priority_tests = [
 
 <!-- as=style -->
 <!-- don't need to test for invalid and explicit auto fetchpriority here, since we already do that in the other link test -->
-<link id=link1 fetchpriority=low rel=preload as=style href=../resources/dummy.css>
-<link id=link2 rel=preload as=style href=../resources/dummy.css?1>
-<link id=link3 fetchpriority=high rel=preload as=style href=../resources/dummy.css?2>
+<link id=link1 fetchpriority=low rel=preload as=style href=../resources/dummy.css?lpil>
+<link id=link2 rel=preload as=style href=../resources/dummy.css?lpil1>
+<link id=link3 fetchpriority=high rel=preload as=style href=../resources/dummy.css?lpil2>
 
 <!-- as=script-->
-<link id=link4 fetchpriority=low rel=preload as=script href=../resources/dummy.js>
-<link id=link5 rel=preload as=script href=../resources/dummy.js?1>
-<link id=link6 fetchpriority=high rel=preload as=script href=../resources/dummy.js?2>
+<link id=link4 fetchpriority=low rel=preload as=script href=../resources/dummy.js?lpil>
+<link id=link5 rel=preload as=script href=../resources/dummy.js?lpil1>
+<link id=link6 fetchpriority=high rel=preload as=script href=../resources/dummy.js?lpil2>
 
 <!-- as=fetch-->
-<link id=link7 fetchpriority=low rel=preload as=fetch href=../resources/dummy.txt>
-<link id=link8 rel=preload as=fetch href=../resources/dummy.txt?1>
-<link id=link9 fetchpriority=high rel=preload as=fetch href=../resources/dummy.txt?2>
+<link id=link7 fetchpriority=low rel=preload as=fetch href=../resources/dummy.txt?lpil>
+<link id=link8 rel=preload as=fetch href=../resources/dummy.txt?lpil1>
+<link id=link9 fetchpriority=high rel=preload as=fetch href=../resources/dummy.txt?lpil2>
 
 <!-- as=image-->
-<link id=link10 fetchpriority=low rel=preload as=image href=../resources/square.png>
-<link id=link11 rel=preload as=image href=../resources/square.png?1>
-<link id=link12 fetchpriority=high rel=preload as=image href=../resources/square.png?2>
+<link id=link10 fetchpriority=low rel=preload as=image href=../resources/square.png?lpil>
+<link id=link11 rel=preload as=image href=../resources/square.png?lpil1>
+<link id=link12 fetchpriority=high rel=preload as=image href=../resources/square.png?lpil2>
 
 <script>
   promise_test(async (t) => {


### PR DESCRIPTION
#### f64fa8056486d65e3f6791c1a98415693d9580d8
<pre>
Make priority hints tests more stable
<a href="https://bugs.webkit.org/show_bug.cgi?id=254885">https://bugs.webkit.org/show_bug.cgi?id=254885</a>

Reviewed by Alexey Proskuryakov.

Some priority hints tests do not produce unique urls, causing failures when using multiple
iterations, fix that by using unique prefixes.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/priority-hints/link-preload-dynamic-insertion.html:
* LayoutTests/http/tests/priority-hints/link-preload-initial-load.html:

Canonical link: <a href="https://commits.webkit.org/262499@main">https://commits.webkit.org/262499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0195b55a7737febb7d70899140acda279cc9cec2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2593 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1793 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1570 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2430 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1412 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1530 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1532 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2597 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1393 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1497 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/417 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1627 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->