### PR TITLE
Cherry-pick 259548.75@safari-7615-branch (22b0e73428bb). rdar://107499524

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -308,7 +308,7 @@ void ScrollingTree::setOverlayScrollbarsEnabled(bool enabled)
     m_overlayScrollbarsEnabled = enabled;
 }
 
-void ScrollingTree::commitTreeState(std::unique_ptr<ScrollingStateTree>&& scrollingStateTree)
+bool ScrollingTree::commitTreeState(std::unique_ptr<ScrollingStateTree>&& scrollingStateTree)
 {
     SetForScope inCommitTreeState(m_inCommitTreeState, true);
     Locker locker { m_treeLock };
@@ -359,7 +359,10 @@ void ScrollingTree::commitTreeState(std::unique_ptr<ScrollingStateTree>&& scroll
     for (auto nodeID : m_nodeMap.keys())
         commitState.unvisitedNodes.add(nodeID);
 
-    updateTreeFromStateNodeRecursive(rootNode, commitState);
+    bool succeeded = updateTreeFromStateNodeRecursive(rootNode, commitState);
+    if (!succeeded)
+        return false;
+
     propagateSynchronousScrollingReasons(commitState.synchronousScrollingNodes);
 
     for (auto nodeID : commitState.unvisitedNodes) {
@@ -374,14 +377,15 @@ void ScrollingTree::commitTreeState(std::unique_ptr<ScrollingStateTree>&& scroll
     didCommitTree();
 
     LOG_WITH_STREAM(ScrollingTree, stream << "committed ScrollingTree" << scrollingTreeAsText(debugScrollingStateTreeAsTextBehaviors));
+    return true;
 }
 
-void ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* stateNode, CommitTreeState& state)
+bool ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* stateNode, CommitTreeState& state)
 {
     if (!stateNode) {
         removeAllNodes();
         m_rootNode = nullptr;
-        return;
+        return true;
     }
     
     ScrollingNodeID nodeID = stateNode->scrollingNodeID();
@@ -397,7 +401,8 @@ void ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* s
         node = createScrollingTreeNode(stateNode->nodeType(), nodeID);
         if (!parentNodeID) {
             // This is the root node. Clear the node map.
-            ASSERT(stateNode->isFrameScrollingNode());
+            if (!is<ScrollingTreeFrameScrollingNode>(node.get()))
+                return false;
             m_rootNode = downcast<ScrollingTreeFrameScrollingNode>(node.get());
             removeAllNodes();
         } 
@@ -424,7 +429,8 @@ void ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* s
         }
     }
 
-    node->commitStateBeforeChildren(*stateNode);
+    if (!node->commitStateBeforeChildren(*stateNode))
+        return false;
     
     // Move all children into the orphanNodes map. Live ones will get added back as we recurse over children.
     for (auto& childScrollingNode : node->children()) {
@@ -435,17 +441,22 @@ void ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* s
 
     // Now update the children if we have any.
     if (auto children = stateNode->children()) {
-        for (auto& child : *children)
-            updateTreeFromStateNodeRecursive(child.get(), state);
+        for (auto& child : *children) {
+            if (!updateTreeFromStateNodeRecursive(child.get(), state))
+                return false;
+        }
     }
 
-    node->commitStateAfterChildren(*stateNode);
+    if (!node->commitStateAfterChildren(*stateNode))
+        return false;
+
     node->didCompleteCommitForNode();
 
 #if ENABLE(SCROLLING_THREAD)
     if (is<ScrollingTreeScrollingNode>(*node) && !downcast<ScrollingTreeScrollingNode>(*node).synchronousScrollingReasons().isEmpty())
         state.synchronousScrollingNodes.add(nodeID);
 #endif
+    return true;
 }
 
 void ScrollingTree::removeAllNodes()

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -102,7 +102,7 @@ public:
     WEBCORE_EXPORT bool hasNodeWithActiveScrollAnimations();
 
     virtual void invalidate() { }
-    WEBCORE_EXPORT void commitTreeState(std::unique_ptr<ScrollingStateTree>&&);
+    WEBCORE_EXPORT bool commitTreeState(std::unique_ptr<ScrollingStateTree>&&);
     
     WEBCORE_EXPORT virtual void applyLayerPositions();
     WEBCORE_EXPORT void applyLayerPositionsAfterCommit();
@@ -263,7 +263,7 @@ protected:
     mutable Lock m_treeLock; // Protects the scrolling tree.
 
 private:
-    void updateTreeFromStateNodeRecursive(const ScrollingStateNode*, struct CommitTreeState&) WTF_REQUIRES_LOCK(m_treeLock);
+    bool updateTreeFromStateNodeRecursive(const ScrollingStateNode*, struct CommitTreeState&) WTF_REQUIRES_LOCK(m_treeLock);
     virtual void propagateSynchronousScrollingReasons(const HashSet<ScrollingNodeID>&) WTF_REQUIRES_LOCK(m_treeLock) { }
 
     void applyLayerPositionsRecursive(ScrollingTreeNode&) WTF_REQUIRES_LOCK(m_treeLock);

--- a/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp
@@ -51,11 +51,16 @@ ScrollingTreeFixedNode::~ScrollingTreeFixedNode()
     scrollingTree().fixedOrStickyNodeRemoved();
 }
 
