### PR TITLE
Adopt setVolumeCapacityOverride in WKWebsiteDataStoreConfiguration.OriginQuotaRatio

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
@@ -716,8 +716,8 @@ TEST(WKWebsiteDataStoreConfiguration, OriginQuotaRatio)
     auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     EXPECT_NULL([websiteDataStoreConfiguration.get() originQuotaRatio]);
-    // 1 GB disk has 1 byte quota.
-    auto ratioNumber = [NSNumber numberWithFloat:0.000000001];
+    [websiteDataStoreConfiguration.get() setVolumeCapacityOverride:[NSNumber numberWithInteger:2 * MB]];
+    auto ratioNumber = [NSNumber numberWithFloat:0.5];
     [websiteDataStoreConfiguration.get() setOriginQuotaRatio:ratioNumber];
     EXPECT_TRUE([[websiteDataStoreConfiguration.get() originQuotaRatio] isEqualToNumber:ratioNumber]);
     auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
@@ -738,7 +738,7 @@ TEST(WKWebsiteDataStoreConfiguration, OriginQuotaRatio)
         request.onupgradeneeded = function(event) { \
             db = event.target.result; \
             os = db.createObjectStore('os'); \
-            const item = new Array(100000).join('x');\
+            const item = new Array(1024 * 1024).join('x'); \
             os.put(item, 'key').onerror = function(event) { sendMessage(event.target.error.name); }; \
         }; \
         request.onsuccess = function() { sendMessage('Unexpected success'); }; \
@@ -775,7 +775,7 @@ TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatio)
     auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     EXPECT_NULL([websiteDataStoreConfiguration.get() totalQuotaRatio]);
     [websiteDataStoreConfiguration.get() setTotalQuotaRatio:[NSNumber numberWithFloat:0.5]];
-    [websiteDataStoreConfiguration.get() setVolumeCapacityOverride:[NSNumber numberWithFloat:100000]];
+    [websiteDataStoreConfiguration.get() setVolumeCapacityOverride:[NSNumber numberWithInteger:100000]];
     auto handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
     auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 8b224cb2e5d0bb3ae1de63da131b6edd4739c593
<pre>
Adopt setVolumeCapacityOverride in WKWebsiteDataStoreConfiguration.OriginQuotaRatio
<a href="https://bugs.webkit.org/show_bug.cgi?id=255122">https://bugs.webkit.org/show_bug.cgi?id=255122</a>
rdar://107730062

Reviewed by Youenn Fablet.

WKWebsiteDataStoreConfiguration.OriginQuotaRatio currently sets a really small OriginQuotaRatio to ensure the computed
quota will be small enough (e.g. close to 0) and quota error will be thrown. This is a bit handwavy. To make the result
more definitive when running the test on machines with different capacity, we could adopt the recently added SPI
setVolumeCapacityOverride to set capacity used for quota computation.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262827@main">https://commits.webkit.org/262827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bd21391458e44ea7df94b0a6795207aa2c2b22f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2500 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2239 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3699 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2114 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2521 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3461 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2306 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2089 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2259 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/672 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2288 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->