### PR TITLE
[GPU Process] Refactor ShareableBitmapConfiguration

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -285,7 +285,7 @@ void RemoteRenderingBackend::getShareableBitmapForImageBufferWithQualifiedIdenti
         auto backendSize = imageBuffer->backendSize();
         auto logicalSize = imageBuffer->logicalSize();
         auto resultSize = preserveResolution == PreserveResolution::Yes ? backendSize : imageBuffer->truncatedLogicalSize();
-        auto bitmap = ShareableBitmap::create(resultSize, { imageBuffer->colorSpace() });
+        auto bitmap = ShareableBitmap::create({ resultSize, imageBuffer->colorSpace() });
         if (!bitmap)
             return;
         auto context = bitmap->createGraphicsContext();
@@ -311,7 +311,7 @@ void RemoteRenderingBackend::getFilteredImageForImageBuffer(RenderingResourceIde
         if (!image)
             return;
         auto imageSize = image->size();
-        auto bitmap = ShareableBitmap::create(IntSize(imageSize), { imageBuffer->colorSpace() });
+        auto bitmap = ShareableBitmap::create({ IntSize(imageSize), imageBuffer->colorSpace() });
         if (!bitmap)
             return;
         auto context = bitmap->createGraphicsContext();

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -228,7 +228,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpateInfo&& update)
 
     std::optional<UpdateInfo> result;
     if (m_usesOffscreenRendering) {
-        auto bitmap = ShareableBitmap::create(windowSize, { });
+        auto bitmap = ShareableBitmap::create({ windowSize });
         glReadPixels(0, 0, windowSize.width(), windowSize.height(), GL_BGRA, GL_UNSIGNED_BYTE, bitmap->data());
         if (auto handle = bitmap->createHandle()) {
             result.emplace();

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
@@ -141,7 +141,7 @@ void RemoteImageDecoderAVFProxy::createFrameImageAtIndex(ImageDecoderIdentifier 
     DestinationColorSpace colorSpace { CGImageGetColorSpace(frameImage.get()) };
     bool isOpaque = false;
 
-    auto bitmap = ShareableBitmap::create(IntSize(width, height), { WTFMove(colorSpace), isOpaque });
+    auto bitmap = ShareableBitmap::create({ IntSize(width, height), WTFMove(colorSpace), isOpaque });
     if (!bitmap)
         return;
     auto context = bitmap->createGraphicsContext();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -207,7 +207,7 @@ ShareableBitmapHandle RemoteMediaPlayerManagerProxy::bitmapImageForCurrentTime(W
         return { };
 
     auto imageSize = image->size();
-    auto bitmap = ShareableBitmap::create(imageSize, { player->colorSpace() });
+    auto bitmap = ShareableBitmap::create({ imageSize, player->colorSpace() });
     if (!bitmap)
         return { };
 

--- a/Source/WebKit/Shared/ContextMenuContextData.cpp
+++ b/Source/WebKit/Shared/ContextMenuContextData.cpp
@@ -87,7 +87,7 @@ ContextMenuContextData::ContextMenuContextData(const WebCore::IntPoint& menuLoca
 void ContextMenuContextData::setImage(WebCore::Image& image)
 {
     // FIXME: figure out the rounding strategy for ShareableBitmap.
-    m_controlledImage = ShareableBitmap::create(IntSize(image.size()), { });
+    m_controlledImage = ShareableBitmap::create({ IntSize(image.size()) });
     if (auto graphicsContext = m_controlledImage->createGraphicsContext())
         graphicsContext->drawImage(image, IntPoint());
 }
@@ -97,14 +97,14 @@ void ContextMenuContextData::setImage(WebCore::Image& image)
 
 void ContextMenuContextData::setPotentialQRCodeNodeSnapshotImage(WebCore::Image& image)
 {
-    m_potentialQRCodeNodeSnapshotImage = ShareableBitmap::create(IntSize(image.size()), { });
+    m_potentialQRCodeNodeSnapshotImage = ShareableBitmap::create({ IntSize(image.size()) });
     if (auto graphicsContext = m_potentialQRCodeNodeSnapshotImage->createGraphicsContext())
         graphicsContext->drawImage(image, IntPoint());
 }
 
 void ContextMenuContextData::setPotentialQRCodeViewportSnapshotImage(WebCore::Image& image)
 {
-    m_potentialQRCodeViewportSnapshotImage = ShareableBitmap::create(IntSize(image.size()), { });
+    m_potentialQRCodeViewportSnapshotImage = ShareableBitmap::create({ IntSize(image.size()) });
     if (auto graphicsContext = m_potentialQRCodeViewportSnapshotImage->createGraphicsContext())
         graphicsContext->drawImage(image, IntPoint());
 }

--- a/Source/WebKit/Shared/ShareableBitmap.serialization.in
+++ b/Source/WebKit/Shared/ShareableBitmap.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,15 +22,20 @@
 
 header: "ShareableBitmap.h"
 
-[CustomHeader] struct WebKit::ShareableBitmapConfiguration {
-    std::optional<WebCore::DestinationColorSpace> colorSpace;
-    bool isOpaque;
+[CustomHeader] class WebKit::ShareableBitmapConfiguration {
+    [Validator='m_size->width() >= 0 && m_size->height() >= 0'] WebCore::IntSize m_size;
+    std::optional<WebCore::DestinationColorSpace> m_colorSpace;
+    bool m_isOpaque;
+    unsigned bytesPerPixel();
+    unsigned bytesPerRow();
+#if USE(CG)
+    CGBitmapInfo m_bitmapInfo;
+#endif
 }
 
 [CustomHeader] class WebKit::ShareableBitmapHandle {
     WebKit::SharedMemory::Handle m_handle;
-    [Validator='m_size->width() >= 0 && m_size->height() >= 0'] WebCore::IntSize m_size;
-    [Validator='!WebKit::ShareableBitmap::numBytesForSize(*m_size, *m_configuration).hasOverflowed() && m_handle->size() >= WebKit::ShareableBitmap::numBytesForSize(*m_size, *m_configuration)'] WebKit::ShareableBitmapConfiguration m_configuration;
+    [Validator='!m_configuration->sizeInBytes().hasOverflowed() && m_handle->size() >= m_configuration->sizeInBytes()'] WebKit::ShareableBitmapConfiguration m_configuration;
 }
 
 [RefCounted, CreateUsing=createReadOnly] class WebKit::ShareableBitmap {

--- a/Source/WebKit/Shared/ShareableBitmapHandle.cpp
+++ b/Source/WebKit/Shared/ShareableBitmapHandle.cpp
@@ -38,9 +38,8 @@ ShareableBitmapHandle::ShareableBitmapHandle()
 {
 }
 
-ShareableBitmapHandle::ShareableBitmapHandle(SharedMemory::Handle&& handle, const WebCore::IntSize& size, const ShareableBitmapConfiguration& config)
+ShareableBitmapHandle::ShareableBitmapHandle(SharedMemory::Handle&& handle, const ShareableBitmapConfiguration& config)
     : m_handle(WTFMove(handle))
-    , m_size(size)
     , m_configuration(config)
 {
 }
@@ -53,7 +52,6 @@ void ShareableBitmapHandle::takeOwnershipOfMemory(MemoryLedger ledger) const
 void ShareableBitmapHandle::clear()
 {
     m_handle.clear();
-    m_size = IntSize();
     m_configuration = { };
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -442,7 +442,7 @@ void ArgumentCoder<RefPtr<Image>>::encode(Encoder& encoder, const RefPtr<Image>&
     if (!hasImage)
         return;
 
-    RefPtr<ShareableBitmap> bitmap = ShareableBitmap::create(IntSize(image->size()), { });
+    RefPtr<ShareableBitmap> bitmap = ShareableBitmap::create({ IntSize(image->size()) });
     auto graphicsContext = bitmap->createGraphicsContext();
     encoder << !!graphicsContext;
     if (!graphicsContext)

--- a/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
+++ b/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
@@ -41,7 +41,7 @@ using namespace WebKit;
 
 static void encodeImage(Encoder& encoder, Image& image)
 {
-    RefPtr<ShareableBitmap> bitmap = ShareableBitmap::create(IntSize(image.size()), { });
+    RefPtr<ShareableBitmap> bitmap = ShareableBitmap::create({ IntSize(image.size()) });
     bitmap->createGraphicsContext()->drawImage(image, IntPoint());
     encoder << bitmap->createHandle();
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -334,8 +334,7 @@ static RefPtr<WebKit::ShareableBitmap> convertPlatformImageToBitmap(CocoaImage *
     auto resultRect = roundedIntRect(largestRectWithAspectRatioInsideRect(originalThumbnailSize.aspectRatio(), { { }, fittingSize }));
     resultRect.setLocation({ });
 
-    WebKit::ShareableBitmapConfiguration bitmapConfiguration;
-    auto bitmap = WebKit::ShareableBitmap::create(resultRect.size(), bitmapConfiguration);
+    auto bitmap = WebKit::ShareableBitmap::create({ resultRect.size() });
     if (!bitmap)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -41,22 +41,13 @@ using namespace WebCore;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ImageBufferShareableBitmapBackend);
 
-ShareableBitmapConfiguration ImageBufferShareableBitmapBackend::configuration(const Parameters& parameters)
-{
-    return { parameters.colorSpace };
-}
-
 IntSize ImageBufferShareableBitmapBackend::calculateSafeBackendSize(const Parameters& parameters)
 {
     IntSize backendSize = calculateBackendSize(parameters);
     if (backendSize.isEmpty())
         return { };
 
-    CheckedUint32 bytesPerRow = ShareableBitmap::calculateBytesPerRow(backendSize, configuration(parameters));
-    if (bytesPerRow.hasOverflowed())
-        return { };
-
-    CheckedSize numBytes = CheckedUint32(backendSize.height()) * bytesPerRow;
+    CheckedUint32 numBytes = ShareableBitmapConfiguration::calculateSizeInBytes(backendSize, parameters.colorSpace);
     if (numBytes.hasOverflowed())
         return { };
 
@@ -66,7 +57,7 @@ IntSize ImageBufferShareableBitmapBackend::calculateSafeBackendSize(const Parame
 unsigned ImageBufferShareableBitmapBackend::calculateBytesPerRow(const Parameters& parameters, const IntSize& backendSize)
 {
     ASSERT(!backendSize.isEmpty());
-    return ShareableBitmap::calculateBytesPerRow(backendSize, configuration(parameters));
+    return ShareableBitmapConfiguration::calculateBytesPerRow(backendSize, parameters.colorSpace);
 }
 
 size_t ImageBufferShareableBitmapBackend::calculateMemoryCost(const Parameters& parameters)
@@ -83,7 +74,7 @@ std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBac
     if (backendSize.isEmpty())
         return nullptr;
 
-    auto bitmap = ShareableBitmap::create(backendSize, configuration(parameters));
+    auto bitmap = ShareableBitmap::create({ backendSize, parameters.colorSpace });
     if (!bitmap)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
@@ -43,7 +43,6 @@ class ImageBufferShareableBitmapBackend final : public WebCore::PlatformImageBuf
     WTF_MAKE_NONCOPYABLE(ImageBufferShareableBitmapBackend);
 
 public:
-    static ShareableBitmapConfiguration configuration(const Parameters&);
     static WebCore::IntSize calculateSafeBackendSize(const Parameters&);
     static unsigned calculateBytesPerRow(const Parameters&, const WebCore::IntSize& backendSize);
     static size_t calculateMemoryCost(const Parameters&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -89,7 +89,7 @@ inline static RefPtr<ShareableBitmap> createShareableBitmapFromNativeImage(Nativ
 {
     auto imageSize = image.size();
 
-    auto bitmap = ShareableBitmap::create(image.size(), { image.colorSpace() });
+    auto bitmap = ShareableBitmap::create({ image.size(), image.colorSpace() });
     if (!bitmap)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1964,7 +1964,7 @@ RefPtr<ShareableBitmap> PDFPlugin::snapshot()
     IntSize backingStoreSize = size();
     backingStoreSize.scale(contentsScaleFactor);
 
-    auto bitmap = ShareableBitmap::create(backingStoreSize, { });
+    auto bitmap = ShareableBitmap::create({ backingStoreSize });
     if (!bitmap)
         return nullptr;
     auto context = bitmap->createGraphicsContext();

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -63,7 +63,7 @@ RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateSh
         if (!snapshotImage)
             return { };
 
-        auto bitmap = ShareableBitmap::create(snapshotRect.size(), { WTFMove(colorSpaceForBitmap) });
+        auto bitmap = ShareableBitmap::create({ snapshotRect.size(), WTFMove(colorSpaceForBitmap) });
         if (!bitmap)
             return { };
 
@@ -87,7 +87,7 @@ RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateSh
         if (imageSize.isEmpty() || imageSize.width() <= 1 || imageSize.height() <= 1)
             return { };
 
-        auto bitmap = ShareableBitmap::create(imageSize, { WTFMove(colorSpaceForBitmap) });
+        auto bitmap = ShareableBitmap::create({ imageSize, WTFMove(colorSpaceForBitmap) });
         if (!bitmap)
             return { };
 
@@ -118,7 +118,7 @@ RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateSh
     }
 
     // FIXME: Only select ExtendedColor on images known to need wide gamut.
-    auto sharedBitmap = ShareableBitmap::create(IntSize(bitmapSize), { WTFMove(colorSpaceForBitmap) });
+    auto sharedBitmap = ShareableBitmap::create({ IntSize(bitmapSize), WTFMove(colorSpaceForBitmap) });
     if (!sharedBitmap)
         return { };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebDragClientGtk.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebDragClientGtk.cpp
@@ -49,7 +49,7 @@ static RefPtr<ShareableBitmap> convertCairoSurfaceToShareableBitmap(cairo_surfac
         return nullptr;
 
     IntSize imageSize(cairo_image_surface_get_width(surface), cairo_image_surface_get_height(surface));
-    auto bitmap = ShareableBitmap::create(imageSize, { });
+    auto bitmap = ShareableBitmap::create({ imageSize });
     auto graphicsContext = bitmap->createGraphicsContext();
 
     ASSERT(graphicsContext->hasPlatformContext());

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -73,7 +73,7 @@ static RefPtr<ShareableBitmap> convertDragImageToBitmap(DragImage image, const I
     if (!localMainFrame)
         return nullptr;
 
-    auto bitmap = ShareableBitmap::create(size, { screenColorSpace(localMainFrame->view()) });
+    auto bitmap = ShareableBitmap::create({ size, screenColorSpace(localMainFrame->view()) });
     if (!bitmap)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
@@ -76,8 +76,8 @@ void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, Pl
     int backingStoreWidth = std::max(pageCoordinates.width() - m_popupClient->clientInsetLeft() - m_popupClient->clientInsetRight(), popupWidth);
 
     IntSize backingStoreSize(backingStoreWidth, (itemCount * data.m_itemHeight));
-    data.m_notSelectedBackingStore = ShareableBitmap::create(backingStoreSize, { });
-    data.m_selectedBackingStore = ShareableBitmap::create(backingStoreSize, { });
+    data.m_notSelectedBackingStore = ShareableBitmap::create({ backingStoreSize });
+    data.m_selectedBackingStore = ShareableBitmap::create({ backingStoreSize });
 
     std::unique_ptr<GraphicsContext> notSelectedBackingStoreContext = data.m_notSelectedBackingStore->createGraphicsContext();
     std::unique_ptr<GraphicsContext> selectedBackingStoreContext = data.m_selectedBackingStore->createGraphicsContext();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -851,7 +851,7 @@ void DrawingAreaCoordinatedGraphics::display(UpdateInfo& updateInfo)
     IntSize bitmapSize = bounds.size();
     float deviceScaleFactor = m_webPage.corePage()->deviceScaleFactor();
     bitmapSize.scale(deviceScaleFactor);
-    auto bitmap = ShareableBitmap::create(bitmapSize, { });
+    auto bitmap = ShareableBitmap::create({ bitmapSize });
     if (!bitmap)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4410,7 +4410,7 @@ void WebPage::drawToImage(WebCore::FrameIdentifier frameID, const PrintInfo& pri
         return;
     }
 
-    auto bitmap = ShareableBitmap::create({ pageWidth, imageHeight }, { });
+    auto bitmap = ShareableBitmap::create({ IntSize(pageWidth, imageHeight) });
     if (!bitmap) {
         reply({ });
         endPrinting();

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
@@ -61,7 +61,7 @@ void WebTextTrackRepresentationCocoa::update()
     if (!image)
         return;
     auto imageSize = image->size();
-    auto bitmap = ShareableBitmap::create(image->size(), { image->colorSpace() });
+    auto bitmap = ShareableBitmap::create({ image->size(), image->colorSpace() });
     if (!bitmap)
         return;
     auto context = bitmap->createGraphicsContext();


### PR DESCRIPTION
#### ecd29c94a78726d4a23e10222a1b00b5572c8fca
<pre>
[GPU Process] Refactor ShareableBitmapConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=254925">https://bugs.webkit.org/show_bug.cgi?id=254925</a>
rdar://107567337

Reviewed by Simon Fraser.

ShareableBitmapConfiguration needs to hold the size of the ShareableBitmap so it
can self calculate the sizeInBytes. Also it should hold and IPC the bitmap properties
instead of calculating them every time they are needed.

The caller should create ShareableBitmap only if sizeInBytes does not have overflow.
So ShareableBitmapConfiguration does not have to return the bitmap properties in
CheckedUint32 but just unsigned.

* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::getShareableBitmapForImageBufferWithQualifiedIdentifier):
(WebKit::RemoteRenderingBackend::getFilteredImageForImageBuffer):
* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
(WebKit::WCScene::update):
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp:
(WebKit::RemoteImageDecoderAVFProxy::createFrameImageAtIndex):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp:
(WebKit::RemoteMediaPlayerManagerProxy::bitmapImageForCurrentTime):
* Source/WebKit/Shared/ContextMenuContextData.cpp:
(WebKit::ContextMenuContextData::setImage):
(WebKit::ContextMenuContextData::setPotentialQRCodeNodeSnapshotImage):
(WebKit::ContextMenuContextData::setPotentialQRCodeViewportSnapshotImage):
* Source/WebKit/Shared/ShareableBitmap.cpp:
(WebKit::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
(WebKit::ShareableBitmapConfiguration::calculateSizeInBytes):
(WebKit::ShareableBitmap::create):
(WebKit::ShareableBitmap::createReadOnly):
(WebKit::ShareableBitmap::createHandle const):
(WebKit::ShareableBitmap::createReadOnlyHandle const):
(WebKit::ShareableBitmap::ShareableBitmap):
(WebKit::ShareableBitmap::numBytesForSize): Deleted.
* Source/WebKit/Shared/ShareableBitmap.h:
(WebKit::ShareableBitmapConfiguration::size const):
(WebKit::ShareableBitmapConfiguration::colorSpace const):
(WebKit::ShareableBitmapConfiguration::platformColorSpace const):
(WebKit::ShareableBitmapConfiguration::isOpaque const):
(WebKit::ShareableBitmapConfiguration::bytesPerPixel const):
(WebKit::ShareableBitmapConfiguration::bytesPerRow const):
(WebKit::ShareableBitmapConfiguration::bitmapInfo const):
(WebKit::ShareableBitmapConfiguration::sizeInBytes const):
(WebKit::ShareableBitmap::size const):
(WebKit::ShareableBitmap::bytesPerRow const):
(WebKit::ShareableBitmap::sizeInBytes const):
* Source/WebKit/Shared/ShareableBitmap.serialization.in:
* Source/WebKit/Shared/ShareableBitmapHandle.cpp:
(WebKit::ShareableBitmapHandle::ShareableBitmapHandle):
(WebKit::ShareableBitmapHandle::clear):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RefPtr&lt;Image&gt;&gt;::encode):
* Source/WebKit/Shared/cairo/ShareableBitmapCairo.cpp:
(WebKit::ShareableBitmapConfiguration::validateColorSpace):
(WebKit::ShareableBitmapConfiguration::calculateBytesPerPixel):
(WebKit::ShareableBitmapConfiguration::calculateBytesPerRow):
(WebKit::ShareableBitmap::paint):
(WebKit::ShareableBitmap::createPersistentCairoSurface):
(WebKit::ShareableBitmap::createCairoSurface):
(WebKit::ShareableBitmap::validateConfiguration): Deleted.
(WebKit::ShareableBitmap::calculateBytesPerRow): Deleted.
(WebKit::ShareableBitmap::calculateBytesPerPixel): Deleted.
* Source/WebKit/Shared/cg/ShareableBitmapCG.cpp:
(WebKit::ShareableBitmapConfiguration::validateColorSpace):
(WebKit::wantsExtendedRange):
(WebKit::ShareableBitmapConfiguration::calculateBytesPerPixel):
(WebKit::ShareableBitmapConfiguration::calculateBytesPerRow):
(WebKit::ShareableBitmapConfiguration::calculateBitmapInfo):
(WebKit::ShareableBitmap::createGraphicsContext):
(WebKit::ShareableBitmap::paint):
(WebKit::ShareableBitmap::createCGImage const):
(WebKit::ShareableBitmap::validateConfiguration): Deleted.
(WebKit::colorSpace): Deleted.
(WebKit::bitmapInfo): Deleted.
(WebKit::ShareableBitmap::calculateBytesPerRow): Deleted.
(WebKit::ShareableBitmap::calculateBytesPerPixel): Deleted.
* Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp:
(IPC::encodeImage):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::convertPlatformImageToBitmap):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::calculateSafeBackendSize):
(WebKit::ImageBufferShareableBitmapBackend::calculateBytesPerRow):
(WebKit::ImageBufferShareableBitmapBackend::create):
(WebKit::ImageBufferShareableBitmapBackend::configuration): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::createShareableBitmapFromNativeImage):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::snapshot):
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
(WebKit::createShareableBitmap):
* Source/WebKit/WebProcess/WebCoreSupport/gtk/WebDragClientGtk.cpp:
(WebKit::convertCairoSurfaceToShareableBitmap):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::convertDragImageToBitmap):
* Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp:
(WebKit::WebPopupMenu::setUpPlatformData):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::display):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::drawToImage):
* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm:
(WebKit::WebTextTrackRepresentationCocoa::update):

Canonical link: <a href="https://commits.webkit.org/262547@main">https://commits.webkit.org/262547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3470299d73e793eae9c9f35432f02114e0d94633

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1842 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2771 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1718 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1861 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2613 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1558 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1697 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2781 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1642 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/452 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1793 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->