### PR TITLE
Avoid calling FrameSelection::updateAppearanceAfterLayout() when performing post-layout tasks

### DIFF
--- a/LayoutTests/accessibility/mac/focus-setting-selection-syncronizing-not-clearing-expected.txt
+++ b/LayoutTests/accessibility/mac/focus-setting-selection-syncronizing-not-clearing-expected.txt
@@ -7,9 +7,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS addedNotification is true
+PASS accessibilityController.focusedElement.isEqual(accessibilityController.accessibleElementById("1")) is true
 PASS axTextStateSyncOne is undefined
 PASS accessibilityController.accessibleElementById("1").isFocusable is true
-PASS accessibilityController.focusedElement.isEqual(accessibilityController.accessibleElementById("1")) is true
 PASS axTextStateSyncTwo is undefined
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/selection-boundary-userinfo.html
+++ b/LayoutTests/accessibility/mac/selection-boundary-userinfo.html
@@ -164,7 +164,9 @@
 
         function waitForAnimationFrame() {
             return new Promise(function(resolve, reject) {
-                requestAnimationFrame(resolve);
+                requestAnimationFrame(() => {
+                    setTimeout(resolve, 0);
+                });
             });
         }
 

--- a/LayoutTests/accessibility/mac/selection-change-userinfo.html
+++ b/LayoutTests/accessibility/mac/selection-change-userinfo.html
@@ -201,38 +201,46 @@
 
         function focusTextBox() {
             return new Promise(function(resolve, reject) {
-                setTimeout(() => {
-                    textbox.focus();
-                    resolve();
-                }, 0);
+                requestAnimationFrame(function() {
+                    setTimeout(() => {
+                        textbox.focus();
+                        resolve();
+                    }, 0);
+                });
             });
         }
 
         function moveSelection(direction, granularity) {
             return new Promise(function(resolve, reject) {
-                setTimeout(function() {
-                    s.modify("move", direction, granularity);
-                    resolve();
-                }, 0);
+                requestAnimationFrame(function() {
+                    setTimeout(function() {
+                        s.modify("move", direction, granularity);
+                        resolve();
+                    }, 0);
+                });
             });
         }
 
         function extendSelection(granularity) {
             return new Promise(function(resolve, reject) {
-                setTimeout(function() {
-                    s.modify("extend", "forward", granularity);
-                    resolve();
-                }, 0);
+                requestAnimationFrame(function() {
+                    setTimeout(function() {
+                        s.modify("extend", "forward", granularity);
+                        resolve();
+                    }, 0);
+                })
             });
         }
 
         function resetPosition() {
             return new Promise(function(resolve, reject) {
-                setTimeout(function() {
-                    s = window.getSelection();
-                    s.setPosition(textbox, 0);
-                    resolve();
-                }, 0);
+                requestAnimationFrame(function() {
+                    setTimeout(function() {
+                        s = window.getSelection();
+                        s.setPosition(textbox, 0);
+                        resolve();
+                    }, 0);
+                })
             });
         }
 

--- a/LayoutTests/accessibility/mac/selection-element-tabbing-to-link.html
+++ b/LayoutTests/accessibility/mac/selection-element-tabbing-to-link.html
@@ -53,8 +53,17 @@
         }
     }
 
+    function waitForRAF() {
+        return new Promise((resolve) => {
+            requestAnimationFrame(() => {
+                setTimeout(resolve, 0);
+            });
+        });
+    }
+
     if (window.accessibilityController) {
         jsTestIsAsync = true;
+        testRunner.waitUntilDone();
 
         accessibilityController.enableEnhancedAccessibility(true);
         webArea = accessibilityController.rootElement.childAtIndex(0);
@@ -66,8 +75,12 @@
         var addedNotification = webArea.addNotificationListener(notificationCallback);
         shouldBe("addedNotification", "true");
 
-        eventSender.keyDown("\t");
-        eventSender.keyDown("\t", ["shiftKey"]);
+        (async function () {
+            await waitForRAF();
+            eventSender.keyDown("\t");
+            await waitForRAF();
+            eventSender.keyDown("\t", ["shiftKey"]);   
+        })();
     }
 
 </script>

