### PR TITLE
Web Inspector: Network tab cleared items reappear with Preserve Log enabled

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js
@@ -1495,7 +1495,7 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
         this._updateStatistics();
     }
 
-    _populateWithInitialResourcesIfNeeded(collection)
+    _populateWithInitialResourcesIfNeeded(mainFrame, collection)
     {
         if (!this._needsInitialPopulate)
             return;
@@ -1524,7 +1524,7 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
 
         for (let target of WI.targets) {
             if (target === WI.pageTarget)
-                populateResourcesForFrame(WI.networkManager.mainFrame);
+                populateResourcesForFrame(mainFrame);
             else
                 populateResourcesForTarget(target);
         }
@@ -1774,7 +1774,7 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
             if (this._transitioningPageTarget) {
                 this._transitioningPageTarget = false;
                 this._needsInitialPopulate = true;
-                this._populateWithInitialResourcesIfNeeded(collection);
+                this._populateWithInitialResourcesIfNeeded(frame, collection);
             } else
                 this._insertResourceAndReloadTable(frame.mainResource);
 
@@ -1786,7 +1786,7 @@ WI.NetworkTableContentView = class NetworkTableContentView extends WI.ContentVie
     _mainFrameDidChange()
     {
         this._runForMainCollection((collection) => {
-            this._populateWithInitialResourcesIfNeeded(collection);
+            this._populateWithInitialResourcesIfNeeded(WI.networkManager.mainFrame, collection);
         });
     }
 


### PR DESCRIPTION
#### 7ef99649a919004832c7490a4497bd8c319fb68b
<pre>
Web Inspector: Network tab cleared items reappear with Preserve Log enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=254948">https://bugs.webkit.org/show_bug.cgi?id=254948</a>

Reviewed by Patrick Angle.

Sometimes `WI.Frame.Event.MainResourceDidChange` can be dispatched before the `WI.networkManager.mainFrame` is changed.

Instead of always using the `WI.networkManager.mainFrame` when populating with the initial resources of the `WI.Frame`, use the `WI.Frame` dispatching `WI.Frame.Event.MainResourceDidChange`.

* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js:
(WI.NetworkTableContentView.prototype._populateWithInitialResourcesIfNeeded):
(WI.NetworkTableContentView.prototype._mainResourceDidChange):
(WI.NetworkTableContentView.prototype._mainFrameDidChange):

Canonical link: <a href="https://commits.webkit.org/262603@main">https://commits.webkit.org/262603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e61cbcf505f1fb62363a511c0dfc24b985f0bb5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2003 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1770 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2687 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1699 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1614 "9 flakes 114 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1759 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2856 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1576 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1710 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/497 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1863 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->