### PR TITLE
Use different cherry-pick format for main

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -12,6 +12,14 @@ CHERRY_PICKING_RE = re.compile(r'^# You are currently cherry-picking commit (?P<
 IDENTIFIER_RE = re.compile(r'(\d+\.)?\d+@\S+')
 PREFER_RADAR = {{ prefer_radar }}
 
+DEFAULT_BRANCH = '{{ default_branch }}'
+SOURCE_REMOTES = {{ source_remotes }}
+TRAILERS_TO_STRIP = {{ trailers_to_strip }}
+
+ENCODING_KWARGS = dict()
+if sys.version_info >= (3, 6):
+    ENCODING_KWARGS = dict(encoding='utf-8')
+
 sys.path.append(SCRIPTS)
 from webkitpy.common.checkout.diff_parser import DiffParser
 from webkitbugspy import radar
@@ -43,7 +51,7 @@ def parseChanges(command, commit_message):
     try:
         for line in subprocess.check_output(
             command,
-            **(dict(encoding='utf-8') if sys.version_info > (3, 0) else dict())
+            **ENCODING_KWARGS
         ).splitlines():
             if line == '~':
                 dirname = None
@@ -90,6 +98,37 @@ Explanation of why this fixes the bug (OOPS!).
         bugs=bugs_string,
         content='\n'.join(commit_message) + os.environ.get('COMMIT_MESSAGE_CONTENT', ''),
     )
