### PR TITLE
MacOS follow-up after 262487@main

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "PlatformImage.h"
+
+OBJC_CLASS CALayer;
+
+namespace WebCore {
+
+class FloatSize;
+
+class VideoFullscreenCaptions {
+public:
+    WEBCORE_EXPORT void setTrackRepresentationImage(PlatformImagePtr textTrack);
+    WEBCORE_EXPORT void setTrackRepresentationContentsScale(float);
+    WEBCORE_EXPORT void setTrackRepresentationHidden(bool);
+    
+    WEBCORE_EXPORT CALayer* captionsLayer();
+    WEBCORE_EXPORT void setCaptionsFrame(const CGRect&);
+    WEBCORE_EXPORT void setupCaptionsLayer(CALayer* parent, const FloatSize&);
+    WEBCORE_EXPORT void removeCaptionsLayer();
+    
+private:
+    RetainPtr<CALayer> m_captionsLayer;
+};
+
+}

--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "VideoFullscreenCaptions.h"
+
+#import "FloatSize.h"
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CATransaction.h>
+
+namespace WebCore {
+    
+void VideoFullscreenCaptions::setTrackRepresentationImage(PlatformImagePtr textTrack)
+{
+    [m_captionsLayer setContents:(__bridge id)textTrack.get()];
+}
+
+void VideoFullscreenCaptions::setTrackRepresentationContentsScale(float scale)
+{
+    [m_captionsLayer setContentsScale:scale];
+}
+
+void VideoFullscreenCaptions::setTrackRepresentationHidden(bool hidden)
+{
+    [m_captionsLayer setHidden:hidden];
+}
+
+CALayer *VideoFullscreenCaptions::captionsLayer()
+{
+    if (!m_captionsLayer) {
+        m_captionsLayer = adoptNS([[CALayer alloc] init]);
+        [m_captionsLayer setName:@"Captions layer"];
+    }
+    return m_captionsLayer.get();
+}
+
+void VideoFullscreenCaptions::setCaptionsFrame(const CGRect& frame)
+{
+    [captionsLayer() setFrame:frame];
+}
+
+void VideoFullscreenCaptions::setupCaptionsLayer(CALayer* parent, const WebCore::FloatSize& initialSize)
+{
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    [captionsLayer() removeFromSuperlayer];
+    [parent addSublayer:captionsLayer()];
+    captionsLayer().zPosition = FLT_MAX;
+    [captionsLayer() setAnchorPoint:CGPointZero];
+    [captionsLayer() setBounds:CGRectMake(0, 0, initialSize.width(), initialSize.height())];
+    [CATransaction commit];
+}
+
+void VideoFullscreenCaptions::removeCaptionsLayer()
+{
+    [m_captionsLayer removeFromSuperlayer];
+    m_captionsLayer = nullptr;
+}
+
+}

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
@@ -34,6 +34,7 @@
 #include "PlatformImage.h"
 #include "PlatformLayer.h"
 #include "PlaybackSessionInterfaceAVKit.h"
+#include "VideoFullscreenCaptions.h"
 #include "VideoFullscreenModel.h"
 #include <objc/objc.h>
 #include <wtf/Forward.h>
@@ -64,6 +65,7 @@ class VideoFullscreenChangeObserver;
 class VideoFullscreenInterfaceAVKit final
     : public VideoFullscreenModelClient
     , public PlaybackSessionModelClient
+    , public VideoFullscreenCaptions
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoFullscreenInterfaceAVKit, WTF::DestructionThread::MainRunLoop> {
 public:
     WEBCORE_EXPORT static Ref<VideoFullscreenInterfaceAVKit> create(PlaybackSessionInterfaceAVKit&);
@@ -163,15 +165,6 @@ public:
     WEBCORE_EXPORT AVPlayerViewController *avPlayerViewController() const;
     WebAVPlayerController *playerController() const;
 
-    WEBCORE_EXPORT void textTrackRepresentationUpdate(PlatformImagePtr textTrack);
-    WEBCORE_EXPORT void textTrackRepresentationSetContentsScale(float scale);
-    WEBCORE_EXPORT void textTrackRepresentationSetHidden(bool hidden);
-
-    WEBCORE_EXPORT CALayer* captionsLayer();
-    WEBCORE_EXPORT void setCaptionsFrame(const CGRect&);
-    WEBCORE_EXPORT void setupCaptionsLayer(CALayer* parent, const WebCore::FloatSize&);
-    WEBCORE_EXPORT void removeCaptionsLayer();
-
 private:
     WEBCORE_EXPORT VideoFullscreenInterfaceAVKit(PlaybackSessionInterfaceAVKit&);
 
@@ -246,8 +239,6 @@ private:
     bool m_shouldIgnoreAVKitCallbackAboutExitFullscreenReason { false };
     bool m_enteringPictureInPicture { false };
     bool m_exitingPictureInPicture { false };
-
-    RetainPtr<CALayer> m_captionsLayer;
 };
 
 }

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -1533,52 +1533,6 @@ bool VideoFullscreenInterfaceAVKit::isPlayingVideoInEnhancedFullscreen() const
     return hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) && [playerController() isPlaying];
 }
 
