### PR TITLE
[WGSL] Add type checking for array constructors

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/array.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/array.wgsl
@@ -1,0 +1,30 @@
+fn testArrayLengthMismatch() {
+  // CHECK-L: array count must be greater than 0
+  let x1 = array<i32, 0>();
+
+  // CHECK-L: array constructor has too few elements: expected 1, found 0
+  let x2 = array<i32, 1>();
+
+  // CHECK-L: array constructor has too many elements: expected 1, found 2
+  let x3 = array<i32, 1>(0, 0);
+
+}
+
+fn testRuntimeSizedArray() {
+  // CHECK-L: cannot construct a runtime-sized array
+  let x1 = array<i32>(0);
+}
+
+fn testArrayTypeMismatch() {
+  // CHECK-L: '<AbstractFloat>' cannot be used to construct an array of 'i32'
+  let x1 = array<i32, 1>(0.0);
+
+}
+
+fn testArrayInferenceError() {
+  // CHECK-L: cannot infer array element type from constructor
+  let x1 = array();
+
+  // CHECK-L: cannot infer common array element type from constructor arguments
+  let x2 = array(0, 0.0, 0u);
+}

--- a/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
@@ -16,3 +16,20 @@ fn testConcretizationOfArguments() {
   // CHECK-L: vec<float, 2>(0, 0);
   let x3 = 0f + vec2(0, 0);
 }
+
+@vertex
+fn testArrayConcretization() {
+  // CHECK-L: vec<int, 2>(0, 0),
+  let x1 = array<vec2<i32>, 1>(vec2(0, 0));
+
+  // CHECK-L: vec<float, 2>(0, 0),
+  let x2 = array<vec2<f32>, 1>(vec2(0, 0));
+
+  // CHECK-L: vec<float, 2>(0, 0),
+  // CHECK-L: vec<float, 2>(0, 0),
+  let x3 = array(vec2(0, 0), vec2(0.0, 0.0));
+
+  // CHECK-L: vec<unsigned, 2>(0, 0),
+  // CHECK-L: vec<unsigned, 2>(0, 0),
+  let x4 = array(vec2(0, 0), vec2(0u, 0u));
+}


### PR DESCRIPTION
#### f4cba86f49cd6234f332827e7dddaa4a00b05295
<pre>
[WGSL] Add type checking for array constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=255110">https://bugs.webkit.org/show_bug.cgi?id=255110</a>
rdar://problem/107722955

Reviewed by Dean Jackson.

Add type inference and validation for the constructors `array(...)` and `array&lt;T, N&gt;(...)`

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/array.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/concretization.wgsl:

Canonical link: <a href="https://commits.webkit.org/262838@main">https://commits.webkit.org/262838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35c0174ceea40c1b57499393ee9293bbaf661eda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3123 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2866 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2795 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3952 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2457 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2508 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3703 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2845 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2460 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/681 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->