### PR TITLE
getFileHandle() should return TypeMismatchError on unexpected entry type

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getDirectoryHandle.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getDirectoryHandle.https.any-expected.txt
@@ -3,7 +3,7 @@ PASS getDirectoryHandle(create=false) rejects for non-existing directories
 PASS getDirectoryHandle(create=true) creates an empty directory
 PASS getDirectoryHandle(create=false) returns existing directories
 PASS getDirectoryHandle(create=true) returns existing directories without erasing
-FAIL getDirectoryHandle() when a file already exists with the same name promise_rejects_dom: function "function () { throw e }" threw object "TypeError: Type error" that is not a DOMException TypeMismatchError: property "code" is equal to undefined, expected 17
+PASS getDirectoryHandle() when a file already exists with the same name
 PASS getDirectoryHandle() with empty name
 PASS getDirectoryHandle() with "." name
 PASS getDirectoryHandle() with ".." name

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getDirectoryHandle.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getDirectoryHandle.https.any.worker-expected.txt
@@ -3,7 +3,7 @@ PASS getDirectoryHandle(create=false) rejects for non-existing directories
 PASS getDirectoryHandle(create=true) creates an empty directory
 PASS getDirectoryHandle(create=false) returns existing directories
 PASS getDirectoryHandle(create=true) returns existing directories without erasing
-FAIL getDirectoryHandle() when a file already exists with the same name promise_rejects_dom: function "function () { throw e }" threw object "TypeError: Type error" that is not a DOMException TypeMismatchError: property "code" is equal to undefined, expected 17
+PASS getDirectoryHandle() when a file already exists with the same name
 PASS getDirectoryHandle() with empty name
 PASS getDirectoryHandle() with "." name
 PASS getDirectoryHandle() with ".." name

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getFileHandle.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getFileHandle.https.any-expected.txt
@@ -5,8 +5,8 @@ PASS getFileHandle(create=true) creates an empty file with all valid ASCII chara
 PASS getFileHandle(create=true) creates an empty file with non-ASCII characters in the name
 FAIL getFileHandle(create=false) returns existing files promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 FAIL getFileHandle(create=true) returns existing files without erasing promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
-FAIL getFileHandle(create=false) when a directory already exists with the same name promise_rejects_dom: function "function () { throw e }" threw object "TypeError: Type error" that is not a DOMException TypeMismatchError: property "code" is equal to undefined, expected 17
-FAIL getFileHandle(create=true) when a directory already exists with the same name promise_rejects_dom: function "function () { throw e }" threw object "TypeError: Type error" that is not a DOMException TypeMismatchError: property "code" is equal to undefined, expected 17
+PASS getFileHandle(create=false) when a directory already exists with the same name
+PASS getFileHandle(create=true) when a directory already exists with the same name
 PASS getFileHandle() with empty name
 PASS getFileHandle() with "." name
 PASS getFileHandle() with ".." name

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getFileHandle.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getFileHandle.https.any.worker-expected.txt
@@ -5,8 +5,8 @@ PASS getFileHandle(create=true) creates an empty file with all valid ASCII chara
 PASS getFileHandle(create=true) creates an empty file with non-ASCII characters in the name
 FAIL getFileHandle(create=false) returns existing files promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
 FAIL getFileHandle(create=true) returns existing files without erasing promise_test: Unhandled rejection with value: object "TypeError: handle.createWritable is not a function. (In 'handle.createWritable()', 'handle.createWritable' is undefined)"
-FAIL getFileHandle(create=false) when a directory already exists with the same name promise_rejects_dom: function "function () { throw e }" threw object "TypeError: Type error" that is not a DOMException TypeMismatchError: property "code" is equal to undefined, expected 17
-FAIL getFileHandle(create=true) when a directory already exists with the same name promise_rejects_dom: function "function () { throw e }" threw object "TypeError: Type error" that is not a DOMException TypeMismatchError: property "code" is equal to undefined, expected 17
+PASS getFileHandle(create=false) when a directory already exists with the same name
+PASS getFileHandle(create=true) when a directory already exists with the same name
 PASS getFileHandle() with empty name
 PASS getFileHandle() with "." name
 PASS getFileHandle() with ".." name

--- a/LayoutTests/storage/filesystemaccess/directory-handle-basics-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/directory-handle-basics-expected.txt
@@ -7,6 +7,7 @@ PASS rootHandle.name is ""
 PASS rootHandle.kind is "directory"
 PASS dirHandle.name is "dir"
 PASS dirHandle.kind is "directory"
