### PR TITLE
???

### DIFF
--- a/Source/WebKit/wpe/NEWS
+++ b/Source/WebKit/wpe/NEWS
@@ -1,4 +1,13 @@
 =================
+WPE WebKit 2.41.1
+=================
+
+What's new in WPE WebKit 2.41.1?
+
+  - Add WebKitClipboardPermissionRequest to handle DOM paste access requests.
+  - Fix several crashes and rendering issues.
+
+=================
 WPE WebKit 2.39.4
 =================
 

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -1,7 +1,7 @@
 include(GNUInstallDirs)
 include(VersioningUtils)
 
-SET_PROJECT_VERSION(2 41 0)
+SET_PROJECT_VERSION(2 41 1)
 
 # This is required because we use the DEPFILE argument to add_custom_command().
 # Remove after upgrading cmake_minimum_required() to 3.20.


### PR DESCRIPTION
#### b637dad0f5db5899f808330fca1f6f4125db4166
<pre>
???
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b637dad0f5db5899f808330fca1f6f4125db4166

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1752 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/1783 "Build was cancelled. Recent messages:OS: Monterey (12.6), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/1842 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/2680 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1876 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1854 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/1850 "Build was cancelled. Recent messages:OS: Ventura (13.2), Xcode: 14.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/2680 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1770 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1589 "Build was cancelled. Recent messages:OS: Monterey (12.6), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/1842 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2519 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1583 "Build was cancelled. Recent messages:OS: Ventura (13.0), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/1842 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1484 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/1485 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC; jscore-tests (cancelled)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1612 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/1842 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2682 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 12316") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/1681 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC; jscore-tests (cancelled)") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1643 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/1850 "Build was cancelled. Recent messages:OS: Ventura (13.2), Xcode: 14.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Failed to upload built product") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1807 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1565 "Build was cancelled. Recent messages:OS: Monterey (12.6.1), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/1842 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/415 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; jscore-tests (cancelled)") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/1705 "Build was cancelled. Recent messages:OS: Monterey (12.6.1), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1853 "Built successfully") | 
| | | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/529 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; jscore-tests (cancelled)") | 
<!--EWS-Status-Bubble-End-->