### PR TITLE
Add canLoad checks to AVVideoCaptureSource::facingModeFitnessScoreAdjustment implementation

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm
@@ -59,29 +59,6 @@ using namespace WebCore;
 
 namespace WebCore {
 
-static NSMutableArray<NSString*>* cameraCaptureDeviceTypes()
-{
-    ASSERT(isMainThread());
-    NSMutableArray<NSString*>* deviceTypes = [[NSMutableArray alloc] initWithCapacity:7];
-
-    if (PAL::canLoad_AVFoundation_AVCaptureDeviceTypeBuiltInWideAngleCamera())
-        [deviceTypes addObject:AVCaptureDeviceTypeBuiltInWideAngleCamera];
-    if (PAL::canLoad_AVFoundation_AVCaptureDeviceTypeBuiltInTelephotoCamera())
-        [deviceTypes addObject:AVCaptureDeviceTypeBuiltInTelephotoCamera];
-    if (PAL::canLoad_AVFoundation_AVCaptureDeviceTypeBuiltInUltraWideCamera())
-        [deviceTypes addObject:AVCaptureDeviceTypeBuiltInUltraWideCamera];
-    if (PAL::canLoad_AVFoundation_AVCaptureDeviceTypeDeskViewCamera())
-        [deviceTypes addObject:AVCaptureDeviceTypeDeskViewCamera];
-    if (PAL::canLoad_AVFoundation_AVCaptureDeviceTypeBuiltInDualWideCamera())
-        [deviceTypes addObject:AVCaptureDeviceTypeBuiltInDualWideCamera];
-    if (PAL::canLoad_AVFoundation_AVCaptureDeviceTypeBuiltInTripleCamera())
-        [deviceTypes addObject:AVCaptureDeviceTypeBuiltInTripleCamera];
-    if (PAL::canLoad_AVFoundation_AVCaptureDeviceTypeExternalUnknown())
-        [deviceTypes addObject:AVCaptureDeviceTypeExternalUnknown];
-
-    return deviceTypes;
-}
-
 void AVCaptureDeviceManager::computeCaptureDevices(CompletionHandler<void()>&& callback)
 {
     if (!m_isInitialized) {
@@ -268,7 +245,7 @@ AVCaptureDeviceManager& AVCaptureDeviceManager::singleton()
 
 AVCaptureDeviceManager::AVCaptureDeviceManager()
     : m_objcObserver(adoptNS([[WebCoreAVCaptureDeviceManagerObserver alloc] initWithCallback:this]))
-    , m_avCaptureDeviceTypes(adoptNS(cameraCaptureDeviceTypes()))
+    , m_avCaptureDeviceTypes(adoptNS(AVVideoCaptureSource::cameraCaptureDeviceTypes()))
     , m_dispatchQueue(WorkQueue::create("com.apple.WebKit.AVCaptureDeviceManager"))
 {
 }

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -44,6 +44,7 @@ OBJC_CLASS AVCaptureSession;
 OBJC_CLASS AVCaptureVideoDataOutput;
 OBJC_CLASS AVFrameRateRange;
 OBJC_CLASS NSError;
+OBJC_CLASS NSMutableArray;
 OBJC_CLASS NSNotification;
 OBJC_CLASS WebCoreAVVideoCaptureSourceObserver;
 
@@ -56,6 +57,7 @@ enum class VideoFrameRotation : uint16_t;
 class AVVideoCaptureSource : public RealtimeVideoCaptureSource, private OrientationNotifier::Observer {
 public:
     static CaptureSourceOrError create(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier);
+    static NSMutableArray* cameraCaptureDeviceTypes();
 
     WEBCORE_EXPORT static VideoCaptureFactory& factory();
 


### PR DESCRIPTION
#### 4adf11746cc77da75176d36c06d0d6ff43f6e31b
<pre>
Add canLoad checks to AVVideoCaptureSource::facingModeFitnessScoreAdjustment implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=255058">https://bugs.webkit.org/show_bug.cgi?id=255058</a>
rdar://107677782

Reviewed by Eric Carlson.

Since we are allowing the strings to not be there, we need to check in every code path whethere they are there.
We do a refactoring to compute the list of device types in AVVideoCaptureSource and reuse it in AVCaptureDeviceManager.

* Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::facingModeFitnessScoreAdjustment const):

Canonical link: <a href="https://commits.webkit.org/262676@main">https://commits.webkit.org/262676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1d2b3e53bfff7c4adba394bf4e3c5dd0264357b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2235 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1983 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2973 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1945 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1840 "147 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2024 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3137 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1802 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1955 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/550 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2129 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->