### PR TITLE
[JSC] Apply the new display computation for digital in Intl.DurationFormat

### DIFF
--- a/JSTests/stress/intl-durationformat-digital.js
+++ b/JSTests/stress/intl-durationformat-digital.js
@@ -90,7 +90,7 @@ if (Intl.DurationFormat) {
         });
 
         shouldBeOneOf(fmt.format({ hours: 10, seconds: 33, milliseconds: 32 }), [
-            `10, 33.032000000`,
+            `10:00:33.032000000`,
         ]);
     }
     {
@@ -101,7 +101,7 @@ if (Intl.DurationFormat) {
         });
 
         shouldBeOneOf(fmt.format({ minutes: 10, seconds: 33, milliseconds: 32 }), [
-            `10:33.032000000`,
+            `0:10:33.032000000`,
         ]);
     }
     {
@@ -122,6 +122,21 @@ if (Intl.DurationFormat) {
 
         shouldBeOneOf(fmt.format({ hours: 10, minutes: 10, milliseconds: 32}), [
             `10:10:00`,
+        ]);
+    }
+    {
+        var fmt = new Intl.DurationFormat('en', {
+            style: 'digital',
+        });
+
+        shouldBeOneOf(fmt.format({ hours: 0, minutes: 10}), [
+            `0:10:00`,
+        ]);
+        shouldBeOneOf(fmt.format({ hours: 5, minutes: 6}), [
+            `5:06:00`,
+        ]);
+        shouldBeOneOf(fmt.format({ minutes: 5, seconds:6}), [
+            `0:05:06`,
         ]);
     }
 }

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -113,13 +113,17 @@ static IntlDurationFormat::UnitData intlDurationUnitOptions(JSGlobalObject* glob
     if (styleValue)
         style = styleValue.value();
     else {
-        displayDefault = IntlDurationFormat::Display::Auto;
-        if (baseStyle == IntlDurationFormat::Style::Digital)
+        if (baseStyle == IntlDurationFormat::Style::Digital) {
+            if (unit != TemporalUnit::Hour && unit != TemporalUnit::Minute && unit != TemporalUnit::Second)
+                displayDefault = IntlDurationFormat::Display::Auto;
             style = digitalBase;
-        else if (prevStyle && (prevStyle.value() == IntlDurationFormat::UnitStyle::Numeric || prevStyle.value() == IntlDurationFormat::UnitStyle::TwoDigit))
-            style = IntlDurationFormat::UnitStyle::Numeric;
-        else
-            style = static_cast<IntlDurationFormat::UnitStyle>(baseStyle);
+        } else {
+            displayDefault = IntlDurationFormat::Display::Auto;
+            if (prevStyle && (prevStyle.value() == IntlDurationFormat::UnitStyle::Numeric || prevStyle.value() == IntlDurationFormat::UnitStyle::TwoDigit))
+                style = IntlDurationFormat::UnitStyle::Numeric;
+            else
+                style = static_cast<IntlDurationFormat::UnitStyle>(baseStyle);
+        }
     }
 
     IntlDurationFormat::Display display = intlOption<IntlDurationFormat::Display>(globalObject, options, displayName, { { "auto"_s, IntlDurationFormat::Display::Auto }, { "always"_s, IntlDurationFormat::Display::Always } }, "display name must be either \"auto\" or \"always\""_s, displayDefault);


### PR DESCRIPTION
#### 0fe5a6846d5f1aa78459dbf8441a16195a9f4adb
<pre>
[JSC] Apply the new display computation for digital in Intl.DurationFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=255108">https://bugs.webkit.org/show_bug.cgi?id=255108</a>
rdar://problem/107721519

Reviewed by Mark Lam.

Apply the change[1]. This makes `hours` / `minutes` / `seconds` display in digital special instead of making them auto.

[1]: <a href="https://github.com/tc39/proposal-intl-duration-format/commit/d28076b3da36e32835a47b2ee0c422ae368f823b">https://github.com/tc39/proposal-intl-duration-format/commit/d28076b3da36e32835a47b2ee0c422ae368f823b</a>

* JSTests/stress/intl-durationformat-digital.js:
(Intl.DurationFormat.shouldBeOneOf):
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::intlDurationUnitOptions):

Canonical link: <a href="https://commits.webkit.org/262682@main">https://commits.webkit.org/262682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/461771c2e4c1383f719b437d87b889f1d98fcc93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3162 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2271 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2317 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3019 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/1977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1989 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1872 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2067 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2036 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2145 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1841 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2301 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1998 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/527 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2170 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2352 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/255 "Built successfully and passed tests") | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/641 "Passed tests") | 
<!--EWS-Status-Bubble-End-->