### PR TITLE
OffscreenCanvas support without WebGL breaks Construct 3 content.

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-disabled-construct3-quirk-expected.txt
+++ b/LayoutTests/fast/canvas/offscreen-disabled-construct3-quirk-expected.txt
@@ -1,0 +1,10 @@
+Test to ensure that OffscreenCanvas is disabled when the Construct3 library is present.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS OffscreenCanvas is undefined and the feature is disabled
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/offscreen-disabled-construct3-quirk.html
+++ b/LayoutTests/fast/canvas/offscreen-disabled-construct3-quirk.html
@@ -1,0 +1,20 @@
+<!-- webkit-test-runner [ NeedsSiteSpecificQuirks=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Test to ensure that OffscreenCanvas is disabled when the Construct3 library is present.");
+
+window.C3_IsSupported = true;
+if (typeof OffscreenCanvas !== "undefined") {
+    testFailed("OffscreenCanvas is valid and the feature is not disabled");
+} else {
+    testPassed("OffscreenCanvas is undefined and the feature is disabled");
+}
+
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/dfg/DFGAvailabilityMap.h
+++ b/Source/JavaScriptCore/dfg/DFGAvailabilityMap.h
@@ -44,7 +44,7 @@ struct AvailabilityMap {
     void merge(const AvailabilityMap& other);
     
     template<typename Functor>
-    void forEachAvailability(const Functor& functor)
+    void forEachAvailability(const Functor& functor) const
     {
         for (unsigned i = m_locals.size(); i--;)
             functor(m_locals[i]);
@@ -53,7 +53,7 @@ struct AvailabilityMap {
     }
     
     template<typename HasFunctor, typename AddFunctor>
-    void closeOverNodes(const HasFunctor& has, const AddFunctor& add)
+    void closeOverNodes(const HasFunctor& has, const AddFunctor& add) const
     {
         bool changed;
         do {
@@ -66,7 +66,7 @@ struct AvailabilityMap {
     }
     
     template<typename HasFunctor, typename AddFunctor>
-    void closeStartingWithLocal(Operand op, const HasFunctor& has, const AddFunctor& add)
+    void closeStartingWithLocal(Operand op, const HasFunctor& has, const AddFunctor& add) const
     {
         Availability availability = m_locals.operand(op);
         if (!availability.hasNode())

--- a/Source/JavaScriptCore/dfg/DFGForAllKills.h
+++ b/Source/JavaScriptCore/dfg/DFGForAllKills.h
@@ -181,15 +181,17 @@ void forAllKillsInBlock(
     
     LocalOSRAvailabilityCalculator localAvailability(graph);
     localAvailability.beginBlock(block);
-    // Start at the second node, because the functor is expected to only inspect nodes from the start of
+    // Start running functor at the second node, because the functor is expected to only inspect nodes from the start of
     // the block up to nodeIndex (exclusive), so if nodeIndex is zero then the functor has nothing to do.
-    for (unsigned nodeIndex = 1; nodeIndex < block->size(); ++nodeIndex) {
+    for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
         dataLogLnIf(ForAllKillsInternal::verbose, "local availability at index: ", nodeIndex, " ", localAvailability.m_availability);
-        forAllKilledNodesAtNodeIndex(
-            graph, localAvailability.m_availability, block, nodeIndex,
-            [&] (Node* node) {
-                functor(nodeIndex, node);
-            });
+        if (nodeIndex) {
+            forAllKilledNodesAtNodeIndex(
+                graph, localAvailability.m_availability, block, nodeIndex,
+                [&] (Node* node) {
+                    functor(nodeIndex, node);
+                });
+        }
         localAvailability.executeNode(block->at(nodeIndex));
     }
 }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/encodeframe_utils.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/encodeframe_utils.c
@@ -1317,10 +1317,11 @@ void av1_source_content_sb(AV1_COMP *cpi, MACROBLOCK *x, int mi_row,
   unsigned int tmp_variance;
   const BLOCK_SIZE bsize = cpi->common.seq_params->sb_size;
   uint8_t *src_y = cpi->source->y_buffer;
-  int src_ystride = cpi->source->y_stride;
+  const int src_ystride = cpi->source->y_stride;
+  const int src_offset = src_ystride * (mi_row << 2) + (mi_col << 2);
   uint8_t *last_src_y = cpi->last_source->y_buffer;
-  int last_src_ystride = cpi->last_source->y_stride;
-  const int offset = cpi->source->y_stride * (mi_row << 2) + (mi_col << 2);
+  const int last_src_ystride = cpi->last_source->y_stride;
+  const int last_src_offset = last_src_ystride * (mi_row << 2) + (mi_col << 2);
   uint64_t avg_source_sse_threshold[2] = { 100000,   // ~5*5*(64*64)
                                            36000 };  // ~3*3*(64*64)
   uint64_t avg_source_sse_threshold_high = 1000000;  // ~15*15*(64*64)
@@ -1329,8 +1330,8 @@ void av1_source_content_sb(AV1_COMP *cpi, MACROBLOCK *x, int mi_row,
   MACROBLOCKD *xd = &x->e_mbd;
   if (xd->cur_buf->flags & YV12_FLAG_HIGHBITDEPTH) return;
 #endif
-  src_y += offset;
-  last_src_y += offset;
+  src_y += src_offset;
+  last_src_y += last_src_offset;
   tmp_variance = cpi->ppi->fn_ptr[bsize].vf(src_y, src_ystride, last_src_y,
                                             last_src_ystride, &tmp_sse);
   // rd thresholds

--- a/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
@@ -198,6 +198,16 @@ bool JSLocalDOMWindow::getOwnPropertySlot(JSObject* object, JSGlobalObject* lexi
 
     auto* thisObject = jsCast<JSLocalDOMWindow*>(object);
 
+    // Construct3 assumes that the presence of OffscreenCanvas implies
+    // that WebGL will always be available, which isn't true yet.
+    // Disable OffscreenCanvas when the Construct3 library is present
+    // rdar://106341361
+    if (UNLIKELY(propertyName == builtinNames(lexicalGlobalObject->vm()).OffscreenCanvasPublicName()) && lexicalGlobalObject->needsSiteSpecificQuirks()) {
+        auto c3SupportedProperty = JSC::Identifier::fromString(lexicalGlobalObject->vm(), "C3_IsSupported"_s);
+        if (object->hasProperty(lexicalGlobalObject, c3SupportedProperty))
+            return false;
+    }
+
     // Hand off all cross-domain access to jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess.
     String errorMessage;
     if (!BindingSecurity::shouldAllowAccessToDOMWindow(*lexicalGlobalObject, thisObject->wrapped(), errorMessage))

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -199,12 +199,14 @@ static bool shouldEnableWebGL(const Settings::Values& settings, bool isWorker)
     if (!settings.webGLEnabled)
         return false;
 
-    if (isWorker && !settings.allowWebGLInWorkers)
+    if (!settings.allowWebGLInWorkers)
         return false;
 
 #if PLATFORM(IOS_FAMILY) || PLATFORM(MAC)
     if (isWorker && !settings.useGPUProcessForWebGLEnabled)
         return false;
+#else
+    UNUSED_PARAM(isWorker);
 #endif
 
     if (!requiresAcceleratedCompositingForWebGL())


### PR DESCRIPTION
#### 171dfb71ff1d63e3153fdaad184979bd8df50f17
<pre>
OffscreenCanvas support without WebGL breaks Construct 3 content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253431">https://bugs.webkit.org/show_bug.cgi?id=253431</a>
&lt;rdar://106341361&gt;

Reviewed by Chris Dumez.

Construct 3 is testing for the presence of OffscreenCanvas on the main thread, and then assumes
that a WebGL context will be able to be constructed from it.
We&apos;ve only enabled Canvas2D on OffscreenCanvas currently, so detect this library and disable
OffscreenCanvas entirely.

* LayoutTests/fast/canvas/offscreen-disabled-construct3-quirk-expected.txt: Added.
* LayoutTests/fast/canvas/offscreen-disabled-construct3-quirk.html: Added.
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::JSDOMWindow::getOwnPropertySlot):

Cherry-pick: 259548.408@safari-7615-branch (0489426718c9). &lt;rdar://107756842&gt;
Canonical link: <a href="https://commits.webkit.org/262741@main">https://commits.webkit.org/262741@main</a>
</pre>
----------------------------------------------------------------------
#### 38d36c5fe33e52c5538107cf2ec3c292fa667726
<pre>
Disable main-thread WebGL in OffscreenCanvas.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253267">https://bugs.webkit.org/show_bug.cgi?id=253267</a>
&lt;rdar://105684718&gt;

Reviewed by Simon Fraser.

* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::shouldEnableWebGL):

Cherry-pick: 259548.355@safari-7615-branch (630b1e2aa50f). rdar://107755518
Canonical link: <a href="https://commits.webkit.org/262740@main">https://commits.webkit.org/262740@main</a>
</pre>
----------------------------------------------------------------------
#### 36c30e42e64c37712540d2bb161372a17e2ad686
<pre>
Cherry-pick aom 3154860bdbe978da9271ba55eea60973b0be06b5
<a href="https://bugs.webkit.org/show_bug.cgi?id=253015">https://bugs.webkit.org/show_bug.cgi?id=253015</a>
rdar://105507028

Reviewed by Geoffrey Garen.

Cherry-pick patch from upstream.

* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/encodeframe_utils.c:
(av1_source_content_sb):

Cherry-pick: 259548.317@safari-7615-branch (92bb5fbd72e5). rdar://107755462
Canonical link: <a href="https://commits.webkit.org/262739@main">https://commits.webkit.org/262739@main</a>
</pre>
----------------------------------------------------------------------
#### 776f5f1ac40f7cb8e7034e6a1e0470c2087af141
<pre>
[JSC] Restore liveness based interference analysis too
<a href="https://bugs.webkit.org/show_bug.cgi?id=252798">https://bugs.webkit.org/show_bug.cgi?id=252798</a>
rdar://problem/105818549

Reviewed by Ryan Haddad and Michael Saboff.

This is partial revert of <a href="https://commits.webkit.org/259548.47@safari-7615-branch.">https://commits.webkit.org/259548.47@safari-7615-branch.</a>
While the above change fixed the global interference problem, we have a problem.

1. We would like to check interference on all the live place since OSR exit may need to restore
   phantomized candidate nodes.
2. If PutStack / GetStack happens in the basic block and the stack state gets incorrect in the
   middle of basic block, we cannot know.

    loc0 =&gt; @b
    PutStack loc0 @a
    ...
    OSR exit
    ...
    PutStack loc0 @b
    ...
    loc0 =&gt; @b

So we partially revert the change in <a href="https://commits.webkit.org/259548.47@safari-7615-branch">https://commits.webkit.org/259548.47@safari-7615-branch</a>,

1. First collect all stack modification. And record which part of stack is modified for each basic block unit.
2. Then, for each basic block
    2.1. If this basic block does not have stack modification, then just check availability for live candidates availability
         this head. Since this basic block does not have stack modification, this basic block itself never incurs interference.
         Only thing we need to check is that now the live nodes are already clobbered in terms of availability because the
         successors modified the stack.
    2.2. If this basic block does stack modification, let&apos;s take live candidates at the tail of basic block and check whether
         the basic block is clobbering this candidate&apos;s relying stack. If so, remove it from candidate.
    2.3. For each newly killed DFG node at a node-index in this basic block, check (2.2)&apos;s stack modification and remove it
         from candidate if its stack is modified.

This added part is effectively the code removed in <a href="https://commits.webkit.org/259548.47@safari-7615-branch">https://commits.webkit.org/259548.47@safari-7615-branch</a> (so, existing code before).
Compared to the old behavior, 2.1 is added newly to cover inter-block handling.

* Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGAvailabilityMap.h:
(JSC::DFG::AvailabilityMap::forEachAvailability const):
(JSC::DFG::AvailabilityMap::closeOverNodes const):
(JSC::DFG::AvailabilityMap::closeStartingWithLocal const):
(JSC::DFG::AvailabilityMap::forEachAvailability): Deleted.
(JSC::DFG::AvailabilityMap::closeOverNodes): Deleted.
(JSC::DFG::AvailabilityMap::closeStartingWithLocal): Deleted.

Cherry-pick: 259548.275@safari-7615-branch (b022d8caf560). rdar://107709855
Canonical link: <a href="https://commits.webkit.org/262738@main">https://commits.webkit.org/262738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da2380103cc8f2d78cdc19dfeb83a8166cd9929e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2462 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2158 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3465 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2024 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2017 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2283 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3342 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2312 "Built successfully and passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2197 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1996 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2480 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2149 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/560 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/608 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2153 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2532 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2326 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/671 "Passed tests") | 
<!--EWS-Status-Bubble-End-->