### PR TITLE
Ensure Win JSC can run complex.yaml tests

### DIFF
--- a/JSTests/complex.yaml
+++ b/JSTests/complex.yaml
@@ -24,10 +24,10 @@
 # This is for writing a bit complex tests to drive in JSC shell (e.g. including multiple files with some special options).
 
 - path: complex/generator-regeneration.js
-  cmd: runComplexTest [], ["generator-regeneration-after.js"], "", "--useDollarVM=1"
+  cmd: runComplexTest [], ["generator-regeneration-after.js"], nil, "--useDollarVM=1"
 
 - path: complex/tagged-template-regeneration.js
-  cmd: runComplexTest [], ["tagged-template-regeneration-after.js"], "", "--useDollarVM=1"
+  cmd: runComplexTest [], ["tagged-template-regeneration-after.js"], nil, "--useDollarVM=1"
 
 - path: complex/timezone-format-de.js
   cmd: runComplexTest [], [], "TZ=Europe/Berlin", "--useDollarVM=1"
@@ -57,10 +57,15 @@
   cmd: runComplexTest [], [], "TZ=America/Los_Angeles", "--useDollarVM=1", "--useTemporal=1"
 
 - path: complex/temporal-now-timezone-with-broken-tz.js
-  cmd: runComplexTest [], [], "TZ=UNDEFINED", "--useDollarVM=1", "--useTemporal=1"
+  cmd: |
+      if ($hostOS == "windows")
+          skip
+      else
+          runComplexTest [], [], "TZ=UNDEFINED", "--useDollarVM=1", "--useTemporal=1"
+      end
 
 - path: complex/for-in-clobberize.js
-  cmd: runComplexTest [], [], "", "--destroy-vm"
+  cmd: runComplexTest [], [], nil, "--destroy-vm"
 
 - path: complex/intl-date-time-format-date-parse.js
   cmd: runComplexTest [], [], "TZ=America/New_York"

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3961,8 +3961,13 @@ int jscmain(int argc, char** argv)
     // comes first.
     mainCommandLine.construct(argc, argv);
 
-#if OS(UNIX)
+#if OS(WINDOWS)
+    // Needed for complex.yaml tests.
+    if (char* tz = getenv("TZ"))
+        setTimeZoneOverride(StringView::fromLatin1(tz));
+#endif
 
+#if OS(UNIX)
     if (getenv("JS_SHELL_WAIT_FOR_SIGUSR2_TO_EXIT")) {
         initializeSignalHandling();
         addSignalHandler(Signal::Usr, SignalHandler([&] (Signal, SigInfo&, PlatformRegisters&) {


### PR DESCRIPTION
#### d31d8491766b5f7149b5a3594eb4ce48b7fe0229
<pre>
Ensure Win JSC can run complex.yaml tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=255078">https://bugs.webkit.org/show_bug.cgi?id=255078</a>

Reviewed by Yusuke Suzuki.

Making this test suite work on Windows boils down to fixing two problems:

1. The tests which don&apos;t set env vars are passing an empty string, but in Ruby, this is appended to a list ($envVars),
   meaning that we end up trying to set a env var with key &quot;&quot;. Use nil instead.

2. On Windows, TZ isn&apos;t a magic env var, so:
   a. Have jsc.cpp call setTimeZoneOverride instead.
   b. Skip temporal-now-timezone-with-broken-tz.js.
      (Obviously we could call setTimeZoneOverride with &quot;UTC&quot; if (a) fails,
      but it would serve no purpose, as this behavior has nothing to do with Temporal.)

* JSTests/complex.yaml:
* Source/JavaScriptCore/jsc.cpp:

Canonical link: <a href="https://commits.webkit.org/262659@main">https://commits.webkit.org/262659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b92526cd4b8c1f1ed370228b9ba0632ee3041c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2221 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1972 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2199 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1945 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2959 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1932 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1821 "Found 1 jsc stress test failure: wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-agressive-inline") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2010 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3124 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2086 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1789 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2241 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1942 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/515 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/541 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2115 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2291 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/630 "Passed tests") | 
<!--EWS-Status-Bubble-End-->