### PR TITLE
[git-webkit] Handle trailing cherry-pick annotation

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.1.8',
+    version='6.1.9',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 1, 8)
+version = Version(6, 1, 9)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -63,6 +63,18 @@ class TestRelationship(TestCase):
             ('original', ['123@main']), Relationship.parse(Commit(
                 hash='deadbeef1234', revision=1234, identifier='1234@main',
                 message='Cherry-picked 123@main. <rdar://54321>',
+            ))
+        )
+        self.assertEqual(
+            ('original', ['123@main']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Commit title\n\nCherry-picked: 123@main. <rdar://54321>',
+            ))
+        )
+        self.assertEqual(
+            ('original', ['123@main']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Commit title\n\nOriginally landed as: 123@main. <rdar://54321>',
             ))
         )
 

--- a/metadata/commit_classes.json
+++ b/metadata/commit_classes.json
@@ -47,7 +47,11 @@
 	{
 		"name": "Cherry-pick",
 		"pickable": true,
-		"headers": ["^[Cc]herry[- ][Pp]ick"]
+		"headers": ["^[Cc]herry[- ][Pp]ick"],
+		"trailers": [
+			"^[Cc]herry[- ][Pp]ick:",
+			"^[Oo]riginally[- ]landed[- ]as:"
+		]
 	},
 	{
 		"name": "Tools",


### PR DESCRIPTION
#### 0a38586f401a2417c7585f867527ad5200013d5e
<pre>
[git-webkit] Handle trailing cherry-pick annotation
<a href="https://bugs.webkit.org/show_bug.cgi?id=255113">https://bugs.webkit.org/show_bug.cgi?id=255113</a>
rdar://107725282

Rubber-stamped by Aakash Jain.

Since cherry-picks may now be denoted by a trailing line in the commit message,
git-webkit should handle these cases. In general, these means that git-webkit
needs to parse trailing lines in a commit message along with the leading line.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Version bump.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py:
(Commit.issues): Any issues in trailers need to take priority over those listed in
the commit message for tooling.
(Commit.trailers): List all message trailers.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py:
(CommitClassifier.LineFilter): Renamed from HeaderFilter.
(CommitClassifier.CommitClass.__init__): Accept &quot;trailer&quot; filters.
(CommitClassifier.classify): Implement processing of trailers. If a classification
defines both headers and trailers, only require either a matching header or a matching trailer,
but not both.
(CommitClassifier.HeaderFilter): Renamed to LineFilter.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py:
(Relationship.parse): Parse trailers along with the commit header.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py:
(TestClassify.test_trailer_success):
(TestClassify.test_trailer_failure):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py:
(TestRelationship.test_cherry_pick):
* metadata/commit_classes.json: Commits which define themselves as cherry-picks in their
trailer should be classified as cherry-picks.

Canonical link: <a href="https://commits.webkit.org/262707@main">https://commits.webkit.org/262707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/509dcec256e0124bf4c8814af8b7cb60be1e3df0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/2340 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/2350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/2454 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/3304 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/2368 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/2313 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/2475 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/2430 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/3304 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/2362 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/2475 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/2454 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/3168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/2373 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/2475 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/2454 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/3168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/2172 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/2475 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/3168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/2454 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/2430 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/2319 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/2454 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2080 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/265 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2271 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->