### PR TITLE
[GLIB] Add API to control originStorageRatio and totalStorageRatio

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -83,7 +83,9 @@ enum {
     PROP_SERVICE_WORKER_REGISTRATIONS_DIRECTORY,
     PROP_DOM_CACHE_DIRECTORY,
 #endif
-    PROP_IS_EPHEMERAL
+    PROP_IS_EPHEMERAL,
+    PROP_ORIGIN_STORAGE_RATIO,
+    PROP_TOTAL_STORAGE_RATIO
 };
 
 struct _WebKitWebsiteDataManagerPrivate {
@@ -111,6 +113,9 @@ struct _WebKitWebsiteDataManagerPrivate {
     GUniquePtr<char> swRegistrationsDirectory;
     GUniquePtr<char> domCacheDirectory;
 #endif
+
+    gdouble originStorageRatio;
+    gdouble totalStorageRatio;
 };
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitWebsiteDataManager, webkit_website_data_manager, G_TYPE_OBJECT, GObject)
@@ -212,6 +217,12 @@ static void webkitWebsiteDataManagerSetProperty(GObject* object, guint propID, c
     case PROP_IS_EPHEMERAL:
         if (g_value_get_boolean(value))
             manager->priv->websiteDataStore = WebKit::WebsiteDataStore::createNonPersistent();
+        break;
+    case PROP_ORIGIN_STORAGE_RATIO:
+        manager->priv->originStorageRatio = g_value_get_double(value);
+        break;
+    case PROP_TOTAL_STORAGE_RATIO:
+        manager->priv->totalStorageRatio = g_value_get_double(value);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propID, paramSpec);
@@ -479,6 +490,42 @@ static void webkit_website_data_manager_class_init(WebKitWebsiteDataManagerClass
             nullptr, nullptr,
             FALSE,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+
+    /**
+     * WebKitWebsiteDataManager:origin-storage-ratio:
+     *
+     * The percentage of volume space that can be used for data storage for every domain.
+     * If the maximum storage is reached the storage request will fail with a QuotaExceededError exception.
+     * A value of 0.0 means that data storage is not allowed. A value of -1.0, which is the default,
+     * means WebKit will use the default quota (1GB).
+     *
+     * Since: 2.42
+     */
+    g_object_class_install_property(
+        gObjectClass,
+        PROP_ORIGIN_STORAGE_RATIO,
+        g_param_spec_double("origin-storage-ratio",
+            nullptr, nullptr,
+            -1.0, 1.0, -1.0,
+            static_cast<GParamFlags>(WEBKIT_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY)));
+
+    /**
+     * WebKitWebsiteDataManager:total-storage-ratio:
+     *
+     * The percentage of volume space that can be used for data storage for all domains.
+     * If the maximum storage is reached the eviction will happen.
+     * A value of 0.0 means that data storage is not allowed. A value of -1.0, which is the default,
+     * means there's no limit for the total storage.
+     *
+     * Since: 2.42
+     */
+    g_object_class_install_property(
+        gObjectClass,
+        PROP_TOTAL_STORAGE_RATIO,
+        g_param_spec_double("total-storage-ratio",
+            nullptr, nullptr,
+            -1.0, 1.0, -1.0,
+            static_cast<GParamFlags>(WEBKIT_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY)));
 }
 
 WebKit::WebsiteDataStore& webkitWebsiteDataManagerGetDataStore(WebKitWebsiteDataManager* manager)
@@ -506,6 +553,12 @@ WebKit::WebsiteDataStore& webkitWebsiteDataManagerGetDataStore(WebKitWebsiteData
         if (priv->domCacheDirectory)
             configuration->setCacheStorageDirectory(FileSystem::stringFromFileSystemRepresentation(priv->domCacheDirectory.get()));
 #endif
+        if (priv->originStorageRatio >= 0.0)
+            configuration->setOriginQuotaRatio(priv->originStorageRatio);
+
+        if (priv->totalStorageRatio >= 0.0)
+            configuration->setTotalQuotaRatio(priv->totalStorageRatio);
+
         priv->websiteDataStore = WebKit::WebsiteDataStore::create(WTFMove(configuration), PAL::SessionID::generatePersistentSessionID());
 #if !ENABLE(2022_GLIB_API)
         priv->websiteDataStore->setIgnoreTLSErrors(priv->tlsErrorsPolicy == WEBKIT_TLS_ERRORS_POLICY_IGNORE);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
@@ -163,6 +163,14 @@ public:
     GList* m_dataList { nullptr };
 };
 
