### PR TITLE
Make priority hints tests more stable

### DIFF
--- a/LayoutTests/http/tests/priority-hints/fetch-api-priority.html
+++ b/LayoutTests/http/tests/priority-hints/fetch-api-priority.html
@@ -7,42 +7,42 @@
 
   const tests = [
     // fetch("url", request_init) tests
-    {description: 'fetch() with URL and request_init whose priority is "high" must be fetched with high load priority', request_info: `${resource_url}?1`, request_init: {priority: 'high'}, expected_priority: "ResourceLoadPriorityHigh"},
-    {description: 'fetch() with URL and request_init whose priority is "auto" must have no effect on resource load priority', request_info: `${resource_url}?2`, request_init: {priority: 'auto'}, expected_priority: "ResourceLoadPriorityMedium"},
-    {description: 'fetch() with URL and request_init whose priority is missing must have no effect on resource load priority', request_info: `${resource_url}?3`, request_init: {}, expected_priority: "ResourceLoadPriorityMedium"},
-    {description: 'fetch() with URL and request_init whose priority is "low" must be fetched with low resource load priority', request_info: `${resource_url}?4`, request_init: {priority: 'low'}, expected_priority: "ResourceLoadPriorityLow"},
+    {description: 'fetch() with URL and request_init whose priority is "high" must be fetched with high load priority', request_info: `${resource_url}?fa1`, request_init: {priority: 'high'}, expected_priority: "ResourceLoadPriorityHigh"},
+    {description: 'fetch() with URL and request_init whose priority is "auto" must have no effect on resource load priority', request_info: `${resource_url}?fa2`, request_init: {priority: 'auto'}, expected_priority: "ResourceLoadPriorityMedium"},
+    {description: 'fetch() with URL and request_init whose priority is missing must have no effect on resource load priority', request_info: `${resource_url}?fa3`, request_init: {}, expected_priority: "ResourceLoadPriorityMedium"},
+    {description: 'fetch() with URL and request_init whose priority is "low" must be fetched with low resource load priority', request_info: `${resource_url}?fa4`, request_init: {priority: 'low'}, expected_priority: "ResourceLoadPriorityLow"},
     // fetch(Request, request_init) tests
     {
       description: 'fetch() with Request whose priority is "low" and request_init whose priority is "high" must have no effect on resource load priority',
-      request_info: new Request(`${resource_url}?5`, {priority: 'low'}),
+      request_info: new Request(`${resource_url}?fa5`, {priority: 'low'}),
       request_init: {priority: 'high'},
       expected_priority: "ResourceLoadPriorityHigh"
     },
     {
       description: 'fetch() with Request whose priority is "high" and request_init whose priority is "low" must be fetched with low resource load priority',
-      request_info: new Request(`${resource_url}?6`, {priority: 'high'}),
+      request_info: new Request(`${resource_url}?fa6`, {priority: 'high'}),
       request_init: {priority: 'low'},
       expected_priority: "ResourceLoadPriorityLow"
     },
     // fetch(Request) tests
     {
       description: 'fetch() with Request whose priority is "high" and no request_init must be fetched with high resource load priority',
-      request_info: new Request(`${resource_url}?7`, {priority: 'high'}),
+      request_info: new Request(`${resource_url}?fa7`, {priority: 'high'}),
       expected_priority: "ResourceLoadPriorityHigh"
     },
     {
       description: 'fetch() with Request whose priority is "auto" and no request_init must have no effect on resource load priority',
-      request_info: new Request(`${resource_url}?8`, {priority: 'auto'}),
+      request_info: new Request(`${resource_url}?fa8`, {priority: 'auto'}),
       expected_priority: "ResourceLoadPriorityMedium"
     },
     {
       description: 'fetch() with Request whose priority is missing and no request_init must have no effect on resource load priority',
-      request_info: new Request(`${resource_url}?9`),
+      request_info: new Request(`${resource_url}?fa9`),
       expected_priority: "ResourceLoadPriorityMedium"
     },
     {
       description: 'fetch() with Request whose priority is "low" and no request_init must be fetched with low resource load priority',
-      request_info: new Request(`${resource_url}?10`, {priority: 'low'}),
+      request_info: new Request(`${resource_url}?fa10`, {priority: 'low'}),
       expected_priority: "ResourceLoadPriorityLow"
     }
   ];

