### PR TITLE
More build fixes for ANGLE on embedded platforms

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/apple/apple_platform.h
+++ b/Source/ThirdParty/ANGLE/src/common/apple/apple_platform.h
@@ -15,9 +15,9 @@
      (((defined(ANGLE_PLATFORM_IOS) && !defined(ANGLE_PLATFORM_IOS_SIMULATOR)) ||    \
        defined(ANGLE_PLATFORM_MACCATALYST)) &&                                       \
       __IPHONE_OS_VERSION_MIN_REQUIRED >= 150000) ||                                 \
-     (defined(ANGLE_PLATFORM_WATCHOS) && !defined(ANGLE_PLATFORM_IOS_SIMULATOR) &&   \
+     (defined(ANGLE_PLATFORM_WATCH) && !defined(ANGLE_PLATFORM_IOS_SIMULATOR) &&     \
       __WATCH_OS_VERSION_MIN_REQUIRED >= 80000) ||                                   \
-     (defined(TARGET_OS_TV) && !defined(ANGLE_PLATFORM_IOS_SIMULATOR) &&             \
+     (defined(ANGLE_PLATFORM_APPLETV) && !defined(ANGLE_PLATFORM_IOS_SIMULATOR) &&   \
       __TV_OS_VERSION_MIN_REQUIRED >= 150000)) &&                                    \
     (defined(__has_include) && __has_include(<Metal/MTLResource_Private.h>))
 #    define ANGLE_HAVE_MTLRESOURCE_SET_OWNERSHIP_IDENTITY 1

--- a/Source/ThirdParty/ANGLE/src/common/apple_platform_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/common/apple_platform_utils.mm
@@ -53,13 +53,13 @@ bool IsMetalRendererAvailable()
                         gpuFamilySufficient = true;
                     ANGLE_APPLE_ALLOW_DEPRECATED_END
                 }
-#elif defined(ANGLE_PLATFORM_IOS) && !TARGET_OS_SIMULATOR
+#elif defined(ANGLE_PLATFORM_APPLE_EMBEDDED) && !TARGET_OS_SIMULATOR
                 // Hardcode constant to sidestep compiler errors. Call will
                 // return false on older macOS versions.
                 const NSUInteger iosFamily3v1 = 4;
                 if ([device supportsFeatureSet:static_cast<MTLFeatureSet>(iosFamily3v1)])
                     gpuFamilySufficient = true;
-#elif defined(ANGLE_PLATFORM_IOS) && TARGET_OS_SIMULATOR
+#elif defined(ANGLE_PLATFORM_APPLE_EMBEDDED) && TARGET_OS_SIMULATOR
                 // FIXME: Currently we do not have good simulator query, as it does not support
                 // the whole feature set needed for iOS.
                 gpuFamilySufficient = true;

--- a/Source/ThirdParty/ANGLE/src/common/platform.h
+++ b/Source/ThirdParty/ANGLE/src/common/platform.h
@@ -127,32 +127,32 @@
 #    include <TargetConditionals.h>
 #    if TARGET_OS_OSX
 #        define ANGLE_PLATFORM_MACOS 1
-#    elif TARGET_OS_IPHONE
-#        define ANGLE_PLATFORM_IOS 1
-#        if TARGET_OS_SIMULATOR
-#            define ANGLE_PLATFORM_IOS_SIMULATOR 1
-#        endif
-#        if TARGET_OS_MACCATALYST
-#            define ANGLE_PLATFORM_MACCATALYST 1
-#        endif
-#    elif TARGET_OS_WATCH
-#        define ANGLE_PLATFORM_WATCHOS 1
-#        if TARGET_OS_SIMULATOR
-#            define ANGLE_PLATFORM_IOS_SIMULATOR 1
-#        endif
-#    elif TARGET_OS_TV
-#        define ANGLE_PLATFORM_APPLETV 1
-#        if TARGET_OS_SIMULATOR
-#            define ANGLE_PLATFORM_IOS_SIMULATOR 1
+#    else
+#        define ANGLE_PLATFORM_APPLE_EMBEDDED 1
+#        if TARGET_OS_IOS
+#            define ANGLE_PLATFORM_IOS 1
+#            if TARGET_OS_MACCATALYST
+#                define ANGLE_PLATFORM_MACCATALYST 1
+#            endif
+#        elif TARGET_OS_WATCH
+#            define ANGLE_PLATFORM_WATCH 1
+#        elif TARGET_OS_TV
+#            define ANGLE_PLATFORM_APPLETV 1
 #        endif
 #    endif
