### PR TITLE
Remove UnencodableHandling::QuestionMarks

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -43,10 +43,6 @@ int TextCodec::getUnencodableReplacement(UChar32 codePoint, UnencodableHandling 
         codePoint = 0xFFFD;
 
     switch (handling) {
-    case UnencodableHandling::QuestionMarks:
-        replacement.data()[0] = '?';
-        replacement.data()[1] = 0;
-        return 1;
     case UnencodableHandling::Entities:
         return snprintf(replacement.data(), sizeof(UnencodableReplacementArray), "&#%u;", codePoint);
     case UnencodableHandling::URLEncodedEntities:

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -94,12 +94,12 @@ void TextCodecCJK::registerEncodingNames(EncodingNameRegistrar registrar)
         "ksc5601",
         "ksc_5601",
         "windows-949",
-        
+
         // These aliases are not in the specification, but WebKit has historically supported them.
         "x-windows-949",
         "x-uhc",
     });
-    
+
     registerAliases({
         "ISO-2022-JP",
         "csiso2022jp"
@@ -423,7 +423,7 @@ String TextCodecCJK::iso2022JPDecode(const uint8_t* bytes, size_t length, bool f
         }
         return SawError::No;
     };
-    
+
     StringBuilder result;
     result.reserveCapacity(length);
 
@@ -506,14 +506,14 @@ static Vector<uint8_t> iso2022JPEncode(StringView string, Function<void(UChar32,
 
     Vector<uint8_t> result;
     result.reserveInitialCapacity(string.length());
-    
+
     auto changeStateToASCII = [&] {
         state = State::ASCII;
         result.append(0x1B);
         result.append(0x28);
         result.append(0x42);
     };
-    
+
     auto statefulUnencodableHandler = [&] (UChar32 codePoint, Vector<uint8_t>& result) {
         if (state == State::Jis0208)
             changeStateToASCII();
@@ -588,14 +588,14 @@ static Vector<uint8_t> iso2022JPEncode(StringView string, Function<void(UChar32,
         result.append(*pointer / 94 + 0x21);
         result.append(*pointer % 94 + 0x21);
     };
-    
+
     auto characters = string.upconvertedCharacters();
     for (WTF::CodePointIterator<UChar> iterator(characters.get(), characters.get() + string.length()); !iterator.atEnd(); ++iterator)
         parseCodePoint(*iterator);
 
     if (state != State::ASCII)
         changeStateToASCII();
-    
+
     return result;
 }
 
@@ -664,7 +664,7 @@ static Vector<uint8_t> shiftJISEncode(StringView string, Function<void(UChar32, 
         }
         if (codePoint == 0x2212)
             codePoint = 0xFF0D;
-        
+
         auto range = findInSortedPairs(jis0208EncodeIndex(), codePoint);
         if (range.first == range.second) {
             unencodableHandler(codePoint, result);
@@ -718,7 +718,7 @@ static Vector<uint8_t> eucKREncode(StringView string, Function<void(UChar32, Vec
             result.append(codePoint);
             continue;
         }
-        
+
         auto pointer = findFirstInSortedPairs(eucKREncodingIndex(), codePoint);
         if (!pointer) {
             unencodableHandler(codePoint, result);
@@ -806,7 +806,7 @@ static Vector<uint8_t> big5Encode(StringView string, Function<void(UChar32, Vect
             unencodableHandler(codePoint, result);
             continue;
         }
-        
+
         uint8_t lead = pointer / 157 + 0x81;
         uint8_t trail = pointer % 157;
         uint8_t offset = trail < 0x3F ? 0x40 : 0x62;
@@ -1081,16 +1081,9 @@ static void entityUnencodableHandler(UChar32 c, Vector<uint8_t>& result)
     result.uncheckedAppend(';');
 }
 
-static void questionMarkUnencodableHandler(UChar32, Vector<uint8_t>& result)
-{
-    result.append('?');
-}
-
 Function<void(UChar32, Vector<uint8_t>&)> unencodableHandler(UnencodableHandling handling)
 {
     switch (handling) {
-    case UnencodableHandling::QuestionMarks:
-        return questionMarkUnencodableHandler;
     case UnencodableHandling::Entities:
         return entityUnencodableHandler;
     case UnencodableHandling::URLEncodedEntities:

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -21,7 +21,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -220,7 +220,7 @@ String TextCodecICU::decode(const char* bytes, size_t length, bool flush, bool s
             return { };
         }
     }
-    
+
     ErrorCallbackSetter callbackSetter(*m_converter, stopOnError);
 
     StringBuilder result;
@@ -286,16 +286,6 @@ Vector<uint8_t> TextCodecICU::encode(StringView string, UnencodableHandling hand
 
     UErrorCode error;
     switch (handling) {
-    case UnencodableHandling::QuestionMarks:
-        error = U_ZERO_ERROR;
-        ucnv_setSubstChars(m_converter.get(), "?", 1, &error);
-        if (U_FAILURE(error))
-            return { };
-        error = U_ZERO_ERROR;
-        ucnv_setFromUCallBack(m_converter.get(), UCNV_FROM_U_CALLBACK_SUBSTITUTE, 0, 0, 0, &error);
-        if (U_FAILURE(error))
-            return { };
-        break;
     case UnencodableHandling::Entities:
         error = U_ZERO_ERROR;
         ucnv_setFromUCallBack(m_converter.get(), UCNV_FROM_U_CALLBACK_ESCAPE, UCNV_ESCAPE_XML_DEC, 0, 0, &error);

--- a/Source/WebCore/PAL/pal/text/UnencodableHandling.h
+++ b/Source/WebCore/PAL/pal/text/UnencodableHandling.h
@@ -29,10 +29,7 @@ namespace PAL {
 
 // Specifies what will happen when a character is encountered that is
 // not encodable in the character set.
-enum class UnencodableHandling {
-    // Substitutes the replacement character "?".
-    QuestionMarks,
-
+enum class UnencodableHandling: bool {
     // Encodes the character as an XML entity. For example, U+06DE
     // would be "&#1758;" (0x6DE = 1758 in octal).
     Entities,
@@ -44,4 +41,3 @@ enum class UnencodableHandling {
 };
 
 }
-


### PR DESCRIPTION
#### b1d9de61e8c5d8732404998716825483d5a085ef
<pre>
Remove UnencodableHandling::QuestionMarks
<a href="https://bugs.webkit.org/show_bug.cgi?id=254903">https://bugs.webkit.org/show_bug.cgi?id=254903</a>
rdar://107544821

Reviewed by Youenn Fablet.

No code used this value and web standards do not support it.

* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::getUnencodableReplacement):
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::TextCodecCJK::registerEncodingNames):
(PAL::TextCodecCJK::iso2022JPDecode):
(PAL::iso2022JPEncode):
(PAL::shiftJISEncode):
(PAL::eucKREncode):
(PAL::big5Encode):
(PAL::Function&lt;void):
(PAL::questionMarkUnencodableHandler): Deleted.
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::decode):
(PAL::TextCodecICU::encode const):
* Source/WebCore/PAL/pal/text/UnencodableHandling.h:

Canonical link: <a href="https://commits.webkit.org/262522@main">https://commits.webkit.org/262522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3075729d25b285c0930f802884000bf37bb5d806

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1852 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1624 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2495 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1476 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1590 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2663 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1442 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/436 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1683 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->