### PR TITLE
designMode should not affect shadow tree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt
@@ -18,16 +18,16 @@ FAIL SelectAll in the closed shadow DOM promise_test: Unhandled rejection with v
 FAIL SelectAll in the <div contenteditable> in the closed shadow DOM promise_test: Unhandled rejection with value: object "IndexSizeError: The index is not in the allowed range."
 PASS Focus after Collapse selection into text in the open shadow DOM
 PASS Typing "A" after Collapse selection into text in the open shadow DOM
-FAIL Focus after Collapse selection into text in <div contenteditable> in the open shadow DOM assert_equals: <div contenteditable> should have focus after Collapse selection into text in <div contenteditable> in the open shadow DOM expected "div" but got ""
-FAIL Typing "A" after Collapse selection into text in <div contenteditable> in the open shadow DOM assert_equals: The shadow DOM shouldn't be modified after Collapse selection into text in <div contenteditable> in the open shadow DOM expected "<style>:focus { outline: 3px red solid; }</style><div>text<div contenteditable=\"\">Aeditable</div><object tabindex=\"0\">object</object><p tabindex=\"0\">paragraph</p></div>" but got "<style>:focus { outline: 3px red solid; }</style><div>text<div contenteditable=\"\">editable</div><object tabindex=\"0\">object</object><p tabindex=\"0\">paragraph</p></div>"
+PASS Focus after Collapse selection into text in <div contenteditable> in the open shadow DOM
+PASS Typing "A" after Collapse selection into text in <div contenteditable> in the open shadow DOM
 PASS Focus after Set focus to <object> in the open shadow DOM
 PASS Typing "A" after Set focus to <object> in the open shadow DOM
 PASS Focus after Set focus to <p tabindex="0"> in the open shadow DOM
 PASS Typing "A" after Set focus to <p tabindex="0"> in the open shadow DOM
 PASS Focus after Collapse selection into text in the closed shadow DOM
 PASS Typing "A" after Collapse selection into text in the closed shadow DOM
-FAIL Focus after Collapse selection into text in <div contenteditable> in the closed shadow DOM assert_equals: <div contenteditable> should have focus after Collapse selection into text in <div contenteditable> in the closed shadow DOM expected "div" but got ""
-FAIL Typing "A" after Collapse selection into text in <div contenteditable> in the closed shadow DOM assert_equals: The shadow DOM shouldn't be modified after Collapse selection into text in <div contenteditable> in the closed shadow DOM expected "<style>:focus { outline: 3px red solid; }</style><div>text<div contenteditable=\"\">Aeditable</div><object tabindex=\"0\">object</object><p tabindex=\"0\">paragraph</p></div>" but got "<style>:focus { outline: 3px red solid; }</style><div>text<div contenteditable=\"\">editable</div><object tabindex=\"0\">object</object><p tabindex=\"0\">paragraph</p></div>"
+PASS Focus after Collapse selection into text in <div contenteditable> in the closed shadow DOM
+PASS Typing "A" after Collapse selection into text in <div contenteditable> in the closed shadow DOM
 PASS Focus after Set focus to <object> in the closed shadow DOM
 PASS Typing "A" after Set focus to <object> in the closed shadow DOM
 PASS Focus after Set focus to <p tabindex="0"> in the closed shadow DOM

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -358,7 +358,7 @@ Node::Editability HTMLElement::editabilityFromContentEditableAttr(const Node& no
     if (containingShadowRoot && containingShadowRoot->mode() == ShadowRootMode::UserAgent)
         return Editability::ReadOnly;
 
-    if (node.document().inDesignMode())
+    if (node.document().inDesignMode() && &node.rootNode() == &node.document())
         return Editability::CanEditRichly;
 
     return Editability::ReadOnly;


### PR DESCRIPTION
#### 155c4f42d9ef0b5655b489dd9e5a83d14f157ff1
<pre>
designMode should not affect shadow tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=254966">https://bugs.webkit.org/show_bug.cgi?id=254966</a>

Reviewed by Wenson Hsieh.

Even when the document is in design mode, its shadow trees shouldn&apos;t be considered as editable.

* LayoutTests/imported/w3c/web-platform-tests/editing/other/editable-state-and-focus-in-shadow-dom-in-designMode.tentative-expected.txt:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::editabilityFromContentEditableAttr):

Canonical link: <a href="https://commits.webkit.org/262563@main">https://commits.webkit.org/262563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f356ddfa9f5aab87181dc408749fe495e7ed430f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1978 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1759 "1 flakes 113 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1921 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/1698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2673 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1684 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1602 "2 flakes 145 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1745 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2833 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1758 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1695 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1849 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/201 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->