### PR TITLE
Round total disk space up to nearest GB value in quota computation

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -118,7 +118,7 @@ static Ref<NetworkStorageManager> createNetworkStorageManager(IPC::Connection* c
     serviceWorkerStorageDirectory = parameters.serviceWorkerRegistrationDirectory;
     SandboxExtension::consumePermanently(parameters.serviceWorkerRegistrationDirectoryExtensionHandle);
 #endif
-    return NetworkStorageManager::create(parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, serviceWorkerStorageDirectory, parameters.perOriginStorageQuota, parameters.perThirdPartyOriginStorageQuota, parameters.originQuotaRatio, parameters.totalQuotaRatio, parameters.volumeCapacityOverride, parameters.unifiedOriginStorageLevel);
+    return NetworkStorageManager::create(parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, serviceWorkerStorageDirectory, parameters.perOriginStorageQuota, parameters.originQuotaRatio, parameters.totalQuotaRatio, parameters.volumeCapacityOverride, parameters.unifiedOriginStorageLevel);
 }
 
 NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
@@ -100,7 +100,7 @@ void NetworkSessionCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << isBlobRegistryTopOriginPartitioningEnabled;
 
     encoder << unifiedOriginStorageLevel;
-    encoder << perOriginStorageQuota << perThirdPartyOriginStorageQuota << originQuotaRatio << totalQuotaRatio << volumeCapacityOverride;
+    encoder << perOriginStorageQuota << originQuotaRatio << totalQuotaRatio << volumeCapacityOverride;
     encoder << localStorageDirectory << localStorageDirectoryExtensionHandle;
     encoder << indexedDBDirectory << indexedDBDirectoryExtensionHandle;
     encoder << cacheStorageDirectory << cacheStorageDirectoryExtensionHandle;
@@ -372,11 +372,6 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
     if (!perOriginStorageQuota)
         return std::nullopt;
 
-    std::optional<uint64_t> perThirdPartyOriginStorageQuota;
-    decoder >> perThirdPartyOriginStorageQuota;
-    if (!perThirdPartyOriginStorageQuota)
-        return std::nullopt;
-
     std::optional<std::optional<double>> originQuotaRatio;
     decoder >> originQuotaRatio;
     if (!originQuotaRatio)
@@ -515,7 +510,6 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
         , *isBlobRegistryTopOriginPartitioningEnabled
         , *unifiedOriginStorageLevel
         , WTFMove(*perOriginStorageQuota)