--- a/LayoutTests/http/tests/priority-hints/link-header-fetch-priority.py
+++ b/LayoutTests/http/tests/priority-hints/link-header-fetch-priority.py
@@ -3,18 +3,18 @@
 import sys
 
 sys.stdout.write(
-    'Link: <../resources/dummy.css>; rel=preload; as=style; fetchpriority=low;\r\n'
-    'Link: <../resources/dummy.css?1>; rel=preload; as=style;\r\n'
-    'Link: <../resources/dummy.css?2>; rel=preload; as=style; fetchpriority=high;\r\n'
-    'Link: <../resources/dummy.js>; rel=preload; as=script; fetchpriority=low;\r\n'
-    'Link: <../resources/dummy.js?1>; rel=preload; as=script;\r\n'
-    'Link: <../resources/dummy.js?2>; rel=preload; as=script; fetchpriority=high;\r\n'
-    'Link: <../resources/dummy.txt>; rel=preload; as=fetch; fetchpriority=low;\r\n'
-    'Link: <../resources/dummy.txt?1>; rel=preload; as=fetch;\r\n'
-    'Link: <../resources/dummy.txt?2>; rel=preload; as=fetch; fetchpriority=high;\r\n'
-    'Link: <../resources/square.png>; rel=preload; as=image; fetchpriority=low;\r\n'
-    'Link: <../resources/square.png?1>; rel=preload; as=image;\r\n'
-    'Link: <../resources/square.png?2>; rel=preload; as=image; fetchpriority=high;\r\n'
+    'Link: <../resources/dummy.css?lh0>; rel=preload; as=style; fetchpriority=low;\r\n'
+    'Link: <../resources/dummy.css?lh1>; rel=preload; as=style;\r\n'
+    'Link: <../resources/dummy.css?lh2>; rel=preload; as=style; fetchpriority=high;\r\n'
+    'Link: <../resources/dummy.js?lh0>; rel=preload; as=script; fetchpriority=low;\r\n'
+    'Link: <../resources/dummy.js?lh1>; rel=preload; as=script;\r\n'
+    'Link: <../resources/dummy.js?lh2>; rel=preload; as=script; fetchpriority=high;\r\n'
+    'Link: <../resources/dummy.txt?lh0>; rel=preload; as=fetch; fetchpriority=low;\r\n'
+    'Link: <../resources/dummy.txt?lh1>; rel=preload; as=fetch;\r\n'
+    'Link: <../resources/dummy.txt?lh2>; rel=preload; as=fetch; fetchpriority=high;\r\n'
+    'Link: <../resources/square.png?lh0>; rel=preload; as=image; fetchpriority=low;\r\n'
+    'Link: <../resources/square.png?lh1>; rel=preload; as=image;\r\n'
+    'Link: <../resources/square.png?lh2>; rel=preload; as=image; fetchpriority=high;\r\n'
     'Content-Type: text/html\r\n\r\n'
 )
 
