### PR TITLE
Use quaternary-fill UIColor in iOS attachment

### DIFF
--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,67) size 47x19
           text run at (0,67) width 47: "Blank: "
         RenderBlock {ATTACHMENT} at (46,0) size 339x92 [color=#007AFF]
-          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#F4F4F5]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderAttachment {ATTACHMENT} at (10,10) size 56x72
             RenderGrid {DIV} at (76,0) size 262x92
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,67) size 39x19
           text run at (0,67) width 39: "Title: "
         RenderBlock {ATTACHMENT} at (38,0) size 339x92 [color=#007AFF]
-          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#F4F4F5]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderAttachment {ATTACHMENT} at (10,10) size 56x72
             RenderGrid {DIV} at (76,0) size 262x92
@@ -25,7 +25,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,67) size 83x19
           text run at (0,67) width 83: "and subtitle: "
         RenderBlock {ATTACHMENT} at (82,0) size 339x92 [color=#007AFF]
-          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#F4F4F5]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderAttachment {ATTACHMENT} at (10,10) size 56x72
             RenderGrid {DIV} at (76,0) size 262x92
@@ -34,7 +34,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,67) size 52x19
           text run at (0,67) width 52: "Action: "
         RenderBlock {ATTACHMENT} at (51,0) size 339x92 [color=#007AFF]
-          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#F4F4F5]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderAttachment {ATTACHMENT} at (10,10) size 56x72
             RenderGrid {DIV} at (76,0) size 262x92
@@ -43,7 +43,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,67) size 40x19
           text run at (0,67) width 40: "Save: "
         RenderBlock {ATTACHMENT} at (39,0) size 339x92 [color=#007AFF]
-          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#F4F4F5]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderAttachment {ATTACHMENT} at (10,10) size 56x72
             RenderGrid {DIV} at (76,0) size 262x92

--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -130,6 +130,7 @@ typedef enum {
 + (UIColor *)systemFillColor;
 + (UIColor *)secondarySystemFillColor;
 + (UIColor *)tertiarySystemFillColor;
++ (UIColor *)quaternarySystemFillColor;
 
 + (UIColor *)systemGroupedBackgroundColor;
 + (UIColor *)secondarySystemGroupedBackgroundColor;

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -310,6 +310,7 @@ accentcolortext
 -apple-system-opaque-secondary-fill enable-if=WTF_PLATFORM_IOS_FAMILY
 -apple-system-opaque-secondary-fill-disabled enable-if=WTF_PLATFORM_IOS_FAMILY
 -apple-system-opaque-tertiary-fill enable-if=WTF_PLATFORM_IOS_FAMILY
+-apple-system-quaternary-fill enable-if=WTF_PLATFORM_IOS_FAMILY
 -apple-system-opaque-separator enable-if=WTF_PLATFORM_IOS_FAMILY
 -webkit-control-background enable-if=WTF_PLATFORM_COCOA|HAVE_OS_DARK_MODE_SUPPORT
 activebuttontext

--- a/Source/WebCore/css/parser/CSSParserIdioms.cpp
+++ b/Source/WebCore/css/parser/CSSParserIdioms.cpp
@@ -39,8 +39,11 @@ bool isValueAllowedInMode(unsigned short id, CSSParserMode mode)
     switch (id) {
     case CSSValueWebkitFocusRingColor:
         return isUASheetBehavior(mode) || isQuirksModeBehavior(mode);
-    case CSSValueInternalThCenter:
+#if PLATFORM(IOS_FAMILY)
+    case CSSValueAppleSystemQuaternaryFill:
+#endif
     case CSSValueInternalDocumentTextColor:
+    case CSSValueInternalThCenter:
     case CSSValueInternalVariableValue:
         return isUASheetBehavior(mode);
     default:

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -29,7 +29,7 @@ div#attachment-container {
     grid-template-columns: 76px auto;
     width: 338px;
     height: 92px;
-    background-color: rgb(244, 244, 245); /* FIXME: Use quaternary-fill when available, see rdar://105252500 depending on rdar://104844460 */
+    background-color: -apple-system-quaternary-fill;
 #else
     grid-template-columns: 68px auto;
     width: 266px;

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -1414,6 +1414,7 @@ static const Vector<CSSValueSystemColorInformation>& cssValueSystemColorInformat
             // FIXME: <rdar://problem/75538507> UIKit should expose this color so that we maintain parity with system buttons.
             { CSSValueAppleSystemOpaqueSecondaryFillDisabled, @selector(secondarySystemFillColor), true, 0.75f },
             { CSSValueAppleSystemOpaqueTertiaryFill, @selector(tertiarySystemFillColor), true },
+            { CSSValueAppleSystemQuaternaryFill, @selector(quaternarySystemFillColor) },
             { CSSValueAppleSystemGroupedBackground, @selector(systemGroupedBackgroundColor) },
             { CSSValueAppleSystemSecondaryGroupedBackground, @selector(secondarySystemGroupedBackgroundColor) },
             { CSSValueAppleSystemTertiaryGroupedBackground, @selector(tertiarySystemGroupedBackgroundColor) },


### PR DESCRIPTION
#### e214b2a322c49e1ff3aa7991b6f9478d8cbd80e5
<pre>
Use quaternary-fill UIColor in iOS attachment
<a href="https://bugs.webkit.org/show_bug.cgi?id=255055">https://bugs.webkit.org/show_bug.cgi?id=255055</a>
rdar://problem/107679227

Reviewed by Aditya Keerthi.

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-container):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::cssValueSystemColorInformationList):

Canonical link: <a href="https://commits.webkit.org/262657@main">https://commits.webkit.org/262657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19020d6a2362e6ac0c3190b3059cccc5f48336a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3089 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2208 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1960 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2944 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1816 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1997 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3106 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1778 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1928 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/539 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2102 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->