### PR TITLE
[WGSL] Type checking should allow concretization of variable initializers

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -617,7 +617,7 @@ bool TypeChecker::unify(Type* lhs, Type* rhs)
     if (isBottom(lhs) || isBottom(rhs))
         return true;
 
-    return false;
+    return !!conversionRank(rhs, lhs);
 }
 
 bool TypeChecker::isBottom(Type* type) const

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -27,6 +27,7 @@
 
 #include "ASTForward.h"
 #include <wtf/HashMap.h>
+#include <wtf/Markable.h>
 #include <wtf/PrintStream.h>
 #include <wtf/text/WTFString.h>
 
@@ -128,6 +129,9 @@ struct Type : public std::variant<
     void dump(PrintStream&) const;
     String toString() const;
 };
+
+using ConversionRank = Markable<unsigned, IntegralMarkableTraits<unsigned, std::numeric_limits<unsigned>::max()>>;
+ConversionRank conversionRank(Type* from, Type* to);
 
 } // namespace WGSL
 

--- a/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
@@ -1,0 +1,6 @@
+fn testVariableInialization() {
+  let x1: u32 = 0;
+  let x2: vec2<u32> = vec2(0, 0);
+  let x3: f32 = 0;
+  let x4: f32 = 0.0;
+}


### PR DESCRIPTION
#### 1b28a1f2ba87296bc224a26c2ab271e5fe0eb4b2
<pre>
[WGSL] Type checking should allow concretization of variable initializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=255020">https://bugs.webkit.org/show_bug.cgi?id=255020</a>
rdar://107647275

Reviewed by Myles C. Maxfield.

Prior to this patch we only supported initializing variables that had an explicit
type annotation with values of the same type, but it should also be possible to
initialize it with an abstract value that can be concretized to the target type,
such as initializing a u32 variable with an AbstractInt. To achieve that we reuse
the conversion rank function as per the spec, which was previously implemented for
resolving function overloads.

* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::considerCandidate):
(WGSL::OverloadResolver::calculateRank):
(WGSL::OverloadResolver::unify):
(WGSL::OverloadResolver::conversionRank const):
(WGSL::primitivePair): Deleted.
(WGSL::OverloadResolver::conversionRankImpl const): Deleted.
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::unify):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::primitivePair):
(WGSL::conversionRank):
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/tests/valid/concretization.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/262790@main">https://commits.webkit.org/262790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/861a2b02bbd3bce6937c1baf72138e3c9bc36663

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2044 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2968 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2106 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1867 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2818 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1810 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1720 "17 flakes 147 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1879 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2985 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1858 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1677 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1821 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/644 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1984 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->