### PR TITLE
AcceleratedSurfaceDMABuf: clean up configuration arguments

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -63,7 +63,7 @@ private:
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    void configure(WTF::UnixFileDescriptor&&, WTF::UnixFileDescriptor&&, int fourcc, int32_t offset, int32_t stride, WebCore::IntSize&&, uint64_t modifier);
+    void configure(WTF::UnixFileDescriptor&&, WTF::UnixFileDescriptor&&, const WebCore::IntSize&, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier);
     void frame(CompletionHandler<void()>&&);
     void ensureGLContext();
 
@@ -99,7 +99,7 @@ private:
 
     class Texture final : public RenderSource {
     public:
-        Texture(GdkGLContext*, const WTF::UnixFileDescriptor&, const WTF::UnixFileDescriptor&, int fourcc, int32_t offset, int32_t stride, const WebCore::IntSize&, uint64_t modifier, float deviceScaleFactor);
+        Texture(GdkGLContext*, const WTF::UnixFileDescriptor&, const WTF::UnixFileDescriptor&, const WebCore::IntSize&, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier, float deviceScaleFactor);
         ~Texture();
 
         unsigned texture() const { return m_textureID; }
@@ -124,7 +124,7 @@ private:
 
     class Surface final : public RenderSource {
     public:
-        Surface(const WTF::UnixFileDescriptor&, const WTF::UnixFileDescriptor&, int fourcc, int32_t offset, int32_t stride, const WebCore::IntSize&, float deviceScaleFactor);
+        Surface(const WTF::UnixFileDescriptor&, const WTF::UnixFileDescriptor&, const WebCore::IntSize&, uint32_t format, uint32_t offset, uint32_t stride, float deviceScaleFactor);
         ~Surface();
 
         cairo_surface_t* surface() const { return m_surface.get(); }
@@ -153,10 +153,10 @@ private:
         uint64_t id { 0 };
         WTF::UnixFileDescriptor backFD;
         WTF::UnixFileDescriptor frontFD;
-        int fourcc { 0 };
-        int32_t offset { 0 };
-        int32_t stride { 0 };
         WebCore::IntSize size;
+        uint32_t format { 0 };
+        uint32_t offset { 0 };
+        uint32_t stride { 0 };
         uint64_t modifier { 0 };
     } m_surface;
     std::unique_ptr<RenderSource> m_pendingSource;

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
@@ -21,6 +21,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
-    Configure(UnixFileDescriptor backFD, UnixFileDescriptor frontFD, int fourcc, int32_t offset, int32_t stride, WebCore::IntSize size, uint64_t modifier)
+    Configure(UnixFileDescriptor backFD, UnixFileDescriptor frontFD, WebCore::IntSize size, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier)
     Frame() -> ()
 }

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
@@ -191,7 +191,7 @@ void AcceleratedSurfaceDMABuf::clientResize(const WebCore::IntSize& size)
     glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, size.width(), size.height());
 
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::Configure(WTFMove(backImage.first), WTFMove(frontImage.first),
-        metadata.format, metadata.offset, metadata.stride, size, metadata.modifier), m_webPage.identifier());
+        size, metadata.format, metadata.offset, metadata.stride, metadata.modifier), m_webPage.identifier());
 }
 
 void AcceleratedSurfaceDMABuf::willRenderFrame()


### PR DESCRIPTION
#### 8be9b9b191ebd20578da7f8b77c615ab0d1554f6
<pre>
AcceleratedSurfaceDMABuf: clean up configuration arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=254994">https://bugs.webkit.org/show_bug.cgi?id=254994</a>

Reviewed by Adrian Perez de Castro.

Adjust the arguments of the AcceleratedBackingStoreDMABuf::Configure message.
The size value, kept as an IntSize, is put earlier in the order, fourcc is
renamed to format, and format, stride and offset values are changed to the
uint32_t type. This subsequently propagates further across the class.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::Texture::Texture):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::Surface):
(WebKit::AcceleratedBackingStoreDMABuf::configure):
(WebKit::AcceleratedBackingStoreDMABuf::createSource):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::clientResize):

Canonical link: <a href="https://commits.webkit.org/262622@main">https://commits.webkit.org/262622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e3b89f70d666d389497d89cffef89bce9c4bb95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2873 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2034 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1797 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2719 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1640 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1790 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1777 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2891 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1605 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1741 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/520 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1893 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->