--- a/LayoutTests/accessibility/mac/selection-value-changes-for-aria-textbox-expected.txt
+++ b/LayoutTests/accessibility/mac/selection-value-changes-for-aria-textbox-expected.txt
@@ -10,7 +10,5 @@ PASS successfullyParsed is true
 TEST COMPLETE
 Successfully received AXSelectedTextChanged
 Successfully received AXSelectedTextChanged
-Successfully received AXSelectedTextChanged
-Successfully received AXSelectedTextChanged
 Successfully received AXValueChanged
 

--- a/LayoutTests/editing/input/caret-at-the-edge-of-input.html
+++ b/LayoutTests/editing/input/caret-at-the-edge-of-input.html
@@ -11,16 +11,18 @@ if (window.testRunner)
 
 var inputEdit = document.getElementById("input-edit");
 inputEdit.focus();
-setTimeout(() => {
-    var inputEditContent = inputEdit.value;
-    inputEdit.setSelectionRange(0, 0);
+requestAnimationFrame(() => {
+    setTimeout(() => {
+        var inputEditContent = inputEdit.value;
+        inputEdit.setSelectionRange(0, 0);
 
-    if (window.eventSender) {
-        for (var i = 0; i < inputEdit.size * 1.2; ++i)
-            eventSender.keyDown(inputEditContent[i]);
-        testRunner.notifyDone();
-    }
-}, 0);
+        if (window.eventSender) {
+            for (var i = 0; i < inputEdit.size * 1.2; ++i)
+                eventSender.keyDown(inputEditContent[i]);
+            testRunner.notifyDone();
+        }
+    }, 0);
+});
 
 </script>
 </body>

--- a/LayoutTests/fast/forms/autofocus-opera-003.html
+++ b/LayoutTests/fast/forms/autofocus-opera-003.html
@@ -18,13 +18,15 @@
         }
 
         requestAnimationFrame(() => {
-            if (document.activeElement == document.getElementsByTagName("input")[0] &&
-                document.scrollingElement.scrollTop != 0)
-                log("SUCCESS");
-            else
-                log("FAILURE");
-            if (window.testRunner)
-                testRunner.notifyDone();
+            setTimeout(() => {
+                if (document.activeElement == document.getElementsByTagName("input")[0] &&
+                    document.scrollingElement.scrollTop != 0)
+                    log("SUCCESS");
+                else
+                    log("FAILURE");
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, 0);
         });
     }
 </script>

--- a/LayoutTests/fast/forms/input-text-scroll-left-on-blur.html
+++ b/LayoutTests/fast/forms/input-text-scroll-left-on-blur.html
@@ -6,9 +6,11 @@
 if (window.testRunner)
     testRunner.waitUntilDone();
 
-function wait(seconds)
+function wait()
 {
-    return new Promise((resolve) => setTimeout(resolve, seconds))
+    return new Promise((resolve) => {
+        requestAnimationFrame(() => setTimeout(resolve, 0));
+    });
 }
 
 async function runTest()
@@ -20,21 +22,21 @@ async function runTest()
 
     var a = document.getElementById("a");
     a.focus();
-    await wait(0);
+    await wait();
     a.setSelectionRange(66, 66);
     if (window.eventSender)
         eventSender.keyDown("l");
 
     var b = document.getElementById("b");
     b.focus();
-    await wait(0);
+    await wait();
     b.setSelectionRange(66, 66);
     if (window.eventSender)
         eventSender.keyDown("l");
 
     var c = document.getElementById("c");
     c.focus();
-    await wait(0);
+    await wait();
     c.setSelectionRange(66, 66);
     if (window.eventSender)
         eventSender.keyDown("l");

