### PR TITLE
[Xcode] Fix yasm build due to apparent code signing race condition

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/yasm.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/yasm.xcconfig
@@ -23,6 +23,9 @@
 
 PRODUCT_NAME = yasm;
 
+// Needs to be ad-hoc signed by the linker due to rdar://107696259.
+CODE_SIGN_IDENTITY = ;
+
 HEADER_SEARCH_PATHS = Source/third_party/yasm;
 
 SKIP_INSTALL = YES;


### PR DESCRIPTION
#### d28d0a98a9474745dc9a13d688df77a2adf8af85
<pre>
[Xcode] Fix yasm build due to apparent code signing race condition
<a href="https://bugs.webkit.org/show_bug.cgi?id=255079">https://bugs.webkit.org/show_bug.cgi?id=255079</a>

Unreviewed build fix.

Builds of libwebrtc are using yasm before Xcode has had a chance to sign
it. Fix by disabling formal code signing, so that the linker performs
adhoc signing. This should be safe since yasm is never used off of the
machine it&apos;s built on.

* Source/ThirdParty/libwebrtc/Configurations/yasm.xcconfig:

Canonical link: <a href="https://commits.webkit.org/262658@main">https://commits.webkit.org/262658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fbb2c9202a53ba8de4943c147b9b179076cca04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3102 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2220 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1971 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2958 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1828 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3120 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1997 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1941 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/540 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2114 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->