-void ScrollingTreeFixedNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeFixedNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    const ScrollingStateFixedNode& fixedStateNode = downcast<ScrollingStateFixedNode>(stateNode);
+    if (!is<ScrollingStateFixedNode>(stateNode))
+        return false;
+
+    const auto& fixedStateNode = downcast<ScrollingStateFixedNode>(stateNode);
     if (stateNode.hasChangedProperty(ScrollingStateNode::Property::ViewportConstraints))
         m_constraints = fixedStateNode.viewportConstraints();
+
+    return true;
 }
 
 FloatPoint ScrollingTreeFixedNode::computeLayerPosition() const

--- a/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h
@@ -47,7 +47,7 @@ protected:
 
     FloatPoint computeLayerPosition() const;
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
     FixedPositionViewportConstraints m_constraints;

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
@@ -49,8 +49,9 @@ ScrollingTreeFrameHostingNode::ScrollingTreeFrameHostingNode(ScrollingTree& scro
 
 ScrollingTreeFrameHostingNode::~ScrollingTreeFrameHostingNode() = default;
 
-void ScrollingTreeFrameHostingNode::commitStateBeforeChildren(const ScrollingStateNode&)
+bool ScrollingTreeFrameHostingNode::commitStateBeforeChildren(const ScrollingStateNode&)
 {
+    return true;
 }
 
 void ScrollingTreeFrameHostingNode::applyLayerPositions()

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
@@ -41,7 +41,7 @@ public:
 private:
     ScrollingTreeFrameHostingNode(ScrollingTree&, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) final;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) final;
     void applyLayerPositions() final;
 
     WEBCORE_EXPORT void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
@@ -45,11 +45,15 @@ ScrollingTreeFrameScrollingNode::ScrollingTreeFrameScrollingNode(ScrollingTree& 
 
 ScrollingTreeFrameScrollingNode::~ScrollingTreeFrameScrollingNode() = default;
 
-void ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    ScrollingTreeScrollingNode::commitStateBeforeChildren(stateNode);
-    
-    const ScrollingStateFrameScrollingNode& state = downcast<ScrollingStateFrameScrollingNode>(stateNode);
+    if (!ScrollingTreeScrollingNode::commitStateBeforeChildren(stateNode))
+        return false;
+
+    if (!is<ScrollingStateFrameScrollingNode>(stateNode))
+        return false;
+
+    const auto& state = downcast<ScrollingStateFrameScrollingNode>(stateNode);
 
     if (state.hasChangedProperty(ScrollingStateNode::Property::FrameScaleFactor))
         m_frameScaleFactor = state.frameScaleFactor();
@@ -88,6 +92,8 @@ void ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(const ScrollingS
         // This requires that minLayoutViewportOrigin and maxLayoutViewportOrigin have been updated.
         updateViewportForCurrentScrollPosition({ });
     }
+    
+    return true;
 }
 
 bool ScrollingTreeFrameScrollingNode::scrollPositionAndLayoutViewportMatch(const FloatPoint& position, std::optional<FloatRect> overrideLayoutViewport)

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
@@ -38,7 +38,7 @@ class WEBCORE_EXPORT ScrollingTreeFrameScrollingNode : public ScrollingTreeScrol
 public:
     virtual ~ScrollingTreeFrameScrollingNode();
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     
     bool fixedElementsLayoutRelativeToFrame() const { return m_fixedElementsLayoutRelativeToFrame; }
     bool visualViewportIsSmallerThanLayoutViewport() const { return m_visualViewportIsSmallerThanLayoutViewport; }

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -70,8 +70,8 @@ public:
     bool isOverflowScrollingNode() const { return nodeType() == ScrollingNodeType::Overflow; }
     bool isOverflowScrollProxyNode() const { return nodeType() == ScrollingNodeType::OverflowProxy; }
 
-    virtual void commitStateBeforeChildren(const ScrollingStateNode&) = 0;
-    virtual void commitStateAfterChildren(const ScrollingStateNode&) { }
+    virtual bool commitStateBeforeChildren(const ScrollingStateNode&) = 0;
+    virtual bool commitStateAfterChildren(const ScrollingStateNode&) { return true; }
     virtual void didCompleteCommitForNode() { }
     
     virtual void willBeDestroyed() { }

--- a/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
@@ -42,9 +42,12 @@ ScrollingTreeOverflowScrollProxyNode::ScrollingTreeOverflowScrollProxyNode(Scrol
 
 ScrollingTreeOverflowScrollProxyNode::~ScrollingTreeOverflowScrollProxyNode() = default;
 
-void ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    const ScrollingStateOverflowScrollProxyNode& overflowProxyStateNode = downcast<ScrollingStateOverflowScrollProxyNode>(stateNode);
+    if (!is<ScrollingStateOverflowScrollProxyNode>(stateNode))
+        return false;
+
+    const auto& overflowProxyStateNode = downcast<ScrollingStateOverflowScrollProxyNode>(stateNode);
 
     if (overflowProxyStateNode.hasChangedProperty(ScrollingStateNode::Property::OverflowScrollingNode))
         m_overflowScrollingNodeID = overflowProxyStateNode.overflowScrollingNode();
@@ -57,6 +60,8 @@ void ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(const Scrol
 
         scrollingTree().activeOverflowScrollProxyNodes().add(*this);
     }
+    
+    return true;
 }
 
 FloatSize ScrollingTreeOverflowScrollProxyNode::scrollDeltaSinceLastCommit() const