+#
+#    if TARGET_OS_SIMULATOR
+#        define ANGLE_PLATFORM_IOS_SIMULATOR 1
+#    endif
+#
 #    // This might be useful globally. At the moment it is used
 #    // to differentiate MacCatalyst on Intel and Apple Silicon.
 #    if defined(__arm64__) || defined(__aarch64__)
 #        define ANGLE_CPU_ARM64 1
 #    endif
 #    // EAGL should be enabled on iOS, but not Mac Catalyst unless it is running on Apple Silicon.
-#    if (defined(ANGLE_PLATFORM_IOS) && !defined(ANGLE_PLATFORM_MACCATALYST)) || \
+#    if ((defined(ANGLE_PLATFORM_IOS) || defined(ANGLE_PLATFORM_WATCH) \
+        || defined(ANGLE_PLATFORM_APPLETV)) && !defined(ANGLE_PLATFORM_MACCATALYST)) || \
         (defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64))
 #        define ANGLE_ENABLE_EAGL
 #    endif

--- a/Source/ThirdParty/ANGLE/src/common/system_utils.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/system_utils.cpp
@@ -226,7 +226,7 @@ void *OpenSystemLibraryAndGetError(const char *libraryName,
     {
         libraryWithExtension += dotExtension;
     }
-#if ANGLE_PLATFORM_IOS
+#if ANGLE_PLATFORM_APPLE_EMBEDDED
     // On iOS, libraryWithExtension is a directory in which the library resides.
     // The actual library name doesn't have an extension at all.
     // E.g. "libEGL.framework/libEGL"

--- a/Source/ThirdParty/ANGLE/src/common/system_utils_posix.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/system_utils_posix.cpp
@@ -197,7 +197,7 @@ void *OpenSystemLibraryWithExtensionAndGetError(const char *libraryName,
     std::string directory;
     if (searchType == SearchType::ModuleDir)
     {
-#if ANGLE_PLATFORM_IOS
+#if ANGLE_PLATFORM_APPLE_EMBEDDED
         // On iOS, shared libraries must be loaded from within the app bundle.
         directory = GetExecutableDirectory() + "/Frameworks/";
 #elif ANGLE_PLATFORM_FUCHSIA

--- a/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_internal.h
+++ b/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_internal.h
@@ -33,7 +33,7 @@ bool CMDeviceIDToDeviceAndVendorID(const std::string &id, uint32_t *vendorId, ui
 bool GetSystemInfo_mac(SystemInfo *info);
 #endif
 
-#if defined(ANGLE_PLATFORM_IOS) || (defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64))
+#if defined(ANGLE_PLATFORM_APPLE_EMBEDDED) || (defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64))
 bool GetSystemInfo_ios(SystemInfo *info);
 #endif
 

--- a/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_ios.cpp
+++ b/Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_ios.cpp
@@ -8,7 +8,7 @@
 
 #include "common/platform.h"
 
-#if defined(ANGLE_PLATFORM_IOS) || (defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64))
+#if defined(ANGLE_PLATFORM_APPLE_EMBEDDED) || (defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64))
 
 #    include "gpu_info_util/SystemInfo_internal.h"
 
@@ -30,5 +30,5 @@ bool GetSystemInfo_ios(SystemInfo *info)
 
 }  // namespace angle
 
-#endif  // defined(ANGLE_PLATFORM_IOS) || (defined(ANGLE_PLATFORM_MACCATALYST) &&
-        // defined(ANGLE_CPU_ARM64))
+#endif  // defined(ANGLE_PLATFORM_APPLE_EMBEDDED) ||
+        // (defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64))

--- a/Source/ThirdParty/ANGLE/src/libANGLE/Caps.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Caps.cpp
@@ -650,7 +650,7 @@ static bool DetermineDepthTextureANGLESupport(const TextureCapsMap &textureCaps)
 {
     constexpr GLenum requiredFormats[] = {
         GL_DEPTH_COMPONENT16,
-#if !defined(ANGLE_PLATFORM_IOS) && \
+#if !defined(ANGLE_PLATFORM_APPLE_EMBEDDED) && \
     (!defined(ANGLE_PLATFORM_MACCATALYST) || !defined(ANGLE_CPU_ARM64))
         // anglebug.com/6082
         // TODO(dino): Temporarily Removing the need for GL_DEPTH_COMPONENT32_OES
@@ -669,7 +669,7 @@ static bool DetermineDepthTextureOESSupport(const TextureCapsMap &textureCaps)
 {
     constexpr GLenum requiredFormats[] = {
         GL_DEPTH_COMPONENT16,
-#if !defined(ANGLE_PLATFORM_IOS) && \
+#if !defined(ANGLE_PLATFORM_APPLE_EMBEDDED) && \
     (!defined(ANGLE_PLATFORM_MACCATALYST) || !defined(ANGLE_CPU_ARM64))
         // anglebug.com/6082
         // TODO(dino): Temporarily Removing the need for GL_DEPTH_COMPONENT32_OES

--- a/Source/ThirdParty/ANGLE/src/libANGLE/Display.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Display.cpp
@@ -53,7 +53,7 @@
 #if defined(ANGLE_ENABLE_OPENGL)
 #    if defined(ANGLE_PLATFORM_WINDOWS)
 #        include "libANGLE/renderer/gl/wgl/DisplayWGL.h"
-#    elif defined(ANGLE_PLATFORM_MACOS) || defined(ANGLE_PLATFORM_IOS)
+#    elif defined(ANGLE_PLATFORM_MACOS) || defined(ANGLE_PLATFORM_APPLE_EMBEDDED)
 #        include "libANGLE/renderer/gl/apple/DisplayApple_api.h"
 #    elif defined(ANGLE_PLATFORM_LINUX)
 #        include "libANGLE/renderer/gl/egl/DisplayEGL.h"
@@ -342,7 +342,7 @@ rx::DisplayImpl *CreateDisplayFromAttribs(EGLAttrib displayType,
             impl = new rx::DisplayWGL(state);
             break;
 
-#    elif defined(ANGLE_PLATFORM_MACOS) || defined(ANGLE_PLATFORM_IOS)
+#    elif defined(ANGLE_PLATFORM_MACOS) || defined(ANGLE_PLATFORM_APPLE_EMBEDDED)
             impl = rx::CreateDisplayCGLOrEAGL(state);
             break;
 
@@ -2050,7 +2050,7 @@ static ClientExtensions GenerateClientExtensions()
     extensions.platformANGLEDeviceTypeEGLANGLE = true;
 #endif
 
-#if (defined(ANGLE_PLATFORM_IOS) && !defined(ANGLE_PLATFORM_MACCATALYST)) || \
+#if (defined(ANGLE_PLATFORM_APPLE_EMBEDDED) && !defined(ANGLE_PLATFORM_MACCATALYST)) || \
     (defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64))
     extensions.platformANGLEDeviceContextVolatileEagl = true;
 #endif

--- a/Source/ThirdParty/ANGLE/src/libANGLE/formatutils.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/formatutils.cpp
@@ -1379,7 +1379,7 @@ static InternalFormatInfoMap BuildInternalFormatInfoMap()
     AddRGBAXFormat(&map, GL_RGBA,           false, FB< 8,  8,  8,  8, 0, 0>(), GL_RGBA,           GL_BYTE,                        GL_SIGNED_NORMALIZED,   false, NeverSupported,                                      NeverSupported,  NeverSupported,                                    NeverSupported, NeverSupported);
     AddRGBAXFormat(&map, GL_SRGB,           false, FB< 8,  8,  8,  0, 0, 0>(), GL_SRGB,           GL_UNSIGNED_BYTE,               GL_UNSIGNED_NORMALIZED, true,  RequireExt<&Extensions::sRGBEXT>,                    AlwaysSupported, NeverSupported,                                    NeverSupported, NeverSupported);
     AddRGBAXFormat(&map, GL_SRGB_ALPHA_EXT, false, FB< 8,  8,  8,  8, 0, 0>(), GL_SRGB_ALPHA_EXT, GL_UNSIGNED_BYTE,               GL_UNSIGNED_NORMALIZED, true,  RequireExt<&Extensions::sRGBEXT>,                    AlwaysSupported, RequireExt<&Extensions::sRGBEXT>,                  NeverSupported, NeverSupported);
-#if (defined(ANGLE_PLATFORM_IOS) && !defined(ANGLE_PLATFORM_MACCATALYST)) || (defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64))
+#if (defined(ANGLE_PLATFORM_APPLE_EMBEDDED) && !defined(ANGLE_PLATFORM_MACCATALYST)) || (defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64))
     angle::SystemInfo info;
     if (angle::GetSystemInfo(&info))
     {

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/driver_utils.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/driver_utils.cpp
@@ -343,7 +343,7 @@ OSVersion GetMacOSVersion()
 }
 #endif
 
-#if !defined(ANGLE_PLATFORM_IOS)
+#if !defined(ANGLE_PLATFORM_APPLE_EMBEDDED)
 OSVersion GetiOSVersion()
 {
     // Return a default version

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/driver_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/driver_utils.h
@@ -249,9 +249,9 @@ inline bool IsFuchsia()
 #endif
 }
 
-inline bool IsIOS()
+inline bool IsAppleEmbedded()
 {
-#if defined(ANGLE_PLATFORM_IOS)
+#if defined(ANGLE_PLATFORM_APPLE_EMBEDDED)
     return true;
 #else
     return false;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/apple/DisplayApple_api.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/apple/DisplayApple_api.cpp
@@ -18,7 +18,7 @@
 #    if defined(ANGLE_PLATFORM_MACCATALYST) && defined(ANGLE_CPU_ARM64)
 #        include "libANGLE/renderer/gl/eagl/DisplayEAGL.h"
 #    endif
-#elif defined(ANGLE_PLATFORM_IOS)
+#else
 #    include "libANGLE/renderer/gl/eagl/DisplayEAGL.h"
 #endif
 
@@ -48,7 +48,7 @@ DisplayImpl *CreateDisplayCGLOrEAGL(const egl::DisplayState &state)
 #    else
     return new rx::DisplayCGL(state);
 #    endif
-#elif defined(ANGLE_PLATFORM_IOS)
+#else// defined(ANGLE_PLATFORM_APPLE_EMBEDDED)
     return new rx::DisplayEAGL(state);
 #endif
 }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/renderergl_utils.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/renderergl_utils.cpp
@@ -2275,7 +2275,7 @@ void InitializeFeatures(const FunctionsGL *functions, angle::FeaturesGL *feature
     // crbug.com/1202928
     ANGLE_FEATURE_CONDITION(features, disableWorkerContexts,
                             (IsWindows() && (isIntel || isAMD)) || (IsLinux() && isNvidia) ||
-                                IsIOS() || IsAndroid() || IsAndroidEmulator(functions));
+                                IsAppleEmbedded() || IsAndroid() || IsAndroidEmulator(functions));
 
     bool limitMaxTextureSize = isIntel && IsLinux() && GetLinuxOSVersion() < OSVersion(5, 0, 0);
     ANGLE_FEATURE_CONDITION(features, limitWebglMaxTextureSizeTo4096,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm
@@ -940,7 +940,7 @@ void DisplayMtl::initializeExtensions() const
     mNativeExtensions.copyTextureCHROMIUM           = true;
     mNativeExtensions.copyCompressedTextureCHROMIUM = false;
 
-#if !defined(ANGLE_PLATFORM_WATCHOS) || !ANGLE_PLATFORM_WATCHOS
+#if !ANGLE_PLATFORM_WATCH
     if (@available(iOS 14.0, macOS 10.11, macCatalyst 14.0, tvOS 16.0, *))
     {
         mNativeExtensions.textureMirrorClampToEdgeEXT = true;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ShaderMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ShaderMtl.mm
@@ -119,7 +119,7 @@ std::shared_ptr<WaitableCompileEvent> ShaderMtl::compile(const gl::Context *cont
     }
 
     options->clampPointSize = true;
-#if defined(ANGLE_PLATFORM_IOS) && !defined(ANGLE_PLATFORM_MACCATALYST)
+#if defined(AANGLE_PLATFORM_APPLE_EMBEDDED) && !defined(ANGLE_PLATFORM_MACCATALYST)
     options->clampFragDepth = true;
 #endif
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
@@ -929,7 +929,7 @@ MTLSamplerAddressMode GetSamplerAddressMode(GLenum wrap)
     {
         case GL_CLAMP_TO_EDGE:
             return MTLSamplerAddressModeClampToEdge;
-#if !defined(ANGLE_PLATFORM_WATCHOS) || !ANGLE_PLATFORM_WATCHOS
+#if !defined(ANGLE_PLATFORM_WATCH) || !ANGLE_PLATFORM_WATCH
         case GL_MIRROR_CLAMP_TO_EDGE_EXT:
             return MTLSamplerAddressModeMirrorClampToEdge;
 #endif


### PR DESCRIPTION
#### 4b5b02b509683ac9d75644be5a3909ee20a670e4
<pre>
More build fixes for ANGLE on embedded platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=254933">https://bugs.webkit.org/show_bug.cgi?id=254933</a>
rdar://107570491

Reviewed by Ken Russell.

The change <a href="https://commits.webkit.org/262190@main">https://commits.webkit.org/262190@main</a> fixed one build issue on
watchOS, but uncovered more on other Apple embedded platforms. Sometimes there
were branches of code not being compiled on anything but iOS and macOS. A lot
of this comes from the slighting confusing way Apple defines targets in
TargetConditionals.h. This patch is an attempt to make better sense of it, and
apply it to ANGLE.

The idea is that this will land first in WebKit, and if it doesn&apos;t break
anything it will be posted to upstream ANGLE.

Note that macOS Catalyst builds might require a followup.

* Source/ThirdParty/ANGLE/src/common/apple/apple_platform.h:
    The meat of the patch is here. Add a new APPLE_EMBEDDED definition
    for iOS/watchOS/tvOS. Split the simulator out into its own
    definition. Everything below this is moving things to use
    the embedded path where needed.

* Source/ThirdParty/ANGLE/src/common/apple_platform_utils.mm:
(angle::IsMetalRendererAvailable):
* Source/ThirdParty/ANGLE/src/common/platform.h:
* Source/ThirdParty/ANGLE/src/common/system_utils.cpp:
(angle::OpenSystemLibraryAndGetError):
* Source/ThirdParty/ANGLE/src/common/system_utils_posix.cpp:
(angle::OpenSystemLibraryWithExtensionAndGetError):
* Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_internal.h:
* Source/ThirdParty/ANGLE/src/gpu_info_util/SystemInfo_ios.cpp:
* Source/ThirdParty/ANGLE/src/libANGLE/Caps.cpp:
(gl::DetermineDepthTextureANGLESupport):
(gl::DetermineDepthTextureOESSupport):
* Source/ThirdParty/ANGLE/src/libANGLE/Display.cpp:
(egl::GenerateClientExtensions):
* Source/ThirdParty/ANGLE/src/libANGLE/formatutils.cpp:
(gl::BuildInternalFormatInfoMap):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/driver_utils.cpp:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/driver_utils.h:
(rx::IsAppleEmbedded):
(rx::IsIOS): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/apple/DisplayApple_api.cpp:
(rx::CreateDisplayCGLOrEAGL):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/renderergl_utils.cpp:
(rx::nativegl_gl::InitializeFeatures):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/DisplayMtl.mm:
(rx::DisplayMtl::initializeExtensions const):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ShaderMtl.mm:
(rx::ShaderMtl::compile):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm:
(rx::mtl::GetSamplerAddressMode):

Canonical link: <a href="https://commits.webkit.org/262636@main">https://commits.webkit.org/262636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fbd91f91e515a32c6efaa84d874722bae68db0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2158 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2174 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2116 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1862 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1933 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1928 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1872 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/530 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2037 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->