### PR TITLE
[Cocoa] Migrate OpticalSizingType from an enum to a variant

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
@@ -70,16 +70,19 @@ public:
 private:
     CGFloat getSize() const;
 
-    enum class OpticalSizingType : uint8_t {
-        None,
-        JustVariation,
-        Everything,
+    struct OpticalSizingTypes { // Ideally this would be a namespace, but clang doesn't seem to let you define a namespace inside a class.
+        // When USE(CORE_TEXT_OPTICAL_SIZING_WORKAROUND) is no longer necessary, we can migrate this back to an enum.
+        struct None { };
+        struct JustVariation { };
+        struct Everything { };
     };
 
-    static void modifyFromContext(CFMutableDictionaryRef attributes, const FontDescription&, const FontCreationContext&, ApplyTraitsVariations, float weight, float width, float slope, CGFloat size, OpticalSizingType);
+    using OpticalSizingType = std::variant<OpticalSizingTypes::None, OpticalSizingTypes::JustVariation, OpticalSizingTypes::Everything>;
+
+    static void modifyFromContext(CFMutableDictionaryRef attributes, const FontDescription&, const FontCreationContext&, ApplyTraitsVariations, float weight, float width, float slope, CGFloat size, const OpticalSizingType&);
 
     using VariationsMap = HashMap<FontTag, float, FourCharacterTagHash, FourCharacterTagHashTraits>;
-    static void addAttributesForOpticalSizing(CFMutableDictionaryRef attributes, VariationsMap& variationsToBeApplied, OpticalSizingType, CGFloat size);
+    static void addAttributesForOpticalSizing(CFMutableDictionaryRef attributes, VariationsMap& variationsToBeApplied, const OpticalSizingType&, CGFloat size);
     static void applyVariations(CFMutableDictionaryRef attributes, const VariationsMap& variationsToBeApplied);
 
     std::variant<RetainPtr<CTFontRef>, RetainPtr<CTFontDescriptorRef>> m_baseFont;
@@ -91,7 +94,7 @@ private:
     float m_slope { 0 };
     CGFloat m_size { 0 };
     FontStyleAxis m_fontStyleAxis { FontStyleAxis::slnt };
-    OpticalSizingType m_opticalSizingType { OpticalSizingType::None };
+    OpticalSizingType m_opticalSizingType { OpticalSizingTypes::None { } };
     FontVariationSettings m_variationSettings;
 };
 


### PR DESCRIPTION
#### f59b6cd00f1c4ab23bcc09cbe8bfbb6025e79d35
<pre>
[Cocoa] Migrate OpticalSizingType from an enum to a variant
<a href="https://bugs.webkit.org/show_bug.cgi?id=254896">https://bugs.webkit.org/show_bug.cgi?id=254896</a>
rdar://107538476

Reviewed by Alan Baradlay.

This is the first half of the fix to &lt;rdar://problem/106814619&gt;. For that bug, the
OpticalSizingType::Everything enum value needs an accompanying data field (to tell
Core Text which value to use for optical sizing). C++ enums can&apos;t store accompanying
data fields, so we need to use a variant instead.

This patch just migrates to the variant, so the actual fix (applied on top of this
patch) is easier to understand.

No test because there is no behavior change.

* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp:
(WebCore::UnrealizedCoreTextFont::addAttributesForOpticalSizing):
(WebCore::UnrealizedCoreTextFont::modifyFromContext):
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h:

Canonical link: <a href="https://commits.webkit.org/262554@main">https://commits.webkit.org/262554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/727d5e38faffb81addee1ad68497645a8ba8bfc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2633 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1607 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1447 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1568 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1566 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2639 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1600 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1425 "10 flakes 1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1530 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/457 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1664 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->