### PR TITLE
Configuring Xcode 14.3 for Embedded Development Fails

### DIFF
--- a/Tools/Scripts/configure-xcode-for-embedded-development
+++ b/Tools/Scripts/configure-xcode-for-embedded-development
@@ -83,7 +83,7 @@ ideplugin = 'XCBSpecifications' if tuple(int(n) for n in xcode_version.split('.'
 
 XCSPEC_INFO = [dict(
     id='com.apple.product-type.tool',
-    dest=f'../PlugIns/{ideplugin}.ideplugin/Contents/Resources/Embedded-Shared.xcspec',
+    dest=f'Library/Xcode/Plug-ins/{ideplugin}.ideplugin/Contents/Resources/Embedded-Shared.xcspec' if tuple(int(n) for n in xcode_version.split('.')) >= (14, 3) else f'../PlugIns/{ideplugin}.ideplugin/Contents/Resources/Embedded-Shared.xcspec',
     content='''
     // Tool (normal Unix command-line executable)
     {   Type = ProductType;
@@ -118,7 +118,7 @@ XCSPEC_INFO = [dict(
 ''',
 ), dict(
     id='com.apple.package-type.mach-o-executable',
-    dest=f'../PlugIns/{ideplugin}.ideplugin/Contents/Resources/Embedded-Shared.xcspec',
+    dest=f'Library/Xcode/Plug-ins/{ideplugin}.ideplugin/Contents/Resources/Embedded-Shared.xcspec' if tuple(int(n) for n in xcode_version.split('.')) >= (14, 3) else f'../PlugIns/{ideplugin}.ideplugin/Contents/Resources/Embedded-Shared.xcspec',
     content='''
     {   Type = PackageType;
         Identifier = com.apple.package-type.mach-o-executable;


### PR DESCRIPTION
#### ff31bbc0bcd40b66a0397e13428e553d282a4359
<pre>
Configuring Xcode 14.3 for Embedded Development Fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=255038">https://bugs.webkit.org/show_bug.cgi?id=255038</a>
rdar://107664570

Reviewed by Jonathan Bedard.

Configuring Xcode for embedded development fails in Xcode 14.3 due to changes to XCBSpecifications.

* Tools/Scripts/configure-xcode-for-embedded-development:

Canonical link: <a href="https://commits.webkit.org/262630@main">https://commits.webkit.org/262630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6558c9be152117bfaf91803a0f3b7e2e9597d8b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1903 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2103 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2860 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1754 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1921 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/1894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3026 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1916 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1856 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/526 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2024 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->