--- a/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.h
@@ -47,7 +47,7 @@ protected:
 
     FloatPoint computeLayerPosition() const;
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
 
     WEBCORE_EXPORT void dumpProperties(TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp
@@ -44,9 +44,12 @@ ScrollingTreePositionedNode::ScrollingTreePositionedNode(ScrollingTree& scrollin
 
 ScrollingTreePositionedNode::~ScrollingTreePositionedNode() = default;
 
-void ScrollingTreePositionedNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreePositionedNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    const ScrollingStatePositionedNode& positionedStateNode = downcast<ScrollingStatePositionedNode>(stateNode);
+    if (!is<ScrollingStatePositionedNode>(stateNode))
+        return false;
+
+    const auto& positionedStateNode = downcast<ScrollingStatePositionedNode>(stateNode);
 
     if (positionedStateNode.hasChangedProperty(ScrollingStateNode::Property::RelatedOverflowScrollingNodes))
         m_relatedOverflowScrollingNodes = positionedStateNode.relatedOverflowScrollingNodes();
@@ -56,6 +59,8 @@ void ScrollingTreePositionedNode::commitStateBeforeChildren(const ScrollingState
 
     if (!m_relatedOverflowScrollingNodes.isEmpty())
         scrollingTree().activePositionedNodes().add(*this);
+
+    return true;
 }
 
 FloatSize ScrollingTreePositionedNode::scrollDeltaSinceLastCommit() const

--- a/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreePositionedNode.h
@@ -46,7 +46,7 @@ public:
 protected:
     ScrollingTreePositionedNode(ScrollingTree&, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
 
     WEBCORE_EXPORT void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -48,9 +48,12 @@ ScrollingTreeScrollingNode::ScrollingTreeScrollingNode(ScrollingTree& scrollingT
 
 ScrollingTreeScrollingNode::~ScrollingTreeScrollingNode() = default;
 
-void ScrollingTreeScrollingNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeScrollingNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    const ScrollingStateScrollingNode& state = downcast<ScrollingStateScrollingNode>(stateNode);
+    if (!is<ScrollingStateScrollingNode>(stateNode))
+        return false;
+
+    const auto& state = downcast<ScrollingStateScrollingNode>(stateNode);
 
     if (state.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaSize))
         m_scrollableAreaSize = state.scrollableAreaSize();
@@ -98,11 +101,16 @@ void ScrollingTreeScrollingNode::commitStateBeforeChildren(const ScrollingStateN
 
     if (state.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
         m_scrolledContentsLayer = state.scrolledContentsLayer();
+
+    return true;
 }
 
-void ScrollingTreeScrollingNode::commitStateAfterChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeScrollingNode::commitStateAfterChildren(const ScrollingStateNode& stateNode)
 {
-    const ScrollingStateScrollingNode& scrollingStateNode = downcast<ScrollingStateScrollingNode>(stateNode);
+    if (!is<ScrollingStateScrollingNode>(stateNode))
+        return false;
+
+    const auto& scrollingStateNode = downcast<ScrollingStateScrollingNode>(stateNode);
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::RequestedScrollPosition))
         handleScrollPositionRequest(scrollingStateNode.requestedScrollData());
 
@@ -114,6 +122,7 @@ void ScrollingTreeScrollingNode::commitStateAfterChildren(const ScrollingStateNo
     m_synchronousScrollingReasons.remove(SynchronousScrollingReason::DescendantScrollersHaveSynchronousScrolling);
 #endif
     m_isFirstCommit = false;
+    return true;
 }
 
 void ScrollingTreeScrollingNode::didCompleteCommitForNode()

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -59,8 +59,8 @@ class WEBCORE_EXPORT ScrollingTreeScrollingNode : public ScrollingTreeNode {
 public:
     virtual ~ScrollingTreeScrollingNode();
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
-    void commitStateAfterChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateAfterChildren(const ScrollingStateNode&) override;
     void didCompleteCommitForNode() final;
 
     virtual bool canHandleWheelEvent(const PlatformWheelEvent&, EventTargeting) const;

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
@@ -53,12 +53,17 @@ ScrollingTreeStickyNode::~ScrollingTreeStickyNode()
     scrollingTree().fixedOrStickyNodeRemoved();
 }
 
-void ScrollingTreeStickyNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeStickyNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    auto& stickyStateNode = downcast<ScrollingStateStickyNode>(stateNode);
+    if (!is<ScrollingStateStickyNode>(stateNode))
+        return false;
+
+    const auto& stickyStateNode = downcast<ScrollingStateStickyNode>(stateNode);
 
     if (stickyStateNode.hasChangedProperty(ScrollingStateNode::Property::ViewportConstraints))
         m_constraints = stickyStateNode.viewportConstraints();
+
+    return true;
 }
 
 void ScrollingTreeStickyNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h
@@ -48,7 +48,7 @@ public:
 protected:
     ScrollingTreeStickyNode(ScrollingTree&, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     FloatPoint computeLayerPosition() const;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
@@ -45,7 +45,7 @@ private:
 
     CALayer* layer() const final { return m_layer.get(); }
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) final;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) final;
     void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree().treeLock());
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const final;

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
@@ -48,9 +48,12 @@ ScrollingTreeFixedNodeCocoa::ScrollingTreeFixedNodeCocoa(ScrollingTree& scrollin
 
 ScrollingTreeFixedNodeCocoa::~ScrollingTreeFixedNodeCocoa() = default;
 
-void ScrollingTreeFixedNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeFixedNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    const ScrollingStateFixedNode& fixedStateNode = downcast<ScrollingStateFixedNode>(stateNode);
+    if (!is<ScrollingStateFixedNode>(stateNode))
+        return false;
+
+    const auto& fixedStateNode = downcast<ScrollingStateFixedNode>(stateNode);
     if (fixedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
         m_layer = static_cast<CALayer*>(fixedStateNode.layer());
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
@@ -58,7 +61,7 @@ void ScrollingTreeFixedNodeCocoa::commitStateBeforeChildren(const ScrollingState
 #endif
     }
 
-    ScrollingTreeFixedNode::commitStateBeforeChildren(stateNode);
+    return ScrollingTreeFixedNode::commitStateBeforeChildren(stateNode);
 }
 
 void ScrollingTreeFixedNodeCocoa::applyLayerPositions()

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h
@@ -39,7 +39,7 @@ public:
 protected:
     WEBCORE_EXPORT ScrollingTreeOverflowScrollProxyNodeCocoa(ScrollingTree&, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     void applyLayerPositions() override;
 
     CALayer* layer() const override { return m_layer.get(); }

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm
@@ -46,7 +46,7 @@ ScrollingTreeOverflowScrollProxyNodeCocoa::ScrollingTreeOverflowScrollProxyNodeC
 
 ScrollingTreeOverflowScrollProxyNodeCocoa::~ScrollingTreeOverflowScrollProxyNodeCocoa() = default;
 
-void ScrollingTreeOverflowScrollProxyNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeOverflowScrollProxyNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
     if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
         m_layer = static_cast<CALayer*>(stateNode.layer());
@@ -56,7 +56,7 @@ void ScrollingTreeOverflowScrollProxyNodeCocoa::commitStateBeforeChildren(const 
     }
 
 
-    ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(stateNode);
+    return ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(stateNode);
 }
 
 void ScrollingTreeOverflowScrollProxyNodeCocoa::applyLayerPositions()

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h
@@ -41,7 +41,7 @@ public:
 private:
     ScrollingTreePositionedNodeCocoa(ScrollingTree&, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
 
     void applyLayerPositions() override;
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
@@ -46,18 +46,16 @@ ScrollingTreePositionedNodeCocoa::ScrollingTreePositionedNodeCocoa(ScrollingTree
 
 ScrollingTreePositionedNodeCocoa::~ScrollingTreePositionedNodeCocoa() = default;
 
-void ScrollingTreePositionedNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreePositionedNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    const ScrollingStatePositionedNode& positionedStateNode = downcast<ScrollingStatePositionedNode>(stateNode);
-    if (positionedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
-        m_layer = static_cast<CALayer*>(positionedStateNode.layer());
+    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
+        m_layer = static_cast<CALayer*>(stateNode.layer());
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        m_interactionRegionsLayer = static_cast<CALayer*>(positionedStateNode.interactionRegionsLayer());
+        m_interactionRegionsLayer = static_cast<CALayer*>(stateNode.interactionRegionsLayer());
 #endif
     }
 
-
-    ScrollingTreePositionedNode::commitStateBeforeChildren(stateNode);
+    return ScrollingTreePositionedNode::commitStateBeforeChildren(stateNode);
 }
 
 void ScrollingTreePositionedNodeCocoa::applyLayerPositions()

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -43,7 +43,7 @@ public:
 private:
     ScrollingTreeStickyNodeCocoa(ScrollingTree&, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) final;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) final;
     void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree().treeLock());
     FloatPoint layerTopLeft() const final;
     CALayer* layer() const final { return m_layer.get(); }

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
@@ -47,19 +47,16 @@ ScrollingTreeStickyNodeCocoa::ScrollingTreeStickyNodeCocoa(ScrollingTree& scroll
 {
 }
 
-void ScrollingTreeStickyNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeStickyNodeCocoa::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    const ScrollingStateStickyNode& stickyStateNode = downcast<ScrollingStateStickyNode>(stateNode);
-
-    if (stickyStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
-        m_layer = static_cast<CALayer*>(stickyStateNode.layer());
+    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
+        m_layer = static_cast<CALayer*>(stateNode.layer());
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        m_interactionRegionsLayer = static_cast<CALayer*>(stickyStateNode.interactionRegionsLayer());
+        m_interactionRegionsLayer = static_cast<CALayer*>(stateNode.interactionRegionsLayer());
 #endif
     }
 
-
-    ScrollingTreeStickyNode::commitStateBeforeChildren(stateNode);
+    return ScrollingTreeStickyNode::commitStateBeforeChildren(stateNode);
 }
 
 void ScrollingTreeStickyNodeCocoa::applyLayerPositions()

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
@@ -50,8 +50,8 @@ protected:
     ScrollingTreeFrameScrollingNodeMac(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
 
     // ScrollingTreeNode member functions.
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
-    void commitStateAfterChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateAfterChildren(const ScrollingStateNode&) override;
 
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -70,9 +70,14 @@ void ScrollingTreeFrameScrollingNodeMac::willBeDestroyed()
     delegate().nodeWillBeDestroyed();
 }
 