+PASS getError.toString() is "TypeMismatchError: File type is incompatible with handle type"
 PASS isSameEntry is false
 PASS fileHandle.name is "file"
 PASS fileHandle.kind is "file"

--- a/LayoutTests/storage/filesystemaccess/directory-handle-basics-worker-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/directory-handle-basics-worker-expected.txt
@@ -8,6 +8,7 @@ PASS [Worker] rootHandle.name is ""
 PASS [Worker] rootHandle.kind is "directory"
 PASS [Worker] dirHandle.name is "dir"
 PASS [Worker] dirHandle.kind is "directory"
+PASS [Worker] getError.toString() is "TypeMismatchError: File type is incompatible with handle type"
 PASS [Worker] isSameEntry is false
 PASS [Worker] fileHandle.name is "file"
 PASS [Worker] fileHandle.kind is "file"

--- a/LayoutTests/storage/filesystemaccess/resources/directory-handle-basics.js
+++ b/LayoutTests/storage/filesystemaccess/resources/directory-handle-basics.js
@@ -5,7 +5,7 @@ if (this.importScripts) {
 
 description("This test checks basic funtionalities of FileSystemDirectoryHandle.");
 
-var rootHandle, dirHandle, fileHandle, isSameEntry, handleNames, createError;
+var rootHandle, dirHandle, fileHandle, isSameEntry, handleNames, getError, createError;
 
 function getDirectory() 
 {
@@ -25,9 +25,20 @@ function createDirectoryHandle(fromHandle)
         dirHandle = handle;
         shouldBeEqualToString("dirHandle.name", "dir");
         shouldBeEqualToString("dirHandle.kind", "directory");
-        checkIfSameEntry(rootHandle, dirHandle);
+        getFileHandleOnDirectory(fromHandle);
     }).catch((error) => {
         finishTest(error);
+    });
+}
+
+function getFileHandleOnDirectory(fromHandle)
+{
+    fromHandle.getFileHandle("dir", { "create" : true }).then(() => {
+        finishTest('Unexpected success from getting file handle on a directory');
+    }).catch((error) => {
+        getError = error;
+        shouldBeEqualToString("getError.toString()", "TypeMismatchError: File type is incompatible with handle type");
+        checkIfSameEntry(fromHandle, dirHandle);
     });
 }
 

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageError.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageError.h
@@ -57,7 +57,7 @@ inline WebCore::Exception convertToException(FileSystemStorageError error)
     case FileSystemStorageError::InvalidState:
         return WebCore::Exception { WebCore::InvalidStateError };
     case FileSystemStorageError::TypeMismatch:
-        return WebCore::Exception { WebCore::TypeError };
+        return WebCore::Exception { WebCore::TypeMismatchError, "File type is incompatible with handle type"_s };
     case FileSystemStorageError::Unknown:
         break;
     }


### PR DESCRIPTION
#### 61f6c4b76a12b1f5cefb40b722d3117db72f13ff
<pre>
getFileHandle() should return TypeMismatchError on unexpected entry type
<a href="https://bugs.webkit.org/show_bug.cgi?id=255092">https://bugs.webkit.org/show_bug.cgi?id=255092</a>
rdar://107716194

Reviewed by Youenn Fablet.

Based on spec: <a href="https://fs.spec.whatwg.org/#dom-filesystemdirectoryhandle-getfilehandle">https://fs.spec.whatwg.org/#dom-filesystemdirectoryhandle-getfilehandle</a>

Updated test LayoutTests/storage/filesystemaccess/directory-handle-basics.html and rebaselined expectations for imported
tests.

* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getDirectoryHandle.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getDirectoryHandle.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getFileHandle.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-getFileHandle.https.any.worker-expected.txt:
* LayoutTests/storage/filesystemaccess/directory-handle-basics-expected.txt:
* LayoutTests/storage/filesystemaccess/directory-handle-basics-worker-expected.txt:
* LayoutTests/storage/filesystemaccess/resources/directory-handle-basics.js:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageError.h:
(WebKit::convertToException):

Canonical link: <a href="https://commits.webkit.org/262710@main">https://commits.webkit.org/262710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e9eadb7dee74792f87c13c9aca95981007af6ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2289 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2036 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3043 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/44 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1909 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2089 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3203 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2058 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1867 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2020 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/591 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2192 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->