### PR TITLE
Simplify PAL::TextCodecUTF8::encodeUTF8 and use it more

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextCodecReplacement.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecReplacement.cpp
@@ -59,9 +59,9 @@ String TextCodecReplacement::decode(const char*, size_t, bool, bool, bool& sawEr
     return String { &replacementCharacter, 1 };
 }
 
-Vector<uint8_t> TextCodecReplacement::encode(StringView string, UnencodableHandling unencodableHandling) const
+Vector<uint8_t> TextCodecReplacement::encode(StringView string, UnencodableHandling) const
 {
-    return TextCodecUTF8::encodeUTF8(string, unencodableHandling);
+    return TextCodecUTF8::encodeUTF8(string);
 }
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -458,7 +458,7 @@ upConvertTo16Bit:
     return String::adopt(WTFMove(buffer16));
 }
 
-Vector<uint8_t> TextCodecUTF8::encodeUTF8(StringView string, UnencodableHandling)
+Vector<uint8_t> TextCodecUTF8::encodeUTF8(StringView string)
 {
     // The maximum number of UTF-8 bytes needed per UTF-16 code unit is 3.
     // BMP characters take only one UTF-16 code unit and can take up to 3 bytes (3x).
@@ -471,9 +471,9 @@ Vector<uint8_t> TextCodecUTF8::encodeUTF8(StringView string, UnencodableHandling
     return bytes;
 }
 
-Vector<uint8_t> TextCodecUTF8::encode(StringView string, UnencodableHandling unencodableHandling) const
+Vector<uint8_t> TextCodecUTF8::encode(StringView string, UnencodableHandling) const
 {
-    return encodeUTF8(string, unencodableHandling);
+    return encodeUTF8(string);
 }
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -36,7 +36,7 @@ public:
     static void registerEncodingNames(EncodingNameRegistrar);
     static void registerCodecs(TextCodecRegistrar);
 
-    static Vector<uint8_t> encodeUTF8(StringView, UnencodableHandling);
+    static Vector<uint8_t> encodeUTF8(StringView);
 
 private:
     void stripByteOrderMark() final { m_shouldStripByteOrderMark = true; }

--- a/Source/WebCore/fileapi/BlobBuilder.cpp
+++ b/Source/WebCore/fileapi/BlobBuilder.cpp
@@ -35,7 +35,7 @@
 #include "Blob.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
-#include <pal/text/TextEncoding.h>
+#include <pal/text/TextCodecUTF8.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/LineEnding.h>
 
@@ -71,7 +71,7 @@ void BlobBuilder::append(RefPtr<Blob>&& blob)
 
 void BlobBuilder::append(const String& text)
 {
-    auto bytes = PAL::UTF8Encoding().encode(text, PAL::UnencodableHandling::Entities, PAL::NFCNormalize::No);
+    auto bytes = PAL::TextCodecUTF8::encodeUTF8(text);
 
     if (m_endings == EndingType::Native)
         bytes = normalizeLineEndingsToNative(WTFMove(bytes));

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -60,6 +60,7 @@
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSLock.h>
+#include <pal/text/TextCodecUTF8.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/RefCountedLeakCounter.h>
 #include <wtf/StdLibExtras.h>
@@ -483,7 +484,7 @@ ExceptionOr<void> XMLHttpRequest::send(Document& document)
         // https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send Step 4.2.
         auto serialized = serializeFragment(document, SerializedNodes::SubtreeIncludingNode);
         auto converted = replaceUnpairedSurrogatesWithReplacementCharacter(WTFMove(serialized));
-        auto encoded = PAL::UTF8Encoding().encode(WTFMove(converted), PAL::UnencodableHandling::Entities);
+        auto encoded = PAL::TextCodecUTF8::encodeUTF8(WTFMove(converted));
         m_requestEntityBody = FormData::create(WTFMove(encoded));
         if (m_upload)
             m_requestEntityBody->setAlwaysStream(true);
@@ -506,7 +507,7 @@ ExceptionOr<void> XMLHttpRequest::send(const String& body)
             m_requestHeaders.set(HTTPHeaderName::ContentType, contentType);
         }
 
-        m_requestEntityBody = FormData::create(PAL::UTF8Encoding().encode(body, PAL::UnencodableHandling::Entities));
+        m_requestEntityBody = FormData::create(PAL::TextCodecUTF8::encodeUTF8(body));
         if (m_upload)
             m_requestEntityBody->setAlwaysStream(true);
     }


### PR DESCRIPTION
#### 2275a8c0d58f4cf88db4a3e5ceeb471e934e2c50
<pre>
Simplify PAL::TextCodecUTF8::encodeUTF8 and use it more
<a href="https://bugs.webkit.org/show_bug.cgi?id=254909">https://bugs.webkit.org/show_bug.cgi?id=254909</a>
rdar://107549740

Reviewed by Youenn Fablet.

The second argument does not end up getting used so remove it. And then make use of it in a number of places that want to UTF-8 encode a string view.

* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::consumeAsStream):
(WebCore::FetchBody::consumeText):
(WebCore::FetchBody::bodyAsFormData const):
(WebCore::FetchBody::take):
* Source/WebCore/PAL/pal/text/TextCodecReplacement.cpp:
(PAL::TextCodecReplacement::encode const):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::encodeUTF8):
(PAL::TextCodecUTF8::encode const):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.h:
* Source/WebCore/fileapi/BlobBuilder.cpp:
(WebCore::BlobBuilder::append):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::clearMediaCache):
(WebCore::MediaPlayerPrivateAVFoundationObjC::cancelLoad):
(WebCore::MediaPlayerPrivateAVFoundationObjC::synchronizeTextTrackState):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem):
(WebCore::MediaPlayerPrivateAVFoundationObjC::accessLog const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformSetVisible):
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformDuration const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::seekToTime):
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformMaxTimeSeekable const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::platformMaxTimeLoaded const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource):
(WebCore::determineChangedTracksFromNewTracksAndOldItems):
(WebCore::MediaPlayerPrivateAVFoundationObjC::processMediaSelectionOptions):
(WebCore::MediaPlayerPrivateAVFoundationObjC::flushCues):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setBufferingPolicy):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::send):

Canonical link: <a href="https://commits.webkit.org/262532@main">https://commits.webkit.org/262532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4fc58e7a6efcc2205ffdda0cb5c25b029c886b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2667 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1864 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1634 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1477 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1601 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2673 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1451 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1558 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/446 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1694 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->