### PR TITLE
Unreviewed, fix PlayStation build after 262488@main

### DIFF
--- a/Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp
@@ -34,6 +34,7 @@
 #include "WKAPICast.h"
 #include "WebEventFactory.h"
 #include "WebPageProxy.h"
+#include <WebCore/Region.h>
 #include <cairo.h>
 #include <wpe/wpe.h>
 

--- a/Source/WebKit/UIProcess/API/C/playstation/WKView.cpp
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKView.cpp
@@ -26,12 +26,14 @@
 #include "config.h"
 #include "WKView.h"
 
+#include "APIClient.h"
 #include "APIPageConfiguration.h"
 #include "APIViewClient.h"
 #include "PlayStationWebView.h"
 #include "WKAPICast.h"
 #include "WKSharedAPICast.h"
 #include <WebCore/Cursor.h>
+#include <WebCore/Region.h>
 
 namespace API {
 template<> struct ClientTraits<WKViewClientBase> {

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -29,6 +29,8 @@
 #include "DrawingAreaProxyCoordinatedGraphics.h"
 #include "PlayStationWebView.h"
 #include "WebPageProxy.h"
+#include <WebCore/DOMPasteAccess.h>
+#include <WebCore/NotImplemented.h>
 
 #if USE(GRAPHICS_LAYER_WC)
 #include "DrawingAreaProxyWC.h"

--- a/Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp
+++ b/Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp
@@ -29,6 +29,7 @@
 #include "EditorState.h"
 #include "WebsiteDataStore.h"
 #include <WebCore/NotImplemented.h>
+#include <WebCore/SearchPopupMenu.h>
 #include <WebCore/UserAgent.h>
 
 namespace WebKit {


### PR DESCRIPTION
#### dd452a4fb465833ed5a95827102143f36bf58aa3
<pre>
Unreviewed, fix PlayStation build after 262488@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=254895">https://bugs.webkit.org/show_bug.cgi?id=254895</a>

The refactor in 262488@main incurred lots of missing includes in platform-specific files; hopefully this is all of them.

* Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp:
* Source/WebKit/UIProcess/API/C/playstation/WKView.cpp:
* Source/WebKit/UIProcess/playstation/PageClientImpl.cpp:
* Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp:

Canonical link: <a href="https://commits.webkit.org/262497@main">https://commits.webkit.org/262497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/535dfd75f27508c3773c35eb73c72631552dd5f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2632 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1831 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1804 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1724 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2470 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/1522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1567 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1599 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1519 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/1529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1663 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/178 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->