### PR TITLE
Refactor some network connection integrity code

### DIFF
--- a/Source/WebCore/page/LookalikeCharactersSanitizationData.h
+++ b/Source/WebCore/page/LookalikeCharactersSanitizationData.h
@@ -35,7 +35,7 @@ struct LookalikeCharactersSanitizationData {
     String lookalikeCharacters;
 
     LookalikeCharactersSanitizationData(RegistrableDomain&& domain, const String& lookalikeCharacters)
-        : domain(domain)
+        : domain(WTFMove(domain))
         , lookalikeCharacters(lookalikeCharacters)
     {
     }
@@ -49,6 +49,22 @@ struct LookalikeCharactersSanitizationData {
     LookalikeCharactersSanitizationData(const String& lookalikeCharacters)
         : lookalikeCharacters(lookalikeCharacters)
     {
+    }
+
+    LookalikeCharactersSanitizationData(const LookalikeCharactersSanitizationData&) = default;
+    LookalikeCharactersSanitizationData& operator=(const LookalikeCharactersSanitizationData&) = default;
+
+    LookalikeCharactersSanitizationData(LookalikeCharactersSanitizationData&& data)
+        : domain(WTFMove(data.domain))
+        , lookalikeCharacters(WTFMove(data.lookalikeCharacters))
+    {
+    }
+
+    LookalikeCharactersSanitizationData& operator=(LookalikeCharactersSanitizationData&& data)
+    {
+        domain = WTFMove(data.domain);
+        lookalikeCharacters = WTFMove(data.lookalikeCharacters);
+        return *this;
     }
 
     template<class Encoder> void encode(Encoder& encoder) const

--- a/Source/WebKit/Platform/cocoa/NetworkConnectionIntegrityHelpers.h
+++ b/Source/WebKit/Platform/cocoa/NetworkConnectionIntegrityHelpers.h
@@ -45,7 +45,7 @@ namespace WebKit {
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
 
 void configureForNetworkConnectionIntegrity(NSURLSession *);
-void requestAllowedLookalikeCharacterStrings(CompletionHandler<void(const Vector<WebCore::LookalikeCharactersSanitizationData>&)>&&);
+void requestAllowedLookalikeCharacterStrings(CompletionHandler<void(Vector<WebCore::LookalikeCharactersSanitizationData>&&)>&&);
 
 class LookalikeCharactersObserver : public RefCounted<LookalikeCharactersObserver>, public CanMakeWeakPtr<LookalikeCharactersObserver> {
 public:

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12289,12 +12289,12 @@ void WebPageProxy::updateAllowedLookalikeCharacterStringsIfNeeded()
     if (!cachedAllowedLookalikeStrings().isEmpty())
         return;
 
-    requestAllowedLookalikeCharacterStrings([weakPage = WeakPtr { *this }](auto&& data) {
+    requestAllowedLookalikeCharacterStrings([weakPage = WeakPtr { *this }](auto&& data) mutable {
         if (cachedAllowedLookalikeStrings().isEmpty()) {
             cachedAllowedLookalikeStrings() = WTFMove(data);
             cachedAllowedLookalikeStrings().shrinkToFit();
         }
-        
+
         if (RefPtr page = weakPage.get(); page && page->hasRunningProcess())
             page->send(Messages::WebPage::SetAllowedLookalikeCharacterStrings(cachedAllowedLookalikeStrings()));
     });


### PR DESCRIPTION
#### c9e61964956a8cb9edc38279a8d8084b3e737d99
<pre>
Refactor some network connection integrity code
<a href="https://bugs.webkit.org/show_bug.cgi?id=254893">https://bugs.webkit.org/show_bug.cgi?id=254893</a>
rdar://107535003

Reviewed by Megan Gardner.

See below for more details.

* Source/WebCore/page/LookalikeCharactersSanitizationData.h:
(WebCore::LookalikeCharactersSanitizationData::LookalikeCharactersSanitizationData):

Add a missing `WTFMove` on the given rvalue reference for `domain`, and implement:
- The copy constructor and assignment operator.
- The move constructor and assignment operator.
...for the `LookalikeCharactersSanitizationData` class.

(WebCore::LookalikeCharactersSanitizationData::operator=):
* Source/WebKit/Platform/cocoa/NetworkConnectionIntegrityHelpers.h:

Change this helper to pass back a `Vector&amp;&amp;` instead of `const Vector&amp;`.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateAllowedLookalikeCharacterStringsIfNeeded):

Add `mutable` to a lambda blocks where we use `WTFMove` on the argument.

Canonical link: <a href="https://commits.webkit.org/262529@main">https://commits.webkit.org/262529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f5e91165bf963a78db93dc822d99a22ff15c622

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1830 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1605 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2469 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1446 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1566 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2638 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1422 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1528 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/443 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1662 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->