### PR TITLE
GraphicsContextGL with*BufferAsNativeImage uses wrong conventions for passing functions

### DIFF
--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -3192,7 +3192,7 @@ void GraphicsContextGLANGLE::paintCompositedResultsToCanvas(ImageBuffer& imageBu
     });
 }
 
-void GraphicsContextGLANGLE::withDrawingBufferAsNativeImage(std::function<void(NativeImage&)> func)
+void GraphicsContextGLANGLE::withDrawingBufferAsNativeImage(Function<void(NativeImage&)> func)
 {
     if (!makeContextCurrent())
         return;
@@ -3209,7 +3209,7 @@ void GraphicsContextGLANGLE::withDrawingBufferAsNativeImage(std::function<void(N
     func(*drawingImage);
 }
 
-void GraphicsContextGLANGLE::withDisplayBufferAsNativeImage(std::function<void(NativeImage&)> func)
+void GraphicsContextGLANGLE::withDisplayBufferAsNativeImage(Function<void(NativeImage&)> func)
 {
     if (!makeContextCurrent())
         return;

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -32,7 +32,7 @@
 #include "GraphicsContextGL.h"
 #include "GraphicsContextGLState.h"
 #include <memory>
-#include <wtf/ListHashSet.h>
+#include <wtf/Function.h>
 
 #if PLATFORM(COCOA)
 #include "GraphicsContextGLIOSurfaceSwapChain.h"
@@ -348,8 +348,8 @@ public:
     RefPtr<PixelBuffer> readRenderingResultsForPainting();
     RefPtr<PixelBuffer> readCompositedResultsForPainting();
 
-    virtual void withDrawingBufferAsNativeImage(std::function<void(NativeImage&)>);
-    virtual void withDisplayBufferAsNativeImage(std::function<void(NativeImage&)>);
+    virtual void withDrawingBufferAsNativeImage(Function<void(NativeImage&)>);
+    virtual void withDisplayBufferAsNativeImage(Function<void(NativeImage&)>);
 
     // Returns true on success.
     bool readnPixelsWithStatus(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, Span<uint8_t> data);

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -92,8 +92,8 @@ public:
     void setDrawingBufferColorSpace(const DestinationColorSpace&) final;
     void prepareForDisplay() override;
 
-    void withDrawingBufferAsNativeImage(std::function<void(NativeImage&)>) override;
-    void withDisplayBufferAsNativeImage(std::function<void(NativeImage&)>) override;
+    void withDrawingBufferAsNativeImage(Function<void(NativeImage&)>) override;
+    void withDisplayBufferAsNativeImage(Function<void(NativeImage&)>) override;
 
 #if PLATFORM(MAC)
     void updateContextOnDisplayReconfiguration();

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -887,7 +887,7 @@ void GraphicsContextGLCocoa::invalidateKnownTextureContent(GCGLuint texture)
         m_cv->invalidateKnownTextureContent(texture);
 }
 
-void GraphicsContextGLCocoa::withDrawingBufferAsNativeImage(std::function<void(NativeImage&)> func)
+void GraphicsContextGLCocoa::withDrawingBufferAsNativeImage(Function<void(NativeImage&)> func)
 {
     if (!makeContextCurrent())
         return;
@@ -928,7 +928,7 @@ void GraphicsContextGLCocoa::withDrawingBufferAsNativeImage(std::function<void(N
     func(*drawingImage);
 }
 
-void GraphicsContextGLCocoa::withDisplayBufferAsNativeImage(std::function<void(NativeImage&)> func)
+void GraphicsContextGLCocoa::withDisplayBufferAsNativeImage(Function<void(NativeImage&)> func)
 {
     auto& displayBuffer = m_swapChain.displayBuffer();
     if (!displayBuffer.surface || !displayBuffer.handle)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -213,14 +213,15 @@ void RemoteGraphicsContextGL::paintRenderingResultsToCanvas(WebCore::RenderingRe
 {
     // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,
     // and use a helper function to make sure that don't accidentally use the RenderingResourceIdentifier (because the helper function can't see it).
-    paintRenderingResultsToCanvasWithQualifiedIdentifier({ imageBuffer, m_webProcessIdentifier }, WTFMove(completionHandler));
+    paintRenderingResultsToCanvasWithQualifiedIdentifier({ imageBuffer, m_webProcessIdentifier });
+    completionHandler();
 }
 
-void RemoteGraphicsContextGL::paintRenderingResultsToCanvasWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier imageBuffer, CompletionHandler<void()>&& completionHandler)
+void RemoteGraphicsContextGL::paintRenderingResultsToCanvasWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier imageBuffer)
 {
     assertIsCurrent(workQueue());
     m_context->withDrawingBufferAsNativeImage([&](NativeImage& image) {
-        paintNativeImageToImageBuffer(image, imageBuffer, WTFMove(completionHandler));
+        paintNativeImageToImageBuffer(image, imageBuffer);
     });
 }
 
@@ -228,14 +229,15 @@ void RemoteGraphicsContextGL::paintCompositedResultsToCanvas(WebCore::RenderingR
 {
     // Immediately turn the RenderingResourceIdentifier (which is error-prone) to a QualifiedRenderingResourceIdentifier,
     // and use a helper function to make sure that don't accidentally use the RenderingResourceIdentifier (because the helper function can't see it).
-    paintCompositedResultsToCanvasWithQualifiedIdentifier({ imageBuffer, m_webProcessIdentifier }, WTFMove(completionHandler));
+    paintCompositedResultsToCanvasWithQualifiedIdentifier({ imageBuffer, m_webProcessIdentifier });
+    completionHandler();
 }
 
-void RemoteGraphicsContextGL::paintCompositedResultsToCanvasWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier imageBuffer, CompletionHandler<void()>&& completionHandler)
+void RemoteGraphicsContextGL::paintCompositedResultsToCanvasWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier imageBuffer)
 {
     assertIsCurrent(workQueue());
     m_context->withDisplayBufferAsNativeImage([&](NativeImage& image) {
-        paintNativeImageToImageBuffer(image, imageBuffer, WTFMove(completionHandler));
+        paintNativeImageToImageBuffer(image, imageBuffer);
     });
 }
 
@@ -250,7 +252,7 @@ void RemoteGraphicsContextGL::paintCompositedResultsToVideoFrame(CompletionHandl
 }
 #endif
 
-void RemoteGraphicsContextGL::paintNativeImageToImageBuffer(NativeImage& image, QualifiedRenderingResourceIdentifier target, CompletionHandler<void()>&& completionHandler)
+void RemoteGraphicsContextGL::paintNativeImageToImageBuffer(NativeImage& image, QualifiedRenderingResourceIdentifier target)
 {
     assertIsCurrent(workQueue());
     // FIXME: We do not have functioning read/write fences in RemoteRenderingBackend. Thus this is synchronous,
@@ -278,7 +280,6 @@ void RemoteGraphicsContextGL::paintNativeImageToImageBuffer(NativeImage& image, 
     conditionVariable.wait(lock, [&] {
         return isFinished;
     });
-    completionHandler();
 }
 
 void RemoteGraphicsContextGL::simulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -146,9 +146,9 @@ protected:
 #include "RemoteGraphicsContextGLFunctionsGenerated.h" // NOLINT
 
 private:
-    void paintRenderingResultsToCanvasWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier, CompletionHandler<void()>&&);
-    void paintCompositedResultsToCanvasWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier, CompletionHandler<void()>&&);
-    void paintNativeImageToImageBuffer(WebCore::NativeImage&, QualifiedRenderingResourceIdentifier, CompletionHandler<void()>&&);
+    void paintRenderingResultsToCanvasWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
+    void paintCompositedResultsToCanvasWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
+    void paintNativeImageToImageBuffer(WebCore::NativeImage&, QualifiedRenderingResourceIdentifier);
 
 protected:
     WeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;


### PR DESCRIPTION
#### 8cfd07c30f40c4f54884da3dcd7c9348ba9db359
<pre>
GraphicsContextGL with*BufferAsNativeImage uses wrong conventions for passing functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=254980">https://bugs.webkit.org/show_bug.cgi?id=254980</a>
rdar://107600402

Reviewed by Matt Woodrow.

Use WTF::Function instead of std::function to match other WebKit code.

In RemoteGraphicsContextGL, do not pass the IPC completion handler into
the calling functions. This would imply deferred call, but the
withDrawingBufferAsNativeImage implies that the call cannot possibly defer,
e.g. the function argument implies limited lifetime of the NativeImage,
which in turn implies the non-deferred invocation.

* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::withDrawingBufferAsNativeImage):
(WebCore::GraphicsContextGLANGLE::withDisplayBufferAsNativeImage):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::withDrawingBufferAsNativeImage):
(WebCore::GraphicsContextGLCocoa::withDisplayBufferAsNativeImage):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::paintRenderingResultsToCanvas):
(WebKit::RemoteGraphicsContextGL::paintRenderingResultsToCanvasWithQualifiedIdentifier):
(WebKit::RemoteGraphicsContextGL::paintCompositedResultsToCanvas):
(WebKit::RemoteGraphicsContextGL::paintCompositedResultsToCanvasWithQualifiedIdentifier):
(WebKit::RemoteGraphicsContextGL::paintNativeImageToImageBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:

Canonical link: <a href="https://commits.webkit.org/262955@main">https://commits.webkit.org/262955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daa37374fc3fe85d4bff47b5b510e042b458b6e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2843 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1771 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1936 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1726 "10 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2688 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1616 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1748 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2852 "267 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1760 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1578 "18 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1712 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/765 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->