### PR TITLE
[git pre-push] Prevent pushing commits for redacted issues

### DIFF
--- a/Tools/Scripts/hooks/pre-push
+++ b/Tools/Scripts/hooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env {{ python }}
-VERSION = '1.4'
+VERSION = '1.5'
 
 import io
 import os
@@ -215,6 +215,18 @@ def security_level_for_commit(commit, remotes, name_to_remote=None):
     message = message_for(commit)
     title = message.splitlines()[0]
 
+    # Compute class 3 before class 2, because a class 3 violation is more interesting than a class 2
+    # if both indicate a commit is potentially sensative
+    did_redact = False
+    if REPOSITORY:
+        obj = Commit(hash=commit, message=message)
+        for issue in obj.issues:
+            redaction = issue.redacted
+            if redaction:
+                did_redact = True
+            if getattr(redaction, 'exemption', False):
+                return 0, CLASS_3
+
     # Class 2: The commit we're pushing is a cherry-pick of something that exists on a remote already
     for r in CHERRY_PICK_RE:
         match = r.match(title)
@@ -228,19 +240,16 @@ def security_level_for_commit(commit, remotes, name_to_remote=None):
             original_remotes = remotes_for(candidate)
             if not original_remotes:
                 continue
-            return security_level_for_remotes(original_remotes, name_to_remote), CLASS_2
+            level = security_level_for_remotes(original_remotes, name_to_remote)
+
+            # If the commit is a cherry-pick of something already public, the state of the bug it's referencing doesn't matter 
+            if did_redact and level != 0:
+                return 1, CLASS_3
+            return level, CLASS_2
         break
 
     # Class 3: We must inspect the commit for bug references
     if REPOSITORY:
-        obj = Commit(hash=commit, message=message)
-        did_redact = False
-        for issue in obj.issues:
-            redaction = issue.redacted
-            if redaction:
-                did_redact = True
-            if getattr(redaction, 'exemption', False):
-                return 0, CLASS_3
         if did_redact:
             return 1, CLASS_3
         return 0, CLASS_3
@@ -326,13 +335,10 @@ def main(name, remote):
             else:
                 return 1
 
-        # Commit is redacted, but we're pushing it publically
+        # Commit references a redacted issue, but we're pushing it publically
         if categorization_class == 3 and (MAX_LEVEL if security_level is None else security_level) > (target_security_level or 0):
             print_error("'{}' fixes a redacted issue, but '{}' is a public remote".format(commit, name))
-            if MODE == DEFAULT_MODE:
-                prompt_for.append(commit)
-            else:
-                return 1
+            return 1
 
         if VERBOSITY >= VERBOSE:
             print_tty('    {} is security level {} by class {}'.format(commit, security_level, categorization_class))


### PR DESCRIPTION
#### 34c241927fad61ad952eea1bbddd205459f1a7a8
<pre>
[git pre-push] Prevent pushing commits for redacted issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=255043">https://bugs.webkit.org/show_bug.cgi?id=255043</a>
rdar://107673301

Reviewed by Elliott Williams and Geoffrey Garen.

Prevent pushing commits which reference redacted issues to public remotes unless:
1. Those commits are already on a public remote
2. Those commits cherry-pick a commit already on a public remote
3. Those commits reference an issue exempt from redaction
Notably, this change removes the prompt allowing a user to override the guard against
publishing a commit for a redacted issue.

* Tools/Scripts/hooks/pre-push:

Canonical link: <a href="https://commits.webkit.org/262635@main">https://commits.webkit.org/262635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b14d036c95a3cfc4712160c11a32b302a82439ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/2114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/2146 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/2212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/3039 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/2172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/2089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/2226 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/2191 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/3039 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/2133 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/2226 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/2212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/2226 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/2212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/2890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/1949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/2212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/2890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/1943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/2191 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/1871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/2212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/233 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->