### PR TITLE
[UI-side compositing] Flash of flipped content when pinching into tab overview in Safari

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
@@ -104,6 +104,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return self;
 }
 
+- (BOOL)isFlipped
+{
+    return YES;
+}
+
 - (BOOL)wantsUpdateLayer
 {
     return YES;

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -25,7 +25,9 @@ DeprecatedGlobalValues.mm
 EditingTestHarness.mm
 WKWebViewConfigurationExtras.mm
 
+cocoa/CGImagePixelReader.cpp
 cocoa/DaemonTestUtilities.mm
+cocoa/EnableUISideCompositingScope.mm
 cocoa/ImageAnalysisTestingUtilities.mm
 cocoa/NSItemProviderAdditions.mm
 cocoa/PlatformUtilitiesCocoa.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */; };
 		51CD1C721B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51CD1C711B38D48400142CA5 /* modal-alerts-in-new-about-blank-window.html */; };
 		51DB16CE1F085137001FA4C5 /* WebViewIconLoading.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51DB16CD1F085047001FA4C5 /* WebViewIconLoading.mm */; };
+		51E1007929C6D947009CEE99 /* file-with-managedmse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E1007129C6D891009CEE99 /* file-with-managedmse.html */; };
 		51E5C7021919C3B200D8B3E1 /* simple2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E780361919AFF8001829A2 /* simple2.html */; };
 		51E5C7031919C3B200D8B3E1 /* simple3.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E780371919AFF8001829A2 /* simple3.html */; };
 		51E6A8961D2F1CA700C004B6 /* LocalStorageClear.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E6A8951D2F1C7700C004B6 /* LocalStorageClear.html */; };
@@ -1003,7 +1004,6 @@
 		CD577799211CE0E4001B371E /* web-audio-only.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD577798211CDE8F001B371E /* web-audio-only.html */; };
 		CD57779C211CE91F001B371E /* audio-with-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779A211CE6B7001B371E /* audio-with-web-audio.html */; };
 		CD57779D211CE91F001B371E /* video-with-audio-and-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */; };
-		51E1007929C6D947009CEE99 /* file-with-managedmse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 51E1007129C6D891009CEE99 /* file-with-managedmse.html */; };
 		CD59F53419E9110D00CF1835 /* file-with-mse.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53219E910AA00CF1835 /* file-with-mse.html */; };
 		CD59F53519E9110D00CF1835 /* test-mse.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53319E910BC00CF1835 /* test-mse.mp4 */; };
 		CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5FF4962162E27E004BD86F /* ISOBox.cpp */; };