-void ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(stateNode);
+    if (!ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(stateNode))
+        return false;
+
+    if (!is<ScrollingStateFrameScrollingNode>(stateNode))
+        return false;
+
     const auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(stateNode);
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::RootContentsLayer))
@@ -103,11 +108,16 @@ void ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren(const Scrolli
     m_delegate->updateFromStateNode(scrollingStateNode);
 
     m_hadFirstUpdate = true;
+    return true;
 }
 
-void ScrollingTreeFrameScrollingNodeMac::commitStateAfterChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeFrameScrollingNodeMac::commitStateAfterChildren(const ScrollingStateNode& stateNode)
 {
-    ScrollingTreeFrameScrollingNode::commitStateAfterChildren(stateNode);
+    if (!ScrollingTreeFrameScrollingNode::commitStateAfterChildren(stateNode))
+        return false;
+
+    if (!is<ScrollingStateScrollingNode>(stateNode))
+        return false;
 
     const auto& scrollingStateNode = downcast<ScrollingStateScrollingNode>(stateNode);
     if (isRootNode()
@@ -115,6 +125,8 @@ void ScrollingTreeFrameScrollingNodeMac::commitStateAfterChildren(const Scrollin
         || scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::TotalContentsSize)
         || scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaSize)))
         updateMainFramePinAndRubberbandState();
