### PR TITLE
[WGSL] Update argument types after overload resolution

### DIFF
--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -84,6 +84,9 @@ public:
     operator T&() { ASSERT(m_ref); return *m_ref; }
     operator const T&() const { ASSERT(m_ref); return *m_ref; }
 
+    T& operator*() { ASSERT(m_ref); return *m_ref.get(); }
+    const T& operator*() const { ASSERT(m_ref); return *m_ref.get(); }
+
     std::unique_ptr<T> moveToUniquePtr() { return WTFMove(m_ref); }
 
     explicit UniqueRef(HashTableEmptyValueType) { }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -474,7 +474,7 @@ void FunctionDefinitionWriter::visit(AST::CallExpression& call)
         }
     }
 
-    visit(call.target());
+    visit(call.inferredType());
     visitArguments(this, call);
 }
 

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -92,7 +92,12 @@ struct OverloadCandidate {
     AbstractType result;
 };
 
-Type* resolveOverloads(TypeStore&, const Vector<OverloadCandidate>&, const Vector<Type*>& valueArguments, const Vector<Type*>& typeArguments);
+struct SelectedOverload {
+    FixedVector<Type*> parameters;
+    Type* result;
+};
+
+std::optional<SelectedOverload> resolveOverloads(TypeStore&, const Vector<OverloadCandidate>&, const Vector<Type*>& valueArguments, const Vector<Type*>& typeArguments);
 
 } // namespace WGSL
 

--- a/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
@@ -10,7 +10,7 @@ struct S {
 fn testConstraints() {
     var x : S;
 
-    // CHECK-L: no matching overload for operator + (S, S)
+    // CHECK-L: no matching overload for operator +(S, S)
     let x2 = x + x;
 
     // CHECK-L:  no matching overload for initializer vec2(S, S)
@@ -25,10 +25,10 @@ fn testConstraints() {
     // CHECK-L:  no matching overload for initializer vec2<S>(vec2<<AbstractInt>>)
     let x6 = vec2<S>(vec2(0, 0));
 
-    // CHECK-L: no matching overload for operator - (u32)
+    // CHECK-L: no matching overload for operator -(u32)
     let x7 = -1u;
 
-    // CHECK-L: no matching overload for operator - (vec2<u32>)
+    // CHECK-L: no matching overload for operator -(vec2<u32>)
     let x8 = -vec2(1u, 1u);
 }
 
@@ -36,6 +36,6 @@ fn testBottomOverload() {
   // CHECK-L: no matching overload for initializer vec2<f32>(<AbstractInt>)
   let m = vec2<f32>(0);
 
-  // CHECK-NOT-L: no matching overload for operator + (⊥, <AbstractInt>)
+  // CHECK-NOT-L: no matching overload for operator +(⊥, <AbstractInt>)
   let x = m + 2;
 }

--- a/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
@@ -4,3 +4,15 @@ fn testVariableInialization() {
   let x3: f32 = 0;
   let x4: f32 = 0.0;
 }
+
+@vertex
+fn testConcretizationOfArguments() {
+  // CHECK-L: vec<unsigned, 2>(0, 0);
+  let x1 = 0u + vec2(0, 0);
+
+  // CHECK-L: vec<int, 2>(0, 0);
+  let x2 = 0i + vec2(0, 0);
+
+  // CHECK-L: vec<float, 2>(0, 0);
+  let x3 = 0f + vec2(0, 0);
+}


### PR DESCRIPTION
#### 7279cacdca96ff523fdeaf956a2f177b46fc2e20
<pre>
[WGSL] Update argument types after overload resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=255049">https://bugs.webkit.org/show_bug.cgi?id=255049</a>
rdar://107676263

Reviewed by Myles C. Maxfield.

Overload resolution might result in argument concretization, in which case we
need to propagate that information back to the arguments. We fix that by making
the overload resolution return not only the result type, but also the resolved
type for all the arguments.

* Source/WTF/wtf/UniqueRef.h:
(WTF::UniqueRef::operator*):
(WTF::UniqueRef::operator* const):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::resolve):
(WGSL::OverloadResolver::considerCandidate):
(WGSL::resolveOverloads):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/tests/valid/concretization.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/262799@main">https://commits.webkit.org/262799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/920eb355bafdffca00ee92f02151b56b950f0f0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4061 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2751 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2678 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3825 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2358 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/2213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2735 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2374 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2537 "Built successfully and passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2409 "Passed tests") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2729 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2361 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/640 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/652 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2399 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2788 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2553 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/755 "Passed tests") | 
<!--EWS-Status-Bubble-End-->