### PR TITLE
GraphicsContextGLANGLE duplicates constructor and accessors across platforms

### DIFF
--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -76,6 +76,10 @@ static void wipeAlphaChannelFromPixels(int width, int height, unsigned char* pix
 }
 #endif
 
+GraphicsContextGLANGLE::GraphicsContextGLANGLE(GraphicsContextGLAttributes attributes)
+    : GraphicsContextGL(attributes)
+{
+}
 
 bool GraphicsContextGLANGLE::initialize()
 {
@@ -1004,23 +1008,6 @@ void GraphicsContextGLANGLE::compileShader(PlatformGLObject shader)
 #endif
 }
 
-void GraphicsContextGLANGLE::compileShaderDirect(PlatformGLObject shader)
-{
-    ASSERT(shader);
-    if (!makeContextCurrent())
-        return;
-
-    GL_CompileShader(shader);
-}
-
-void GraphicsContextGLANGLE::texImage2DDirect(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, const void* pixels)
-{
-    if (!makeContextCurrent())
-        return;
-    GL_TexImage2D(target, level, internalformat, width, height, border, format, type, pixels);
-    invalidateKnownTextureContent(m_state.currentBoundTexture());
-}
-
 void GraphicsContextGLANGLE::copyTexImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLint border)
 {
     if (!makeContextCurrent())
@@ -1270,11 +1257,6 @@ int GraphicsContextGLANGLE::getAttribLocation(PlatformGLObject program, const St
         return -1;
 
     return GL_GetAttribLocation(program, name.utf8().data());
-}
-
-int GraphicsContextGLANGLE::getAttribLocationDirect(PlatformGLObject program, const String& name)
-{
-    return getAttribLocation(program, name);
 }
 
 bool GraphicsContextGLANGLE::updateErrors()

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -45,7 +45,7 @@ namespace WebCore {
 // Base class for GraphicsContextGL contexts that use ANGLE.
 class WEBCORE_EXPORT GraphicsContextGLANGLE : public GraphicsContextGL {
 public:
-    virtual ~GraphicsContextGLANGLE();
+    ~GraphicsContextGLANGLE();
 
     GCGLDisplay platformDisplay() const;
     GCGLConfig platformConfig() const;
@@ -62,15 +62,6 @@ public:
         TerminateAndReleaseThreadResources
     };
     static bool releaseThreadResources(ReleaseThreadResourceBehavior);
-
-    // Get an attribute location without checking the name -> mangledname mapping.
-    int getAttribLocationDirect(PlatformGLObject program, const String& name);
-
-    // Compile a shader without going through ANGLE.
-    void compileShaderDirect(PlatformGLObject);
-
-    // Equivalent to ::glTexImage2D(). Allows pixels==0 with no allocation.
-    void texImage2DDirect(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, const void* pixels);
 
     // GraphicsContextGL overrides.
     bool isGLES2Compliant() const final;
@@ -409,7 +400,6 @@ protected:
     // Returns false if context should be lost due to timeout.
     bool waitAndUpdateOldestFrame() WARN_UNUSED_RETURN;
 
-    // Platform specific behavior for releaseResources();
     static void platformReleaseThreadResources();
 
     virtual void invalidateKnownTextureContent(GCGLuint);
@@ -438,7 +428,6 @@ protected:
     GCGLint m_drawingBufferTextureTarget { -1 };
     GCGLErrorCodeSet m_errors;
     bool m_isForWebGL2 { false };
-    unsigned m_statusCheckCount { 0 };
     bool m_failNextStatusCheck { false };
     bool m_useFenceSyncForDisplayRateLimit = false;
     static constexpr size_t maxPendingFrames = 3;
@@ -461,6 +450,16 @@ protected:
 #endif
 };
 
+
+inline GCGLDisplay GraphicsContextGLANGLE::platformDisplay() const 
+{
+    return m_displayObj; 
+}
+
+inline GCGLConfig GraphicsContextGLANGLE::platformConfig() const
+{
+    return m_configObj;
+}
 }
 
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -211,8 +211,6 @@ static EGLDisplay initializeEGLDisplay(const GraphicsContextGLAttributes& attrs)
     return display;
 }
 
-static const unsigned statusCheckThreshold = 5;
-
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
 static bool needsEAGLOnMac()
 {
@@ -249,13 +247,6 @@ IOSurface* GraphicsContextGLCocoa::displayBuffer()
 void GraphicsContextGLCocoa::markDisplayBufferInUse()
 {
     return m_swapChain.markDisplayBufferInUse();
-}
-
-// FIXME: Below is functionality that should be moved to GraphicsContextGLCocoa to simplify the base class.
-
-GraphicsContextGLANGLE::GraphicsContextGLANGLE(GraphicsContextGLAttributes attrs)
-    : GraphicsContextGL(attrs)
-{
 }
 
 bool GraphicsContextGLCocoa::platformInitializeContext()
@@ -505,7 +496,6 @@ GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
     }
     ASSERT(currentContext != this);
     m_drawingBufferTextureTarget = -1;