+
+    return true;
 }
 
 WheelEventHandlingResult ScrollingTreeFrameScrollingNodeMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h
@@ -43,7 +43,7 @@ public:
 protected:
     ScrollingTreeOverflowScrollingNodeMac(ScrollingTree&, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
 
     void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) final;
     void willDoProgrammaticScroll(const FloatPoint&) final;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
@@ -61,10 +61,16 @@ void ScrollingTreeOverflowScrollingNodeMac::willBeDestroyed()
     delegate().nodeWillBeDestroyed();
 }
 
-void ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    ScrollingTreeOverflowScrollingNode::commitStateBeforeChildren(stateNode);
+    if (!ScrollingTreeOverflowScrollingNode::commitStateBeforeChildren(stateNode))
+        return false;
+
+    if (!is<ScrollingStateOverflowScrollingNode>(stateNode))
+        return false;
+
     m_delegate->updateFromStateNode(downcast<ScrollingStateOverflowScrollingNode>(stateNode));
+    return true;
 }
 
 WheelEventHandlingResult ScrollingTreeOverflowScrollingNodeMac::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp
@@ -50,15 +50,18 @@ ScrollingTreeFixedNodeNicosia::ScrollingTreeFixedNodeNicosia(ScrollingTree& scro
 
 ScrollingTreeFixedNodeNicosia::~ScrollingTreeFixedNodeNicosia() = default;
 
-void ScrollingTreeFixedNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeFixedNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
+    if (!is<ScrollingStateFixedNode>(stateNode))
+        return false;
+
     auto& fixedStateNode = downcast<ScrollingStateFixedNode>(stateNode);
     if (fixedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
         auto* layer = static_cast<Nicosia::PlatformLayer*>(fixedStateNode.layer());
         m_layer = downcast<Nicosia::CompositionLayer>(layer);
     }
 
-    ScrollingTreeFixedNode::commitStateBeforeChildren(stateNode);
+    return ScrollingTreeFixedNode::commitStateBeforeChildren(stateNode);
 }
 
 void ScrollingTreeFixedNodeNicosia::applyLayerPositions()

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.h
@@ -46,7 +46,7 @@ private:
 
     Nicosia::CompositionLayer* layer() const override { return m_layer.get(); }
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     void applyLayerPositions() override WTF_REQUIRES_LOCK(scrollingTree().treeLock());
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
@@ -58,9 +58,13 @@ ScrollingTreeScrollingNodeDelegateNicosia& ScrollingTreeFrameScrollingNodeNicosi
     return *static_cast<ScrollingTreeScrollingNodeDelegateNicosia*>(m_delegate.get());
 }
 
-void ScrollingTreeFrameScrollingNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeFrameScrollingNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(stateNode);
+    if (!ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(stateNode))
+        return false;
+
+    if (!is<ScrollingStateFrameScrollingNode>(stateNode))
+        return false;
 
     const auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(stateNode);
 
@@ -90,6 +94,7 @@ void ScrollingTreeFrameScrollingNodeNicosia::commitStateBeforeChildren(const Scr
     }
 
     m_delegate->updateFromStateNode(scrollingStateNode);
+    return true;
 }
 
 WheelEventHandlingResult ScrollingTreeFrameScrollingNodeNicosia::handleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting)

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.h
@@ -53,7 +53,7 @@ private:
 
     ScrollingTreeScrollingNodeDelegateNicosia& delegate() const;
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
 
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
     void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) override;

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
@@ -48,14 +48,14 @@ ScrollingTreeOverflowScrollProxyNodeNicosia::ScrollingTreeOverflowScrollProxyNod
 
 ScrollingTreeOverflowScrollProxyNodeNicosia::~ScrollingTreeOverflowScrollProxyNodeNicosia() = default;
 
-void ScrollingTreeOverflowScrollProxyNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeOverflowScrollProxyNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
     if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
         auto* layer = static_cast<Nicosia::PlatformLayer*>(stateNode.layer());
         m_layer = downcast<Nicosia::CompositionLayer>(layer);
     }
 
