### PR TITLE
Avoid calling scanTagName() in HTMLFastPathParser::parseContainerElement()

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -305,6 +305,7 @@ private:
 
         struct A : ContainerTag<HTMLAnchorElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_a;
+            static constexpr Char tagNameCharacters[] = { 'a' };
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -318,6 +319,7 @@ private:
 
         struct AWithPhrasingContent : ContainsPhrasingContentTag<HTMLAnchorElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_a;
+            static constexpr Char tagNameCharacters[] = { 'a' };
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -331,6 +333,7 @@ private:
 
         struct B : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_b;
+            static constexpr Char tagNameCharacters[] = { 'b' };
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -340,18 +343,22 @@ private:
 
         struct Br : VoidTag<HTMLBRElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_br;
+            static constexpr Char tagNameCharacters[] = { 'b', 'r' };
         };
 
         struct Button : ContainsPhrasingContentTag<HTMLButtonElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_button;
+            static constexpr Char tagNameCharacters[] = { 'b', 'u', 't', 't', 'o', 'n' };
         };
 
         struct Div : ContainerTag<HTMLDivElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_div;
+            static constexpr Char tagNameCharacters[] = { 'd', 'i', 'v' };
         };
 
         struct Footer : ContainerTag<HTMLDivElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_footer;
+            static constexpr Char tagNameCharacters[] = { 'f', 'o', 'o', 't', 'e', 'r' };
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -361,6 +368,7 @@ private:
 
         struct I : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_i;
+            static constexpr Char tagNameCharacters[] = { 'i' };
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -370,6 +378,7 @@ private:
 
         struct Input : VoidTag<HTMLInputElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_input;
+            static constexpr Char tagNameCharacters[] = { 'i', 'n', 'p', 'u', 't' };
 
             static Ref<HTMLInputElement> create(Document& document)
             {
@@ -379,14 +388,17 @@ private:
 
         struct Li : ContainerTag<HTMLLIElement, PermittedParents::Special> {
             static constexpr ElementName tagName = ElementName::HTML_li;
+            static constexpr Char tagNameCharacters[] = { 'l', 'i' };
         };
 
         struct Label : ContainsPhrasingContentTag<HTMLLabelElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_label;
+            static constexpr Char tagNameCharacters[] = { 'l', 'a', 'b', 'e', 'l' };
         };
 
         struct Option : ContainerTag<HTMLOptionElement, PermittedParents::Special> {
             static constexpr ElementName tagName = ElementName::HTML_option;
+            static constexpr Char tagNameCharacters[] = { 'o', 'p', 't', 'i', 'o', 'n' };
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -397,6 +409,7 @@ private:
 
         struct Ol : ContainerTag<HTMLOListElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_ol;
+            static constexpr Char tagNameCharacters[] = { 'o', 'l' };
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -406,10 +419,12 @@ private:
 
         struct P : ContainsPhrasingContentTag<HTMLParagraphElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_p;
+            static constexpr Char tagNameCharacters[] = { 'p' };
         };
 
         struct Select : ContainerTag<HTMLSelectElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_select;
+            static constexpr Char tagNameCharacters[] = { 's', 'e', 'l', 'e', 'c', 't' };
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -419,10 +434,12 @@ private:
 
         struct Span : ContainsPhrasingContentTag<HTMLSpanElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_span;
+            static constexpr Char tagNameCharacters[] = { 's', 'p', 'a', 'n' };
         };
 
         struct Strong : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_strong;
+            static constexpr Char tagNameCharacters[] = { 's', 't', 'r', 'o', 'n', 'g' };
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -432,6 +449,7 @@ private:
 
         struct Ul : ContainerTag<HTMLUListElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementName::HTML_ul;
