### PR TITLE
iOS 16.4 and macOS Ventura 13.3 build fix for third-party (254951)

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig
@@ -76,7 +76,7 @@ WARNING_CFLAGS = $(inherited) $(WK_FIXME_WARNING_CFLAGS) -Wexit-time-destructors
 
 // Remove WK_FIXME_WARNING_CFLAGS once all warnings are fixed.
 // -Wno-unknown-warning-option added for -Wno-unused-but-set-parameter.
-WK_FIXME_WARNING_CFLAGS = -Wno-conditional-uninitialized -Wno-missing-field-initializers -Wno-sign-compare -Wno-undef -Wno-unknown-warning-option -Wno-unused-but-set-parameter -Wno-unused-parameter -Wno-array-parameter;
+WK_FIXME_WARNING_CFLAGS = -Wno-conditional-uninitialized -Wno-missing-field-initializers -Wno-sign-compare -Wno-undef -Wno-unknown-warning-option -Wno-unused-but-set-parameter -Wno-unused-parameter -Wno-array-parameter -Wno-unused-but-set-variable;
 
 ENTITLEMENTS_REQUIRED = $(ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_$(USE_INTERNAL_SDK))
 ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_ = NO;


### PR DESCRIPTION
#### 951180b3bdc6d11a9f926366b1154082022b8509
<pre>
iOS 16.4 and macOS Ventura 13.3 build fix for third-party (254951)
<a href="https://bugs.webkit.org/show_bug.cgi?id=254951">https://bugs.webkit.org/show_bug.cgi?id=254951</a>
rdar://107582190

Reviewed by Jonathan Bedard and David Kilzer.

Build fix to ignore set, but un-used variables that cause build failures in third-party.

* Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig:

Canonical link: <a href="https://commits.webkit.org/262552@main">https://commits.webkit.org/262552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ea82fa0c342b1fda735a09b2f54aca32036431a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2787 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/1961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1728 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1880 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2632 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1649 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1711 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1696 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/2801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1660 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/451 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1810 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->