### PR TITLE
[JSC] Intl tests should support ICU 72 / CLDR 42

### DIFF
--- a/JSTests/stress/intl-displaynames.js
+++ b/JSTests/stress/intl-displaynames.js
@@ -107,7 +107,7 @@ if ($vm.icuVersion() >= 61) {
     // Get display names of script in Traditional Chinese
     scriptNames = new Intl.DisplayNames(['zh-Hant'], {type: 'script'});
     shouldBe(scriptNames.of('Latn'), "拉丁文");
-    shouldBe(scriptNames.of('Arab'), "阿拉伯文");
+    shouldBe(scriptNames.of('Arab'), $vm.icuVersion() >= 72 ? "阿拉伯字母" : "阿拉伯文");
     shouldBe(scriptNames.of('Kana'), "片假名");
 
     if ($vm.icuVersion() >= 64) {

--- a/JSTests/stress/intl-numberformat-unified.js
+++ b/JSTests/stress/intl-numberformat-unified.js
@@ -50,5 +50,5 @@ if ($vm.icuVersion() >= 64 && $vm.icuHeaderVersion() >= 64) {
         style: "currency",
         currency: "USD",
         currencyDisplay: "narrowSymbol"
-    }), `$100.00`);
+    }), $vm.icuVersion() >= 72 ? `US$100.00` : `$100.00`);
 }

--- a/JSTests/stress/intl-relativetimeformat.js
+++ b/JSTests/stress/intl-relativetimeformat.js
@@ -192,7 +192,7 @@ for (let unit of units) {
 
 shouldBe(new Intl.RelativeTimeFormat('en', { style: 'short' }).format(10, 'second'), 'in 10 sec.');
 shouldBe(new Intl.RelativeTimeFormat('ru', { style: 'short' }).format(10, 'second'), 'через 10 сек.');
-shouldBe(new Intl.RelativeTimeFormat('en', { style: 'narrow' }).format(10, 'second'), 'in 10 sec.');
+shouldBe(new Intl.RelativeTimeFormat('en', { style: 'narrow' }).format(10, 'second'), $vm.icuVersion() >= 72 ? 'in 10s' : 'in 10 sec.');
 shouldBe(new Intl.RelativeTimeFormat('ru', { style: 'narrow' }).format(10, 'second'), '+10 с');
 
 shouldBe(new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(0, 'second'), 'now');


### PR DESCRIPTION
#### 45c07eac52a534b1d50c0ef6cd60f43b0df4da8a
<pre>
[JSC] Intl tests should support ICU 72 / CLDR 42
<a href="https://bugs.webkit.org/show_bug.cgi?id=254904">https://bugs.webkit.org/show_bug.cgi?id=254904</a>

Reviewed by Yusuke Suzuki.

A few of our Intl tests have different results with the latest CLDR data, so let&apos;s update them accordingly.

* JSTests/stress/intl-displaynames.js:
* JSTests/stress/intl-numberformat-unified.js:
* JSTests/stress/intl-relativetimeformat.js:

Canonical link: <a href="https://commits.webkit.org/262604@main">https://commits.webkit.org/262604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b38554d65a9d22c0c8a191f151c277695c179c6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2657 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1856 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1625 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2496 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1466 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1464 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1591 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2661 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1659 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1443 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1785 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1543 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1547 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/413 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/501 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1684 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1831 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/527 "Passed tests") | 
<!--EWS-Status-Bubble-End-->