-    LOG(WebGL, "Destroyed a GraphicsContextGLANGLE (%p).", this);
 }
 
 bool GraphicsContextGLANGLE::makeContextCurrent()
@@ -535,14 +525,6 @@ void GraphicsContextGLANGLE::checkGPUStatus()
         makeCurrent(m_displayObj, EGL_NO_CONTEXT);
         return;
     }
-
-    // Only do the check every statusCheckThreshold calls.
-    if (m_statusCheckCount)
-        return;
-
-    m_statusCheckCount = (m_statusCheckCount + 1) % statusCheckThreshold;
-
-    // FIXME: check via KHR_robustness.
 }
 
 void GraphicsContextGLCocoa::setContextVisibility(bool isVisible)
@@ -893,16 +875,6 @@ bool GraphicsContextGLCocoa::copyTextureFromMedia(MediaPlayer& player, PlatformG
     return contextCV->copyVideoSampleToTexture(*videoFrameCV, outputTexture, level, internalFormat, format, type, GraphicsContextGL::FlipY(flipY));
 }
 #endif
-
-GCGLDisplay GraphicsContextGLANGLE::platformDisplay() const
-{
-    return m_displayObj;
-}
-
-GCGLConfig GraphicsContextGLANGLE::platformConfig() const
-{
-    return m_configObj;
-}
 
 RefPtr<GraphicsLayerContentsDisplayDelegate> GraphicsContextGLCocoa::layerContentsDisplayDelegate()
 {

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
@@ -57,11 +57,6 @@ RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContex
     return GraphicsContextGLFallback::create(GraphicsContextGLAttributes(attributes));
 }
 
-GraphicsContextGLANGLE::GraphicsContextGLANGLE(GraphicsContextGLAttributes attributes)
-    : GraphicsContextGL(attributes)
-{
-}
-
 GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
 {
     bool success = makeContextCurrent();
@@ -81,16 +76,6 @@ GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
             GL_DeleteRenderbuffers(1, &m_depthStencilBuffer);
     }
     GL_DeleteFramebuffers(1, &m_fbo);
-}
-
-GCGLDisplay GraphicsContextGLANGLE::platformDisplay() const
-{
-    return m_displayObj;
-}
-
-GCGLConfig GraphicsContextGLANGLE::platformConfig() const
-{
-    return m_configObj;
 }
 
 void GraphicsContextGLANGLE::checkGPUStatus()

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -45,11 +45,6 @@
 
 namespace WebCore {
 
-GraphicsContextGLANGLE::GraphicsContextGLANGLE(GraphicsContextGLAttributes attributes)
-    : GraphicsContextGL(attributes)
-{
-}
-
 GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
 {
     if (!makeContextCurrent())
@@ -70,16 +65,6 @@ GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
             GL_DeleteRenderbuffers(1, &m_depthStencilBuffer);
     }
     GL_DeleteFramebuffers(1, &m_fbo);
-}
-
-GCGLDisplay GraphicsContextGLANGLE::platformDisplay() const
-{
-    return m_displayObj;
-}
-
-GCGLConfig GraphicsContextGLANGLE::platformConfig() const
-{
-    return m_configObj;
 }
 
 bool GraphicsContextGLANGLE::makeContextCurrent()


### PR DESCRIPTION
#### bb7a5ea543d43ce804a674d3be33353763881d1b
<pre>
GraphicsContextGLANGLE duplicates constructor and accessors across platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=254907">https://bugs.webkit.org/show_bug.cgi?id=254907</a>
rdar://problem/107548342

Reviewed by Matt Woodrow.

Move the trivial implementations to shared GraphicsContextGLANGLE.
Remove unused *direct functions.

* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::GraphicsContextGLANGLE):
(WebCore::GraphicsContextGLANGLE::compileShaderDirect): Deleted.
(WebCore::GraphicsContextGLANGLE::texImage2DDirect): Deleted.
(WebCore::GraphicsContextGLANGLE::getAttribLocationDirect): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLANGLE::~GraphicsContextGLANGLE):
(WebCore::GraphicsContextGLANGLE::GraphicsContextGLANGLE): Deleted.
(WebCore::GraphicsContextGLANGLE::platformDisplay const): Deleted.
(WebCore::GraphicsContextGLANGLE::platformConfig const): Deleted.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp:
(WebCore::GraphicsContextGLANGLE::GraphicsContextGLANGLE): Deleted.
(WebCore::GraphicsContextGLANGLE::platformDisplay const): Deleted.
(WebCore::GraphicsContextGLANGLE::platformConfig const): Deleted.
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::GraphicsContextGLANGLE): Deleted.
(WebCore::GraphicsContextGLANGLE::platformDisplay const): Deleted.
(WebCore::GraphicsContextGLANGLE::platformConfig const): Deleted.

Canonical link: <a href="https://commits.webkit.org/262571@main">https://commits.webkit.org/262571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bd7a0620f9f3d51776dc2bce2ce3e669a3c9abe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1861 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1631 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2503 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1547 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1474 "1 flakes 142 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1598 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1590 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2672 "9 api tests failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1449 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1554 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/464 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1691 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->