-void VideoFullscreenInterfaceAVKit::textTrackRepresentationUpdate(PlatformImagePtr textTrack)
-{
-    [m_captionsLayer setContents:(__bridge id)textTrack.get()];
-}
-
-void VideoFullscreenInterfaceAVKit::textTrackRepresentationSetContentsScale(float scale)
-{
-    [m_captionsLayer setContentsScale:scale];
-}
-
-void VideoFullscreenInterfaceAVKit::textTrackRepresentationSetHidden(bool hidden)
-{
-    [m_captionsLayer setHidden:hidden];
-}
-
-CALayer *VideoFullscreenInterfaceAVKit::captionsLayer()
-{
-    if (!m_captionsLayer)
-        m_captionsLayer = adoptNS([[CALayer alloc] init]);
-    return m_captionsLayer.get();
-}
-
-void VideoFullscreenInterfaceAVKit::setCaptionsFrame(const CGRect& frame)
-{
-    [captionsLayer() setFrame:frame];
-}
-
-void VideoFullscreenInterfaceAVKit::setupCaptionsLayer(CALayer* parent, const WebCore::FloatSize& initialSize)
-{
-    [captionsLayer() removeFromSuperlayer];
-    [parent addSublayer:captionsLayer()];
-
-    [CATransaction begin];
-    [CATransaction setDisableActions:YES];
-    captionsLayer().zPosition = FLT_MAX;
-    [captionsLayer() setAnchorPoint:CGPointZero];
-    [captionsLayer() setBounds:CGRectMake(0, 0, initialSize.width(), initialSize.height())];
-    [CATransaction commit];
-}
-
-void VideoFullscreenInterfaceAVKit::removeCaptionsLayer()
-{
-    [m_captionsLayer removeFromSuperlayer];
-    m_captionsLayer = nullptr;
-}
-
 static std::optional<bool> isPictureInPictureSupported;
 
 void WebCore::setSupportsPictureInPicture(bool isSupported)

--- a/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.h
@@ -31,6 +31,7 @@
 #include "MediaPlayerIdentifier.h"
 #include "PlaybackSessionInterfaceMac.h"
 #include "PlaybackSessionModel.h"
+#include "VideoFullscreenCaptions.h"
 #include "VideoFullscreenModel.h"
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
@@ -48,6 +49,7 @@ class VideoFullscreenChangeObserver;
 class VideoFullscreenInterfaceMac
     : public VideoFullscreenModelClient
     , private PlaybackSessionModelClient
+    , public VideoFullscreenCaptions
     , public RefCounted<VideoFullscreenInterfaceMac> {
 
 public:

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1144,6 +1144,8 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
         if (m_graphicsLayer->layerMode() == GraphicsLayer::LayerMode::LayerHostingContextId
 #if ENABLE(GPU_PROCESS)
             && videoElement.document().settings().blockMediaLayerRehostingInWebContentProcess()
+            && videoElement.document().page()
+            && videoElement.document().page()->chrome().client().isUsingUISideCompositing()
 #endif
             )
             m_graphicsLayer->setContentsToVideoElement(videoElement, GraphicsLayer::ContentsLayerPurpose::Media);

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -600,9 +600,7 @@ RetainPtr<WKLayerHostView> VideoFullscreenManagerProxy::createLayerHostViewWithI
     [view layer].frame = CGRectMake(0, 0, initialSize.width(), initialSize.height());
     [view setContextID:videoLayerID];
 
-#if PLATFORM(IOS_FAMILY)
     interface->setupCaptionsLayer([view layer], initialSize);
-#endif
 
     return view;
 }