@@ -2448,6 +2448,7 @@
 		51D124971E763AF8002B2820 /* WKHTTPCookieStore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKHTTPCookieStore.mm; sourceTree = "<group>"; };
 		51D8C18F2267B26700797E40 /* PDFLinkReferrer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PDFLinkReferrer.mm; sourceTree = "<group>"; };
 		51DB16CD1F085047001FA4C5 /* WebViewIconLoading.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebViewIconLoading.mm; sourceTree = "<group>"; };
+		51E1007129C6D891009CEE99 /* file-with-managedmse.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "file-with-managedmse.html"; sourceTree = "<group>"; };
 		51E5C7041919EA5F00D8B3E1 /* ShouldKeepCurrentBackForwardListItemInList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShouldKeepCurrentBackForwardListItemInList.cpp; sourceTree = "<group>"; };
 		51E6A8921D2F1BEC00C004B6 /* LocalStorageClear.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LocalStorageClear.mm; sourceTree = "<group>"; };
 		51E6A8951D2F1C7700C004B6 /* LocalStorageClear.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = LocalStorageClear.html; sourceTree = "<group>"; };
@@ -3215,7 +3216,6 @@
 		CD577798211CDE8F001B371E /* web-audio-only.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "web-audio-only.html"; sourceTree = "<group>"; };
 		CD57779A211CE6B7001B371E /* audio-with-web-audio.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "audio-with-web-audio.html"; sourceTree = "<group>"; };
 		CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "video-with-audio-and-web-audio.html"; sourceTree = "<group>"; };
-		51E1007129C6D891009CEE99 /* file-with-managedmse.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "file-with-managedmse.html"; sourceTree = "<group>"; };
 		CD59F53219E910AA00CF1835 /* file-with-mse.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "file-with-mse.html"; sourceTree = "<group>"; };
 		CD59F53319E910BC00CF1835 /* test-mse.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse.mp4"; sourceTree = "<group>"; };
 		CD5FF4962162E27E004BD86F /* ISOBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISOBox.cpp; sourceTree = "<group>"; };
@@ -3481,6 +3481,10 @@
 		F4A32EC31F05F3780047C544 /* dragstart-change-selection-offscreen.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "dragstart-change-selection-offscreen.html"; sourceTree = "<group>"; };
 		F4A32ECA1F0642F40047C544 /* contenteditable-in-iframe.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "contenteditable-in-iframe.html"; sourceTree = "<group>"; };
 		F4A715A72950C8D900B4D0D6 /* NetworkConnectionIntegrityTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkConnectionIntegrityTests.mm; sourceTree = "<group>"; };
+		F4A74B9129DDD9F100CB5288 /* CGImagePixelReader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CGImagePixelReader.h; path = cocoa/CGImagePixelReader.h; sourceTree = "<group>"; };
+		F4A74B9229DDD9F100CB5288 /* CGImagePixelReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CGImagePixelReader.cpp; path = cocoa/CGImagePixelReader.cpp; sourceTree = "<group>"; };
+		F4A74B9D29DDE1AC00CB5288 /* EnableUISideCompositingScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = EnableUISideCompositingScope.h; path = cocoa/EnableUISideCompositingScope.h; sourceTree = "<group>"; };
+		F4A74BA829DDE8C000CB5288 /* EnableUISideCompositingScope.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = EnableUISideCompositingScope.mm; path = cocoa/EnableUISideCompositingScope.mm; sourceTree = "<group>"; };
 		F4A7CE772662D6E800228685 /* TouchEventTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TouchEventTests.mm; sourceTree = "<group>"; };
 		F4A7CE792662D83E00228685 /* active-touch-events.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "active-touch-events.html"; sourceTree = "<group>"; };
 		F4A9202E1FEE34C800F59590 /* apple-data-url.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "apple-data-url.html"; sourceTree = "<group>"; };
@@ -3720,6 +3724,8 @@
 			isa = PBXGroup;
 			children = (
 				A13EBB441B87332B00097110 /* WebProcessPlugIn */,
+				F4A74B9229DDD9F100CB5288 /* CGImagePixelReader.cpp */,
+				F4A74B9129DDD9F100CB5288 /* CGImagePixelReader.h */,
 				F44A530F21B8976900DBB99C /* ClassMethodSwizzler.h */,
 				F44A530E21B8976900DBB99C /* ClassMethodSwizzler.mm */,
 				5C157A082717C56600ED5280 /* DaemonTestUtilities.h */,
@@ -3728,6 +3734,8 @@
 				F46128B4211C861A00D9FADB /* DragAndDropSimulator.h */,
 				F44D06481F3962E3001A0E29 /* EditingTestHarness.h */,
 				F44D06491F3962E3001A0E29 /* EditingTestHarness.mm */,
+				F4A74B9D29DDE1AC00CB5288 /* EnableUISideCompositingScope.h */,
+				F4A74BA829DDE8C000CB5288 /* EnableUISideCompositingScope.mm */,
 				5C7C24FB237C972300599C91 /* HTTPServer.h */,
 				5C7C24FA237C972300599C91 /* HTTPServer.mm */,
 				F42F081727449FFD007E0D90 /* ImageAnalysisTestingUtilities.h */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
