### PR TITLE
Use more ICU surrogate code point macros

### DIFF
--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp
@@ -183,13 +183,13 @@ JSImmutableButterfly* JSImmutableButterfly::createFromString(JSGlobalObject* glo
     auto forEachCodePointViaStringIteratorProtocol = [](const UChar* characters, unsigned length, auto func) {
         for (unsigned i = 0; i < length; ++i) {
             UChar character = characters[i];
-            if (character < 0xD800 || character > 0xDBFF || (i + 1) == length) {
+            if (!U16_IS_LEAD(character) || (i + 1) == length) {
                 if (func(i, 1) == IterationStatus::Done)
                     return;
                 continue;
             }
             UChar second = characters[i + 1];
-            if (second < 0xDC00 || second > 0xDFFF) {
+            if (!U16_IS_TRAIL(second)) {
                 if (func(i, 1) == IterationStatus::Done)
                     return;
                 continue;

--- a/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
@@ -130,11 +130,11 @@ inline unsigned advanceStringUnicode(String s, unsigned length, unsigned current
         return currentIndex + 1;
 
     UChar first = s[currentIndex];
-    if (first < 0xD800 || first > 0xDBFF)
+    if (!U16_IS_LEAD(first))
         return currentIndex + 1;
 
     UChar second = s[currentIndex + 1];
-    if (second < 0xDC00 || second > 0xDFFF)
+    if (!U16_IS_TRAIL(second))
         return currentIndex + 1;
 
     return currentIndex + 2;

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1573,7 +1573,7 @@ Expected<size_t, UTF8ConversionError> StringImpl::utf8ForCharactersIntoBuffer(co
             // Conversion fails when there is an unpaired surrogate.
             // Put replacement character (U+FFFD) instead of the unpaired surrogate.
             if (result != ConversionResult::Success) {
-                ASSERT((0xD800 <= *characters && *characters <= 0xDFFF));
+                ASSERT(U16_IS_SURROGATE(*characters));
                 // There should be room left, since one UChar hasn't been converted.
                 ASSERT((buffer + 3) <= bufferEnd);
                 putUTF8Triple(buffer, replacementCharacter);
@@ -1593,7 +1593,7 @@ Expected<size_t, UTF8ConversionError> StringImpl::utf8ForCharactersIntoBuffer(co
             if (strict)
                 return makeUnexpected(UTF8ConversionError::SourceExhausted);
             ASSERT(characters + 1 == charactersEnd);
-            ASSERT((0xD800 <= *characters && *characters <= 0xDFFF));
+            ASSERT(U16_IS_SURROGATE(*characters));
             putUTF8Triple(buffer, *characters);
                 break;
         case ConversionResult::TargetExhausted:

--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -26,6 +26,7 @@
 
 #include "config.h"
 #include "TextCodec.h"
+#include <wtf/unicode/CharacterNames.h>
 
 #include <array>
 #include <cstdio>
@@ -39,8 +40,8 @@ int TextCodec::getUnencodableReplacement(UChar32 codePoint, UnencodableHandling 
     // The Encoding Standard doesn't have surrogate code points in the input, but that would require
     // scanning and potentially manipulating inputs ahead of time. Instead handle them at the last
     // possible point.
-    if (codePoint >= 0xD800 && codePoint <= 0xDFFF)
-        codePoint = 0xFFFD;
+    if (U_IS_SURROGATE(codePoint))
+        codePoint = replacementCharacter;
 
     switch (handling) {
     case UnencodableHandling::Entities:

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -805,7 +805,7 @@ UChar32 CSSTokenizer::consumeEscape()
         };
         consumeSingleWhitespaceIfNext();
         auto codePoint = parseInteger<uint32_t>(hexChars, 16).value();
-        if (!codePoint || (0xD800 <= codePoint && codePoint <= 0xDFFF) || codePoint > 0x10FFFF)
+        if (!codePoint || U_IS_SURROGATE(codePoint) || codePoint > 0x10FFFF)
             return replacementCharacter;
         return codePoint;
     }

--- a/Source/WebCore/dom/TextEncoderStreamEncoder.h
+++ b/Source/WebCore/dom/TextEncoderStreamEncoder.h
@@ -42,7 +42,7 @@ public:
 private:
     TextEncoderStreamEncoder() = default;
 
-    std::optional<UChar> m_pendingHighSurrogate;
+    std::optional<UChar> m_pendingLeadSurrogate;
 };
 
 }


### PR DESCRIPTION
#### b58c8bed4445a0192e15f9bdc67bd0f0c45d4ea2
<pre>
Use more ICU surrogate code point macros
<a href="https://bugs.webkit.org/show_bug.cgi?id=254984">https://bugs.webkit.org/show_bug.cgi?id=254984</a>
rdar://107602109

Reviewed by Darin Adler.

Make WebKit rely more on centrally defined checks and constants for code points, in particular for surrogates.

* Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp:
(JSC::JSImmutableButterfly::createFromString):
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::advanceStringUnicode):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::utf8ForCharactersIntoBuffer):
* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::getUnencodableReplacement):
* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::consumeEscape):
* Source/WebCore/dom/TextEncoderStreamEncoder.cpp:
(WebCore::TextEncoderStreamEncoder::encode):
(WebCore::TextEncoderStreamEncoder::flush):
* Source/WebCore/dom/TextEncoderStreamEncoder.h:

Canonical link: <a href="https://commits.webkit.org/262581@main">https://commits.webkit.org/262581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e96a07399951c1d5e9567c6c7f2c6965aec5624e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1794 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2713 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1738 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1638 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1629 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1769 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2887 "10 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1859 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1796 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2000 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1733 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/456 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/472 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1887 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2045 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/571 "Passed tests") | 
<!--EWS-Status-Bubble-End-->