### PR TITLE
[GStreamer] Refactor appsink callbacks handling

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -319,19 +319,10 @@ void AudioFileReader::handleNewDeinterleavePad(GstPad* pad)
     }
     m_channels++;
 
-    static GstAppSinkCallbacks callbacks = {
-        nullptr, // eos
-        nullptr, // new_preroll
-        // new_sample
-        [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
-            return static_cast<AudioFileReader*>(userData)->handleSample(sink);
-        },
-#if GST_CHECK_VERSION(1, 20, 0)
-        // new_event
-        nullptr,
-#endif
-        { nullptr }
-    };
+    static GstAppSinkCallbacks callbacks { .new_sample = [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
+        return static_cast<AudioFileReader*>(userData)->handleSample(sink);
+    } };
+
     gst_app_sink_set_callbacks(GST_APP_SINK(sink), &callbacks, this, nullptr);
 
     g_object_set(sink, "sync", FALSE, "async", FALSE, "enable-last-sample", FALSE, nullptr);

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -379,19 +379,14 @@ void AudioSourceProviderGStreamer::handleNewDeinterleavePad(GstPad* pad)
     auto* sink = makeGStreamerElement("appsink", nullptr);
 
     static GstAppSinkCallbacks callbacks = {
-        nullptr,
-        [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
+        .new_preroll = [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
             return static_cast<AudioSourceProviderGStreamer*>(userData)->handleSample(sink, true);
         },
-        [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
+        .new_sample = [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
             return static_cast<AudioSourceProviderGStreamer*>(userData)->handleSample(sink, false);
-        },
-#if GST_CHECK_VERSION(1, 20, 0)
-        // new_event
-        nullptr,
-#endif
-        { nullptr }
+        }
     };
+
     gst_app_sink_set_callbacks(GST_APP_SINK(sink), &callbacks, this, nullptr);
     // The provider client might request samples faster than the current clock speed, so this sink
     // should process buffers as fast as possible.


### PR DESCRIPTION
#### 166485b94d6b7191966ace68c2edd0d31226ab6d
<pre>
[GStreamer] Refactor appsink callbacks handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=255093">https://bugs.webkit.org/show_bug.cgi?id=255093</a>

Reviewed by NOBODY (OOPS!).

We now assign only the callbacks that we need, thus avoiding the need for ifdefs when building
against GStreamer versions adding new members in the GstAppSinkCallbacks structure.

* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::AudioFileReader::handleNewDeinterleavePad):
* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp:
(WebCore::AudioSourceProviderGStreamer::handleNewDeinterleavePad):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateGStreamer::setSink):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/166485b94d6b7191966ace68c2edd0d31226ab6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2844 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4110 "Failed to compile WebKit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2800 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/4110 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2415 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3876 "Failed to compile WebKit") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2400 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/3876 "Failed to compile WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2785 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2419 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/3876 "Failed to compile WebKit") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2451 "Passed tests") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2233 "6 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2403 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->