### PR TITLE
Handle lone surrogates correctly for non-UTF-8 encodings

### DIFF
--- a/LayoutTests/fast/url/query-expected.txt
+++ b/LayoutTests/fast/url/query-expected.txt
@@ -8,7 +8,7 @@ PASS canonicalize('http://www.example.com/?as?df') is 'http://www.example.com/?a
 PASS canonicalize('http://www.example.com/?\x02hello bye') is 'http://www.example.com/?%02hello%7F%20bye'
 PASS canonicalize('http://www.example.com/?%40%41123') is 'http://www.example.com/?%40%41123'
 PASS canonicalize('http://www.example.com/?q=你好') is 'http://www.example.com/?q=%26%2320320%3B%26%2322909%3B'
-PASS canonicalize('http://www.example.com/?q=\ud800\ud800') is 'http://www.example.com/?q=%26%2355296%3B%26%2355296%3B'
+PASS canonicalize('http://www.example.com/?q=\ud800\ud800') is 'http://www.example.com/?q=%26%2365533%3B%26%2365533%3B'
 PASS canonicalize('http://www.example.com/?q=<asdf>') is 'http://www.example.com/?q=%3Casdf%3E'
 PASS canonicalize('http://www.example.com/?q="asdf"') is 'http://www.example.com/?q=%22asdf%22'
 PASS successfullyParsed is true

--- a/LayoutTests/fast/url/query.html
+++ b/LayoutTests/fast/url/query.html
@@ -9,7 +9,7 @@
 <script>
 description("Test URLs that have a query string.");
 
-cases = [ 
+cases = [
   // Regular ASCII case in some different encodings.
   ["foo=bar", "foo=bar"],
   // Allow question marks in the query without escaping
@@ -22,8 +22,8 @@ cases = [
   ["%40%41123", "%40%41123"],
   // Chinese input/output
   ["q=\u4F60\u597D", "q=%26%2320320%3B%26%2322909%3B"],
-  // Invalid UTF-8/16 input should be replaced with invalid characters.
-  ["q=\\ud800\\ud800", "q=%26%2355296%3B%26%2355296%3B"],
+  // Invalid UTF-16 input (i.e., lone surrogates) should be replaced with U+FFFD.
+  ["q=\\ud800\\ud800", "q=%26%2365533%3B%26%2365533%3B"],
   // Don't allow < or > because sometimes they are used for XSS if the
   // URL is echoed in content. Firefox does this, IE doesn't.
   ["q=<asdf>", "q=%3Casdf%3E"],

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/lone-surrogates.sub_encoding=windows-1252-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/lone-surrogates.sub_encoding=windows-1252-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Query parsing with lone surrogates in windows-1252 assert_true: http://localhost:8800/html/infrastructure/urls/resolving-urls/query-encoding/lone-surrogates.sub.html?%26%2355296%3B did not end with ?%26%2365533%3B expected true got false
+PASS Query parsing with lone surrogates in windows-1252
 

--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -21,7 +21,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -34,6 +34,14 @@ namespace PAL {
 
 int TextCodec::getUnencodableReplacement(UChar32 codePoint, UnencodableHandling handling, UnencodableReplacementArray& replacement)
 {
+    ASSERT(!(codePoint > 0x10FFFF));
+
+    // The Encoding Standard doesn't have surrogate code points in the input, but that would require
+    // scanning and potentially manipulating inputs ahead of time. Instead handle them at the last
+    // possible point.
+    if (codePoint >= 0xD800 && codePoint <= 0xDFFF)
+        codePoint = 0xFFFD;
+
     switch (handling) {
     case UnencodableHandling::QuestionMarks:
         replacement.data()[0] = '?';


### PR DESCRIPTION
#### 8a954b16d853431cc8dfd069e2994cf4904ca3e3
<pre>
Handle lone surrogates correctly for non-UTF-8 encodings
<a href="https://bugs.webkit.org/show_bug.cgi?id=254888">https://bugs.webkit.org/show_bug.cgi?id=254888</a>
rdar://107530253

Reviewed by Alexey Proskuryakov.

Replace lone surrogates with the replacement code point. Unlike the standard our encoders operate on code points and turning those into scalar values ahead-of-time would be expensive. The next best thing is not surfacing the consequences thereof.

* LayoutTests/fast/url/query-expected.txt:
* LayoutTests/fast/url/query.html:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/lone-surrogates.sub_encoding=windows-1252-expected.txt:
* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::getUnencodableReplacement):

Canonical link: <a href="https://commits.webkit.org/262513@main">https://commits.webkit.org/262513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f57cf5d5adeef7b15137db2ae1e7cb08e60ab44a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1578 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2440 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1420 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1540 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2616 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1401 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1506 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/430 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1637 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->