-        , WTFMove(*perThirdPartyOriginStorageQuota)
         , WTFMove(*originQuotaRatio)
         , WTFMove(*totalQuotaRatio)
         , WTFMove(*volumeCapacityOverride)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -119,7 +119,6 @@ struct NetworkSessionCreationParameters {
 
     UnifiedOriginStorageLevel unifiedOriginStorageLevel { UnifiedOriginStorageLevel::Basic };
     uint64_t perOriginStorageQuota;
-    uint64_t perThirdPartyOriginStorageQuota;
     std::optional<double> originQuotaRatio;
     std::optional<double> totalQuotaRatio;
     std::optional<uint64_t> volumeCapacityOverride;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -85,7 +85,7 @@ class StorageAreaRegistry;
 
 class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver {
 public:
-    static Ref<NetworkStorageManager> create(PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
+    static Ref<NetworkStorageManager> create(PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);
     static OptionSet<WebsiteDataType> allManagedTypes();
 
@@ -128,7 +128,7 @@ public:
 #endif // ENABLE(SERVICE_WORKER)
 
 private:
-    NetworkStorageManager(PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, uint64_t defaultThirdPartyOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
+    NetworkStorageManager(PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     ~NetworkStorageManager();
     NetworkQuotaManager& quotaManager();
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
@@ -244,7 +244,6 @@ private:
     String m_customCacheStoragePath;
     String m_customServiceWorkerStoragePath;
     uint64_t m_defaultOriginQuota;
-    uint64_t m_defaultThirdPartyOriginQuota;
     std::optional<double> m_originQuotaRatio;
     std::optional<double> m_totalQuotaRatio;
     std::optional<uint64_t> m_volumeCapacityOverride;

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
@@ -38,7 +38,7 @@ public:
     using GetUsageFunction = Function<uint64_t()>;
     using IncreaseQuotaFunction = Function<void(QuotaIncreaseRequestIdentifier, uint64_t currentQuota, uint64_t currentUsage, uint64_t requestedIncrease)>;
     using NotifyUsageUpdateFunction = Function<void(uint64_t)>;
-    static Ref<OriginQuotaManager> create(uint64_t quota, GetUsageFunction&&, IncreaseQuotaFunction&& = { }, NotifyUsageUpdateFunction&& = { });
+    static Ref<OriginQuotaManager> create(uint64_t quota, uint64_t standardReportedQuota, GetUsageFunction&&, IncreaseQuotaFunction&& = { }, NotifyUsageUpdateFunction&& = { });
     uint64_t reportedQuota() const;
     uint64_t usage();
     enum class Decision : bool { Deny, Grant };
@@ -50,7 +50,7 @@ public:
     void resetQuotaForTesting();
 
 private:
-    OriginQuotaManager(uint64_t quota, GetUsageFunction&&, IncreaseQuotaFunction&&, NotifyUsageUpdateFunction&&);
+    OriginQuotaManager(uint64_t quota, uint64_t standardReportedQuota, GetUsageFunction&&, IncreaseQuotaFunction&&, NotifyUsageUpdateFunction&&);
     void handleRequests();
     bool grantWithCurrentQuota(uint64_t spaceRequested);
     bool grantFastPath(uint64_t spaceRequested);
@@ -66,6 +66,7 @@ private:
     bool m_isHandlingRequests { false };
     uint64_t m_quotaCountdown { 0 };
     uint64_t m_quota;
+    uint64_t m_standardReportedQuota;
     uint64_t m_initialQuota; // Test only.
     std::optional<uint64_t> m_usage;
     GetUsageFunction m_getUsageFunction;

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -664,15 +664,16 @@ Ref<OriginQuotaManager> OriginStorageManager::createQuotaManager()
         }
         return IDBStorageManager::idbStorageSize(idbStoragePath) + CacheStorageManager::cacheStorageSize(cacheStoragePath) + fileSystemStorageSize;
     };
-    return OriginQuotaManager::create(m_quota, WTFMove(getUsageFunction), std::exchange(m_increaseQuotaFunction, { }), std::exchange(m_notifyUsageUpdateFunction, { }));
+    return OriginQuotaManager::create(m_quota, m_standardReportedQuota, WTFMove(getUsageFunction), std::exchange(m_increaseQuotaFunction, { }), std::exchange(m_notifyUsageUpdateFunction, { }));
 }
 
-OriginStorageManager::OriginStorageManager(uint64_t quota, OriginQuotaManager::IncreaseQuotaFunction&& increaseQuotaFunction, OriginQuotaManager::NotifyUsageUpdateFunction&& notifyUsageUpdateFunction, String&& path, String&& customLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel level)
+OriginStorageManager::OriginStorageManager(uint64_t quota, uint64_t standardReportedQuota, OriginQuotaManager::IncreaseQuotaFunction&& increaseQuotaFunction, OriginQuotaManager::NotifyUsageUpdateFunction&& notifyUsageUpdateFunction, String&& path, String&& customLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel level)
     : m_path(WTFMove(path))
     , m_customLocalStoragePath(WTFMove(customLocalStoragePath))
     , m_customIDBStoragePath(WTFMove(customIDBStoragePath))
     , m_customCacheStoragePath(WTFMove(customCacheStoragePath))
     , m_quota(quota)
+    , m_standardReportedQuota(standardReportedQuota)
     , m_increaseQuotaFunction(WTFMove(increaseQuotaFunction))
     , m_notifyUsageUpdateFunction(WTFMove(notifyUsageUpdateFunction))
     , m_level(level)

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -58,7 +58,7 @@ class OriginStorageManager : public CanMakeWeakPtr<OriginStorageManager> {
 public:
     static String originFileIdentifier();
 
-    OriginStorageManager(uint64_t quota, OriginQuotaManager::IncreaseQuotaFunction&&, OriginQuotaManager::NotifyUsageUpdateFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel);
+    OriginStorageManager(uint64_t quota, uint64_t standardReportedQuota, OriginQuotaManager::IncreaseQuotaFunction&&, OriginQuotaManager::NotifyUsageUpdateFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel);
     ~OriginStorageManager();
 
     void connectionClosed(IPC::Connection::UniqueID);
@@ -111,6 +111,7 @@ private:
     String m_customIDBStoragePath;
     String m_customCacheStoragePath;
     uint64_t m_quota;
+    uint64_t m_standardReportedQuota;
     OriginQuotaManager::IncreaseQuotaFunction m_increaseQuotaFunction;
     OriginQuotaManager::NotifyUsageUpdateFunction m_notifyUsageUpdateFunction;
     RefPtr<OriginQuotaManager> m_quotaManager;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1807,12 +1807,6 @@ void WebsiteDataStore::dispatchOnQueue(Function<void()>&& function)
     m_queue->dispatch(WTFMove(function));
 }
 
-uint64_t WebsiteDataStore::perThirdPartyOriginStorageQuota() const
-{
-    // FIXME: Consider whether allowing to set a perThirdPartyOriginStorageQuota from a WebsiteDataStore.
-    return perOriginStorageQuota() / 10;
-}
-
 void WebsiteDataStore::setCacheModelSynchronouslyForTesting(CacheModel cacheModel)
 {
     for (auto& processPool : WebProcessPool::allProcessPools())
@@ -1926,7 +1920,6 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     networkSessionParameters.isBlobRegistryTopOriginPartitioningEnabled = isBlobRegistryPartitioningEnabled();
     networkSessionParameters.unifiedOriginStorageLevel = m_configuration->unifiedOriginStorageLevel();
     networkSessionParameters.perOriginStorageQuota = perOriginStorageQuota();
-    networkSessionParameters.perThirdPartyOriginStorageQuota = perThirdPartyOriginStorageQuota();
     networkSessionParameters.originQuotaRatio = originQuotaRatio();
     networkSessionParameters.totalQuotaRatio = m_configuration->totalQuotaRatio();
     networkSessionParameters.volumeCapacityOverride = m_configuration->volumeCapacityOverride();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -172,7 +172,6 @@ public:
     void storePrivateClickMeasurement(const WebCore::PrivateClickMeasurement&);
 
     uint64_t perOriginStorageQuota() const { return m_resolvedConfiguration->perOriginStorageQuota(); }
-    uint64_t perThirdPartyOriginStorageQuota() const;
     std::optional<double> originQuotaRatio() { return m_resolvedConfiguration->originQuotaRatio(); }
 
     bool isBlobRegistryPartitioningEnabled() const;


### PR DESCRIPTION
#### 68c9c237cbb1fd36a04c0ee4b24fb2016d9c9590
<pre>
Round total disk space up to nearest GB value in quota computation
<a href="https://bugs.webkit.org/show_bug.cgi?id=255016">https://bugs.webkit.org/show_bug.cgi?id=255016</a>
rdar://problem/107711233

Reviewed by Youenn Fablet.

We plan to calculate quota based on total disk space, and we currently use FileSystem::volumeCapacity to get total disk
space. However, the result returned by FileSystem::volumeCapacity is not necessarily a multiple of 1 GB and might be
slightly different for machines with the same hard disk space, depending on implementation of file systems. To address
this privacy concern, we now round up the value returned by volumeCapacity() when doing quota computation.

The patch also contains two drive-by fixes:
1. Introduce standardReportedQuota used for reported quota when an origin has a small usage and a big quota.
2. Replace defaultThirdPartyOriginQuota with defaultThirdPartyOriginQuotaRatio, since quota of third-party orgin should
never be greater than that of first-party origin.

* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::createNetworkStorageManager):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp:
(WebKit::NetworkSessionCreationParameters::encode const):
(WebKit::NetworkSessionCreationParameters::decode):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::create):
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::quotaManager):
(WebKit::NetworkStorageManager::originStorageManager):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp:
(WebKit::OriginQuotaManager::create):
(WebKit::OriginQuotaManager::OriginQuotaManager):
(WebKit::OriginQuotaManager::reportedQuota const):
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h:
(WebKit::OriginQuotaManager::create):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::createQuotaManager):
(WebKit::OriginStorageManager::OriginStorageManager):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
(WebKit::WebsiteDataStore::perThirdPartyOriginStorageQuota const): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::perOriginStorageQuota const):

Canonical link: <a href="https://commits.webkit.org/262713@main">https://commits.webkit.org/262713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/502327ace356f3cd8f8bcca9c7611529af40c8cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2284 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2033 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3037 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1 "21 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2004 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1908 "5 flakes 142 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2083 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3202 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2050 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1863 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2012 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/592 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->