### PR TITLE
[git-webkit] Cache filed bug

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -25,20 +25,39 @@ from webkitpy.common.checkout.diff_parser import DiffParser
 from webkitbugspy import radar
 
 
+BRANCH = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], **ENCODING_KWARGS).strip()
+for name, variable in dict(
+    title='COMMIT_MESSAGE_TITLE',
+    bug='COMMIT_MESSAGE_BUG',
+    cherry_picked='GIT_WEBKIT_CHERRY_PICKED',
+).items():
+    if variable in os.environ:
+        continue
+    try:
+        value = subprocess.check_output(
+            ['git', 'config', '--get-all', 'branch.{}.{}'.format(BRANCH, name)],
+            **ENCODING_KWARGS
+        ).strip()
+        if not value:
+            continue
+        os.environ[variable] = value
+    except subprocess.CalledProcessError:
+        continue
+
+
 def get_bugs_string():
     """Determines what bug URLs to fill or suggest in a WebKit commit message."""
-    env = os.environ
     need_the_bug_url = 'Need the bug URL (OOPS!).'
     need_the_radar = 'Include a Radar link (OOPS!).'
     has_radar = any([bool(regex.match(line))
-                     for line in env.get('COMMIT_MESSAGE_BUG', '').splitlines()
+                     for line in os.environ.get('COMMIT_MESSAGE_BUG', '').splitlines()
                      for regex in radar.Tracker.RES])
 
-    if env.get('COMMIT_MESSAGE_BUG'):
+    if os.environ.get('COMMIT_MESSAGE_BUG'):
         if has_radar or not bool(radar.Tracker.radarclient()):
-            return env['COMMIT_MESSAGE_BUG']
+            return os.environ['COMMIT_MESSAGE_BUG']
         else:
-            return env['COMMIT_MESSAGE_BUG'] + '\n' + need_the_radar
+            return os.environ['COMMIT_MESSAGE_BUG'] + '\n' + need_the_radar
 
     bugs_string = need_the_bug_url
     if bool(radar.Tracker.radarclient()):
@@ -133,7 +152,7 @@ def source_branches():
 
 def cherry_pick(content):
     cherry_picked = os.environ.get('GIT_WEBKIT_CHERRY_PICKED')
-    bug = os.environ.get('GIT_WEBKIT_BUG')
+    bug = os.environ.get('COMMIT_MESSAGE_BUG', '').splitlines()[0]
 
     if PREFER_RADAR and not bug:
         RADAR_RES = [

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.3.1',
+    version='6.4.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 3, 1)
+version = Version(6, 4, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -191,6 +191,16 @@ class Branch(Command):
             sys.stderr.write("'{}' is an invalid branch name, cannot create it\n".format(args.issue))
             return 1
 
+        bug_urls = getattr(args, '_bug_urls', None) or ''
+        if isinstance(bug_urls, (list, tuple)):
+            bug_urls = '\n'.join(bug_urls)
+        title = getattr(args, '_title', None) or ''
+        cls.write_branch_variables(
+            repository, args.issue,
+            title=title,
+            bug=bug_urls,
+        )
+
         if args.issue in repository.branches_for(remote=target_remote):
             if not args.delete_existing:
                 sys.stderr.write("'{}' exists on the remote '{}' and will be overwritten by a push\n".format(args.issue, target_remote))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/cherry_pick.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/cherry_pick.py
@@ -89,7 +89,14 @@ class CherryPick(Command):
 
         env = os.environ.copy()
         env['GIT_WEBKIT_CHERRY_PICKED'] = cherry_pick_string
-        env['GIT_WEBKIT_BUG'] = issue.link if issue else ''
+        env['COMMIT_MESSAGE_BUG'] = issue.link if issue else ''
+
+        cls.write_branch_variables(
+            repository, repository.branch,
+            cherry_pick=cherry_pick_string,
+            bug=[issue.link] if issue else [],
+        )
+
         return run(
             [repository.executable(), 'cherry-pick', '-e', commit.hash],
             cwd=repository.root_path,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py
@@ -27,14 +27,29 @@ import subprocess
 import sys
 import time
 
-from webkitcorepy import Terminal
-from webkitscmpy.commit import Commit
+from webkitcorepy import Terminal, run
+from webkitscmpy import local, Commit
 
 
 class Command(object):
     name = None
     aliases = []
     help = None
+
+    @classmethod
+    def write_branch_variables(cls, repository, branch, **variables):
+        if not isinstance(repository, local.Git):
+            return False
+        result = True
+        for key, value in variables.items():
+            if not value:
+                continue
+            for v in value if isinstance(value, (list, tuple)) else [value]:
+                result &= run(
+                    [repository.executable(), 'config', '--add', 'branch.{}.{}'.format(branch, key), str(v)],
+                    cwd=repository.root_path, capture_output=True,
+                ).returncode == 0
+        return result
 
     @classmethod
     def parser(cls, parser, loggers=None):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -114,6 +114,13 @@ class Revert(Command):
         env = os.environ
         env['COMMIT_MESSAGE_TITLE'] = cls.REVERT_TITLE_TEMPLATE.format(commit, commit_title)
         env['COMMIT_MESSAGE_BUG'] = '\n'.join(bug_urls)
+
+        cls.write_branch_variables(
+            repository, repository.branch,
+            title=cls.REVERT_TITLE_TEMPLATE.format(commit, commit_title),
+            bug=bug_urls,
+        )
+
         result = run([repository.executable(), 'commit', '--date=now'], cwd=repository.root_path, env=env)
         if result.returncode:
             run([repository.executable(), 'revert', '--abort'], cwd=repository.root_path)


### PR DESCRIPTION
#### 2425de1c879b13f96a49d4b2cb83d587d73e536b
<pre>
[git-webkit] Cache filed bug
<a href="https://bugs.webkit.org/show_bug.cgi?id=255007">https://bugs.webkit.org/show_bug.cgi?id=255007</a>
rdar://107629444

Reviewed by Elliott Williams.

git-webkit branch will file a bug. However, that bug is only picked up
in a commit message through environment variables, which means that
bugs filed by `git-webkit branch` aren&apos;t very useful except when happening
through `git-webkit pr`&apos;s invocation of `git-webkit branch`. We have a
similar problem when crafting cherry-picks or reverting changes.

* Tools/Scripts/hooks/prepare-commit-msg: Pull title, bug and cherry-pick message from
`git config` if they aren&apos;t available in the environment.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py: Add ability to get
and set `git config` values.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.main): Save filed bug into `git config` environment.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/cherry_pick.py:
(CherryPick.main): Save cherry-pick pattern and bug details into `git config`, use
COMMIT_MESSAGE_BUG instead of GIT_WEBKIT_BUG.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py:
(Command.write_branch_variables): Write variable to `git config`&apos;s branch specific namespace.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.revert_commit): Save filed bug into `git config` environment.

Canonical link: <a href="https://commits.webkit.org/263641@main">https://commits.webkit.org/263641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb5201fb4aa515f0b01ca342183802289951e753

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6863 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/5368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5444 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5425 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/5498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/4771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6889 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/5431 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/2978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/4776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/11847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/4844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/4855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5281 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/5275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/4747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/8843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/597 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/5107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->