### PR TITLE
Non-unified build fixes, 6th April 2023 edition

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(SPEECH_SYNTHESIS)
 
+#include "SpeechSynthesisErrorCode.h"
 #include "SpeechSynthesisEventInit.h"
 
 namespace WebCore {

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -34,6 +34,7 @@
 #import "FrameSelection.h"
 #import "HTMLFieldSetElement.h"
 #import "HTMLInputElement.h"
+#import "LocalFrame.h"
 #import "LocalFrameView.h"
 #import "LocalizedStrings.h"
 #import "RenderObject.h"

--- a/Source/WebCore/dom/DeviceMotionEvent.h
+++ b/Source/WebCore/dom/DeviceMotionEvent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "DeviceOrientationOrMotionPermissionState.h"
+#include "Document.h"
 #include "Event.h"
 #include "IDLTypes.h"
 

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -34,6 +34,7 @@
 
 #include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
+#include <wtf/RefCounted.h>
 #include <wtf/UUID.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebKit/UIProcess/API/APIAttachment.cpp
+++ b/Source/WebKit/UIProcess/API/APIAttachment.cpp
@@ -30,6 +30,7 @@
 
 #include "WebPageProxy.h"
 #include <WebCore/SharedBuffer.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/text/WTFString.h>
 
 namespace API {

--- a/Source/WebKit/UIProcess/API/APIAttachment.h
+++ b/Source/WebKit/UIProcess/API/APIAttachment.h
@@ -35,6 +35,7 @@
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
+OBJC_CLASS NSData;
 OBJC_CLASS NSFileWrapper;
 OBJC_CLASS NSString;
 

--- a/Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.cpp
@@ -28,6 +28,7 @@
 
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
+#include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h
@@ -29,6 +29,7 @@
 
 #import "APIInspectorExtensionClient.h"
 #import "WKFoundation.h"
+#import <WebCore/FrameIdentifier.h>
 #import <wtf/WeakObjCPtr.h>
 
 @class _WKInspectorExtension;

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -29,21 +29,22 @@
 #if PLATFORM(MAC)
 
 #import "APINavigation.h"
-#import <WebKit/WKFrameInfo.h>
+#import "WKContextMenuItemTypes.h"
 #import "WKInspectorResourceURLSchemeHandler.h"
 #import "WKInspectorWKWebView.h"
-#import <WebKit/WKNavigationAction.h>
-#import <WebKit/WKNavigationDelegate.h>
 #import "WKOpenPanelParameters.h"
-#import <WebKit/WKPreferencesPrivate.h>
 #import "WKProcessPoolInternal.h"
-#import <WebKit/WKUIDelegatePrivate.h>
-#import <WebKit/WKWebViewConfigurationPrivate.h>
-#import <WebKit/WKWebViewPrivate.h>
 #import "WebInspectorUIProxy.h"
 #import "WebInspectorUtilities.h"
 #import "WebPageProxy.h"
 #import "_WKInspectorConfigurationInternal.h"
+#import <WebKit/WKFrameInfo.h>
+#import <WebKit/WKNavigationAction.h>
+#import <WebKit/WKNavigationDelegate.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKUIDelegatePrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -35,6 +35,7 @@
 #import "WKAnimationDelegate.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
+#import "WindowKind.h"
 #import <QuartzCore/QuartzCore.h>
 #import <WebCore/DestinationColorSpace.h>
 #import <WebCore/GraphicsContextCG.h>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -32,6 +32,7 @@
 #include "RemoteScrollingCoordinatorProxy.h"
 #include <WebCore/ScrollingTreeFixedNodeCocoa.h>
 #include <WebCore/ScrollingTreeFrameHostingNode.h>
+#include <WebCore/ScrollingTreeFrameScrollingNode.h>
 #include <WebCore/ScrollingTreeOverflowScrollProxyNodeCocoa.h>
 #include <WebCore/ScrollingTreePositionedNodeCocoa.h>
 #include <WebCore/ScrollingTreeStickyNodeCocoa.h>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/ScrollingCoordinatorTypes.h>
 #include <WebCore/ScrollingThread.h>
 #include <WebCore/WheelEventDeltaFilter.h>
+#include <wtf/SystemTracing.h>
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
+#include <wtf/MediaTime.h>
 
 #if PLATFORM(COCOA)
 #include "SharedCARingBuffer.h"

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "SpeechRecognitionRemoteRealtimeMediaSourceManager.h"
+#include "MessageSenderInlines.h"
 
 #if ENABLE(MEDIA_STREAM)
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "LocalConnection.h"
+#include <WebCore/AuthenticatorAssertionResponse.h>
 #include <WebCore/MockWebAuthenticationConfiguration.h>
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(CONTEXT_MENUS)
 
 #include "APIContextMenuClient.h"
+#include "MessageSenderInlines.h"
 #include "WebPageMessages.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -28,6 +28,7 @@
 
 #include "APIUIClient.h"
 #include "MessageSenderInlines.h"
+#include "WebCoreArgumentCoders.h"
 #include "WebFullScreenManagerProxy.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -116,7 +116,7 @@ std::optional<WebCore::CaptureDevice> DisplayCaptureSessionManager::deviceSelect
 
 bool DisplayCaptureSessionManager::useMockCaptureDevices() const
 {
-    return m_indexOfDeviceSelectedForTesting || MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled();
+    return m_indexOfDeviceSelectedForTesting || WebCore::MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled();
 }
 
 void DisplayCaptureSessionManager::showWindowPicker(const WebCore::SecurityOriginData& origin, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&& completionHandler)

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -42,6 +42,7 @@
 #import <WebCore/GeometryUtilities.h>
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalizedStrings.h>
+#import <WebCore/PlatformScreen.h>
 #import <WebCore/VideoFullscreenInterfaceMac.h>
 #import <WebCore/VideoFullscreenModel.h>
 #import <WebCore/WebCoreFullScreenPlaceholderView.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -32,6 +32,7 @@
 #import "DataReference.h"
 #import "FrameInfoData.h"
 #import "Logging.h"
+#import "MessageSenderInlines.h"
 #import "PDFAnnotationTextWidgetDetails.h"
 #import "PDFContextMenu.h"
 #import "PDFLayerControllerSPI.h"


### PR DESCRIPTION
#### fadbbbd24cac9706bd5112d8934e4dbe0146d076
<pre>
Non-unified build fixes, 6th April 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=255083">https://bugs.webkit.org/show_bug.cgi?id=255083</a>

Reviewed by Adrian Perez de Castro.

* Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.h:
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
* Source/WebCore/dom/DeviceMotionEvent.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
* Source/WebKit/Shared/WebEvent.h:
* Source/WebKit/UIProcess/API/APIAttachment.cpp:
* Source/WebKit/UIProcess/API/APIAttachment.h:
* Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.cpp:
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.h:
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalConnection.h:
* Source/WebKit/UIProcess/WebContextMenuProxy.cpp:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::useMockCaptureDevices const):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:

Canonical link: <a href="https://commits.webkit.org/262661@main">https://commits.webkit.org/262661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3b6f3a6c8e34bc5ff1c5bb28827c0607a24b093

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3112 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1978 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2208 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2968 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1835 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2019 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3130 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1797 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1949 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2124 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/244 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->