+static void loadChanged(WebKitWebView* webView, WebKitLoadEvent loadEvent, WebViewTest* test)
+{
+    if (loadEvent != WEBKIT_LOAD_FINISHED)
+        return;
+    g_signal_handlers_disconnect_by_func(webView, reinterpret_cast<void*>(loadChanged), test);
+    g_main_loop_quit(test->m_mainLoop);
+}
+
 static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
 {
 #if !ENABLE(2022_GLIB_API)
@@ -279,6 +287,7 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     GRefPtr<WebKitWebsiteDataManager> baseDataManager = adoptGRef(webkit_website_data_manager_new(
         "base-data-directory", Test::dataDirectory(), "base-cache-directory", Test::dataDirectory(),
         "indexeddb-directory", indexedDBDirectory.get(), "offline-application-cache-directory", applicationCacheDirectory.get(),
+        "origin-storage-ratio", 1.0, "total-storage-ratio", 1.0,
         nullptr));
     g_assert_true(WEBKIT_IS_WEBSITE_DATA_MANAGER(baseDataManager.get()));
 
@@ -292,6 +301,29 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     g_assert_cmpstr(webkit_website_data_manager_get_disk_cache_directory(baseDataManager.get()), ==, diskCacheDirectory.get());
 
     ALLOW_DEPRECATED_DECLARATIONS_END
+#endif
+}
+
+static void testWebsiteDataOriginAndTotalStorageRatio(WebsiteDataTest* test, gconstpointer)
+{
+#if !ENABLE(2022_GLIB_API)
+    GUniquePtr<char> baseDirectory(g_build_filename(Test::dataDirectory(), "ShouldNotExist", nullptr));
+    GUniquePtr<char> indexedDBDirectory(g_build_filename(baseDirectory.get(), "databases", "indexeddb", nullptr));
+
+    GRefPtr<WebKitWebsiteDataManager> baseDataManager = adoptGRef(webkit_website_data_manager_new(
+        "base-data-directory", baseDirectory.get(), "base-cache-directory", baseDirectory.get(),
+        "origin-storage-ratio", 0.0, "total-storage-ratio", 0.0,
+        nullptr));
+    g_assert_true(WEBKIT_IS_WEBSITE_DATA_MANAGER(baseDataManager.get()));
+
+    GRefPtr<WebKitWebContext> webContext = adoptGRef(webkit_web_context_new_with_website_data_manager(baseDataManager.get()));
+    auto webView = Test::adoptView(Test::createWebView(webContext.get()));
+    g_signal_connect(webView.get(), "load-changed", G_CALLBACK(loadChanged), test);
+
+    webkit_web_view_load_uri(webView.get(), kServer->getURIForPath("/empty").data());
+    test->waitUntilLoadFinished(webView.get());
+    test->runJavaScriptAndWaitUntilFinished("window.indexedDB.open('TestDatabase');", nullptr, webView.get());
+    test->assertFileIsNotCreated(indexedDBDirectory.get());
 #endif
 }
 
@@ -983,6 +1015,7 @@ void beforeAll()
     WebsiteDataTest::add("WebKitWebsiteData", "dom-cache", testWebsiteDataDOMCache);
     WebsiteDataTest::add("WebKitWebsiteData", "handle-corrupted-local-storage", testWebViewHandleCorruptedLocalStorage);
     MemoryPressureTest::add("WebKitWebsiteData", "memory-pressure", testMemoryPressureSettings);
+    WebsiteDataTest::add("WebKitWebsiteData", "origin-and-total-storage-ratio", testWebsiteDataOriginAndTotalStorageRatio);
 }
 
 void afterAll()

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
@@ -273,6 +273,15 @@ void WebViewTest::assertFileIsCreated(const char *filename)
     g_assert_true(g_file_test(filename, G_FILE_TEST_EXISTS));
 }
 
+void WebViewTest::assertFileIsNotCreated(const char* filename)
+{
+    constexpr double intervalInSeconds = 0.25;
+    unsigned tries = 4;
+    while (!g_file_test(filename, G_FILE_TEST_EXISTS) && --tries)
+        wait(intervalInSeconds);
+    g_assert_false(g_file_test(filename, G_FILE_TEST_EXISTS));
+}
+
 void WebViewTest::assertJavaScriptBecomesTrue(const char* javascript)
 {
     unsigned triesCount = 4;

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
@@ -54,6 +54,7 @@ public:
     void waitUntilTitleChanged();
     void waitUntilIsWebProcessResponsiveChanged();
     void assertFileIsCreated(const char*);
+    void assertFileIsNotCreated(const char*);
     void assertJavaScriptBecomesTrue(const char*);
     void resizeView(int width, int height);
     void hideView();


### PR DESCRIPTION
#### 34c3ebb7bacda0a74abfd5c7fe61e2cc387dba4b
<pre>
[GLIB] Add API to control originStorageRatio and totalStorageRatio
<a href="https://bugs.webkit.org/show_bug.cgi?id=254905">https://bugs.webkit.org/show_bug.cgi?id=254905</a>

Reviewed by Carlos Garcia Campos.

Add API to control originStorageRatio and totalStorageRatio.

* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
(webkitWebsiteDataManagerSetProperty):
(webkit_website_data_manager_class_init):
(webkitWebsiteDataManagerGetDataStore):

Canonical link: <a href="https://commits.webkit.org/265317@main">https://commits.webkit.org/265317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/114743677191e106831fff9ff1af6f4ae30530c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13101 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12654 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16835 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12978 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10195 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8276 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13613 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1180 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->