### PR TITLE
GraphicsContextGLCocoa does not signal context loss immediately on failed prepare

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5989,14 +5989,6 @@ void WebGLRenderingContextBase::activityStateDidChange(OptionSet<ActivityState> 
         m_context->setContextVisibility(newActivityState.contains(ActivityState::IsVisible));
 }
 
-void WebGLRenderingContextBase::didComposite()
-{
-    m_compositingResultsNeedUpdating = false;
-
-    if (UNLIKELY(hasActiveInspectorCanvasCallTracer()))
-        InspectorInstrumentation::didFinishRecordingCanvasFrame(*this);
-}
-
 void WebGLRenderingContextBase::forceContextLost()
 {
     forceLostContext(WebGLRenderingContextBase::RealLostContext);
@@ -6066,6 +6058,11 @@ void WebGLRenderingContextBase::prepareForDisplay()
         return;
 
     m_context->prepareForDisplay();
+
+    m_compositingResultsNeedUpdating = false;
+
+    if (UNLIKELY(hasActiveInspectorCanvasCallTracer()))
+        InspectorInstrumentation::didFinishRecordingCanvasFrame(*this);
 }
 
 void WebGLRenderingContextBase::updateActiveOrdinal()

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -458,7 +458,6 @@ public:
     void vertexAttribDivisor(GCGLuint index, GCGLuint divisor);
 
     // GraphicsContextGL::Client
-    void didComposite() override;
     void forceContextLost() override;
     void dispatchContextChangedNotification() override;
 

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -681,8 +681,6 @@ void GraphicsContextGL::markLayerComposited()
         if (attrs.stencil)
             m_buffersToAutoClear |= GraphicsContextGL::STENCIL_BUFFER_BIT;
     }
-    if (m_client)
-        m_client->didComposite();
 }
 
 void GraphicsContextGL::paintToCanvas(NativeImage& image, const IntSize& canvasSize, GraphicsContext& context)

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1151,7 +1151,6 @@ public:
     public:
         WEBCORE_EXPORT Client();
         WEBCORE_EXPORT virtual ~Client();
-        virtual void didComposite() = 0;
         virtual void forceContextLost() = 0;
         virtual void dispatchContextChangedNotification() = 0;
     };
@@ -1553,7 +1552,7 @@ public:
 
     // FIXME: these should be removed, caller is interested in buffer clear status and
     // should track that in a variable that the caller holds. Caller should receive
-    // the value from reshape() and didComposite().
+    // the value from reshape().
     bool layerComposited() const;
     void setBuffersToAutoClear(GCGLbitfield);
     GCGLbitfield getBuffersToAutoClear() const;

--- a/Source/WebCore/platform/graphics/GraphicsContextGLEnums.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLEnums.h
@@ -32,7 +32,8 @@ namespace WebCore {
 enum class GraphicsContextGLSimulatedEventForTesting {
     ContextChange,
     GPUStatusFailure,
-    Timeout
+    Timeout,
+    DisplayBufferAllocationFailure
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -3167,7 +3167,7 @@ void GraphicsContextGLANGLE::simulateEventForTesting(SimulatedEventForTesting ev
         dispatchContextChangedNotification();
         return;
     }
-    if (event == SimulatedEventForTesting::GPUStatusFailure) {
+    if (event == SimulatedEventForTesting::GPUStatusFailure || event == SimulatedEventForTesting::DisplayBufferAllocationFailure) {
         m_failNextStatusCheck = true;
         return;
     }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -156,11 +156,6 @@ void RemoteGraphicsContextGL::workQueueUninitialize()
     m_renderingResourcesRequest = { };
 }
 
-void RemoteGraphicsContextGL::didComposite()
-{
-    assertIsCurrent(workQueue());
-}
-
 void RemoteGraphicsContextGL::forceContextLost()
 {
     assertIsCurrent(workQueue());

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -104,7 +104,6 @@ protected:
     bool send(T&& message) const { return m_streamConnection->send(WTFMove(message), m_graphicsContextGLIdentifier); }
 
     // GraphicsContextGL::Client overrides.
-    void didComposite() final;
     void forceContextLost() final;
     void dispatchContextChangedNotification() final;
 


### PR DESCRIPTION
#### a2684c1fef12d5e6c462081cf6aca95c13ee81cc
<pre>
GraphicsContextGLCocoa does not signal context loss immediately on failed prepare
<a href="https://bugs.webkit.org/show_bug.cgi?id=254911">https://bugs.webkit.org/show_bug.cgi?id=254911</a>
rdar://problem/107553596

Reviewed by Dean Jackson.

Previously, if a new surface could not be allocated during prepare for display,
the error would be signalled on the next context call during makeContextCurrent().

This had the problem that makeContextCurrent() would need to check for
m_displayBufferPbuffer existence. This is a problem since the m_displayBufferPbuffer is
a Cocoa specific variable but preferably makeContextCurrent() would be using only
the GraphicsContextGLANGLE state. This prevents Cocoa specific state from being
declared in GraphicsContextGLCocoa.h.

This also had the problem that makeContextCurrent() should work even if the
display buffer is not allocated. This would be used during construction and
destruction.

Make the code structure less error-prone by signaling the context loss during
prepare, and let the makeContextCurrent() always be able to make the context
current.

This is work towards being able to move the Cocoa specific state to the
Cocoa class.

* Source/WebCore/platform/graphics/GraphicsContextGLEnums.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::simulateEventForTesting):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::allocateAndBindDisplayBufferBacking):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
(TestWebKitAPI::TEST_P):
(TestWebKitAPI::createDefaultTestContext): Deleted.

Canonical link: <a href="https://commits.webkit.org/263297@main">https://commits.webkit.org/263297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/add373edbfed0f65aaef095e9d64917f9d50a73d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4196 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5392 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5717 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3566 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3263 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3588 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1023 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3621 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->