### PR TITLE
Don't show 'cursor: pointer' on unclickable <area> by updating UA Stylesheet

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/mouse-cursor-imagemap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/mouse-cursor-imagemap-expected.txt
@@ -2,5 +2,5 @@
 An unclickable (non-link) area should not show the link cursor when hovered.
 
 
-FAIL Only clickable areas should show the link cursor. assert_equals: expected "pointer" but got "auto"
+PASS Only clickable areas should show the link cursor.
 

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1320,6 +1320,10 @@ a:any-link:active {
     color: -webkit-activelink;
 }
 
+area:any-link {
+    cursor: pointer;
+}
+
 /* HTML5 ruby elements */
 
 ruby, rt {


### PR DESCRIPTION
#### 565c294fbf5fe2ba6ef15fbb52f561bd5b7e1420
<pre>
Don&apos;t show &apos;cursor: pointer&apos; on unclickable &lt;area&gt; by updating UA Stylesheet

<a href="https://bugs.webkit.org/show_bug.cgi?id=254769">https://bugs.webkit.org/show_bug.cgi?id=254769</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/459b7d5eaf26a0c71ebb81a12ce354eaefe980c0">https://chromium.googlesource.com/chromium/src.git/+/459b7d5eaf26a0c71ebb81a12ce354eaefe980c0</a>

This patch is to update unclickable &apos;area&apos; element to not show &apos;pointer&apos; cursor
aligned with HTML Web-Spec [1]:

&apos;The href attribute on a and area elements is not
   required; when those elements do not have href
   attributes they do not create hyperlinks.&apos;

[1] <a href="https://html.spec.whatwg.org/#links-created-by-a-and-area-elements">https://html.spec.whatwg.org/#links-created-by-a-and-area-elements</a>

* Source/WebCore/css/html.css: Updated for &apos;area&apos; link
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/the-css-user-agent-style-sheet-and-presentational-hints/mouse-cursor-imagemap-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/262559@main">https://commits.webkit.org/262559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7aaa576417ad0a2f012f985435fd0dec5a65d503

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1938 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1703 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2597 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1620 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1683 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2776 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1515 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1629 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1627 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/459 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1778 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->