--- a/LayoutTests/fast/forms/password-scrolled-after-caps-lock-toggled.html
+++ b/LayoutTests/fast/forms/password-scrolled-after-caps-lock-toggled.html
@@ -98,9 +98,13 @@ function _toggleCapsLockWithCallbackAndRunNextTest(expectCapsLockEnabled, callba
 
     let oldValue = document.getElementById("input").scrollLeft;
     function handleCapsLockChange(event) {
-        console.assert(event.key === "CapsLock");
-        callback(oldValue, document.getElementById("input").scrollLeft);
-        runNextTest();
+        requestAnimationFrame(() => {
+            setTimeout(() => {
+                console.assert(event.key === "CapsLock");
+                callback(oldValue, document.getElementById("input").scrollLeft);
+                runNextTest();
+            }, 0);
+        });
     }
     input.addEventListener(eventToListenFor, handleCapsLockChange, { once: true });
     debug(`<br>After caps lock ${newCapsLockStateDisplayName}:`);

--- a/LayoutTests/fast/forms/scroll-into-view-and-show-validation-message.html
+++ b/LayoutTests/fast/forms/scroll-into-view-and-show-validation-message.html
@@ -15,18 +15,22 @@ jsTestIsAsync = true;
 onload = function() {
     button.click();
 
-    getValidationMessage().then((_message) => {
-        if (_message !== "Fill out this field")
-            testFailed("Unexpected message: " + _message);
-
-        // Make sure the message stays visible.
+    requestAnimationFrame(() => {
         setTimeout(() => {
             getValidationMessage().then((_message) => {
-                message = _message;
-                shouldBeEqualToString("message", "Fill out this field");
-                finishJSTest();
+                if (_message !== "Fill out this field")
+                    testFailed("Unexpected message: " + _message);
+
+                // Make sure the message stays visible.
+                setTimeout(() => {
+                    getValidationMessage().then((_message) => {
+                        message = _message;
+                        shouldBeEqualToString("message", "Fill out this field");
+                        finishJSTest();
+                    });
+                }, 10);
             });
-        }, 10);
+        });
     });
 }
 </script>

--- a/LayoutTests/fast/repaint/4776765.html
+++ b/LayoutTests/fast/repaint/4776765.html
@@ -3,14 +3,28 @@
 <script type="text/javascript">
 function repaintTest() {
     document.execCommand("InsertParagraph");
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}
+
+function startTest() {
+    requestAnimationFrame(() => {
+        setTimeout(runRepaintTest, 0);
+    });
 }
 </script>
-<body onload="runRepaintTest();">
+<body onload="startTest()">
 <div contenteditable="true">
 <div><br></div>
 <div id="div"><br></div>
 </div>
 <script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
 var div = document.getElementById("div");
 var sel = window.getSelection();
 sel.setPosition(div, 0);

--- a/LayoutTests/fast/repaint/selection-gap-absolute-child.html
+++ b/LayoutTests/fast/repaint/selection-gap-absolute-child.html
@@ -13,15 +13,17 @@
         var target = document.getElementById("target");
         getSelection().setBaseAndExtent(target, 0, target.nextSibling, 0);
 
-        setTimeout(function() {
-            if (window.internals) {
-                document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
-                internals.stopTrackingRepaints();
-            }
+        requestAnimationFrame(function() {
+            setTimeout(function() {
+                if (window.internals) {
+                    document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
+                    internals.stopTrackingRepaints();
+                }
 
-            if (window.testRunner)
-                testRunner.notifyDone();
-        }, 0);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, 0);
+        });
     }
     </script>
     <style>

--- a/LayoutTests/fast/repaint/selection-gap-flipped-absolute-child.html
+++ b/LayoutTests/fast/repaint/selection-gap-flipped-absolute-child.html
@@ -13,15 +13,17 @@
         var target = document.getElementById("target");
         getSelection().setBaseAndExtent(target, 0, target.nextSibling, 0);
 
-        setTimeout(function() {
-            if (window.internals) {
-                document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
-                internals.stopTrackingRepaints();
-            }
+        requestAnimationFrame(function() {
+            setTimeout(function() {
+                if (window.internals) {
+                    document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
+                    internals.stopTrackingRepaints();
+                }
 
-            if (window.testRunner)
-                testRunner.notifyDone();
-        }, 0);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, 0);
+        });
     }
     </script>
     <style>

--- a/LayoutTests/fast/repaint/selection-gap-transformed-absolute-child.html
+++ b/LayoutTests/fast/repaint/selection-gap-transformed-absolute-child.html
@@ -13,15 +13,17 @@
         var target = document.getElementById("target");
         getSelection().setBaseAndExtent(target, 0, target.nextSibling, 0);
 
-        setTimeout(function() {
-            if (window.internals) {
-                document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
-                internals.stopTrackingRepaints();
-            }
+        requestAnimationFrame(() => {
+            setTimeout(function() {
+                if (window.internals) {
+                    document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
+                    internals.stopTrackingRepaints();
+                }
 
-            if (window.testRunner)
-                testRunner.notifyDone();
-        }, 0);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, 0);
+        });
     }
     </script>
     <style>

--- a/LayoutTests/fast/repaint/selection-gap-transformed-fixed-child.html
+++ b/LayoutTests/fast/repaint/selection-gap-transformed-fixed-child.html
@@ -13,15 +13,17 @@
         var target = document.getElementById("target");
         getSelection().setBaseAndExtent(target, 0, target.nextSibling, 0);
 
-        setTimeout(function() {
-            if (window.internals) {
-                document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
-                internals.stopTrackingRepaints();
-            }
+        requestAnimationFrame(() => {
+            setTimeout(function() {
+                if (window.internals) {
+                    document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
+                    internals.stopTrackingRepaints();
+                }
 
-            if (window.testRunner)
-                testRunner.notifyDone();
-        }, 0);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, 0);
+        });
     }
     </script>
     <style>

--- a/LayoutTests/fast/repaint/selection-ruby-rl.html
+++ b/LayoutTests/fast/repaint/selection-ruby-rl.html
@@ -20,15 +20,17 @@ function runRepaintTest() {
         eventSender.mouseUp();
     }
 
-    setTimeout(function() {
-        if (window.internals) {
-            document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
-            internals.stopTrackingRepaints();
-        }
+    requestAnimationFrame(function () {
+        setTimeout(() => {
+          if (window.internals) {
+              document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
+              internals.stopTrackingRepaints();
+          }
 
-        if (window.testRunner)
-            testRunner.notifyDone();
-    }, 0);
+          if (window.testRunner)
+              testRunner.notifyDone();
+        }, 0);
+    });
 }
 </script>
 

