### PR TITLE
[GLib] Fix various -Werror,-Wundefined-inline build failures after 262488@main

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(DRAG_SUPPORT) && USE(GTK4)
 
+#include "SandboxExtension.h"
 #include "WebKitWebViewBasePrivate.h"
 #include <WebCore/DragData.h>
 #include <WebCore/GtkUtilities.h>

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -34,6 +34,7 @@
 #include "InjectedBundleNodeHandle.h"
 #include "InjectedBundleRangeHandle.h"
 #include "InjectedBundleScriptWorld.h"
+#include "MessageSenderInlines.h"
 #include "NetworkConnectionToWebProcessMessages.h"
 #include "NetworkProcessConnection.h"
 #include "PluginView.h"

--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -28,6 +28,7 @@
 
 #include "EditorState.h"
 #include "InputMethodState.h"
+#include "MessageSenderInlines.h"
 #include "UserMessage.h"
 #include "WebKitUserMessage.h"
 #include "WebKitWebPagePrivate.h"

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "WebPage.h"
 
+#include "MessageSenderInlines.h"
 #include "WebFrame.h"
 #include "WebKeyboardEvent.h"
 #include "WebPageProxyMessages.h"


### PR DESCRIPTION
#### c806f295aa72067c3d9e154bcf94d8c4a39eff2f
<pre>
[GLib] Fix various -Werror,-Wundefined-inline build failures after 262488@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=254932">https://bugs.webkit.org/show_bug.cgi?id=254932</a>

Unreviewed build fixes.

* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
* Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp:
* Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp:

Canonical link: <a href="https://commits.webkit.org/262526@main">https://commits.webkit.org/262526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffe5b38a3d24ff6aeb540b1c09d000cb185d7305

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2730 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1895 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1820 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2570 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1601 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1659 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1644 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1608 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/438 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1754 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->