### PR TITLE
REGRESSION(262547@main) ASSERTION FAILED: !m_size.isEmpty()

### DIFF
--- a/Source/WebKit/Shared/ShareableBitmap.cpp
+++ b/Source/WebKit/Shared/ShareableBitmap.cpp
@@ -47,7 +47,6 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     , m_bitmapInfo(calculateBitmapInfo(this->colorSpace(), isOpaque))
 #endif
 {
-    ASSERT(!m_size.isEmpty());
 }
 
 ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, bool isOpaque, unsigned bytesPerPixel, unsigned bytesPerRow
@@ -64,7 +63,6 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     , m_bitmapInfo(bitmapInfo)
 #endif
 {
-    ASSERT(!m_size.isEmpty());
 }
 
 CheckedUint32 ShareableBitmapConfiguration::calculateSizeInBytes(const IntSize& size, const DestinationColorSpace& colorSpace)


### PR DESCRIPTION
#### 533f864df45a3d7576494f01ead4b5035e38a72c
<pre>
REGRESSION(262547@main) ASSERTION FAILED: !m_size.isEmpty()
<a href="https://bugs.webkit.org/show_bug.cgi?id=255025">https://bugs.webkit.org/show_bug.cgi?id=255025</a>

Reviewed by NOBODY (OOPS!).

We sometimes need to create an instance of `ShareableBitmapConfiguration`
with an empty size. For example, when we send a
`ShareableBitmapConfiguration` object in its initial state over IPC.

* Source/WebKit/Shared/ShareableBitmap.cpp:
(WebKit::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/533f864df45a3d7576494f01ead4b5035e38a72c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2050 "Failed to checkout and rebase branch from PR 12406") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2078 "Failed to checkout and rebase branch from PR 12406") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2145 "Failed to checkout and rebase branch from PR 12406") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/2975 "Failed to checkout and rebase branch from PR 12406") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2113 "Failed to checkout and rebase branch from PR 12406") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2158 "Failed to checkout and rebase branch from PR 12406") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2120 "Failed to checkout and rebase branch from PR 12406") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/2975 "Failed to checkout and rebase branch from PR 12406") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2068 "Failed to checkout and rebase branch from PR 12406") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/2158 "Failed to checkout and rebase branch from PR 12406") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/2145 "Failed to checkout and rebase branch from PR 12406") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2825 "Failed to checkout and rebase branch from PR 12406") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/2158 "Failed to checkout and rebase branch from PR 12406") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/2145 "Failed to checkout and rebase branch from PR 12406") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/2825 "Failed to checkout and rebase branch from PR 12406") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1886 "Failed to checkout and rebase branch from PR 12406") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/2145 "Failed to checkout and rebase branch from PR 12406") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/2825 "Failed to checkout and rebase branch from PR 12406") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1883 "Failed to checkout and rebase branch from PR 12406") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/2120 "Failed to checkout and rebase branch from PR 12406") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1810 "Failed to checkout and rebase branch from PR 12406") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/2145 "Failed to checkout and rebase branch from PR 12406") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1990 "Failed to checkout and rebase branch from PR 12406") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->