### PR TITLE
Scrollbar does not pick up changed styles until hovered

### DIFF
--- a/LayoutTests/fast/css/scrollbar-dynamic-style-change-expected.html
+++ b/LayoutTests/fast/css/scrollbar-dynamic-style-change-expected.html
@@ -2,6 +2,9 @@
 ::-webkit-scrollbar {
     background: green;
 }
+html {
+    color: black;
+}
 body {
     overflow: scroll;
 }

--- a/LayoutTests/fast/css/scrollbar-dynamic-style-change.html
+++ b/LayoutTests/fast/css/scrollbar-dynamic-style-change.html
@@ -2,6 +2,9 @@
 ::-webkit-scrollbar {
     background: red;
 }
+html {
+    color: black;
+}
 body {
     overflow: scroll;
 }

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -282,6 +282,7 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
     resolveAndAddPseudoElementStyle(PseudoId::Before);
     resolveAndAddPseudoElementStyle(PseudoId::After);
     resolveAndAddPseudoElementStyle(PseudoId::Backdrop);
+    resolveAndAddPseudoElementStyle(PseudoId::Scrollbar);
 
 #if ENABLE(TOUCH_ACTION_REGIONS)
     // FIXME: Track this exactly.
@@ -336,7 +337,8 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
     bool alwaysNeedsPseudoElement = resolvedStyle->style->hasAnimationsOrTransitions()
         || element.hasKeyframeEffects(pseudoId)
         || pseudoId == PseudoId::FirstLine
-        || pseudoId == PseudoId::FirstLetter;
+        || pseudoId == PseudoId::FirstLetter
+        || pseudoId == PseudoId::Scrollbar;
     if (!alwaysNeedsPseudoElement && !pseudoElementRendererIsNeeded(resolvedStyle->style.get()))
         return { };
 


### PR DESCRIPTION
#### dfd97e668d4ac82721a6f233a392b695c42ab799
<pre>
Scrollbar does not pick up changed styles until hovered
<a href="https://bugs.webkit.org/show_bug.cgi?id=113727">https://bugs.webkit.org/show_bug.cgi?id=113727</a>

Reviewed by Simon Fraser.

Resolve the pseudo-element `::-webkit-scrollbar` in the same way as it
is done with other pseudo-elements that can be applied to any element.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::resolvePseudoElement):
* LayoutTests/fast/css/scrollbar-dynamic-style-change-expected.html: Rebaselined
* LayoutTests/fast/css/scrollbar-dynamic-style-change.html: Ditto

Canonical link: <a href="https://commits.webkit.org/264356@main">https://commits.webkit.org/264356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/532906f89a81a54b7cbe1b6a67cb9cd15b0e443d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7622 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10508 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9159 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6748 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14476 "1 flakes 110 failures") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10155 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6012 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6659 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1759 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->