### PR TITLE
SVGPathSegValue::clone<>() rename to SVGPathSegValue::cloneInternal<>()

### DIFF
--- a/Source/WebCore/svg/SVGPathSeg.h
+++ b/Source/WebCore/svg/SVGPathSeg.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2008 Rob Buis <buis@kde.org>
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -79,12 +79,7 @@ public:
 
     virtual unsigned short pathSegType() const = 0;
     virtual String pathSegTypeAsLetter() const = 0;
-
-IGNORE_GCC_WARNINGS_BEGIN("overloaded-virtual")
-    // FIXME: SVGPathSegValue has a templated (and therefore non-virtual) clone
-    // function that hides this one, which is fragile and very confusing.
     virtual Ref<SVGPathSeg> clone() const = 0;
-IGNORE_GCC_WARNINGS_END
 
 protected:
     using SVGProperty::SVGProperty;

--- a/Source/WebCore/svg/SVGPathSegImpl.h
+++ b/Source/WebCore/svg/SVGPathSegImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc.  All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,7 +46,7 @@ private:
     using SVGPathSegLinetoHorizontal::SVGPathSegLinetoHorizontal;
     unsigned short pathSegType() const final { return PATHSEG_LINETO_HORIZONTAL_ABS; }
     String pathSegTypeAsLetter() const final { return "H"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegLinetoHorizontalAbs>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegLinetoHorizontalAbs>(); }
 };
 
 class SVGPathSegLinetoHorizontalRel final : public SVGPathSegLinetoHorizontal {
@@ -56,7 +56,7 @@ private:
     using SVGPathSegLinetoHorizontal::SVGPathSegLinetoHorizontal;
     unsigned short pathSegType() const final { return PATHSEG_LINETO_HORIZONTAL_REL; }
     String pathSegTypeAsLetter() const final { return "h"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegLinetoHorizontalRel>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegLinetoHorizontalRel>(); }
 };
 
 class SVGPathSegLinetoVerticalAbs final : public SVGPathSegLinetoVertical {
@@ -66,7 +66,7 @@ private:
     using SVGPathSegLinetoVertical::SVGPathSegLinetoVertical;
     unsigned short pathSegType() const final { return PATHSEG_LINETO_VERTICAL_ABS; }
     String pathSegTypeAsLetter() const final { return "V"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegLinetoVerticalAbs>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegLinetoVerticalAbs>(); }
 };
 
 class SVGPathSegLinetoVerticalRel final : public SVGPathSegLinetoVertical {
@@ -76,7 +76,7 @@ private:
     using SVGPathSegLinetoVertical::SVGPathSegLinetoVertical;
     unsigned short pathSegType() const final { return PATHSEG_LINETO_VERTICAL_REL; }
     String pathSegTypeAsLetter() const final { return "v"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegLinetoVerticalRel>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegLinetoVerticalRel>(); }
 };
 
 class SVGPathSegMovetoAbs final : public SVGPathSegSingleCoordinate {
@@ -86,7 +86,7 @@ private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     unsigned short pathSegType() const final { return PATHSEG_MOVETO_ABS; }
     String pathSegTypeAsLetter() const final { return "M"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegMovetoAbs>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegMovetoAbs>(); }
 };
 
 class SVGPathSegMovetoRel final : public SVGPathSegSingleCoordinate {
@@ -96,7 +96,7 @@ private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     unsigned short pathSegType() const final { return PATHSEG_MOVETO_REL; }
     String pathSegTypeAsLetter() const final { return "m"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegMovetoRel>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegMovetoRel>(); }
 };
 
 class SVGPathSegLinetoAbs final : public SVGPathSegSingleCoordinate {
@@ -106,7 +106,7 @@ private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     unsigned short pathSegType() const final { return PATHSEG_LINETO_ABS; }
     String pathSegTypeAsLetter() const final { return "L"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegLinetoAbs>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegLinetoAbs>(); }
 };
 
 class SVGPathSegLinetoRel final : public SVGPathSegSingleCoordinate {
@@ -116,7 +116,7 @@ private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     unsigned short pathSegType() const final { return PATHSEG_LINETO_REL; }
     String pathSegTypeAsLetter() const final { return "l"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegLinetoRel>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegLinetoRel>(); }
 };
 
 class SVGPathSegCurvetoQuadraticAbs final : public SVGPathSegCurvetoQuadratic {
@@ -126,7 +126,7 @@ private:
     using SVGPathSegCurvetoQuadratic::SVGPathSegCurvetoQuadratic;
     unsigned short pathSegType() const final { return PATHSEG_CURVETO_QUADRATIC_ABS; }
     String pathSegTypeAsLetter() const final { return "Q"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegCurvetoQuadraticAbs>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegCurvetoQuadraticAbs>(); }
 };
 
 class SVGPathSegCurvetoQuadraticRel final : public SVGPathSegCurvetoQuadratic {
@@ -136,7 +136,7 @@ private:
     using SVGPathSegCurvetoQuadratic::SVGPathSegCurvetoQuadratic;
     unsigned short pathSegType() const final { return PATHSEG_CURVETO_QUADRATIC_REL; }
     String pathSegTypeAsLetter() const final { return "q"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegCurvetoQuadraticRel>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegCurvetoQuadraticRel>(); }
 };
 
 class SVGPathSegCurvetoCubicAbs final : public SVGPathSegCurvetoCubic {
@@ -146,7 +146,7 @@ private:
     using SVGPathSegCurvetoCubic::SVGPathSegCurvetoCubic;
     unsigned short pathSegType() const final { return PATHSEG_CURVETO_CUBIC_ABS; }
     String pathSegTypeAsLetter() const final { return "C"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegCurvetoCubicAbs>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegCurvetoCubicAbs>(); }
 };
 
 class SVGPathSegCurvetoCubicRel final : public SVGPathSegCurvetoCubic {
@@ -156,7 +156,7 @@ private:
     using SVGPathSegCurvetoCubic::SVGPathSegCurvetoCubic;
     unsigned short pathSegType() const final { return PATHSEG_CURVETO_CUBIC_REL; }
     String pathSegTypeAsLetter() const final { return "c"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegCurvetoCubicRel>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegCurvetoCubicRel>(); }
 };
 
 class SVGPathSegArcAbs final : public SVGPathSegArc {
@@ -166,7 +166,7 @@ private:
     using SVGPathSegArc::SVGPathSegArc;
     unsigned short pathSegType() const final { return PATHSEG_ARC_ABS; }
     String pathSegTypeAsLetter() const final { return "A"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegArcAbs>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegArcAbs>(); }
 };
 
 class SVGPathSegArcRel final : public SVGPathSegArc {
@@ -176,7 +176,7 @@ private:
     using SVGPathSegArc::SVGPathSegArc;
     unsigned short pathSegType() const final { return PATHSEG_ARC_REL; }
     String pathSegTypeAsLetter() const final { return "a"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegArcRel>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegArcRel>(); }
 };
 
 class SVGPathSegCurvetoQuadraticSmoothAbs final : public SVGPathSegSingleCoordinate {
@@ -186,7 +186,7 @@ private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     unsigned short pathSegType() const final { return PATHSEG_CURVETO_QUADRATIC_SMOOTH_ABS; }
     String pathSegTypeAsLetter() const final { return "T"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegCurvetoQuadraticSmoothAbs>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegCurvetoQuadraticSmoothAbs>(); }
 };
 
 class SVGPathSegCurvetoQuadraticSmoothRel final : public SVGPathSegSingleCoordinate {
@@ -196,7 +196,7 @@ private:
     using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
     unsigned short pathSegType() const final { return PATHSEG_CURVETO_QUADRATIC_SMOOTH_REL; }
     String pathSegTypeAsLetter() const final { return "t"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegCurvetoQuadraticSmoothRel>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegCurvetoQuadraticSmoothRel>(); }
 };
 
 class SVGPathSegCurvetoCubicSmoothAbs final : public SVGPathSegCurvetoCubicSmooth {
@@ -206,7 +206,7 @@ private:
     using SVGPathSegCurvetoCubicSmooth::SVGPathSegCurvetoCubicSmooth;
     unsigned short pathSegType() const final { return PATHSEG_CURVETO_CUBIC_SMOOTH_ABS; }
     String pathSegTypeAsLetter() const final { return "S"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegCurvetoCubicSmoothAbs>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegCurvetoCubicSmoothAbs>(); }
 };
 
 class SVGPathSegCurvetoCubicSmoothRel final : public SVGPathSegCurvetoCubicSmooth {
@@ -216,7 +216,7 @@ private:
     using SVGPathSegCurvetoCubicSmooth::SVGPathSegCurvetoCubicSmooth;
     unsigned short pathSegType() const final { return PATHSEG_CURVETO_CUBIC_SMOOTH_REL; }
     String pathSegTypeAsLetter() const final { return "s"_s; }
-    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::clone<SVGPathSegCurvetoCubicSmoothRel>(); }
+    Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegCurvetoCubicSmoothRel>(); }
 };
 
