### PR TITLE
Don't let intrinsic padding skew pagination struts on table cells

### DIFF
--- a/LayoutTests/fast/table/intrinsic-padding-when-cell-child-doesnt-layout-expected.html
+++ b/LayoutTests/fast/table/intrinsic-padding-when-cell-child-doesnt-layout-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+table {
+	width:100px;
+}
+td {
+	background:red;
+}
+</style>
+<p>crbug.com/778682: Don't clear intrinsic padding when the cell child doesn't need a layout.</p>
+<table><tr>
+		<td>aaaaaaaaaaa aaaaaaaaaaa aaaaaaaaaaa </td>
+		<td><br/><a id="target" href="#">Click</a></td></tr>
+</table>

--- a/LayoutTests/fast/table/intrinsic-padding-when-cell-child-doesnt-layout.html
+++ b/LayoutTests/fast/table/intrinsic-padding-when-cell-child-doesnt-layout.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+table {
+	width:100px;
+}
+td {
+	background:red;
+}
+</style>
+<p>crbug.com/778682: Don't clear intrinsic padding when the cell child doesn't need a layout.</p>
+<table><tr>
+		<td>aaaaaaaaaaa aaaaaaaaaaa aaaaaaaaaaa </td>
+		<td><br/><a id="target" href="#">Click</a></td></tr>
+</table>
+<script src="../forms/resources/common.js"></script>
+<script>
+document.body.offsetTop;
+// The click triggers a layout on the table but because the width
+// of the cells hasn't changed their children don't get a layout.
+// This is required to reproduce the bug.
+clickElement(document.getElementById('target'));
+</script>
+</body>

--- a/LayoutTests/fast/table/table-cell-intrinsic-padding-pagination-strut-expected.html
+++ b/LayoutTests/fast/table/table-cell-intrinsic-padding-pagination-strut-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<style>
+body {
+  width: 600px;
+}
+table{
+  width: 100%;
+  border-collapse: collapse;
+}
+td, th {
+  border: 1px solid black;
+  line-height: 20px;
+}
+</style>
+<p>crbug.com/768330: Don't let intrinsic padding in table cells skew pagination struts. The borders in the table should be properly aligned.</p>
+<div style="height:285px; column-fill: auto; column-width: 200px;background-color: yellow;">
+  <table id="table">
+    <tr>
+      <td>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Hic, enim.</td>
+      <td>Veritatis, dignissimos inventore quam repellendus fuga aliquid molestiae deserunt pariatur.</td>
+    </tr>
+    <tr>
+      <td>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab, in.</td>
+      <td>Expedita repellat, minus eius error, velit facilis! Doloribus reiciendis, praesentium.</td>
+    </tr>
+    <tr>
+      <td>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione, aut!</td>
+      <td>Iusto optio deleniti sed dicta saepe mollitia illum deserunt fuga.</td>
+    </tr>
+    <tr>
+      <td>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cum, nam.</td>
+      <td>Laudantium sint commodi explicabo voluptate non amet, totam nam dolorem.</td>
+    </tr>
+  </table>
+</div>

--- a/LayoutTests/fast/table/table-cell-intrinsic-padding-pagination-strut.html
+++ b/LayoutTests/fast/table/table-cell-intrinsic-padding-pagination-strut.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<style>
+body {
+  width: 600px;
+}
+table{
+  width: 50%;
+  border-collapse: collapse;
+}
+td, th {
+  border: 1px solid black;
+  line-height: 20px;
+}
+</style>
+<p>crbug.com/768330: Don't let intrinsic padding in table cells skew pagination struts. The borders in the table should be properly aligned.</p>
+<div style="height:285px; column-fill: auto; column-width: 200px;background-color: yellow;">
+  <table id="table">
+    <tr>
+      <td>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Hic, enim.</td>
+      <td>Veritatis, dignissimos inventore quam repellendus fuga aliquid molestiae deserunt pariatur.</td>
+    </tr>
+    <tr>
+      <td>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab, in.</td>
+      <td>Expedita repellat, minus eius error, velit facilis! Doloribus reiciendis, praesentium.</td>
+    </tr>
+    <tr>
+      <td>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione, aut!</td>
+      <td>Iusto optio deleniti sed dicta saepe mollitia illum deserunt fuga.</td>
+    </tr>
+    <tr>
+      <td>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cum, nam.</td>
+      <td>Laudantium sint commodi explicabo voluptate non amet, totam nam dolorem.</td>
+    </tr>
+  </table>
+</div>
+<script>
+document.body.offsetTop;
+table.style['width'] = "100%";
+</script>

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -5,7 +5,7 @@
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2015 Google Inc. All rights reserved.
+ * Copyright (C) 2015-2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -149,6 +149,9 @@ void RenderTableRow::layout()
             cell->setChildNeedsLayout(MarkOnlyThis);
 
         if (cell->needsLayout()) {
+            // If we are laying out the cell's children clear its intrinsic padding so it doesn't skew the position of the content.
+            if (cell->cellWidthChanged())
+                cell->clearIntrinsicPadding();
             cell->layout();
         }
     }


### PR DESCRIPTION
<pre>
Don't let intrinsic padding skew pagination struts on table cells
<a href="https://bugs.webkit.org/show_bug.cgi?id=252834">https://bugs.webkit.org/show_bug.cgi?id=252834</a>
rdar://problem/106148471

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/eacb4f4eb2e61cc6febe80fe23eb44eba2bde8e8">https://chromium.googlesource.com/chromium/src.git/+/eacb4f4eb2e61cc6febe80fe23eb44eba2bde8e8</a>

This patch is to only clear the intrinsic padding on a cell
during row layout if we plan to layout the children in the cell.

* Source/WebCore/rendering/RenderTableRow.cpp:
(RenderTableRow::layout):
* LayoutTests/fast/table/table-cell-intrinsic-padding-pagination-strut.html: Add Test Case
* LayoutTests/fast/table/table-cell-intrinsic-padding-pagination-strut-expected.html: Add Test Case Expectations
* LayoutTests/fast/table/intrinsic-padding-when-cell-child-doesnt-layout.html: Add Test Case
* LayoutTests/fast/table/intrinsic-padding-when-cell-child-doesnt-layout-expected.html: Add Test Case Expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72f96f8754541296ee27f4d972b1b304f8ecfe8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2062 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1829 "114 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2010 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1789 "10 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2764 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4995 "An unexpected error occured. Recent messages:OS: Monterey (12.6.3), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1676 "7 flakes 140 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1779 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1816 "6 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2932 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1828 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1634 "19 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1780 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1758 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->