-    ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(stateNode);
+    return ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren(stateNode);
 }
 
 void ScrollingTreeOverflowScrollProxyNodeNicosia::applyLayerPositions()

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.h
@@ -41,7 +41,7 @@ public:
 private:
     ScrollingTreeOverflowScrollProxyNodeNicosia(ScrollingTree&, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     void applyLayerPositions() override;
 
     Nicosia::CompositionLayer* layer() const override { return m_layer.get(); }

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp
@@ -55,10 +55,13 @@ ScrollingTreeScrollingNodeDelegateNicosia& ScrollingTreeOverflowScrollingNodeNic
     return *static_cast<ScrollingTreeScrollingNodeDelegateNicosia*>(m_delegate.get());
 }
 
-void ScrollingTreeOverflowScrollingNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeOverflowScrollingNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    ScrollingTreeOverflowScrollingNode::commitStateBeforeChildren(stateNode);
+    if (!ScrollingTreeOverflowScrollingNode::commitStateBeforeChildren(stateNode))
+        return false;
+
     m_delegate->updateFromStateNode(downcast<ScrollingStateScrollingNode>(stateNode));
+    return true;
 }
 
 void ScrollingTreeOverflowScrollingNodeNicosia::repositionScrollingLayers()

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.h
@@ -46,7 +46,7 @@ private:
 
     ScrollingTreeScrollingNodeDelegateNicosia& delegate() const;
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     void repositionScrollingLayers() override;
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
 };

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
@@ -49,15 +49,18 @@ ScrollingTreePositionedNodeNicosia::ScrollingTreePositionedNodeNicosia(Scrolling
 
 ScrollingTreePositionedNodeNicosia::~ScrollingTreePositionedNodeNicosia() = default;
 
-void ScrollingTreePositionedNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreePositionedNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
+    if (!is<ScrollingStatePositionedNode>(stateNode))
+        return false;
+
     const ScrollingStatePositionedNode& positionedStateNode = downcast<ScrollingStatePositionedNode>(stateNode);
     if (positionedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
         auto* layer = static_cast<Nicosia::PlatformLayer*>(positionedStateNode.layer());
         m_layer = downcast<Nicosia::CompositionLayer>(layer);
     }
 
-    ScrollingTreePositionedNode::commitStateBeforeChildren(stateNode);
+    return ScrollingTreePositionedNode::commitStateBeforeChildren(stateNode);
 }
 
 void ScrollingTreePositionedNodeNicosia::applyLayerPositions()

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.h
@@ -45,7 +45,7 @@ public:
 private:
     ScrollingTreePositionedNodeNicosia(ScrollingTree&, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     void applyLayerPositions() override;
 
     RefPtr<Nicosia::CompositionLayer> m_layer;

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
@@ -51,15 +51,18 @@ ScrollingTreeStickyNodeNicosia::ScrollingTreeStickyNodeNicosia(ScrollingTree& sc
 {
 }
 
-void ScrollingTreeStickyNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeStickyNodeNicosia::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
+    if (!is<ScrollingStateStickyNode>(stateNode))
+        return false;
+
     auto& stickyStateNode = downcast<ScrollingStateStickyNode>(stateNode);
     if (stickyStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
         auto* layer = static_cast<Nicosia::PlatformLayer*>(stickyStateNode.layer());
         m_layer = downcast<Nicosia::CompositionLayer>(layer);
     }
 
-    ScrollingTreeStickyNode::commitStateBeforeChildren(stateNode);
+    return ScrollingTreeStickyNode::commitStateBeforeChildren(stateNode);
 }
 
 void ScrollingTreeStickyNodeNicosia::applyLayerPositions()

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.h
@@ -45,7 +45,7 @@ public:
 private:
     ScrollingTreeStickyNodeNicosia(ScrollingTree&, ScrollingNodeID);
 
-    void commitStateBeforeChildren(const ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     void applyLayerPositions() override;
     FloatPoint layerTopLeft() const override;
     Nicosia::CompositionLayer* layer() const override { return m_layer.get(); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -47,6 +47,8 @@
 namespace WebKit {
 using namespace WebCore;
 
+#define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, (webPageProxy().process().connection()), returnValue)
+
 RemoteScrollingCoordinatorProxy::RemoteScrollingCoordinatorProxy(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)
     , m_scrollingTree(RemoteScrollingTree::create(*this))
@@ -92,7 +94,8 @@ std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScroll
     }
 
     connectStateNodeLayers(*stateTree, *layerTreeHost);
-    m_scrollingTree->commitTreeState(WTFMove(stateTree));
+    bool succeeded = m_scrollingTree->commitTreeState(WTFMove(stateTree));
+    MESSAGE_CHECK_WITH_RETURN_VALUE(succeeded, std::nullopt);
 
     establishLayerTreeScrollingRelations(*layerTreeHost);
     

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
@@ -47,8 +47,8 @@ private:
 
     ScrollingTreeScrollingNodeDelegateIOS* delegate() const;
 
-    void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
-    void commitStateAfterChildren(const WebCore::ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
+    bool commitStateAfterChildren(const WebCore::ScrollingStateNode&) override;
 
     WebCore::FloatPoint minimumScrollPosition() const override;
     WebCore::FloatPoint maximumScrollPosition() const override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
@@ -61,10 +61,14 @@ UIScrollView *ScrollingTreeFrameScrollingNodeRemoteIOS::scrollView() const
     return m_delegate ? delegate()->scrollView() : nil;
 }
 
-void ScrollingTreeFrameScrollingNodeRemoteIOS::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeFrameScrollingNodeRemoteIOS::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(stateNode);
-    
+    if (!ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(stateNode))
+        return false;
+
+    if (!is<ScrollingStateFrameScrollingNode>(stateNode))
+        return false;
+
     const auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(stateNode);
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CounterScrollingLayer))
@@ -84,16 +88,21 @@ void ScrollingTreeFrameScrollingNodeRemoteIOS::commitStateBeforeChildren(const S
     }
 
     if (m_delegate)
-        delegate()->commitStateBeforeChildren(downcast<ScrollingStateScrollingNode>(stateNode));
+        delegate()->commitStateBeforeChildren(scrollingStateNode);
+
+    return true;
 }
 
