### PR TITLE
REGRESSION (iOS 16.4): Our page crashes on page load due to service workers

### DIFF
--- a/LayoutTests/http/wpt/service-workers/controlled-module-dedicatedworker.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/controlled-module-dedicatedworker.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Register service worker
+PASS Verify dedicated module worker load went well
+

--- a/LayoutTests/http/wpt/service-workers/controlled-module-dedicatedworker.https.html
+++ b/LayoutTests/http/wpt/service-workers/controlled-module-dedicatedworker.https.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (test) => {
+    const registration = await navigator.serviceWorker.register("module-dedicatedworker-worker.js", { scope : 'resources' });
+    activeWorker = registration.active;
+    if (activeWorker)
+        return;
+
+    activeWorker = registration.installing;
+    await new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve();
+        });
+    });
+}, "Register service worker");
+
+promise_test(async (test) => {
+    worker = new Worker('resources/controlled-module-worker.js', { type: 'module' });
+    const event = await new Promise(resolve => worker.onmessage = resolve);
+    assert_equals(event.data, "PASS");
+}, "Verify dedicated module worker load went well");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/module-dedicatedworker-worker.js
+++ b/LayoutTests/http/wpt/service-workers/module-dedicatedworker-worker.js
@@ -1,0 +1,22 @@
+async function doTest(event)
+{
+    if (event.data === "SET-FETCH") {
+        self.receivedFetch = 0;
+        self.addEventListener("fetch", (event) => {
+            self.receivedFetch++;
+        });
+        event.source.postMessage("OK");
+        return;
+    }
+    if (event.data === "GET-FETCH") {
+        event.source.postMessage(self.receivedFetch);
+        return;
+    }
+    if (event.data === "ping") {
+        event.source.postMessage("pong");
+        return;
+    }
+    event.source.postMessage("KO");
+}
+
+self.addEventListener("message", doTest);

--- a/LayoutTests/http/wpt/service-workers/resources/controlled-module-worker.js
+++ b/LayoutTests/http/wpt/service-workers/resources/controlled-module-worker.js
@@ -1,0 +1,1 @@
+import('./export-on-load-script.js').finally(() => self.postMessage("PASS"));


### PR DESCRIPTION
#### 96af04c5e6b2f257ec424cf11c12721886d19fe3
<pre>
REGRESSION (iOS 16.4): Our page crashes on page load due to service workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=254938">https://bugs.webkit.org/show_bug.cgi?id=254938</a>
rdar://problem/107602025

Reviewed by Chris Dumez.

We are thinking module worker loads are main worker load and were expecting to get a resulting client identifier but got none.
Check on the resulting client identifier to identify whether the request is for a new client.
Covered by newly added test in Debug.

* LayoutTests/http/wpt/service-workers/controlled-module-dedicatedworker.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/controlled-module-dedicatedworker.https.html: Added.
* LayoutTests/http/wpt/service-workers/module-dedicatedworker-worker.js: Added.
(async doTest):
* LayoutTests/http/wpt/service-workers/resources/controlled-module-worker.js: Added.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::controlClient):
(WebKit::WebSWServerConnection::createFetchTask):

Canonical link: <a href="https://commits.webkit.org/262666@main">https://commits.webkit.org/262666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c755a9e40c9f611a0bca0fe47e758e6394fcc66e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3021 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2156 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2172 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1910 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2872 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1763 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1931 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1902 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3037 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1721 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1864 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/546 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2035 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->