### PR TITLE
Regenerate ModuleProgramExecutable unlinkedCodeBlock after being destroyed by low memory cleaning

### DIFF
--- a/Source/JavaScriptCore/runtime/ModuleProgramExecutable.h
+++ b/Source/JavaScriptCore/runtime/ModuleProgramExecutable.h
@@ -52,6 +52,9 @@ public:
         return bitwise_cast<ModuleProgramCodeBlock*>(Base::codeBlock());
     }
 
+    enum class PossibleExceptionsExpected { Yes, No };
+    UnlinkedModuleProgramCodeBlock* getUnlinkedCodeBlock(JSGlobalObject*, PossibleExceptionsExpected);
+
     UnlinkedModuleProgramCodeBlock* unlinkedCodeBlock() const
     {
         return bitwise_cast<UnlinkedModuleProgramCodeBlock*>(Base::unlinkedCodeBlock());

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.cpp
@@ -252,6 +252,11 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
         RELEASE_ASSERT(kind == CodeForCall);
         RELEASE_ASSERT(!executable->m_codeBlock);
         RELEASE_ASSERT(!function);
+
+        // FIXME: There might be a case that executable->unlinkedCodeBlock() will be a nullptr 
+        // since ScriptExecutable::clearCode might be triggered due to limited memory usage. 
+        // We should regenerate unlinkedCodeBlock if necessary for both EvalExecutable and ProgramExecutable.
+        // See similar problem for ModuleProgramExecutable in https://bugs.webkit.org/show_bug.cgi?id=255044.
         RELEASE_AND_RETURN(throwScope, EvalCodeBlock::create(vm, executable, executable->unlinkedCodeBlock(), scope));
     }
 
@@ -268,7 +273,11 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
         RELEASE_ASSERT(kind == CodeForCall);
         RELEASE_ASSERT(!executable->m_codeBlock);
         RELEASE_ASSERT(!function);
-        RELEASE_AND_RETURN(throwScope, ModuleProgramCodeBlock::create(vm, executable, executable->unlinkedCodeBlock(), scope));
+
+        UnlinkedModuleProgramCodeBlock* unlinkedCodeBlock = executable->getUnlinkedCodeBlock(globalObject, ModuleProgramExecutable::PossibleExceptionsExpected::No);
+        EXCEPTION_ASSERT(!throwScope.exception());
+        ASSERT(executable->unlinkedCodeBlock());
+        RELEASE_AND_RETURN(throwScope, ModuleProgramCodeBlock::create(vm, executable, unlinkedCodeBlock, scope));
     }
 
     RELEASE_ASSERT(classInfo() == FunctionExecutable::info());
@@ -295,11 +304,11 @@ CodeBlock* ScriptExecutable::newCodeBlockFor(CodeSpecializationKind kind, JSFunc
         executable->m_unlinkedExecutable->lexicalScopeFeatures(),
         executable->m_unlinkedExecutable->hasCapturedVariables(),
         lastLine(), endColumn()); 
+    // FIXME: We should remove this and add ASSERT(unlinkedCodeBlock).
     if (!unlinkedCodeBlock) {
         throwException(globalObject, throwScope, error.toErrorObject(globalObject, executable->source()));
         return nullptr;
     }
-
     RELEASE_AND_RETURN(throwScope, FunctionCodeBlock::create(vm, executable, unlinkedCodeBlock, scope));
 }
 


### PR DESCRIPTION
#### e9cb06ebfbf530f4d571fa5103ebd3d3d6f9aad6
<pre>
Regenerate ModuleProgramExecutable unlinkedCodeBlock after being destroyed by low memory cleaning
<a href="https://bugs.webkit.org/show_bug.cgi?id=255044">https://bugs.webkit.org/show_bug.cgi?id=255044</a>
rdar://104937190

Reviewed by Mark Lam and Yusuke Suzuki.

ModuleProgramExecutable&apos;s unlinkedCodeBlock can be cleared by ScriptExecutable::clearCode
during low memory handling. As a result, ScriptExecutable::newCodeBlockFor can encounter
a null unlinkedCodeBlock. This patch fixes this issue by regenerating the unlinkedCodeBlock
if needed.

No test is added because the manifestation of this bug depends on a race condition.
The race condition requires that ScriptExecutable::clearCode be called after
ModuleProgramExecutable is instantiated and before ScriptExecutable::newCodeBlockFor
runs. This can happen due to low memory handling. We manually simulated this condition
in local testing to reproduce the issue by forcing ScriptExecutable::clearCode to be called
after ModuleProgramExecutable is instantiated and just before the VM returns to the idle loop.
Using this method, we confirmed that the fix works.

* Source/JavaScriptCore/runtime/ModuleProgramExecutable.cpp:
(JSC::ModuleProgramExecutable::generateOrGetUnlinkedCodeBlock):
(JSC::ModuleProgramExecutable::create):
* Source/JavaScriptCore/runtime/ModuleProgramExecutable.h:
* Source/JavaScriptCore/runtime/ScriptExecutable.cpp:
(JSC::ScriptExecutable::newCodeBlockFor):

Canonical link: <a href="https://commits.webkit.org/262788@main">https://commits.webkit.org/262788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75e8f0e27d9702a92962919ebb1ed65d82802678

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4003 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2993 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2298 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2624 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3769 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2316 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2176 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2673 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3544 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2494 "Built successfully and passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2367 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2160 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2678 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2319 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/622 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/642 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2355 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2734 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2504 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/736 "Passed tests") | 
<!--EWS-Status-Bubble-End-->