### PR TITLE
AcceleratedSurfaceDMABuf: properly handle modifier values

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DMABufFormat.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufFormat.h
@@ -77,6 +77,10 @@ struct DMABufFormat {
         Y42B = DMABufFormatImpl::createFourCC('Y', '4', '2', 'B'),
     };
 
+    enum class Modifier : uint64_t {
+        Invalid = ((1ULL << 56) - 1),
+    };
+
     static constexpr unsigned c_maxPlanes = 4;
 
     template<FourCC> static DMABufFormat create() = delete;

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -63,7 +63,7 @@ private:
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    void configure(WTF::UnixFileDescriptor&&, WTF::UnixFileDescriptor&&, int fourcc, int32_t offset, int32_t stride, WebCore::IntSize&&);
+    void configure(WTF::UnixFileDescriptor&&, WTF::UnixFileDescriptor&&, int fourcc, int32_t offset, int32_t stride, WebCore::IntSize&&, uint64_t modifier);
     void frame(CompletionHandler<void()>&&);
     void ensureGLContext();
 
@@ -99,7 +99,7 @@ private:
 
     class Texture final : public RenderSource {
     public:
-        Texture(GdkGLContext*, const WTF::UnixFileDescriptor&, const WTF::UnixFileDescriptor&, int fourcc, int32_t offset, int32_t stride, const WebCore::IntSize&, float deviceScaleFactor);
+        Texture(GdkGLContext*, const WTF::UnixFileDescriptor&, const WTF::UnixFileDescriptor&, int fourcc, int32_t offset, int32_t stride, const WebCore::IntSize&, uint64_t modifier, float deviceScaleFactor);
         ~Texture();
 
         unsigned texture() const { return m_textureID; }
@@ -157,6 +157,7 @@ private:
         int32_t offset { 0 };
         int32_t stride { 0 };
         WebCore::IntSize size;
+        uint64_t modifier { 0 };
     } m_surface;
     std::unique_ptr<RenderSource> m_pendingSource;
     std::unique_ptr<RenderSource> m_committedSource;

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
@@ -21,6 +21,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
-    Configure(UnixFileDescriptor backFD, UnixFileDescriptor frontFD, int fourcc, int32_t offset, int32_t stride, WebCore::IntSize size)
+    Configure(UnixFileDescriptor backFD, UnixFileDescriptor frontFD, int fourcc, int32_t offset, int32_t stride, WebCore::IntSize size, uint64_t modifier)
     Frame() -> ()
 }


### PR DESCRIPTION
#### 3d2513728de85583a327016e600350eaf9c794ff
<pre>
AcceleratedSurfaceDMABuf: properly handle modifier values
<a href="https://bugs.webkit.org/show_bug.cgi?id=254937">https://bugs.webkit.org/show_bug.cgi?id=254937</a>

Reviewed by Carlos Garcia Campos.

In AcceleratedSurfaceDMABuf, the backing object and EGLImage creation is packed
into a helper lambda. Buffer metadata is stored for the purposes of the
configuration message. Alongside everything else, the modifier value is now also
retrieved and passed in the EGL attributes array, as long as the EGL driver
indicates support for the relevant extension. The modifier value is also passed
in the configuration message.

In AcceleratedBackingStoreDMABuf, the newly-received modifier value is received
and passed over to the Texture class, where it&apos;s again used in the EGLImage
creation around the DMABuf object, as long as the EGL driver advertises the
extension as supported. A helper lambda is again used here to handle EGLImage
creation for a given DMABuf file descriptor.

DMABufFormat::Modifier::Invalid is added, the standard invalid-modifier value.
This is useful in place of including the whole drm_fourcc.h header.

* Source/WebCore/platform/graphics/gbm/DMABufFormat.h:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::Texture::Texture):
(WebKit::AcceleratedBackingStoreDMABuf::configure):
(WebKit::AcceleratedBackingStoreDMABuf::createSource):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::clientResize):

Canonical link: <a href="https://commits.webkit.org/262576@main">https://commits.webkit.org/262576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ede7f83816ab9bcd75fcfec9323c684acbd11eb3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2023 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2012 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/1788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1742 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1715 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1779 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1762 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1792 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1726 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1883 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/208 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->