### PR TITLE
Implement `ReadableStream.from`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any-expected.txt
@@ -1,0 +1,40 @@
+
+PASS ReadableStream.from accepts an array of values
+PASS ReadableStream.from accepts an array of promises
+PASS ReadableStream.from accepts an array iterator
+PASS ReadableStream.from accepts a string
+PASS ReadableStream.from accepts a Set
+PASS ReadableStream.from accepts a Set iterator
+PASS ReadableStream.from accepts a sync generator
+PASS ReadableStream.from accepts an async generator
+PASS ReadableStream.from accepts a sync iterable of values
+PASS ReadableStream.from accepts a sync iterable of promises
+PASS ReadableStream.from accepts an async iterable
+FAIL ReadableStream.from accepts a ReadableStream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from requires that the property of the first argument, iterable[Symbol.iterator], when exists, be a function"
+FAIL ReadableStream.from accepts a ReadableStream async iterator promise_test: Unhandled rejection with value: object "TypeError: undefined is not a function (near '...ymbol.asyncIterator]();...')"
+PASS ReadableStream.from throws on invalid iterables; specifically null
+PASS ReadableStream.from throws on invalid iterables; specifically undefined
+PASS ReadableStream.from throws on invalid iterables; specifically 0
+PASS ReadableStream.from throws on invalid iterables; specifically NaN
+PASS ReadableStream.from throws on invalid iterables; specifically true
+PASS ReadableStream.from throws on invalid iterables; specifically {}
+PASS ReadableStream.from throws on invalid iterables; specifically Object.create(null)
+PASS ReadableStream.from throws on invalid iterables; specifically a function
+PASS ReadableStream.from throws on invalid iterables; specifically a symbol
+PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@iterator method
+PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@asyncIterator method
+PASS ReadableStream.from re-throws errors from calling the @@iterator method
+PASS ReadableStream.from re-throws errors from calling the @@asyncIterator method
+PASS ReadableStream.from ignores @@iterator if @@asyncIterator exists
+PASS ReadableStream.from accepts an empty iterable
+PASS ReadableStream.from: stream errors when next() rejects
+PASS ReadableStream.from: stream stalls when next() never settles
+PASS ReadableStream.from: calls next() after first read()
+PASS ReadableStream.from: cancelling the returned stream calls and awaits return()
+PASS ReadableStream.from: return() is not called when iterator completes normally
+PASS ReadableStream.from: cancel() rejects when return() fulfills with a non-object
+PASS ReadableStream.from: reader.read() inside next()
+PASS ReadableStream.from: reader.cancel() inside next()
+PASS ReadableStream.from: reader.cancel() inside return()
+PASS ReadableStream.from(array), push() to array while reading
+

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.js
@@ -1,0 +1,474 @@
+// META: global=window,worker,jsshell
+// META: script=../resources/test-utils.js
+'use strict';
+
+const iterableFactories = [
+  ['an array of values', () => {
+    return ['a', 'b'];
+  }],
+
+  ['an array of promises', () => {
+    return [
+      Promise.resolve('a'),
+      Promise.resolve('b')
+    ];
+  }],
+
+  ['an array iterator', () => {
+    return ['a', 'b'][Symbol.iterator]();
+  }],
+
+  ['a string', () => {
+    // This iterates over the code points of the string.
+    return 'ab';
+  }],
+
+  ['a Set', () => {
+    return new Set(['a', 'b']);
+  }],
+
+  ['a Set iterator', () => {
+    return new Set(['a', 'b'])[Symbol.iterator]();
+  }],
+
+  ['a sync generator', () => {
+    function* syncGenerator() {
+      yield 'a';
+      yield 'b';
+    }
+
+    return syncGenerator();
+  }],
+
+  ['an async generator', () => {
+    async function* asyncGenerator() {
+      yield 'a';
+      yield 'b';
+    }
+
+    return asyncGenerator();
+  }],
+
+  ['a sync iterable of values', () => {
+    const chunks = ['a', 'b'];
+    const it = {
+      next() {
+        return {
+          done: chunks.length === 0,
+          value: chunks.shift()
+        };
+      },
+      [Symbol.iterator]: () => it
+    };
+    return it;
+  }],
+
+  ['a sync iterable of promises', () => {
+    const chunks = ['a', 'b'];
+    const it = {
+      next() {
+        return chunks.length === 0 ? { done: true } : {
+          done: false,
+          value: Promise.resolve(chunks.shift())
+        };
+      },
+      [Symbol.iterator]: () => it
+    };
+    return it;
+  }],
+
+  ['an async iterable', () => {
+    const chunks = ['a', 'b'];
+    const it = {
+      next() {
+        return Promise.resolve({
+          done: chunks.length === 0,
+          value: chunks.shift()
+        })
+      },
+      [Symbol.asyncIterator]: () => it
+    };
+    return it;
+  }],
+
+  ['a ReadableStream', () => {
+    return new ReadableStream({
+      start(c) {
+        c.enqueue('a');
+        c.enqueue('b');
+        c.close();
+      }
+    });
+  }],
+
+  ['a ReadableStream async iterator', () => {
+    return new ReadableStream({
+      start(c) {
+        c.enqueue('a');
+        c.enqueue('b');
+        c.close();
+      }
+    })[Symbol.asyncIterator]();
+  }]
+];
+
+for (const [label, factory] of iterableFactories) {
+  promise_test(async () => {
+
+    const iterable = factory();
+    const rs = ReadableStream.from(iterable);
+    assert_equals(rs.constructor, ReadableStream, 'from() should return a ReadableStream');
+
+    const reader = rs.getReader();
+    assert_object_equals(await reader.read(), { value: 'a', done: false }, 'first read should be correct');
+    assert_object_equals(await reader.read(), { value: 'b', done: false }, 'second read should be correct');
+    assert_object_equals(await reader.read(), { value: undefined, done: true }, 'third read should be done');
+    await reader.closed;
+
+  }, `ReadableStream.from accepts ${label}`);
+}
+
+const badIterables = [
+  ['null', null],
+  ['undefined', undefined],
+  ['0', 0],
+  ['NaN', NaN],
+  ['true', true],
+  ['{}', {}],
+  ['Object.create(null)', Object.create(null)],
+  ['a function', () => 42],
+  ['a symbol', Symbol()],
+  ['an object with a non-callable @@iterator method', {
+    [Symbol.iterator]: 42
+  }],
+  ['an object with a non-callable @@asyncIterator method', {
+    [Symbol.asyncIterator]: 42
+  }],
+];
+
+for (const [label, iterable] of badIterables) {
+  test(() => {
+    assert_throws_js(TypeError, () => ReadableStream.from(iterable), 'from() should throw a TypeError')
+  }, `ReadableStream.from throws on invalid iterables; specifically ${label}`);
+}
+
+test(() => {
+  const theError = new Error('a unique string');
+  const iterable = {
+    [Symbol.iterator]() {
+      throw theError;
+    }
+  };
+
+  assert_throws_exactly(theError, () => ReadableStream.from(iterable), 'from() should re-throw the error');
+}, `ReadableStream.from re-throws errors from calling the @@iterator method`);
+
+test(() => {
+  const theError = new Error('a unique string');
+  const iterable = {
+    [Symbol.asyncIterator]() {
+      throw theError;
+    }
+  };
+
+  assert_throws_exactly(theError, () => ReadableStream.from(iterable), 'from() should re-throw the error');
+}, `ReadableStream.from re-throws errors from calling the @@asyncIterator method`);
+
+test(t => {
+  const theError = new Error('a unique string');
+  const iterable = {
+    [Symbol.iterator]: t.unreached_func('@@iterator should not be called'),
+    [Symbol.asyncIterator]() {
+      throw theError;
+    }
+  };
+
+  assert_throws_exactly(theError, () => ReadableStream.from(iterable), 'from() should re-throw the error');
+}, `ReadableStream.from ignores @@iterator if @@asyncIterator exists`);
+
+promise_test(async () => {
+
+  const iterable = {
+    async next() {
+      return { value: undefined, done: true };
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  const reader = rs.getReader();
+
+  const read = await reader.read();
+  assert_object_equals(read, { value: undefined, done: true }, 'first read should be done');
+
+  await reader.closed;
+
+}, `ReadableStream.from accepts an empty iterable`);
+
+promise_test(async t => {
+
+  const theError = new Error('a unique string');
+
+  const iterable = {
+    async next() {
+      throw theError;
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  const reader = rs.getReader();
+
+  await Promise.all([
+    promise_rejects_exactly(t, theError, reader.read()),
+    promise_rejects_exactly(t, theError, reader.closed)
+  ]);
+
+}, `ReadableStream.from: stream errors when next() rejects`);
+
+promise_test(async t => {
+
+  const iterable = {
+    next() {
+      return new Promise(() => {});
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  const reader = rs.getReader();
+
+  await Promise.race([
+    reader.read().then(t.unreached_func('read() should not resolve'), t.unreached_func('read() should not reject')),
+    reader.closed.then(t.unreached_func('closed should not resolve'), t.unreached_func('closed should not reject')),
+    flushAsyncEvents()
+  ]);
+
+}, 'ReadableStream.from: stream stalls when next() never settles');
+
+promise_test(async () => {
+
+  let nextCalls = 0;
+  let nextArgs;
+  const iterable = {
+    async next(...args) {
+      nextCalls += 1;
+      nextArgs = args;
+      return { value: 'a', done: false };
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  const reader = rs.getReader();
+
+  await flushAsyncEvents();
+  assert_equals(nextCalls, 0, 'next() should not be called yet');
+
+  const read = await reader.read();
+  assert_object_equals(read, { value: 'a', done: false }, 'first read should be correct');
+  assert_equals(nextCalls, 1, 'next() should be called after first read()');
+  assert_array_equals(nextArgs, [], 'next() should be called with no arguments');
+
+}, `ReadableStream.from: calls next() after first read()`);
+
+promise_test(async t => {
+
+  const theError = new Error('a unique string');
+
+  let returnCalls = 0;
+  let returnArgs;
+  let resolveReturn;
+  const iterable = {
+    next: t.unreached_func('next() should not be called'),
+    throw: t.unreached_func('throw() should not be called'),
+    async return(...args) {
+      returnCalls += 1;
+      returnArgs = args;
+      await new Promise(r => resolveReturn = r);
+      return { done: true };
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  const reader = rs.getReader();
+  assert_equals(returnCalls, 0, 'return() should not be called yet');
+
+  let cancelResolved = false;
+  const cancelPromise = reader.cancel(theError).then(() => {
+    cancelResolved = true;
+  });
+
+  await flushAsyncEvents();
+  assert_equals(returnCalls, 1, 'return() should be called');
+  assert_array_equals(returnArgs, [theError], 'return() should be called with cancel reason');
+  assert_false(cancelResolved, 'cancel() should not resolve while promise from return() is pending');
+
+  resolveReturn();
+  await Promise.all([
+    cancelPromise,
+    reader.closed
+  ]);
+
+}, `ReadableStream.from: cancelling the returned stream calls and awaits return()`);
+
+promise_test(async t => {
+
+  let nextCalls = 0;
+  let returnCalls = 0;
+
+  const iterable = {
+    async next() {
+      nextCalls += 1;
+      return { value: undefined, done: true };
+    },
+    throw: t.unreached_func('throw() should not be called'),
+    async return() {
+      returnCalls += 1;
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  const reader = rs.getReader();
+
+  const read = await reader.read();
+  assert_object_equals(read, { value: undefined, done: true }, 'first read should be done');
+  assert_equals(nextCalls, 1, 'next() should be called once');
+
+  await reader.closed;
+  assert_equals(returnCalls, 0, 'return() should not be called');
+
+}, `ReadableStream.from: return() is not called when iterator completes normally`);
+
+promise_test(async t => {
+
+  const theError = new Error('a unique string');
+
+  const iterable = {
+    next: t.unreached_func('next() should not be called'),
+    throw: t.unreached_func('throw() should not be called'),
+    async return() {
+      return 42;
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  const reader = rs.getReader();
+
+  await promise_rejects_js(t, TypeError, reader.cancel(theError), 'cancel() should reject with a TypeError');
+
+  await reader.closed;
+
+}, `ReadableStream.from: cancel() rejects when return() fulfills with a non-object`);
+
+promise_test(async () => {
+
+  let nextCalls = 0;
+  let reader;
+  let values = ['a', 'b', 'c'];
+
+  const iterable = {
+    async next() {
+      nextCalls += 1;
+      if (nextCalls === 1) {
+        reader.read();
+      }
+      return { value: values.shift(), done: false };
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  reader = rs.getReader();
+
+  const read1 = await reader.read();
+  assert_object_equals(read1, { value: 'a', done: false }, 'first read should be correct');
+  await flushAsyncEvents();
+  assert_equals(nextCalls, 2, 'next() should be called two times');
+
+  const read2 = await reader.read();
+  assert_object_equals(read2, { value: 'c', done: false }, 'second read should be correct');
+  assert_equals(nextCalls, 3, 'next() should be called three times');
+
+}, `ReadableStream.from: reader.read() inside next()`);
+
+promise_test(async () => {
+
+  let nextCalls = 0;
+  let returnCalls = 0;
+  let reader;
+
+  const iterable = {
+    async next() {
+      nextCalls++;
+      await reader.cancel();
+      assert_equals(returnCalls, 1, 'return() should be called once');
+      return { value: 'something else', done: false };
+    },
+    async return() {
+      returnCalls++;
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  reader = rs.getReader();
+
+  const read = await reader.read();
+  assert_object_equals(read, { value: undefined, done: true }, 'first read should be done');
+  assert_equals(nextCalls, 1, 'next() should be called once');
+
+  await reader.closed;
+
+}, `ReadableStream.from: reader.cancel() inside next()`);
+
+promise_test(async t => {
+
+  let returnCalls = 0;
+  let reader;
+
+  const iterable = {
+    next: t.unreached_func('next() should not be called'),
+    async return() {
+      returnCalls++;
+      await reader.cancel();
+      return { done: true };
+    },
+    [Symbol.asyncIterator]: () => iterable
+  };
+
+  const rs = ReadableStream.from(iterable);
+  reader = rs.getReader();
+
+  await reader.cancel();
+  assert_equals(returnCalls, 1, 'return() should be called once');
+
+  await reader.closed;
+
+}, `ReadableStream.from: reader.cancel() inside return()`);
+
+promise_test(async t => {
+
+  let array = ['a', 'b'];
+
+  const rs = ReadableStream.from(array);
+  const reader = rs.getReader();
+
+  const read1 = await reader.read();
+  assert_object_equals(read1, { value: 'a', done: false }, 'first read should be correct');
+  const read2 = await reader.read();
+  assert_object_equals(read2, { value: 'b', done: false }, 'second read should be correct');
+
+  array.push('c');
+
+  const read3 = await reader.read();
+  assert_object_equals(read3, { value: 'c', done: false }, 'third read after push() should be correct');
+  const read4 = await reader.read();
+  assert_object_equals(read4, { value: undefined, done: true }, 'fourth read should be done');
+
+  await reader.closed;
+
+}, `ReadableStream.from(array), push() to array while reading`);

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker-expected.txt
@@ -1,0 +1,40 @@
+
+PASS ReadableStream.from accepts an array of values
+PASS ReadableStream.from accepts an array of promises
+PASS ReadableStream.from accepts an array iterator
+PASS ReadableStream.from accepts a string
+PASS ReadableStream.from accepts a Set
+PASS ReadableStream.from accepts a Set iterator
+PASS ReadableStream.from accepts a sync generator
+PASS ReadableStream.from accepts an async generator
+PASS ReadableStream.from accepts a sync iterable of values
+PASS ReadableStream.from accepts a sync iterable of promises
+PASS ReadableStream.from accepts an async iterable
+FAIL ReadableStream.from accepts a ReadableStream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from requires that the property of the first argument, iterable[Symbol.iterator], when exists, be a function"
+FAIL ReadableStream.from accepts a ReadableStream async iterator promise_test: Unhandled rejection with value: object "TypeError: undefined is not a function (near '...ymbol.asyncIterator]();...')"
+PASS ReadableStream.from throws on invalid iterables; specifically null
+PASS ReadableStream.from throws on invalid iterables; specifically undefined
+PASS ReadableStream.from throws on invalid iterables; specifically 0
+PASS ReadableStream.from throws on invalid iterables; specifically NaN
+PASS ReadableStream.from throws on invalid iterables; specifically true
+PASS ReadableStream.from throws on invalid iterables; specifically {}
+PASS ReadableStream.from throws on invalid iterables; specifically Object.create(null)
+PASS ReadableStream.from throws on invalid iterables; specifically a function
+PASS ReadableStream.from throws on invalid iterables; specifically a symbol
+PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@iterator method
+PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@asyncIterator method
+PASS ReadableStream.from re-throws errors from calling the @@iterator method
+PASS ReadableStream.from re-throws errors from calling the @@asyncIterator method
+PASS ReadableStream.from ignores @@iterator if @@asyncIterator exists
+PASS ReadableStream.from accepts an empty iterable
+PASS ReadableStream.from: stream errors when next() rejects
+PASS ReadableStream.from: stream stalls when next() never settles
+PASS ReadableStream.from: calls next() after first read()
+PASS ReadableStream.from: cancelling the returned stream calls and awaits return()
+PASS ReadableStream.from: return() is not called when iterator completes normally
+PASS ReadableStream.from: cancel() rejects when return() fulfills with a non-object
+PASS ReadableStream.from: reader.read() inside next()
+PASS ReadableStream.from: reader.cancel() inside next()
+PASS ReadableStream.from: reader.cancel() inside return()
+PASS ReadableStream.from(array), push() to array while reading
+

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker-expected.txt
@@ -1,0 +1,40 @@
+
+PASS ReadableStream.from accepts an array of values
+PASS ReadableStream.from accepts an array of promises
+PASS ReadableStream.from accepts an array iterator
+PASS ReadableStream.from accepts a string
+PASS ReadableStream.from accepts a Set
+PASS ReadableStream.from accepts a Set iterator
+PASS ReadableStream.from accepts a sync generator
+PASS ReadableStream.from accepts an async generator
+PASS ReadableStream.from accepts a sync iterable of values
+PASS ReadableStream.from accepts a sync iterable of promises
+PASS ReadableStream.from accepts an async iterable
+FAIL ReadableStream.from accepts a ReadableStream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from requires that the property of the first argument, iterable[Symbol.iterator], when exists, be a function"
+FAIL ReadableStream.from accepts a ReadableStream async iterator promise_test: Unhandled rejection with value: object "TypeError: undefined is not a function (near '...ymbol.asyncIterator]();...')"
+PASS ReadableStream.from throws on invalid iterables; specifically null
+PASS ReadableStream.from throws on invalid iterables; specifically undefined
+PASS ReadableStream.from throws on invalid iterables; specifically 0
+PASS ReadableStream.from throws on invalid iterables; specifically NaN
+PASS ReadableStream.from throws on invalid iterables; specifically true
+PASS ReadableStream.from throws on invalid iterables; specifically {}
+PASS ReadableStream.from throws on invalid iterables; specifically Object.create(null)
+PASS ReadableStream.from throws on invalid iterables; specifically a function
+PASS ReadableStream.from throws on invalid iterables; specifically a symbol
+PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@iterator method
+PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@asyncIterator method
+PASS ReadableStream.from re-throws errors from calling the @@iterator method
+PASS ReadableStream.from re-throws errors from calling the @@asyncIterator method
+PASS ReadableStream.from ignores @@iterator if @@asyncIterator exists
+PASS ReadableStream.from accepts an empty iterable
+PASS ReadableStream.from: stream errors when next() rejects
+PASS ReadableStream.from: stream stalls when next() never settles
+PASS ReadableStream.from: calls next() after first read()
+PASS ReadableStream.from: cancelling the returned stream calls and awaits return()
+PASS ReadableStream.from: return() is not called when iterator completes normally
+PASS ReadableStream.from: cancel() rejects when return() fulfills with a non-object
+PASS ReadableStream.from: reader.read() inside next()
+PASS ReadableStream.from: reader.cancel() inside next()
+PASS ReadableStream.from: reader.cancel() inside return()
+PASS ReadableStream.from(array), push() to array while reading
+

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.worker-expected.txt
@@ -1,0 +1,40 @@
+
+PASS ReadableStream.from accepts an array of values
+PASS ReadableStream.from accepts an array of promises
+PASS ReadableStream.from accepts an array iterator
+PASS ReadableStream.from accepts a string
+PASS ReadableStream.from accepts a Set
+PASS ReadableStream.from accepts a Set iterator
+PASS ReadableStream.from accepts a sync generator
+PASS ReadableStream.from accepts an async generator
+PASS ReadableStream.from accepts a sync iterable of values
+PASS ReadableStream.from accepts a sync iterable of promises
+PASS ReadableStream.from accepts an async iterable
+FAIL ReadableStream.from accepts a ReadableStream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from requires that the property of the first argument, iterable[Symbol.iterator], when exists, be a function"
+FAIL ReadableStream.from accepts a ReadableStream async iterator promise_test: Unhandled rejection with value: object "TypeError: undefined is not a function (near '...ymbol.asyncIterator]();...')"
+PASS ReadableStream.from throws on invalid iterables; specifically null
+PASS ReadableStream.from throws on invalid iterables; specifically undefined
+PASS ReadableStream.from throws on invalid iterables; specifically 0
+PASS ReadableStream.from throws on invalid iterables; specifically NaN
+PASS ReadableStream.from throws on invalid iterables; specifically true
+PASS ReadableStream.from throws on invalid iterables; specifically {}
+PASS ReadableStream.from throws on invalid iterables; specifically Object.create(null)
+PASS ReadableStream.from throws on invalid iterables; specifically a function
+PASS ReadableStream.from throws on invalid iterables; specifically a symbol
+PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@iterator method
+PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@asyncIterator method
+PASS ReadableStream.from re-throws errors from calling the @@iterator method
+PASS ReadableStream.from re-throws errors from calling the @@asyncIterator method
+PASS ReadableStream.from ignores @@iterator if @@asyncIterator exists
+PASS ReadableStream.from accepts an empty iterable
+PASS ReadableStream.from: stream errors when next() rejects
+PASS ReadableStream.from: stream stalls when next() never settles
+PASS ReadableStream.from: calls next() after first read()
+PASS ReadableStream.from: cancelling the returned stream calls and awaits return()
+PASS ReadableStream.from: return() is not called when iterator completes normally
+PASS ReadableStream.from: cancel() rejects when return() fulfills with a non-object
+PASS ReadableStream.from: reader.read() inside next()
+PASS ReadableStream.from: reader.cancel() inside next()
+PASS ReadableStream.from: reader.cancel() inside return()
+PASS ReadableStream.from(array), push() to array while reading
+

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/w3c-import.log
@@ -23,6 +23,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/cross-realm-crash.window.js
 /LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/default-reader.any.js
 /LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/floating-point-total-queue-size.any.js
+/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.js
 /LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/garbage-collection.any.js
 /LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/general.any.js
 /LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/global.html

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5255,6 +5255,20 @@ ReadableByteStreamAPIEnabled:
     WebKit:
       default: false
 
+ReadableStreamFromAPIEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "ReadableStream.from() API"
+  humanReadableDescription: "Enable ReadableStream.from() API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
 RemotePlaybackEnabled:
   type: bool

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -71,6 +71,16 @@ Ref<ReadableStream> ReadableStream::create(Ref<InternalReadableStream>&& interna
     return adoptRef(*new ReadableStream(WTFMove(internalReadableStream)));
 }
 
+ExceptionOr<Ref<ReadableStream>> ReadableStream::from(JSDOMGlobalObject& globalObject, JSC::JSValue asyncIterable)
+{
+    RefPtr protectedContext { globalObject.scriptExecutionContext() };
+    auto result = InternalReadableStream::createFromAsyncIterable(globalObject, asyncIterable);
+    if (result.hasException())
+        return result.releaseException();
+
+    return adoptRef(*new ReadableStream(result.releaseReturnValue()));
+}
+
 ReadableStream::ReadableStream(Ref<InternalReadableStream>&& internalReadableStream)
     : m_internalReadableStream(WTFMove(internalReadableStream))
 {

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -41,6 +41,8 @@ public:
     static ExceptionOr<Ref<ReadableStream>> create(JSDOMGlobalObject&, Ref<ReadableStreamSource>&&);
     static Ref<ReadableStream> create(Ref<InternalReadableStream>&&);
 
+    static ExceptionOr<Ref<ReadableStream>> from(JSDOMGlobalObject&, JSC::JSValue asyncIterable);
+
     ~ReadableStream() = default;
 
     void lock() { m_internalReadableStream->lock(); }

--- a/Source/WebCore/Modules/streams/ReadableStream.idl
+++ b/Source/WebCore/Modules/streams/ReadableStream.idl
@@ -35,6 +35,8 @@
 ] interface ReadableStream {
     [CallWith=CurrentGlobalObject] constructor(optional object underlyingSource, optional object options);
 
+    [CallWith=CurrentGlobalObject, EnabledBySetting=ReadableStreamFromAPIEnabled] static ReadableStream from(any asyncIterable);
+
     [Custom, ReturnsOwnPromise] Promise<any> cancel(optional any reason);
     [Custom] Object getReader(optional any options);
     [Custom, ReturnsOwnPromise] Promise<any> pipeTo(any streams, optional any options);

--- a/Source/WebCore/bindings/js/InternalReadableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStream.cpp
@@ -78,6 +78,23 @@ Ref<InternalReadableStream> InternalReadableStream::fromObject(JSDOMGlobalObject
     return adoptRef(*new InternalReadableStream(globalObject, object));
 }
 
+ExceptionOr<Ref<InternalReadableStream>> InternalReadableStream::createFromAsyncIterable(JSDOMGlobalObject& globalObject, JSC::JSValue asyncIterable)
+{
+    auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
+    auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().createInternalReadableStreamFromAsyncIterablePrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(asyncIterable);
+    ASSERT(!arguments.hasOverflowed());
+
+    auto result = invokeReadableStreamFunction(globalObject, privateName, arguments);
+    if (UNLIKELY(result.hasException()))
+        return result.releaseException();
+
+    ASSERT(result.returnValue().isObject());
+    return adoptRef(*new InternalReadableStream(globalObject, *result.returnValue().toObject(&globalObject)));
+}
+
 bool InternalReadableStream::isLocked() const
 {
     auto* globalObject = this->globalObject();

--- a/Source/WebCore/bindings/js/InternalReadableStream.h
+++ b/Source/WebCore/bindings/js/InternalReadableStream.h
@@ -36,6 +36,7 @@ class InternalReadableStream final : public DOMGuarded<JSC::JSObject> {
 public:
     static ExceptionOr<Ref<InternalReadableStream>> createFromUnderlyingSource(JSDOMGlobalObject&, JSC::JSValue underlyingSink, JSC::JSValue strategy);
     static Ref<InternalReadableStream> fromObject(JSDOMGlobalObject&, JSC::JSObject&);
+    static ExceptionOr<Ref<InternalReadableStream>> createFromAsyncIterable(JSDOMGlobalObject&, JSC::JSValue asyncIterable);
 
     operator JSC::JSValue() const { return guarded(); }
 


### PR DESCRIPTION
#### 1eea8e2ede0e4b4428af42d91ef60fd10cb10ff1
<pre>
Implement `ReadableStream.from`
<a href="https://bugs.webkit.org/show_bug.cgi?id=255086">https://bugs.webkit.org/show_bug.cgi?id=255086</a>

Reviewed by NOBODY (OOPS!).

The `ReadableStream.from` static method allows creating a ReadableStream
from a JS iterable object, whether sync or async.

* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.js: Added.
(async asyncGenerator):
(const.it.next):
(return.new.ReadableStream.start):
(factory.of.iterableFactories.promise_test.async const):
(factory.of.iterableFactories.promise_test):
(iterable.of.badIterables.test):
(test):
(test.t.const.iterable.Symbol.asyncIterator):
(promise_test.async const.iterable.async next):
(promise_test.async const):
(promise_test):
(promise_test.async t.const.iterable.async next):
(promise_test.async t):
(promise_test.const.iterable.async next):
(promise_test.async let):
(promise_test.async t.const.iterable.async return):
(promise_test.const.iterable.async return):
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/w3c-import.log:
* Source/WebCore/Modules/streams/ReadableStream.cpp:
(WebCore::ReadableStream::from):
* Source/WebCore/Modules/streams/ReadableStream.h:
* Source/WebCore/Modules/streams/ReadableStream.idl:
* Source/WebCore/Modules/streams/ReadableStreamInternals.js:
(createInternalReadableStreamFromAsyncIterable):
* Source/WebCore/bindings/js/InternalReadableStream.cpp:
(WebCore::InternalReadableStream::createFromAsyncIterable):
* Source/WebCore/bindings/js/InternalReadableStream.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eea8e2ede0e4b4428af42d91ef60fd10cb10ff1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24098 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29007 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3383 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23615 "Found 2 new test failures: imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker.html, imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29676 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22954 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27569 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25545 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3414 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1623 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/windows/browsing-context-names/choose-_blank-001.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32990 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23362 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7133 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3737 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->