### PR TITLE
REGRESSION (macOS 13.3): Holding down-arrow beeps while scrolling before reaching end of document in WKWebView

### DIFF
--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -209,7 +209,7 @@ bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(ScrollDirection direc
     }
 
     if (m_scrollTriggeringKeyIsPressed)
-        return false;
+        return true;
 
     if (!rubberbandableDirections().at(boxSideForDirection(direction)))
         return false;


### PR DESCRIPTION
#### 77d05a5a85fdd306862c249bd0b8429baaf6bc4d
<pre>
REGRESSION (macOS 13.3): Holding down-arrow beeps while scrolling before reaching end of document in WKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=255039">https://bugs.webkit.org/show_bug.cgi?id=255039</a>
rdar://107667589

Reviewed by Aditya Keerthi.

This was happening because the keyboard event is considered &quot;unhandled&quot; if the triggering key is
already held down.

This PR fixes this by simply correcting this behavior, since these events should actually be
considered &quot;handled&quot;.

* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::beginKeyboardScrollGesture):
* Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm:
(-[NSViewWithKeyDownOverride keyDown:]):
(TestWebKitAPI::arrowKeyDownWithKeyRepeat):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262743@main">https://commits.webkit.org/262743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a9f25badf5f12711da7437a70431645a3ccc02b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2536 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/3643 "Build was cancelled. Recent messages:Failed to print configuration") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2458 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2504 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/3643 "Build was cancelled. Recent messages:Failed to print configuration") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3469 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2020 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2268 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3337 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2203 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2002 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2155 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/610 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2179 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->