### PR TITLE
REGRESSION(262518@main) [cairo] Crash under GraphicsContextGL::paintToCanvas

### DIFF
--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -33,6 +33,10 @@
 #include "PlatformImage.h"
 #include "RenderingResource.h"
 
+#if USE(CAIRO)
+#include "PixelBuffer.h"
+#endif
+
 namespace WebCore {
 
 class GraphicsContext;
@@ -41,6 +45,9 @@ class NativeImage final : public RenderingResource {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generateThreadSafe());
+#if USE(CAIRO)
+    static RefPtr<NativeImage> create(Ref<PixelBuffer>&&, bool premultipliedAlpha);
+#endif
 
     WEBCORE_EXPORT void setPlatformImage(PlatformImagePtr&&);
     const PlatformImagePtr& platformImage() const { return m_platformImage; }
@@ -55,8 +62,14 @@ public:
 
 private:
     NativeImage(PlatformImagePtr&&, RenderingResourceIdentifier);
+#if USE(CAIRO)
+    NativeImage(PlatformImagePtr&&, RenderingResourceIdentifier, Ref<PixelBuffer>&&);
+#endif
 
     PlatformImagePtr m_platformImage;
+#if USE(CAIRO)
+    RefPtr<PixelBuffer> m_pixelBuffer;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
@@ -108,27 +108,7 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
 
 RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const GraphicsContextGLAttributes& sourceContextAttributes, Ref<PixelBuffer>&& pixelBuffer)
 {
-    ASSERT(!pixelBuffer->size().isEmpty());
-
-    // Convert RGBA to BGRA. BGRA is CAIRO_FORMAT_ARGB32 on little-endian architectures.
-    size_t totalBytes = pixelBuffer->sizeInBytes();
-    uint8_t* pixels = pixelBuffer->bytes();
-    for (size_t i = 0; i < totalBytes; i += 4)
-        std::swap(pixels[i], pixels[i + 2]);
-
-    if (!sourceContextAttributes.premultipliedAlpha) {
-        for (size_t i = 0; i < totalBytes; i += 4) {
-            pixels[i + 0] = std::min(255, pixels[i + 0] * pixels[i + 3] / 255);
-            pixels[i + 1] = std::min(255, pixels[i + 1] * pixels[i + 3] / 255);
-            pixels[i + 2] = std::min(255, pixels[i + 2] * pixels[i + 3] / 255);
-        }
-    }
-
-    auto imageSize = pixelBuffer->size();
-    RefPtr<cairo_surface_t> imageSurface = adoptRef(cairo_image_surface_create_for_data(
-        pixelBuffer->bytes(), CAIRO_FORMAT_ARGB32, imageSize.width(), imageSize.height(), imageSize.width() * 4));
-
-    return NativeImage::create(WTFMove(imageSurface));
+    return NativeImage::create(WTFMove(pixelBuffer), sourceContextAttributes.premultipliedAlpha);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
@@ -35,6 +35,38 @@
 
 namespace WebCore {
 
+RefPtr<NativeImage> NativeImage::create(Ref<PixelBuffer>&& pixelBuffer, bool premultipliedAlpha)
+{
+    ASSERT(!pixelBuffer->size().isEmpty());
+
+    // Convert RGBA to BGRA. BGRA is CAIRO_FORMAT_ARGB32 on little-endian architectures.
+    size_t totalBytes = pixelBuffer->sizeInBytes();
+    uint8_t* pixels = pixelBuffer->bytes();
+    for (size_t i = 0; i < totalBytes; i += 4)
+        std::swap(pixels[i], pixels[i + 2]);
+
+    if (!premultipliedAlpha) {
+        for (size_t i = 0; i < totalBytes; i += 4) {
+            pixels[i + 0] = std::min(255, pixels[i + 0] * pixels[i + 3] / 255);
+            pixels[i + 1] = std::min(255, pixels[i + 1] * pixels[i + 3] / 255);
+            pixels[i + 2] = std::min(255, pixels[i + 2] * pixels[i + 3] / 255);
+        }
+    }
+
+    auto imageSize = pixelBuffer->size();
+    RefPtr<cairo_surface_t> imageSurface = adoptRef(cairo_image_surface_create_for_data(
+        pixelBuffer->bytes(), CAIRO_FORMAT_ARGB32, imageSize.width(), imageSize.height(), imageSize.width() * 4));
+
+    return adoptRef(*new NativeImage(WTFMove(imageSurface), RenderingResourceIdentifier::generateThreadSafe(), WTFMove(pixelBuffer)));
+}
+
+NativeImage::NativeImage(PlatformImagePtr&& platformImage, RenderingResourceIdentifier renderingResourceIdentifier, Ref<PixelBuffer>&& pixelBuffer)
+    : RenderingResource(renderingResourceIdentifier)
+    , m_platformImage(WTFMove(platformImage))
+    , m_pixelBuffer(WTFMove(pixelBuffer))
+{
+}
+
 IntSize NativeImage::size() const
 {
     return cairoSurfaceSize(m_platformImage.get());


### PR DESCRIPTION
#### fc5e0e6a297b4373a182086c9e862323fd70abaa
<pre>
REGRESSION(262518@main) [cairo] Crash under GraphicsContextGL::paintToCanvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=254942">https://bugs.webkit.org/show_bug.cgi?id=254942</a>

Reviewed by Kimmo Kinnunen.

GraphicsContextGL::createNativeImageFromPixelBuffer creates a
NativeImage from a PixelBuffer. The NativeImage object has to retain
the given PixelBuffer. CG port is using CGDataProviderCreateWithData
to do that. However, cairo image surface can&apos;t attach a user data.
Added a new member variable of PixelBuffer to NativeImage only for
cairo port.

* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer):
* Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp:
(WebCore::NativeImage::create):
(WebCore::NativeImage::NativeImage):

Canonical link: <a href="https://commits.webkit.org/262575@main">https://commits.webkit.org/262575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13fbbf7abc0a7fb16b106ec07c2975d9cba848f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2845 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2006 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1774 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2690 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1702 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1619 "1 flakes 145 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1762 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2858 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1775 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1713 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/466 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1866 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->