@@ -28,51 +28,51 @@ print('''<!DOCTYPE html>
 <script>
 const priority_tests = [
   {
-    url: new URL('../resources/dummy.css', location), expected_priority: "ResourceLoadPriorityMedium",
+    url: new URL('../resources/dummy.css?lh0', location), expected_priority: "ResourceLoadPriorityMedium",
     description: 'low fetchpriority on <link rel=preload as=style> must be fetched with medium resource load priority'
   },
   {
-    url: new URL('../resources/dummy.css?1', location), expected_priority: "ResourceLoadPriorityHigh",
+    url: new URL('../resources/dummy.css?lh1', location), expected_priority: "ResourceLoadPriorityHigh",
     description: 'missing fetchpriority on <link rel=preload as=style> must have no effect on resource load priority'
   },
   {
-    url: new URL('../resources/dummy.css?2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    url: new URL('../resources/dummy.css?lh2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
     description: 'high fetchpriority on <link rel=preload as=style> must be fetched with very high resource load priority'
   },
   {
-    url: new URL('../resources/dummy.css', location), expected_priority: "ResourceLoadPriorityMedium",
+    url: new URL('../resources/dummy.js?lh0', location), expected_priority: "ResourceLoadPriorityMedium",
     description: 'low fetchpriority on <link rel=preload as=script> must be fetched with medium resource load priority'
   },
   {
-    url: new URL('../resources/dummy.css?1', location), expected_priority: "ResourceLoadPriorityHigh",
+    url: new URL('../resources/dummy.js?lh1', location), expected_priority: "ResourceLoadPriorityHigh",
     description: 'missing fetchpriority on <link rel=preload as=script> must have no effect on resource load priority'
   },
   {
-    url: new URL('../resources/dummy.css?2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
+    url: new URL('../resources/dummy.js?lh2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
     description: 'high fetchpriority on <link rel=preload as=script> must be fetched with very high resource load priority'
   },
   {
-    url: new URL('../resources/dummy.css', location), expected_priority: "ResourceLoadPriorityMedium",
-    description: 'low fetchpriority on <link rel=preload as=fetch> must be fetched with medium resource load priority'
+    url: new URL('../resources/dummy.txt?lh0', location), expected_priority: "ResourceLoadPriorityLow",
+    description: 'low fetchpriority on <link rel=preload as=fetch> must be fetched with low resource load priority'
   },
   {
-    url: new URL('../resources/dummy.css?1', location), expected_priority: "ResourceLoadPriorityHigh",
+    url: new URL('../resources/dummy.txt?lh1', location), expected_priority: "ResourceLoadPriorityMedium",
     description: 'missing fetchpriority on <link rel=preload as=fetch> must have no effect on resource load priority'
   },
   {
-    url: new URL('../resources/dummy.css?2', location), expected_priority: "ResourceLoadPriorityVeryHigh",
-    description: 'high fetchpriority on <link rel=preload as=fetch> must be fetched with very high resource load priority'
+    url: new URL('../resources/dummy.txt?lh2', location), expected_priority: "ResourceLoadPriorityHigh",
+    description: 'high fetchpriority on <link rel=preload as=fetch> must be fetched with high resource load priority'
   },
   {
-    url: new URL('../resources/square.png', location), expected_priority: "ResourceLoadPriorityVeryLow",
+    url: new URL('../resources/square.png?lh0', location), expected_priority: "ResourceLoadPriorityVeryLow",
     description: 'low fetchpriority on <link rel=preload as=image> must be fetched with very low resource load priority'
   },
   {
-    url: new URL('../resources/square.png?1', location), expected_priority: "ResourceLoadPriorityLow",
+    url: new URL('../resources/square.png?lh1', location), expected_priority: "ResourceLoadPriorityLow",
     description: 'missing fetchpriority on <link rel=preload as=image> must have no effect on resource load priority'
   },
   {
-    url: new URL('../resources/square.png?2', location), expected_priority: "ResourceLoadPriorityMedium",
+    url: new URL('../resources/square.png?lh2', location), expected_priority: "ResourceLoadPriorityMedium",
     description: 'high fetchpriority on <link rel=preload as=image> must be fetched with medium resource load priority'
   }
 ];

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -69,6 +69,7 @@ class AudioTrack;
 class BaseAudioContext;
 class Blob;
 class CacheStorageConnection;
+class CachedResource;
 class CaptionUserPreferencesTestingModeToken;
 class DOMPointReadOnly;
 class DOMRect;
@@ -1403,6 +1404,8 @@ private:
 #endif
 
     static RefPtr<SharedBuffer> pngDataForTesting();
+
+    CachedResource* resourceFromMemoryCache(const String& url);
 
 #if ENABLE(MEDIA_STREAM)
     // RealtimeMediaSource::Observer API


### PR DESCRIPTION
#### ed46651c79801e40b8e2d1fa5fd53d9dad7af48f
<pre>
Make priority hints tests more stable
<a href="https://bugs.webkit.org/show_bug.cgi?id=254885">https://bugs.webkit.org/show_bug.cgi?id=254885</a>

Reviewed by Fujii Hironori.

Make two priority hints tests stable. To fix fetch-api-priority.html
in addition we need getResourcePriority to fallback to the memory
cache, since gc could clear the document resources in CachedResourceLoader
at any time.

* LayoutTests/http/tests/priority-hints/fetch-api-priority.html:
* LayoutTests/http/tests/priority-hints/link-header-fetch-priority.py:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isLoadingFromMemoryCache):
(WebCore::Internals::resourceFromMemoryCache):
(WebCore::Internals::getResourcePriority):
* Source/WebCore/testing/Internals.h:

Canonical link: <a href="https://commits.webkit.org/262883@main">https://commits.webkit.org/262883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a31b83053adfd795a19f6a4bb24c30c3cc7b940a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3276 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2497 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4046 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2393 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2522 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2568 "5 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3788 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2333 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2520 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/718 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2563 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->