### PR TITLE
offscreen-scaling.html fails intermittently.

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-scaling.html
+++ b/LayoutTests/fast/canvas/offscreen-scaling.html
@@ -9,21 +9,23 @@ const canvas = document.getElementById('offscreen');
 const offscreenCanvas = canvas.transferControlToOffscreen();
 const offscreenContext = offscreenCanvas.getContext('2d');
 
-const square = new Path2D();
-square.rect(50, 50, 100, 100);
-offscreenContext.fillStyle = 'red';
-offscreenContext.fill(square);
-offscreenContext.commit();
-
 if (window.testRunner)
     testRunner.waitUntilDone();
 
-function finishTest() {
-    if (window.testRunner)
-        testRunner.notifyDone();
-}
-requestAnimationFrame(finishTest);
+requestAnimationFrame(function() {
+  requestAnimationFrame(function() {
+    const square = new Path2D();
+    square.rect(50, 50, 100, 100);
+    offscreenContext.fillStyle = 'red';
+    offscreenContext.fill(square);
+    offscreenContext.commit();
 
+    requestAnimationFrame(function() {
+      if (window.testRunner)
+        testRunner.notifyDone();
+    });
+  });
+});
 </script>
 </body>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4044,8 +4044,6 @@ webkit.org/b/251302 accessibility/ios-simulator/table-cell-ranges.html [ Failure
 
 webkit.org/b/251306 http/tests/in-app-browser-privacy/sub-frame-redirect-to-non-app-bound-domain-blocked.html [ Pass Crash ]
 
-webkit.org/b/254630 fast/canvas/offscreen-scaling.html [ Pass Failure ]
-
 webkit.org/b/254714 imported/w3c/web-platform-tests/css/css-images/image-set/image-set-calc-x-rendering-2.html [ ImageOnlyFailure ]
 
 http/tests/webgpu/webgpu/idl/constants/flags.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1916,8 +1916,6 @@ webkit.org/b/244696 [ Debug ] media/modern-media-controls/media-documents/insert
 
 webkit.org/b/213896 imported/w3c/web-platform-tests/css/css-flexbox/overflow-auto-008.html [ Pass Failure ]
 
-webkit.org/b/254630 fast/canvas/offscreen-scaling.html [ Pass Failure ]
-
 # ENABLE_INPUT_TYPE_* are not enabled on wk1.
 fast/forms/date
 fast/forms/datetimelocal


### PR DESCRIPTION
#### 527c1533b874970428dbc36287c19875f1ff702f
<pre>
offscreen-scaling.html fails intermittently.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254630">https://bugs.webkit.org/show_bug.cgi?id=254630</a>
&lt;rdar://107369322&gt;

Reviewed by Ryosuke Niwa.

Adds a frame of delay before drawing into the offscreen canvas.

* LayoutTests/fast/canvas/offscreen-scaling.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/262693@main">https://commits.webkit.org/262693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61cdf633ad62abe755ed7ad8bf0173ca3ec11436

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3078 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2200 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1951 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2933 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1808 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1987 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3092 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1769 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1920 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/569 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2092 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->