### PR TITLE
Remove redundant code from RenderBox::hasTrimmedMargin(PhysicalDirection)

### DIFF
--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1475,16 +1475,6 @@ bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) c
 
 bool RenderBox::hasTrimmedMargin(PhysicalDirection physicalDirection) const
 {
-    if (!isInFlow())
-        return false;
-#if ASSERT_ENABLED
-    // containingBlock->isBlockContainer() can return true even if the item is in a RenderFlexibleBox
-    // (e.g. buttons) so we should explicitly check that the item is not a flex item to catch block containers here
-    if (auto* containingBlock = this->containingBlock(); containingBlock && !containingBlock->isFlexibleBox() &&  (containingBlock->isBlockContainer() || containingBlock->isRenderGrid())) {
-        ASSERT_NOT_IMPLEMENTED_YET();
-        return false;
-    }
-#endif
     ASSERT(!needsLayout());
 
     if (physicalDirection == PhysicalDirection::Top || physicalDirection == PhysicalDirection::Right)


### PR DESCRIPTION
#### 0c3876d9cb24a6f50f694d4e7ba5f8f4512ca0b7
<pre>
Remove redundant code from RenderBox::hasTrimmedMargin(PhysicalDirection)
<a href="https://bugs.webkit.org/show_bug.cgi?id=255098">https://bugs.webkit.org/show_bug.cgi?id=255098</a>
rdar://problem/107713529

Reviewed by Brent Fulgham.

RenderBox::hasTrimmedMargin is a overloaded function with two versions
that take in either a PhysicalDirection or std::optional&lt;MarginTrimType&gt;.
The version that takes in a PhysicalDirection simply maps the argument
to a MarginTrimType and then calls the other to perform the actual logic.

They both have the same pieces of debug code as well as an !isInFlow()
check. It is unnecessary to have this code in the PhysicalDirection one
since all it does it map the argument to a different type and then
call the other. The only benefit to this is that it would either trigger
a debug assert or return false earlier, but it also becomes tedious to
keep both versions in sync as more margin-trim patches are landed. It
increases the likelihood that one version would get some logic added in
a patch but would get missed in the other.

To address this we can just remove this shared code from the version
that takes in a PhysicalDirection and just keep it in the other. Now
the only time this function will change is when we add logic for it
to take in another value of PhysicalDirection.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hasTrimmedMargin const):

Canonical link: <a href="https://commits.webkit.org/262684@main">https://commits.webkit.org/262684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33144ecb344c7d3ea1633180c11a4456437d3c2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2258 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2192 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/2366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2009 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2240 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/1988 "Build was cancelled. Recent messages:OS: Monterey (12.6), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results; layout-tests (exception)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3003 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1965 "Build was cancelled. Recent messages:OS: Monterey (12.6), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1973 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2052 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2020 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3176 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1827 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/553 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2155 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->