### PR TITLE
[UI-side compositing] fast/scrolling/mac/momentum-scroll-with-borders.html is flakey

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h
@@ -66,6 +66,9 @@ public:
 
     void monitorWheelEvents(MonitorWheelEventsOptions*);
     void callAfterScrollingCompletes(JSValueRef functionCallback);
+    
+    void sentWheelPhaseEndOrCancel() { m_sentWheelPhaseEndOrCancel = true; }
+    void sentWheelMomentumPhaseEnd() { m_sentWheelMomentumPhaseEnd = true; }
 
     void keyDown(JSStringRef key, JSValueRef modifierArray, int location);
     void rawKeyDown(JSStringRef key, JSValueRef modifierArray, int location);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -501,6 +501,19 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
         return;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "WheelEventMarker")) {
+        ASSERT(messageBody);
+        ASSERT(WKGetTypeID(messageBody) == WKStringGetTypeID());
+
+        auto bodyString = toWTFString(static_cast<WKStringRef>(messageBody));
+        // These match the strings in EventSenderProxy::sendWheelEvent().
+        if (bodyString == "SentWheelPhaseEndOrCancel"_s)
+            m_eventSendingController->sentWheelPhaseEndOrCancel();
+        else if (bodyString == "SentWheelMomentumPhaseEnd"_s)
+            m_eventSendingController->sentWheelMomentumPhaseEnd();
+        return;
+    }
+
     postPageMessage("Error", "Unknown");
 }
 

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -812,6 +812,15 @@ void EventSenderProxy::sendWheelEvent(EventTimestamp timestamp, double windowX, 
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventScrollPhase, cgScrollPhaseFromPhase(phase));
     CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventMomentumPhase, cgMomentumPhaseFromPhase(momentumPhase));
 
+    const char* markerMessage = nullptr;
+    if (phase == WheelEventPhase::Ended || phase == WheelEventPhase::Cancelled)
+        markerMessage = "SentWheelPhaseEndOrCancel";
+    else if (momentumPhase == WheelEventPhase::Ended)
+        markerMessage = "SentWheelMomentumPhaseEnd";
+
+    if (markerMessage)
+        WKPagePostMessageToInjectedBundle(m_testController->mainWebView()->page(), toWK("WheelEventMarker").get(), toWK(markerMessage).get());
+
     NSEvent* event = [NSEvent eventWithCGEvent:cgScrollEvent.get()];
     // Our event should have the correct settings:
     if (NSView *targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]]) {


### PR DESCRIPTION
#### b9a297652bdcc651ab0621152c9751da494289aa
<pre>
[UI-side compositing] fast/scrolling/mac/momentum-scroll-with-borders.html is flakey
<a href="https://bugs.webkit.org/show_bug.cgi?id=254855">https://bugs.webkit.org/show_bug.cgi?id=254855</a>
rdar://107499791

Reviewed by Tim Horton.

Tests that use `UIHelper.mouseWheelSequence()` are flakey. `mouseWheelSequence()` generates a sequence
of wheel events in the UI process and dispatches them, and then waits on `eventSender.callAfterScrollingCompletes()`,
which internally uses `WheelEventTestMonitor`.

`WheelEventTestMonitor` stores state tracking whether events related to the end of the gesture have been dispatched
(m_expectWheelEndOrCancel, m_expectMomentumEnd), and that state normally gets updated when `EventSendingController`,
which runs in the web process, messages the UI process to synthesize the events. However, in the `mouseWheelSequence`
code path, in which the events are synthesized directly by the UI process via `UIScriptControllerMac::sendEventStream()`,
we never get to set the state on `WheelEventTestMonitor`.

Fix by having `EventSenderProxy::sendWheelEvent`, which is called in the UI process, message the injected bundle
which we can respond to in `InjectedBundle::didReceiveMessageToPage()` to set the appropriate state on
`EventSendingController`.

* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
* Tools/WebKitTestRunner/mac/EventSenderProxy.mm:
(WTR::EventSenderProxy::sendWheelEvent):

Canonical link: <a href="https://commits.webkit.org/262598@main">https://commits.webkit.org/262598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77edc6f8e9f2dd33f2b7051a9ec477c72f9e69c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2756 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1941 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1810 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1707 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1549 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2762 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1517 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1631 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/494 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1781 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->