+            static constexpr Char tagNameCharacters[] = { 'u', 'l' };
 
             static RefPtr<Element> parseChild(HTMLFastPathParser& self)
             {
@@ -842,9 +860,6 @@ private:
         // Similarly, we disallow nesting <a> tags. But tables for example have
         // complex re-parenting rules that cannot be captured in this way, so we
         // cannot support them.
-        //
-        // If this switch has duplicate cases, then `tagNameHash()` needs to be
-        // updated.
         switch (tagName) {
 #define TAG_CASE(TagName, TagClassName)                                                  \
         case ElementName::HTML_ ## TagName:                                              \
@@ -894,12 +909,16 @@ private:
         // and fails if the the current char is not '/'.
         ASSERT(*m_parsingBuffer == '/');
         m_parsingBuffer.advance();
-        auto endtag = scanTagName();
-        if (endtag == Tag::tagName) {
-            if (m_parsingBuffer.atEnd() || m_parsingBuffer.consume() != '>')
-                return didFail(HTMLFastPathResult::FailedUnexpectedTagNameCloseState, element);
-        } else
-            return didFail(HTMLFastPathResult::FailedEndTagNameMismatch, element);
+
+        if (UNLIKELY(!skipCharactersExactly(m_parsingBuffer, Tag::tagNameCharacters))) {
+            if (!skipLettersExactlyIgnoringASCIICase(m_parsingBuffer, Tag::tagNameCharacters))
+                return didFail(HTMLFastPathResult::FailedEndTagNameMismatch, element);
+        }
+        skipWhile<isHTMLSpace>(m_parsingBuffer);
+
+        if (m_parsingBuffer.atEnd() || m_parsingBuffer.consume() != '>')
+            return didFail(HTMLFastPathResult::FailedUnexpectedTagNameCloseState, element);
+
         element->finishParsingChildren();
         return WTFMove(element);
     }

--- a/Source/WebCore/html/parser/ParsingUtilities.h
+++ b/Source/WebCore/html/parser/ParsingUtilities.h
@@ -198,6 +198,19 @@ template<typename CharacterType> bool skipExactlyIgnoringASCIICase(StringParsing
     return true;
 }
 
+template<typename CharacterType, unsigned characterCount> bool skipLettersExactlyIgnoringASCIICase(StringParsingBuffer<CharacterType>& buffer, const CharacterType(&letters)[characterCount])
+{
+    if (buffer.lengthRemaining() < characterCount)
+        return false;
+    for (unsigned i = 0; i < characterCount; ++i) {
+        ASSERT(isASCIIAlpha(letters[i]));
+        if (!isASCIIAlphaCaselessEqual(buffer.position()[i], static_cast<char>(letters[i])))
+            return false;
+    }
+    buffer += characterCount;
+    return true;
+}
+
 template<typename CharacterType, unsigned characterCount> constexpr bool skipCharactersExactly(const CharacterType*& ptr, const CharacterType* end, const CharacterType(&str)[characterCount])
 {
     if (end - ptr < characterCount)


### PR DESCRIPTION
#### c727638623487a921b8bee06568220f69965db10
<pre>
Avoid calling scanTagName() in HTMLFastPathParser::parseContainerElement()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254920">https://bugs.webkit.org/show_bug.cgi?id=254920</a>

Reviewed by Ryosuke Niwa.

parseContainerElement() used to call scanTagName(), which would read all the
characters of the tag and convert them to lowercase. Then it would convert
the Span of characters to an ElementName enum.

However, in this case, we&apos;re parsing the end tag and we know it has to match
the start tag. If it doesn&apos;t then the element wouldn&apos;t be valid. As a result,
we can just call skipCharactersExactly() in the fast path, which will do a
simple memcmp() and succeed most of the time. In the slow case, we fall back
to calling skipLettersExactlyIgnoringASCIICase() in case the end tag is not
lowercase.

This is slightly more efficient.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseContainerElement):
* Source/WebCore/html/parser/ParsingUtilities.h:
(WebCore::skipLettersExactlyIgnoringASCIICase):
(WebCore::skipCharactersExactly): Deleted.

Canonical link: <a href="https://commits.webkit.org/262520@main">https://commits.webkit.org/262520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80a4d3d1c8150528248e6ef03cdd20bbca1aea05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2697 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1893 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1658 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2535 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1499 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1628 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1615 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2698 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1476 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1579 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/434 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1720 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->