@@ -27,6 +27,7 @@
 
 #if ENABLE(IMAGE_ANALYSIS)
 
+#import "CGImagePixelReader.h"
 #import "ImageAnalysisTestingUtilities.h"
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
@@ -36,7 +37,6 @@
 #import "TestWKWebView.h"
 #import "UIKitSPI.h"
 #import "WKWebViewConfigurationExtras.h"
-#import <WebCore/Color.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -103,45 +103,6 @@ static CGPoint swizzledLocationInView(id, SEL, UIView *)
 @end
 
 namespace TestWebKitAPI {
-
-// FIXME: We can unify most of this helper class with the logic in `TestPDFPage::colorAtPoint`, and deploy this
-// helper class in several other tests that read pixel data from CGImages.
-class CGImagePixelReader {
-    WTF_MAKE_FAST_ALLOCATED; WTF_MAKE_NONCOPYABLE(CGImagePixelReader);
-public:
-    CGImagePixelReader(CGImageRef image)
-        : m_width(CGImageGetWidth(image))
-        , m_height(CGImageGetHeight(image))
-    {
-        auto colorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-        auto bytesPerPixel = 4;
-        auto bytesPerRow = bytesPerPixel * CGImageGetWidth(image);
-        auto bitsPerComponent = 8;
-        auto bitmapInfo = kCGImageAlphaPremultipliedLast | kCGImageByteOrder32Big;
-        m_context = adoptCF(CGBitmapContextCreateWithData(nullptr, m_width, m_height, bitsPerComponent, bytesPerRow, colorSpace.get(), bitmapInfo, nullptr, nullptr));
-        CGContextDrawImage(m_context.get(), CGRectMake(0, 0, m_width, m_height), image);
-    }
-
-    bool isTransparentBlack(unsigned x, unsigned y) const
-    {
-        return at(x, y) == WebCore::Color::transparentBlack;
-    }
-
-    WebCore::Color at(unsigned x, unsigned y) const
-    {
-        auto* data = reinterpret_cast<uint8_t*>(CGBitmapContextGetData(m_context.get()));
-        auto offset = 4 * (width() * y + x);
-        return WebCore::makeFromComponentsClampingExceptAlpha<WebCore::SRGBA<uint8_t>>(data[offset], data[offset + 1], data[offset + 2], data[offset + 3]);
-    }
-
-    unsigned width() const { return m_width; }
-    unsigned height() const { return m_height; }
-
-private:
-    unsigned m_width { 0 };
-    unsigned m_height { 0 };
-    RetainPtr<CGContextRef> m_context;
-};
 
 static Vector<RetainPtr<VKImageAnalyzerRequest>>& processedRequests()
 {

--- a/Tools/TestWebKitAPI/cocoa/CGImagePixelReader.cpp
+++ b/Tools/TestWebKitAPI/cocoa/CGImagePixelReader.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CGImagePixelReader.h"
+
+namespace TestWebKitAPI {
+using namespace WebCore;
+
+CGImagePixelReader::CGImagePixelReader(CGImageRef image)
+    : m_width(CGImageGetWidth(image))
+    , m_height(CGImageGetHeight(image))
+{
+    auto colorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    auto bytesPerPixel = 4;
+    auto bytesPerRow = bytesPerPixel * CGImageGetWidth(image);
+    auto bitsPerComponent = 8;
+    auto bitmapInfo = kCGImageAlphaPremultipliedLast | kCGImageByteOrder32Big;
+    m_context = adoptCF(CGBitmapContextCreateWithData(nullptr, m_width, m_height, bitsPerComponent, bytesPerRow, colorSpace.get(), bitmapInfo, nullptr, nullptr));
+    CGContextDrawImage(m_context.get(), CGRectMake(0, 0, m_width, m_height), image);
+}
+
+bool CGImagePixelReader::isTransparentBlack(unsigned x, unsigned y) const
+{
+    return at(x, y) == Color::transparentBlack;
+}
+
+Color CGImagePixelReader::at(unsigned x, unsigned y) const
+{
+    auto* data = reinterpret_cast<uint8_t*>(CGBitmapContextGetData(m_context.get()));
+    auto offset = 4 * (width() * y + x);
+    return makeFromComponentsClampingExceptAlpha<SRGBA<uint8_t>>(data[offset], data[offset + 1], data[offset + 2], data[offset + 3]);
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/cocoa/CGImagePixelReader.h
+++ b/Tools/TestWebKitAPI/cocoa/CGImagePixelReader.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <WebCore/Color.h>
+#include <wtf/Forward.h>
+#include <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+// FIXME: We can unify most of this helper class with the logic in `TestPDFPage::colorAtPoint`, and deploy this
+// helper class in several other tests that read pixel data from CGImages.
+class CGImagePixelReader {
+    WTF_MAKE_FAST_ALLOCATED; WTF_MAKE_NONCOPYABLE(CGImagePixelReader);
+public:
+    CGImagePixelReader(CGImageRef);
+
+    bool isTransparentBlack(unsigned x, unsigned y) const;
+    WebCore::Color at(unsigned x, unsigned y) const;
+
+    unsigned width() const { return m_width; }
+    unsigned height() const { return m_height; }
+
+private:
+    unsigned m_width { 0 };
+    unsigned m_height { 0 };
+    RetainPtr<CGContextRef> m_context;
+};
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/cocoa/EnableUISideCompositingScope.h
+++ b/Tools/TestWebKitAPI/cocoa/EnableUISideCompositingScope.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <Foundation/Foundation.h>
+#include <objc/runtime.h>
+#include <wtf/Forward.h>
+
+@interface NSUserDefaults (TestSupport)
+- (NSURL *)swizzled_objectForKey:(NSString *)key;
+@end
+
+namespace TestWebKitAPI {
+
+class EnableUISideCompositingScope {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    EnableUISideCompositingScope();
+    ~EnableUISideCompositingScope();
+
+private:
+    Method m_originalMethod;
+    Method m_swizzledMethod;
+    IMP m_originalImplementation;
+    IMP m_swizzledImplementation;
+};
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/cocoa/EnableUISideCompositingScope.mm
+++ b/Tools/TestWebKitAPI/cocoa/EnableUISideCompositingScope.mm
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EnableUISideCompositingScope.h"
+
+@implementation NSUserDefaults (TestSupport)
+
+- (id)swizzled_objectForKey:(NSString *)key
+{
+    if ([key isEqualToString:@"WebKit2UseRemoteLayerTreeDrawingArea"])
+        return @(YES);
+    return [self swizzled_objectForKey:key];
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+EnableUISideCompositingScope::EnableUISideCompositingScope()
+    : m_originalMethod(class_getInstanceMethod(NSUserDefaults.class, @selector(objectForKey:)))
+    , m_swizzledMethod(class_getInstanceMethod(NSUserDefaults.class, @selector(swizzled_objectForKey:)))
+{
+    m_originalImplementation = method_getImplementation(m_originalMethod);
+    m_swizzledImplementation = method_getImplementation(m_swizzledMethod);
+    class_replaceMethod(NSUserDefaults.class, @selector(swizzled_objectForKey:), m_originalImplementation, method_getTypeEncoding(m_originalMethod));
+    class_replaceMethod(NSUserDefaults.class, @selector(objectForKey:), m_swizzledImplementation, method_getTypeEncoding(m_swizzledMethod));
+}
+
+EnableUISideCompositingScope::~EnableUISideCompositingScope()
+{
+    class_replaceMethod(NSUserDefaults.class, @selector(swizzled_objectForKey:), m_swizzledImplementation, method_getTypeEncoding(m_originalMethod));
+    class_replaceMethod(NSUserDefaults.class, @selector(objectForKey:), m_originalImplementation, method_getTypeEncoding(m_swizzledMethod));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### b51b2033860f0b19c303ae83cb2c0551d066baf5
<pre>
[UI-side compositing] Flash of flipped content when pinching into tab overview in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=255042">https://bugs.webkit.org/show_bug.cgi?id=255042</a>
rdar://107499419

Reviewed by Simon Fraser.

Currently, when pinching out to tab overview when UI-side compositing is enabled, there&apos;s a brief
flash of partially-flipped page tiles in the `_WKThumbnailView`, as Safari swaps out the contents of
the tab with the web view thumbnail. When this happens, the thumbnail view asynchronously requests a
snapshot from the web page; before the snapshot arrives, however, we reparent the web view&apos;s root
layer inside the layer hierarchy of the thumbnail view, to continue displaying live web content.

When UI-side compositing is enabled, however, this reparenting causes page tiles to become flipped
underneath the `_WKThumbnailView`; this is because while `WKWebView` on macOS returns `YES` for
`-isFlipped`, `_WKThumbnailView` does not (all other aspects being equal). Note that when UI-side
compositing is disabled, the hosting layer has `geometryFlipped=true`, which allows us to get the
flipping behavior right.

To fix this, we simply implement `-[_WKThumbnailView isFlipped]` and return `YES`, to align with
`WKWebView`. Note that this is safe to do even when UI-side compositing is disabled, since it&apos;s the
only layer underneath `_WKThumbnailView`&apos;s layer anyways, and covers the entire layer (which is how
it works in `WKWebView` as well).

Test: WebKit.WKThumbnailViewLayerReparentingWithUISideCompositing

* Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm:
(-[_WKThumbnailView isFlipped]):

Return `YES` here to align with `WKWebView` on macOS. See above for more details.

* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm:
(-[NSView _test_cgImage]):

Add a testing helper method to grab a layer snapshot of an `NSView`, and return it as a `CGImage`.

(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm:
(-[NSUserDefaults swizzled_objectForKey:]): Deleted.
(TestWebKitAPI::EnableUISideCompositingScope::EnableUISideCompositingScope): Deleted.
(TestWebKitAPI::EnableUISideCompositingScope::~EnableUISideCompositingScope): Deleted.

Move the `CGImagePixelReader` helper class out into a separate file.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm:
(TestWebKitAPI::CGImagePixelReader::CGImagePixelReader): Deleted.
(TestWebKitAPI::CGImagePixelReader::isTransparentBlack const): Deleted.
(TestWebKitAPI::CGImagePixelReader::at const): Deleted.
(TestWebKitAPI::CGImagePixelReader::width const): Deleted.
(TestWebKitAPI::CGImagePixelReader::height const): Deleted.
* Tools/TestWebKitAPI/cocoa/CGImagePixelReader.cpp: Added.
(TestWebKitAPI::CGImagePixelReader::CGImagePixelReader):
(TestWebKitAPI::CGImagePixelReader::isTransparentBlack const):
(TestWebKitAPI::CGImagePixelReader::at const):
* Tools/TestWebKitAPI/cocoa/CGImagePixelReader.h: Added.
(TestWebKitAPI::CGImagePixelReader::width const):
(TestWebKitAPI::CGImagePixelReader::height const):
* Tools/TestWebKitAPI/cocoa/EnableUISideCompositingScope.h: Added.
* Tools/TestWebKitAPI/cocoa/EnableUISideCompositingScope.mm: Added.

Move the `EnableUISideCompositingScope` helper class out into a separate file.

(-[NSUserDefaults swizzled_objectForKey:]):
(TestWebKitAPI::EnableUISideCompositingScope::EnableUISideCompositingScope):
(TestWebKitAPI::EnableUISideCompositingScope::~EnableUISideCompositingScope):

Canonical link: <a href="https://commits.webkit.org/262649@main">https://commits.webkit.org/262649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e45643396fb1170c1bf2bf4afc90c8beb9d8882a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3042 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1927 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2893 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1781 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1952 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3060 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1742 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/534 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2056 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->