### PR TITLE
AcceleratedSurfaceDMABuf: Use WeakPtrFactoryInitialization::Eager

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
@@ -37,7 +37,7 @@ namespace WebKit {
 
 class WebPage;
 
-class AcceleratedSurfaceDMABuf final : public AcceleratedSurface, public CanMakeWeakPtr<AcceleratedSurfaceDMABuf> {
+class AcceleratedSurfaceDMABuf final : public AcceleratedSurface, public CanMakeWeakPtr<AcceleratedSurfaceDMABuf, WeakPtrFactoryInitialization::Eager> {
 public:
     static std::unique_ptr<AcceleratedSurfaceDMABuf> create(WebPage&, Client&);
     ~AcceleratedSurfaceDMABuf();


### PR DESCRIPTION
#### 11dcc4ddf457c756422ee1c09a37f795d725bcdb
<pre>
AcceleratedSurfaceDMABuf: Use WeakPtrFactoryInitialization::Eager
<a href="https://bugs.webkit.org/show_bug.cgi?id=255085">https://bugs.webkit.org/show_bug.cgi?id=255085</a>

Reviewed by Philippe Normand and Adrian Perez de Castro.

WeakPtrFactory must be initialized with `initializeIfNeeded()` in the
same thread it was constructed. This is guaranteed if you use
WeakPtrFactoryInitialization::Eager, but by default CanMakeWeakPtr uses
WeakPtrFactoryInitialization::Lazy, which defers initialization to the
first time a WeakPtr() is actually created.

That optimization breaks in the case of AcceleratedSurfaceDMABuf as the
WeakPtr are created in the compositor thread but
AcceleratedSurfaceDMABuf was created in the main thread.

This patch fixes the problem by using
WeakPtrFactoryInitialization::Eager as usually required for objects
shared between threads.

* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/262660@main">https://commits.webkit.org/262660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/203878e3a1fbdfd71ad97109be0e9891317cbe02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3113 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2231 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1979 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/2969 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1837 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2020 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3132 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2008 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1951 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/542 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2125 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->