-void ScrollingTreeFrameScrollingNodeRemoteIOS::commitStateAfterChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeFrameScrollingNodeRemoteIOS::commitStateAfterChildren(const ScrollingStateNode& stateNode)
 {
-    const auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(stateNode);
-    if (m_delegate)
-        delegate()->commitStateAfterChildren(scrollingStateNode);
+    if (m_delegate) {
+        if (!is<ScrollingStateFrameScrollingNode>(stateNode))
+            return false;
 
-    ScrollingTreeFrameScrollingNode::commitStateAfterChildren(stateNode);
+        delegate()->commitStateAfterChildren(downcast<ScrollingStateFrameScrollingNode>(stateNode));
+    }
+
+    return ScrollingTreeFrameScrollingNode::commitStateAfterChildren(stateNode);
 }
 
 FloatPoint ScrollingTreeFrameScrollingNodeRemoteIOS::minimumScrollPosition() const

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
@@ -47,8 +47,8 @@ private:
 
     ScrollingTreeScrollingNodeDelegateIOS& delegate() const;
 
-    void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) final;
-    void commitStateAfterChildren(const WebCore::ScrollingStateNode&) final;
+    bool commitStateBeforeChildren(const WebCore::ScrollingStateNode&) final;
+    bool commitStateAfterChildren(const WebCore::ScrollingStateNode&) final;
     
     void repositionScrollingLayers() final;
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
@@ -61,21 +61,30 @@ UIScrollView* ScrollingTreeOverflowScrollingNodeIOS::scrollView() const
     return delegate().scrollView();
 }
 
-void ScrollingTreeOverflowScrollingNodeIOS::commitStateBeforeChildren(const WebCore::ScrollingStateNode& stateNode)
+bool ScrollingTreeOverflowScrollingNodeIOS::commitStateBeforeChildren(const WebCore::ScrollingStateNode& stateNode)
 {
+    if (!is<ScrollingStateScrollingNode>(stateNode))
+        return false;
+
     if (stateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer))
         delegate().resetScrollViewDelegate();
 
-    ScrollingTreeOverflowScrollingNode::commitStateBeforeChildren(stateNode);
+    if (!ScrollingTreeOverflowScrollingNode::commitStateBeforeChildren(stateNode))
+        return false;
+
     delegate().commitStateBeforeChildren(downcast<ScrollingStateScrollingNode>(stateNode));
+    return true;
 }
 
-void ScrollingTreeOverflowScrollingNodeIOS::commitStateAfterChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeOverflowScrollingNodeIOS::commitStateAfterChildren(const ScrollingStateNode& stateNode)
 {
+    if (!is<ScrollingStateScrollingNode>(stateNode))
+        return false;
+
     const auto& scrollingStateNode = downcast<ScrollingStateScrollingNode>(stateNode);
     delegate().commitStateAfterChildren(scrollingStateNode);
 
-    ScrollingTreeOverflowScrollingNode::commitStateAfterChildren(stateNode);
+    return ScrollingTreeOverflowScrollingNode::commitStateAfterChildren(stateNode);
 }
 
 void ScrollingTreeOverflowScrollingNodeIOS::repositionScrollingLayers()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -48,11 +48,17 @@ Ref<ScrollingTreeFrameScrollingNodeRemoteMac> ScrollingTreeFrameScrollingNodeRem
     return adoptRef(*new ScrollingTreeFrameScrollingNodeRemoteMac(tree, nodeType, nodeID));
 }
 
-void ScrollingTreeFrameScrollingNodeRemoteMac::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeFrameScrollingNodeRemoteMac::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren(stateNode);
+    if (!ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren(stateNode))
+        return false;
+
+    if (!is<ScrollingStateFrameScrollingNode>(stateNode))
+        return false;
+
     const auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(stateNode);
     m_delegate->updateFromStateNode(scrollingStateNode);
+    return true;
 }
 
 void ScrollingTreeFrameScrollingNodeRemoteMac::repositionRelatedLayers()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h
@@ -43,7 +43,7 @@ public:
 private:
     ScrollingTreeFrameScrollingNodeRemoteMac(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);
 
-    void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
     void handleWheelEventPhase(const WebCore::PlatformWheelEventPhase) override;
 
     void repositionRelatedLayers() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
@@ -50,11 +50,17 @@ ScrollingTreeOverflowScrollingNodeRemoteMac::~ScrollingTreeOverflowScrollingNode
 {
 }
 
-void ScrollingTreeOverflowScrollingNodeRemoteMac::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
+bool ScrollingTreeOverflowScrollingNodeRemoteMac::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren(stateNode);
+    if (!ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren(stateNode))
+        return false;
+
+    if (!is<ScrollingStateOverflowScrollingNode>(stateNode))
+        return false;
+
     const auto& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(stateNode);
     m_delegate->updateFromStateNode(scrollingStateNode);