--- a/LayoutTests/fast/repaint/text-selection-overflow-hidden.html
+++ b/LayoutTests/fast/repaint/text-selection-overflow-hidden.html
@@ -22,15 +22,17 @@
 
         getSelection().setBaseAndExtent(test, 0, test, 1);
 
-        setTimeout(function() {
-            if (window.internals) {
-                document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
-                internals.stopTrackingRepaints();
-            }
+        requestAnimationFrame(function() {
+            setTimeout(function() {
+                if (window.internals) {
+                    document.querySelector('#repaints').innerHTML = window.internals.repaintRectsAsText();
+                    internals.stopTrackingRepaints();
+                }
 
-            if (window.testRunner)
-                testRunner.notifyDone();
-        }, 0);
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, 0);
+        });
     };
 </script>
 

--- a/LayoutTests/fast/text/incorrect-deselection-across-multiple-elements.html
+++ b/LayoutTests/fast/text/incorrect-deselection-across-multiple-elements.html
@@ -16,17 +16,22 @@ if (window.testRunner) {
   testRunner.waitUntilDone();
 }
 window.getSelection().selectAllChildren(document.body);
-setTimeout(function() {
-  if (window.internals)
-    internals.startTrackingRepaints();
-  window.getSelection().selectAllChildren(second);
+requestAnimationFrame(function() {
   setTimeout(function() {
-    if (window.internals) {
-      result.innerText = internals.repaintRectsAsText().indexOf("784 70") == -1 ? "FAIL" : "PASS";
-      internals.stopTrackingRepaints();
-    }
-    if (window.testRunner)
-      testRunner.notifyDone();
+    if (window.internals)
+      internals.startTrackingRepaints();
+    window.getSelection().selectAllChildren(second);
+    requestAnimationFrame(function() {
+      setTimeout(function() {
+        if (window.internals) {
+          result.innerText = internals.repaintRectsAsText().indexOf("784 70") == -1 ? "FAIL" : "PASS";
+          internals.stopTrackingRepaints();
+        }
+        if (window.testRunner)
+          testRunner.notifyDone();
+      }, 0);
+    });
   }, 0);
-}, 0);
+});
+
 </script>