@@ -863,28 +861,22 @@ void VideoFullscreenManagerProxy::preparedToExitFullscreen(PlaybackSessionContex
 
 void VideoFullscreenManagerProxy::textTrackRepresentationUpdate(PlaybackSessionContextIdentifier contextId, const ShareableBitmapHandle& textTrack)
 {
-#if PLATFORM(IOS_FAMILY)
     auto bitmap = ShareableBitmap::create(textTrack);
     if (!bitmap)
         return;
     
     auto platformImage = bitmap->createPlatformImage();
-    ensureInterface(contextId).textTrackRepresentationUpdate(platformImage);
-#endif
+    ensureInterface(contextId).setTrackRepresentationImage(platformImage);
 }
 
 void VideoFullscreenManagerProxy::textTrackRepresentationSetContentsScale(PlaybackSessionContextIdentifier contextId, float scale)
 {
-#if PLATFORM(IOS_FAMILY)
-    ensureInterface(contextId).textTrackRepresentationSetContentsScale(scale);
-#endif
+    ensureInterface(contextId).setTrackRepresentationContentsScale(scale);
 }
 
 void VideoFullscreenManagerProxy::textTrackRepresentationSetHidden(PlaybackSessionContextIdentifier contextId, bool hidden)
 {
-#if PLATFORM(IOS_FAMILY)
-    ensureInterface(contextId).textTrackRepresentationSetHidden(hidden);
-#endif
+    ensureInterface(contextId).setTrackRepresentationHidden(hidden);
 }
 
 #pragma mark Messages to VideoFullscreenManager
@@ -998,9 +990,7 @@ void VideoFullscreenManagerProxy::didCleanupFullscreen(PlaybackSessionContextIde
     auto& [model, interface] = ensureModelAndInterface(contextId);
 
     [model->layerHostView() removeFromSuperview];
-#if PLATFORM(IOS_FAMILY)
     interface->removeCaptionsLayer();
-#endif
     if (auto playerLayer = model->playerLayer()) {
         // Return the video layer to the player layer
         auto videoView = model->layerHostView();
@@ -1020,10 +1010,10 @@ void VideoFullscreenManagerProxy::didCleanupFullscreen(PlaybackSessionContextIde
 
 void VideoFullscreenManagerProxy::setVideoLayerFrame(PlaybackSessionContextIdentifier contextId, WebCore::FloatRect frame)
 {
-#if PLATFORM(IOS_FAMILY)
     auto& [model, interface] = ensureModelAndInterface(contextId);
-    auto fenceSendRight = MachSendRight::adopt([UIWindow _synchronizeDrawingAcrossProcesses]);
     interface->setCaptionsFrame(CGRectMake(0, 0, frame.width(), frame.height()));
+#if PLATFORM(IOS_FAMILY)
+    auto fenceSendRight = MachSendRight::adopt([UIWindow _synchronizeDrawingAcrossProcesses]);
 #else
     MachSendRight fenceSendRight;
     if (DrawingAreaProxy* drawingArea = m_page->drawingArea())

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
@@ -95,7 +95,7 @@ public:
     void setIsFullscreen(bool flag) { m_isFullscreen = flag; }
 
     RetainPtr<CALayer> rootLayer() const { return m_rootLayer; }
-    void setRootLayer(RetainPtr<CALayer> layer) { m_rootLayer = layer; }
+    void setRootLayer(RetainPtr<CALayer>);
 
 private:
     // VideoFullscreenModelClient


### PR DESCRIPTION
#### fc633e7073a21283e1b912abb788ca0f60c4b5b9
<pre>
MacOS follow-up after 262487@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=254922">https://bugs.webkit.org/show_bug.cgi?id=254922</a>
rdar://107560995

Reviewed by Eric Carlson.

MacOS should also forward the caption bitmaps to the UI process, as was done for iOS in 262487@main.
This patch adds the required pieces to a new VideoFullscreenCaptions class, shared by iOS and macOS.
This patch also fixes a null pointer crash when entering fullscreen on macOS. Additionally, the
setting BlockMediaLayerRehostingInWebContentProcess is changed to only take effect when UI side
compositing is enabled, since this is the case it is intended for.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h:
* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm:
(WebCore::VideoFullscreenCaptions::setTrackRepresentationImage):
(WebCore::VideoFullscreenCaptions::setTrackRepresentationContentsScale):
(WebCore::VideoFullscreenCaptions::setTrackRepresentationHidden):
(WebCore::VideoFullscreenCaptions::captionsLayer):
(WebCore::VideoFullscreenCaptions::setCaptionsFrame):
(WebCore::VideoFullscreenCaptions::setupCaptionsLayer):
(WebCore::VideoFullscreenCaptions::removeCaptionsLayer):
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(VideoFullscreenInterfaceAVKit::textTrackRepresentationUpdate): Deleted.
(VideoFullscreenInterfaceAVKit::textTrackRepresentationSetContentsScale): Deleted.
(VideoFullscreenInterfaceAVKit::textTrackRepresentationSetHidden): Deleted.
(VideoFullscreenInterfaceAVKit::captionsLayer): Deleted.
(VideoFullscreenInterfaceAVKit::setCaptionsFrame): Deleted.
(VideoFullscreenInterfaceAVKit::setupCaptionsLayer): Deleted.
(VideoFullscreenInterfaceAVKit::removeCaptionsLayer): Deleted.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
* Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.h:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenManagerProxy::createLayerHostViewWithID):
(WebKit::VideoFullscreenManagerProxy::textTrackRepresentationUpdate):
(WebKit::VideoFullscreenManagerProxy::textTrackRepresentationSetContentsScale):
(WebKit::VideoFullscreenManagerProxy::textTrackRepresentationSetHidden):
(WebKit::VideoFullscreenManagerProxy::didCleanupFullscreen):
(WebKit::VideoFullscreenManagerProxy::setVideoLayerFrame):
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h:
(WebKit::VideoFullscreenInterfaceContext::setRootLayer): Deleted.
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenInterfaceContext::setRootLayer):
(WebKit::VideoFullscreenManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::didExitFullscreen):
(WebKit::VideoFullscreenManager::didCleanupFullscreen):
(WebKit::VideoFullscreenManager::setupRemoteLayerHosting):

Canonical link: <a href="https://commits.webkit.org/262591@main">https://commits.webkit.org/262591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/493cd80f9e9d17acc72cc802193006de6c0e01b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2049 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1808 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2735 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1654 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1805 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1786 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2915 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1617 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1750 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/488 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1908 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->