-}
+} // namespace WebCore

--- a/Source/WebCore/svg/SVGPathSegValue.h
+++ b/Source/WebCore/svg/SVGPathSegValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc.  All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,12 +38,6 @@ public:
         return adoptRef(*new PathSegType(std::forward<Arguments>(arguments)...));
     }
 
-    template<typename PathSegType>
-    Ref<PathSegType> clone() const
-    {
-        return adoptRef(*new PathSegType(m_arguments));
-    }
-
     SVGPathSegValue(Arguments... arguments)
         : m_arguments(std::forward<Arguments>(arguments)...)
     {
@@ -66,6 +60,12 @@ protected:
     {
         std::get<I>(m_arguments) = value;
         commitChange();
+    }
+
+    template<typename PathSegType>
+    Ref<PathSegType> cloneInternal() const
+    {
+        return adoptRef(*new PathSegType(m_arguments));
     }
 
     std::tuple<Arguments...> m_arguments;
@@ -188,4 +188,4 @@ private:
     using SVGPathSegValue::SVGPathSegValue;
 };
 
-}
+} // namespace WebCore


### PR DESCRIPTION
#### 9fc3aff2f3870364e33a99d82b67f2372472167f
<pre>
SVGPathSegValue::clone&lt;&gt;() rename to SVGPathSegValue::cloneInternal&lt;&gt;()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254757">https://bugs.webkit.org/show_bug.cgi?id=254757</a>
rdar://107719787

Reviewed by Michael Catanzaro.

GCC 13 considers the template function SVGPathSegValue::clone&lt;&gt;() hides the virtual
function SVGPathSeg::clone&lt;&gt;() so the SVGPathSegValue super-classes can&apos;t override it.

Renaming it will make the classes in SVGPathSegValueImpl.h be complied on GCC 13
without the need for -Woverloaded-virtual.

* Source/WebCore/svg/SVGPathSeg.h:
* Source/WebCore/svg/SVGPathSegImpl.h:
* Source/WebCore/svg/SVGPathSegValue.h:
(WebCore::SVGPathSegValue::cloneInternal const):
(WebCore::SVGPathSegValue::clone const): Deleted.

Canonical link: <a href="https://commits.webkit.org/262690@main">https://commits.webkit.org/262690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6c1d385dff8f10aa9674fd2dbec2ed56b7b4063

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2254 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2285 "Build is in progress. Recent messages:") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2227 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/2371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2037 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2274 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/2371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3038 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/2371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1892 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3200 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2066 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2014 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/561 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2187 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->