### PR TITLE
REGRESSION(259904@main): Comment editor on huffpost.com doesn't update the caret position after inserting new line

### DIFF
--- a/LayoutTests/fast/shadow-dom/selection-collapse-expected.txt
+++ b/LayoutTests/fast/shadow-dom/selection-collapse-expected.txt
@@ -1,0 +1,6 @@
+
+PASS collapse can set selection to a node inside a shadow tree
+PASS collapse abort steps when called with a disconnected node inside a shadow tree
+PASS extend can set selection to a node inside a shadow tree
+PASS extend abort steps when called with a disconnected node inside a shadow tree
+

--- a/LayoutTests/fast/shadow-dom/selection-collapse.html
+++ b/LayoutTests/fast/shadow-dom/selection-collapse.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<body>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="Selection's collapse and extend should abort only when the node's root is not connected">
+<link rel="help" href="https://w3c.github.io/selection-api/#dom-selection-collapse">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<div id="container"></div>
+<script>
+
+test(() => {
+    const host = document.createElement('div');
+    container.appendChild(host);
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<div contenteditable><p>hello, world</p></div>';
+    const textNode = shadowRoot.querySelector('p').firstChild;
+    getSelection().removeAllRanges();
+    getSelection().collapse(textNode, 5);
+    const ranges = getSelection().getComposedRanges(shadowRoot);
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, textNode);
+    assert_equals(ranges[0].startOffset, 5);
+    assert_equals(ranges[0].endContainer, textNode);
+    assert_equals(ranges[0].endOffset, 5);
+    assert_true(ranges[0].collapsed);
+}, 'collapse can set selection to a node inside a shadow tree');
+
+test(() => {
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<div contenteditable><p>hello, world</p></div>';
+    const textNode = shadowRoot.querySelector('p').firstChild;
+    getSelection().removeAllRanges();
+    getSelection().collapse(textNode, 5);
+    const ranges = getSelection().getComposedRanges(shadowRoot);
+    assert_equals(ranges.length, 0);
+}, 'collapse abort steps when called with a disconnected node inside a shadow tree');
+
+test(() => {
+    const host = document.createElement('div');
+    container.appendChild(host);
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<div contenteditable><p>hello, world</p></div>';
+    const textNode = shadowRoot.querySelector('p').firstChild;
+    getSelection().removeAllRanges();
+    getSelection().collapse(textNode, 5);
+    let ranges = getSelection().getComposedRanges(shadowRoot);
+    assert_equals(ranges.length, 1);
+    getSelection().extend(textNode, 11);
+    ranges = getSelection().getComposedRanges(shadowRoot);
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, textNode);
+    assert_equals(ranges[0].startOffset, 5);
+    assert_equals(ranges[0].endContainer, textNode);
+    assert_equals(ranges[0].endOffset, 11);
+    assert_false(ranges[0].collapsed);
+}, 'extend can set selection to a node inside a shadow tree');
+
+test(() => {
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<div contenteditable><p>hello, world</p></div>';
+    const textNode = shadowRoot.querySelector('p').firstChild;
+    getSelection().removeAllRanges();
+    getSelection().collapse(container, 0);
+    getSelection().extend(textNode, 5);
+    const ranges = getSelection().getComposedRanges(shadowRoot);
+    assert_equals(ranges.length, 1);
+    assert_equals(ranges[0].startContainer, container);
+    assert_equals(ranges[0].startOffset, 0);
+    assert_equals(ranges[0].endContainer, container);
+    assert_equals(ranges[0].endOffset, 0);
+    assert_true(ranges[0].collapsed);
+}, 'extend abort steps when called with a disconnected node inside a shadow tree');
+
+container.remove();
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### c48d7192b1295bb453bb8a0d3e1af78812967eca
<pre>
REGRESSION(259904@main): Comment editor on huffpost.com doesn&apos;t update the caret position after inserting new line
<a href="https://bugs.webkit.org/show_bug.cgi?id=254957">https://bugs.webkit.org/show_bug.cgi?id=254957</a>
&lt;rdar://106426103&gt;

Reviewed by Wenson Hsieh.

The bug was caused by DOMSelection::collapse exiting early due to the node being inside a shadow tree.
When live range selection is enabled, we exit early if frame-&gt;document()-&gt;contains(*node) isn’t true.
Fixed the bug by relaxing this restriction to allow a connected node of the same document.

This patch also relaxes the same restriction on DOMSelection::extend.

* LayoutTests/fast/shadow-dom/selection-collapse-expected.txt: Added.
* LayoutTests/fast/shadow-dom/selection-collapse.html: Added.
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::collapse): Fixed the bug by relaxing the condition for an early exit when
selectionAPIForShadowDOMEnabled returns true. Also made the check slightly more efficient by avoiding
the tree walk to find the root node in most cases.
(WebCore::DOMSelection::extend): Ditto.

Canonical link: <a href="https://commits.webkit.org/262573@main">https://commits.webkit.org/262573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbfdae0422bdab15ba9d14b52770d659d8abd8a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1995 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1765 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1927 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1716 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2679 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1707 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1607 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2839 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1764 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1703 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1855 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/206 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->