+
+
+def source_branches():
+    proc = None
+    try:
+        proc = subprocess.Popen(
+            ['git', 'rev-list', 'HEAD'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            **ENCODING_KWARGS
+        )
+        outer_line = proc.stdout.readline()
+        while outer_line:
+            branches = set()
+            for inner_line in subprocess.check_output(
+                ['git', 'branch', '--contains', outer_line.strip(), '-a', '--format', '%(refname)'],
+                **ENCODING_KWARGS
+            ).splitlines():
+                if not inner_line.startswith('refs/remotes'):
+                    continue
+                _, _, remote, branch = inner_line.split('/', 3)
+                if remote in SOURCE_REMOTES and branch != 'HEAD':
+                    branches.add(branch)
+            if branches:
+                return sorted(branches)
+            outer_line = proc.stdout.readline()
+    finally:
+        if proc and proc.poll() is None:
+            proc.kill()
+
+    return []
 
 
 def cherry_pick(content):
@@ -144,15 +183,28 @@ def cherry_pick(content):
             elif from_last_line:
                 cherry_picked = '{} ({})'.format(from_last_line.group(0), cherry_picked)
 
-    result = 'Cherry-pick {}. {}\n\n'.format(cherry_picked or '???', bug or '<bug>')
+    is_trunk_bound = DEFAULT_BRANCH in source_branches()
+    in_suffix = False
+    cherry_pick_metadata = '{}. {}'.format(cherry_picked or '???', bug or '<bug>')
+    result = []
+    if not is_trunk_bound:
+        result += ['Cherry-pick {}'.format(cherry_pick_metadata), '']
     for line in content.splitlines():
+        line = line.rstrip()
         if not line:
-            result += '\n'
+            result.append('')
             continue
-        if line[0] != '#':
-            result += 4*' '
-        result += line + '\n'
-    return result
+        if line[0] == '#' and not in_suffix:
+            in_suffix = True
+            if is_trunk_bound:
+                while len(result) and not result[-1] or (result[-1].split(':', 1)[0] in TRAILERS_TO_STRIP):
+                    del result[-1]
+                result += ['', 'Originally-landed-as: {}'.format(cherry_pick_metadata)]
+        if line[0] != '#' and not is_trunk_bound:
+            result.append(4*' ' + line)
+        else:
+            result.append(line)
+    return '\n'.join(result)
 
 
 def main(file_name=None, source=None, sha=None):
@@ -183,7 +235,7 @@ def main(file_name=None, source=None, sha=None):
         if sha:
             commit_message_file.write(subprocess.check_output(
                 ['git', 'log', sha, '-1', '--pretty=format:%B'],
-                **(dict(encoding='utf-8') if sys.version_info > (3, 5) else dict())
+                **ENCODING_KWARGS
             ))
         else:
             commit_message_file.write(message(source=source, sha=sha))
@@ -199,7 +251,7 @@ def main(file_name=None, source=None, sha=None):
             commit_message_file.write('\n')
         for line in subprocess.check_output(
             ['git', 'status'],
-            **(dict(encoding='utf-8') if sys.version_info > (3, 5) else dict())
+            **ENCODING_KWARGS
         ).splitlines():
             commit_message_file.write('# {}\n'.format(line))
 

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.1.9',
+    version='6.2.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 1, 9)
+version = Version(6, 2, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py
@@ -26,6 +26,7 @@ import os
 import sys
 
 from webkitscmpy.local import Git
+from webkitscmpy import Commit
 
 
 def main(inputfile, identifier_template):
@@ -78,9 +79,14 @@ def main(inputfile, identifier_template):
                 break
         else:
             lines.insert(identifier_index, identifier_template.format(commit))
+            identifier_index = identifier_index - 1
 
-    if lines[identifier_index]:
-        lines.insert(identifier_index, '')
+    while identifier_index >= 0 and lines[identifier_index]:
+        if Commit.TRAILER_RE.match(lines[identifier_index]):
+            identifier_index -= 1
+        else:
+            lines.insert(identifier_index + 1, '')
+            break
 
     # Turn multiple empty lines at the end of a commit into a single one
     index = len(lines) - 1

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
@@ -136,7 +136,7 @@ class InstallHooks(Command):
         return result
 
     @classmethod
-    def main(cls, args, repository, hooks=None, **kwargs):
+    def main(cls, args, repository, hooks=None, identifier_template=None, **kwargs):
         if not isinstance(repository, local.Git):
             sys.stderr.write('Can only install hooks in a native git repository\n')
             return 1
@@ -179,6 +179,9 @@ class InstallHooks(Command):
         if early_exit:
             return 1
 
+        trailers_to_strip = ['Identifier'] + ([identifier_template.split(':', 1)[0]] if identifier_template else [])
+        source_remotes = repository.source_remotes() or ['origin']
+
         for hook in hook_names:
             source_path = os.path.join(hooks, hook)
             if not os.path.isfile(source_path):
@@ -193,6 +196,9 @@ class InstallHooks(Command):
                     default_pre_push_mode="'{}'".format(getattr(args, 'mode', cls.MODES[0])),
                     security_levels=security_levels,
                     remote_re=cls.REMOTE_RE.pattern,
+                    default_branch=repository.default_branch,
+                    trailers_to_strip=trailers_to_strip,
+                    source_remotes=source_remotes,
                 )
 
             target = os.path.join(repository.common_directory, 'hooks', hook)


### PR DESCRIPTION
#### 659cd39a8658844cd7a44aeecfc4fa607b73eb73
<pre>
Use different cherry-pick format for main
<a href="https://bugs.webkit.org/show_bug.cgi?id=255088">https://bugs.webkit.org/show_bug.cgi?id=255088</a>
rdar://107708812

Reviewed by Dewei Zhu.

When cherry-picking into main, retain the original commit message in it&apos;s entireity
and tag the bottom of the commit with a &apos;Originally-landed-as&apos; message. Use existing behavior
for all other branches.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/hooks/prepare-commit-msg:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py:
(main): Do not insert lines between trailers.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py:
(InstallHooks.main): Pass default branch, trailers to strip and source remotes to hook templates.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py:
(TestCanonicalize.test_alternate_trailer):

Canonical link: <a href="https://commits.webkit.org/262726@main">https://commits.webkit.org/262726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2e8d317db620f6783f1e88c200ca19a340eb5de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3308 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2371 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2433 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2105 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2365 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/2104 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3172 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/2376 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/83 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2094 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1969 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2175 "Built successfully") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2121 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3289 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2142 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1933 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/2322 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2100 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2083 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/275 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->