### PR TITLE
Web Inspector: Regression(261966@main) Popovers are 2x the correct size on 2x displays

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/Popover.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Popover.css
@@ -40,6 +40,8 @@
     position: absolute;
     inset: 0;
     z-index : -1;
+    width: 100%;
+    height: 100%;
 }
 
 .popover.arrow-up {


### PR DESCRIPTION
#### 63cd0995822b54b725b9746dbd3c7e23f2ce81fb
<pre>
Web Inspector: Regression(261966@main) Popovers are 2x the correct size on 2x displays
<a href="https://bugs.webkit.org/show_bug.cgi?id=254899">https://bugs.webkit.org/show_bug.cgi?id=254899</a>
rdar://107539887

Reviewed by Devin Rousso.

The popover&apos;s background must explicitly be told to size itself to match the popover, otherwise it will be laid out at
the size defined by its width and height attribute which are used to determine the number of actual pixels the canvas
should have, while the number of screen points those pixels should fit in may be less than the number of pixels if a
display scale factor is present, like on a Retina display.

* Source/WebInspectorUI/UserInterface/Views/Popover.css:
(.popover &gt; .background-canvas):

Canonical link: <a href="https://commits.webkit.org/262510@main">https://commits.webkit.org/262510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e8b1e66dde7cf1d214bb2afb46c2f62cbdbb07f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2647 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1845 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1619 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2485 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1534 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1460 "145 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1582 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2655 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1436 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1541 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/428 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1677 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->