--- a/LayoutTests/platform/mac-wk1/fast/repaint/4776765-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/repaint/4776765-expected.txt
@@ -2,10 +2,6 @@
 
 
 (repaint rects
-  (rect 1 19 15 32)
-  (rect 8 26 1 18)
-  (rect 1 19 15 32)
-  (rect 8 26 1 18)
   (rect 1 37 798 32)
   (rect 8 44 784 18)
   (rect 1 37 798 32)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2187,10 +2187,6 @@ void Document::resolveStyle(ResolveStyleType type)
         if (m_renderView->needsLayout())
             frameView.layoutContext().scheduleLayout();
 
-        // Usually this is handled by post-layout.
-        if (!frameView.needsLayout() && is<LocalFrame>(frameView.frame()))
-            downcast<LocalFrame>(frameView.frame()).selection().scheduleAppearanceUpdateAfterStyleChange();
-
         // As a result of the style recalculation, the currently hovered element might have been
         // detached (for example, by setting display:none in the :hover style), schedule another mouseMove event
         // to check if any other elements ended up under the mouse pointer due to re-layout.

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1746,6 +1746,7 @@ void Editor::revealSelectionIfNeededAfterLoadingImageForElement(HTMLImageElement
 
     // FIXME: This should be queued as a task for the next rendering update.
     document().updateLayout();
+    document().selection().setCaretRectNeedsUpdate();
     revealSelectionAfterEditingOperation();
 }
 

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -35,7 +35,6 @@
 #include "Range.h"
 #include "ScrollAlignment.h"
 #include "ScrollBehavior.h"
-#include "Timer.h"
 #include "VisibleSelection.h"
 #include <wtf/Noncopyable.h>
 
@@ -156,7 +155,7 @@ public:
     WEBCORE_EXPORT void clear();
     void willBeRemovedFromFrame();
 
-    void updateAppearanceAfterLayout();
+    void updateAppearanceAfterUpdatingRendering();
     void scheduleAppearanceUpdateAfterStyleChange();
 
     enum class RevealSelectionAfterUpdate : bool { NotForced, Forced };
@@ -312,9 +311,6 @@ private:
     void setFocusedElementIfNeeded();
     void focusedOrActiveStateChanged();
 
-    void updateAppearanceAfterLayoutOrStyleChange();
-    void appearanceUpdateTimerFired();
-
     enum class ShouldUpdateAppearance : bool { No, Yes };
     WEBCORE_EXPORT void setCaretVisibility(CaretVisibility, ShouldUpdateAppearance);
 
@@ -344,7 +340,6 @@ private:
     RefPtr<Node> m_previousCaretNode; // The last node which painted the caret. Retained for clearing the old caret when it moves.
 
     RefPtr<EditingStyle> m_typingStyle;
-    Timer m_appearanceUpdateTimer;
     // The painted bounds of the caret in absolute coordinates
     IntRect m_absCaretBounds;
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3796,12 +3796,6 @@ void LocalFrameView::performPostLayoutTasks()
     LOG(Layout, "LocalFrameView %p performPostLayoutTasks", this);
     updateHasReachedSignificantRenderedTextThreshold();
 
-    if (auto& selection = m_frame->selection(); selection.isFocusedAndActive()) {
-        // FIXME (247041): We should be able to remove this appearance update altogether,
-        // and instead defer updates until the next rendering update.
-        selection.updateAppearanceAfterLayout();
-    }
-
     flushPostLayoutTasksQueue();
 
     if (!layoutContext().isLayoutNested() && m_frame->document()->documentElement())

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1863,7 +1863,7 @@ void Page::doAfterUpdateRendering()
     });
 
     forEachDocument([] (Document& document) {
-        document.selection().updateAppearanceAfterLayout();
+        document.selection().updateAppearanceAfterUpdatingRendering();
     });
 
     forEachDocument([] (Document& document) {


### PR DESCRIPTION
#### 44856812df2915e4c0236ed677fdeb485b50bf5b
<pre>
Avoid calling FrameSelection::updateAppearanceAfterLayout() when performing post-layout tasks
<a href="https://bugs.webkit.org/show_bug.cgi?id=247041">https://bugs.webkit.org/show_bug.cgi?id=247041</a>

Reviewed by Wenson Hsieh.

Removed the calls to scheduleAppearanceUpdateAfterStyleChange in Document::resolveStyle
and updateAppearanceAfterLayout in LocalFrameView::performPostLayoutTasks.

Now every appearance update happens with the rendering update in Page::doAfterUpdateRendering.

Fixed &amp; rebaselined the various tests to account for this delayed update of selection &amp; focus.

* LayoutTests/accessibility/mac/focus-setting-selection-syncronizing-not-clearing-expected.txt:
* LayoutTests/accessibility/mac/selection-boundary-userinfo.html:
* LayoutTests/accessibility/mac/selection-change-userinfo.html:
* LayoutTests/accessibility/mac/selection-element-tabbing-to-link.html:
* LayoutTests/accessibility/mac/selection-value-changes-for-aria-textbox-expected.txt:
* LayoutTests/editing/input/caret-at-the-edge-of-input.html:
* LayoutTests/fast/forms/autofocus-opera-003.html:
* LayoutTests/fast/forms/input-text-scroll-left-on-blur.html:
* LayoutTests/fast/forms/password-scrolled-after-caps-lock-toggled.html:
* LayoutTests/fast/forms/scroll-into-view-and-show-validation-message.html:
* LayoutTests/fast/repaint/4776765.html:
* LayoutTests/fast/repaint/selection-gap-absolute-child.html:
* LayoutTests/fast/repaint/selection-gap-flipped-absolute-child.html:
* LayoutTests/fast/repaint/selection-gap-transformed-absolute-child.html:
* LayoutTests/fast/repaint/selection-gap-transformed-fixed-child.html:
* LayoutTests/fast/repaint/selection-ruby-rl.html:
* LayoutTests/fast/repaint/text-selection-overflow-hidden.html:
* LayoutTests/fast/text/incorrect-deselection-across-multiple-elements.html:
* LayoutTests/platform/mac-wk1/fast/repaint/4776765-expected.txt:

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::revealSelectionIfNeededAfterLoadingImageForElement): Invalidate the caret rect
since the act of loading an image may have shifted the caret. Without this change,
TestWebKitAPI.PasteImage.RevealSelectionAfterPastingImage will fail.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::FrameSelection):
(WebCore::FrameSelection::setSelection):
(WebCore::FrameSelection::willBeRemovedFromFrame):
(WebCore::FrameSelection::updateAppearanceAfterUpdatingRendering): Renamed from
updateAppearanceAfterLayoutOrStyleChange.
(WebCore::FrameSelection::updateAppearanceAfterLayout): Deleted.
(WebCore::FrameSelection::scheduleAppearanceUpdateAfterStyleChange): Deleted.
(WebCore::FrameSelection::appearanceUpdateTimerFired): Deleted.

* Source/WebCore/editing/FrameSelection.h:

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::performPostLayoutTasks):

* Source/WebCore/page/Page.cpp:
(WebCore::Page::doAfterUpdateRendering):

Canonical link: <a href="https://commits.webkit.org/262691@main">https://commits.webkit.org/262691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee663495839b962599d4a888dda9535eea0c0f6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2287 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/2307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2396 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3220 "Failed to checkout and rebase branch from PR 12397") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2319 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2262 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/2396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2370 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/3220 "Failed to checkout and rebase branch from PR 12397") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2308 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/2396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3074 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/2396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2041 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2118 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2089 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2100 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2047 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2223 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/258 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->