+    return true;
 }
 
 void ScrollingTreeOverflowScrollingNodeRemoteMac::repositionRelatedLayers()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h
@@ -43,7 +43,7 @@ public:
 private:
     ScrollingTreeOverflowScrollingNodeRemoteMac(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);
 
-    void commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
+    bool commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
     void handleWheelEventPhase(const WebCore::PlatformWheelEventPhase) override;
     void repositionRelatedLayers() override;
     String scrollbarStateForOrientation(WebCore::ScrollbarOrientation) const override;


### PR DESCRIPTION
#### d65209dce0af0b475ef0ccbba83948d513fdcb75
<pre>
Cherry-pick 259548.75@safari-7615-branch (22b0e73428bb). rdar://107499524

    [CoreIPC] Type confusion bug in ScrollingTree::updateTreeFromStateNodeRecursive
    <a href="https://bugs.webkit.org/show_bug.cgi?id=251969">https://bugs.webkit.org/show_bug.cgi?id=251969</a>
    rdar://102603165

    Reviewed by Ryosuke Niwa.

    Make sure we type-check before all the downcast&lt;&gt; calls in code under scrolling tree commits.
    If a type-check fails, MESSAGE_CHECK in RemoteScrollingCoordinatorProxy::commitScrollingTree().

    commitStateBeforeChildren() and commitStateAfterChildren() on all the scrolling tree node classes
    now return bool, indicating success or failure.

    * Source/WebCore/page/scrolling/ScrollingTree.cpp:
    (WebCore::ScrollingTree::commitTreeState):
    (WebCore::ScrollingTree::updateTreeFromStateNodeRecursive):
    * Source/WebCore/page/scrolling/ScrollingTree.h:
    * Source/WebCore/page/scrolling/ScrollingTreeFixedNode.cpp:
    (WebCore::ScrollingTreeFixedNode::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/ScrollingTreeFixedNode.h:
    * Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp:
    (WebCore::ScrollingTreeFrameHostingNode::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h:
    * Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp:
    (WebCore::ScrollingTreeFrameScrollingNode::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h:
    * Source/WebCore/page/scrolling/ScrollingTreeNode.h:
    (WebCore::ScrollingTreeNode::commitStateAfterChildren):
    * Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp:
    (WebCore::ScrollingTreeOverflowScrollProxyNode::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollProxyNode.h:
    * Source/WebCore/page/scrolling/ScrollingTreePositionedNode.cpp:
    (WebCore::ScrollingTreePositionedNode::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/ScrollingTreePositionedNode.h:
    * Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
    (WebCore::ScrollingTreeScrollingNode::commitStateBeforeChildren):
    (WebCore::ScrollingTreeScrollingNode::commitStateAfterChildren):
    * Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
    * Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
    (WebCore::ScrollingTreeStickyNode::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/ScrollingTreeStickyNode.h:
    * Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h:
    * Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm:
    (WebCore::ScrollingTreeFixedNodeCocoa::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.h:
    * Source/WebCore/page/scrolling/cocoa/ScrollingTreeOverflowScrollProxyNodeCocoa.mm:
    (WebCore::ScrollingTreeOverflowScrollProxyNodeCocoa::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h:
    * Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm:
    (WebCore::ScrollingTreePositionedNodeCocoa::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
    * Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
    (WebCore::ScrollingTreeStickyNodeCocoa::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
    * Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
    (WebCore::ScrollingTreeFrameScrollingNodeMac::commitStateBeforeChildren):
    (WebCore::ScrollingTreeFrameScrollingNodeMac::commitStateAfterChildren):
    * Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h:
    * Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm:
    (WebCore::ScrollingTreeOverflowScrollingNodeMac::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp:
    (WebCore::ScrollingTreeFixedNodeNicosia::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.h:
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp:
    (WebCore::ScrollingTreeFrameScrollingNodeNicosia::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.h:
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp:
    (WebCore::ScrollingTreeOverflowScrollProxyNodeNicosia::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.h:
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp:
    (WebCore::ScrollingTreeOverflowScrollingNodeNicosia::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.h:
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp:
    (WebCore::ScrollingTreePositionedNodeNicosia::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.h:
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp:
    (WebCore::ScrollingTreeStickyNodeNicosia::commitStateBeforeChildren):
    * Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.h:
    * Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
    (WebKit::RemoteScrollingCoordinatorProxy::commitScrollingTreeState):
    * Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h:
    * Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm:
    (WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::commitStateBeforeChildren):
    (WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::commitStateAfterChildren):
    * Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h:
    * Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm:
    (WebKit::ScrollingTreeOverflowScrollingNodeIOS::commitStateBeforeChildren):
    (WebKit::ScrollingTreeOverflowScrollingNodeIOS::commitStateAfterChildren):
    * Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp:
    (WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::commitStateBeforeChildren):
    * Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h:
    * Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp:
    (WebKit::ScrollingTreeOverflowScrollingNodeRemoteMac::commitStateBeforeChildren):
    * Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.h:

    Canonical link: <a href="https://commits.webkit.org/259548.75@safari-7615-branch">https://commits.webkit.org/259548.75@safari-7615-branch</a>

Canonical link: <a href="https://commits.webkit.org/262517@main">https://commits.webkit.org/262517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e1e985f99f79175021f80d13ae58a824372dd62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2694 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1653 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2533 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1493 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1626 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1613 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2691 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1472 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1577 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/433 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1718 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->