### PR TITLE
Harden WebArchive response deserialization

### DIFF
--- a/Source/WebCore/loader/archive/cf/LegacyWebArchiveMac.mm
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchiveMac.mm
@@ -35,8 +35,11 @@ static NSString * const LegacyWebArchiveResourceResponseKey = @"WebResourceRespo
 
 // FIXME: If is is possible to parse in a serialized NSURLResponse manually, without using
 // NSKeyedUnarchiver, manipulating plists directly, we would prefer to do that instead.
-ResourceResponse LegacyWebArchive::createResourceResponseFromMacArchivedData(CFDataRef responseData)
-{    
+ResourceResponse LegacyWebArchive::createResourceResponseFromMacArchivedData(CFDataRef)
+{
+    // Don't review this. I'm just running through EWS to see what tests cover this.
+    return { };
+    /*
     ASSERT(responseData);
     if (!responseData)
         return ResourceResponse();
@@ -53,6 +56,7 @@ ResourceResponse LegacyWebArchive::createResourceResponseFromMacArchivedData(CFD
     }
 
     return ResourceResponse(response);
+     */
 }
 
 RetainPtr<CFDataRef> LegacyWebArchive::createPropertyListRepresentation(const ResourceResponse& response)


### PR DESCRIPTION
#### 1f2e5afc5dc2733671ca610063d4cf611fada2f3
<pre>
Harden WebArchive response deserialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=255011">https://bugs.webkit.org/show_bug.cgi?id=255011</a>
rdar://107633540

Reviewed by NOBODY (OOPS!).

* Source/WebCore/loader/archive/cf/LegacyWebArchiveMac.mm:
(WebCore::LegacyWebArchive::createResourceResponseFromMacArchivedData):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f2e5afc5dc2733671ca610063d4cf611fada2f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2932 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2077 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/1981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1838 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2779 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1689 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1843 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2947 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1645 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1791 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1949 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->