### PR TITLE
[margin-trim] block-start margins for grid items in horizontal writing-mode should be reflected in computed style.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-start-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-start-expected.txt
@@ -1,0 +1,6 @@
+
+PASS grid > item 1
+PASS grid > item 2
+PASS grid > item 3
+PASS grid > item 4
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-start.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<meta name="assert" content="Grid items with trimmed block start margins should be reflected in computed style">
+<style>
+grid {
+    display: grid;
+    width: min-content;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+    margin-trim: block-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    background-color: green;
+}
+.locked-location {
+    grid-row: 1;
+    grid-column: 2;
+}
+item:nth-child(1) {
+    margin-block-start: 50%;
+}
+item:nth-child(2) {
+    margin-block-start: -30px;
+}
+item:nth-child(3) {
+    margin-block-start: 10px;
+}
+item:nth-child(4) {
+    margin-block-start: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+    <grid>
+        <item class="locked-location" data-expected-margin-top="0"></item>
+        <item data-expected-margin-top="0"></item>
+        <item data-expected-margin-top="10"></item>
+        <item data-expected-margin-top="10"></item>
+    </grid>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2304,7 +2304,7 @@ static bool rendererCanHaveTrimmedMargin(const RenderBox& renderer, std::optiona
 
     // containingBlock->isBlockContainer() can return true even if the item is in a RenderFlexibleBox
     // (e.g. buttons) so we should explicitly check that the item is not a flex item to catch block containers here
-    if (!renderer.isFlexItem() && (containingBlock->isRenderGrid() || containingBlock->isBlockContainer()))
+    if (!renderer.isFlexItem() && containingBlock->isBlockContainer())
         return false;
 
     if (containingBlock->isFlexibleBox()) {
@@ -2312,6 +2312,8 @@ static bool rendererCanHaveTrimmedMargin(const RenderBox& renderer, std::optiona
             return !containingBlock->style().marginTrim().isEmpty();
         return containingBlock->style().marginTrim().contains(marginTrimType.value());
     }
+    if (containingBlock->isRenderGrid() && (!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart))
+        return containingBlock->style().marginTrim().contains(marginTrimType.value());
     return false;
 }
 
@@ -2348,7 +2350,7 @@ static bool isLayoutDependent(CSSPropertyID propertyID, const RenderStyle* style
             || (rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), { }));
     }
     case CSSPropertyMarginTop:
-        return paddingOrMarginIsRendererDependent<&RenderStyle::marginTop>(style, renderer) || (isFlexItem(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::BlockStart));
+        return paddingOrMarginIsRendererDependent<&RenderStyle::marginTop>(style, renderer) || (is<RenderBox>(renderer) && (rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::BlockStart)));
     case CSSPropertyMarginRight:
         return paddingOrMarginIsRendererDependent<&RenderStyle::marginRight>(style, renderer) || (isFlexItem(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::InlineEnd));
     case CSSPropertyMarginBottom:

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1392,7 +1392,7 @@ void RenderBox::clearOverridingLogicalWidthLength()
 FlowRelativeDirection RenderBox::physicalToFlowRelativeDirectionMapping(PhysicalDirection direction) const
 {
     auto determineFormattingContextRootStyle = [&]() -> const RenderStyle& {
-        if (isFlexItem())
+        if (isFlexItem() || isGridItem())
             return parent()->style();
         ASSERT_NOT_IMPLEMENTED_YET();
         return style();
@@ -1469,10 +1469,12 @@ bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) c
     // containingBlock->isBlockContainer() can return true even if the item is in a RenderFlexibleBox
     // (e.g. buttons) so we should explicitly check that the item is not a flex item to catch block containers here
     auto* containingBlock = this->containingBlock(); 
-    if (containingBlock && !containingBlock->isFlexibleBox() && (containingBlock->isBlockContainer() || containingBlock->isRenderGrid())) {
+    if (containingBlock && !containingBlock->isFlexibleBox() && containingBlock->isBlockContainer()) {
         ASSERT_NOT_IMPLEMENTED_YET();
         return false;
     }
+    if (containingBlock && containingBlock->isRenderGrid())
+        ASSERT(!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart);
 #endif
     if (!hasRareData())
         return false;
@@ -3814,9 +3816,18 @@ void RenderBox::computeAndSetBlockDirectionMargins(const RenderBlock& containing
 
 LayoutUnit RenderBox::constrainBlockMarginInAvailableSpaceOrTrim(const RenderBox& containingBlock, LayoutUnit availableSpace, MarginTrimType marginSide) const
 {
+    
     ASSERT(marginSide == MarginTrimType::BlockStart || marginSide == MarginTrimType::BlockEnd);
-    if (containingBlock.shouldTrimChildMargin(marginSide, *this))
+    if (containingBlock.shouldTrimChildMargin(marginSide, *this)) {
+        // FIXME(255434): This should be set when the margin is being trimmed
+        // within the context of its layout system (block, flex, grid) and should not 
+        // be done at this level within RenderBox. We should be able to leave the 
+        // trimming responsibility to each of those contexts and not need to
+        // do any of it here (trimming the margin and setting the rare data bit)
+        if (isGridItem() && marginSide == MarginTrimType::BlockStart)
+            const_cast<RenderBox&>(*this).markMarginAsTrimmed(MarginTrimType::BlockStart);
         return 0_lu;
+    }
     
     return marginSide == MarginTrimType::BlockStart ? minimumValueForLength(style().marginBeforeUsing(&containingBlock.style()), availableSpace) : minimumValueForLength(style().marginAfterUsing(&containingBlock.style()), availableSpace);
 }


### PR DESCRIPTION
#### c87ee9281557b041309d82cc2a04fff613444fc9
<pre>
[margin-trim] block-start margins for grid items in horizontal writing-mode should be reflected in computed style.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253716">https://bugs.webkit.org/show_bug.cgi?id=253716</a>
rdar://106559103

Reviewed by Alan Baradlay.

When the block-start margins for grid items that are adjacent to the
block-start edge of the grid, We need to set the rare data bits for
the item to indicate that the margin has been trimmed. We can then check
if this bit is set within ComputedStyleExtractor to get the trimmed
value for this margin by directly querying the renderer&apos;s m_marginBox.
In a horizontal writing mode this bit would correspond to the &quot;top,&quot;
margin value.

For block-start margins, the trimming occurs when a renderer goes
through layout and calls RenderBox::constrainBlockMarginInAvailableSpaceOrTrim,
which is called from RenderBox::computeBlockDirectionMargins. This
function consults the layout system, which is grid in this case, via
shouldTrimChildMargin to see if it should trim its margin. If this
returns true, then the renderer will not compute the margin and will
return 0_lu. We can use this opportunity to set the rare data for the
renderer to indicate that this margin has been trimmed.

Inside of ComputedStyleExtractor, we need to update
rendererCanHaveTrimmedMargin so that this returns true for grid items.
This will allow us to do 2 things:
1.) Have isLayoutDependent return true for grid items with margin-trim
set on the grid so that layout is forced when checking the &quot;top,&quot; margin
for grid items
2.) Allow us to call box-&gt;hasTrimmedMargin when computing the margin
value (since that call is guarded by a call to rendererCanHaveTrimmedMargin)

Similarly, there are a couple of other extra pieces of code in RenderBox
(particularly in physicalToFlowRelativeDirectionMapping and hasTrimmedMargin)
that should now be used with grid items.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-start-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-start.html: Added.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::rendererCanHaveTrimmedMargin):
(WebCore::isLayoutDependent):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::physicalToFlowRelativeDirectionMapping const):
(WebCore::RenderBox::hasTrimmedMargin const):
(WebCore::RenderBox::constrainBlockMarginInAvailableSpaceOrTrim const):

Canonical link: <a href="https://commits.webkit.org/262967@main">https://commits.webkit.org/262967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f41c7f021fae7b4f979f523e3c610cbfbb26054f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4547 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3495 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2725 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4353 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2631 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4104 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2562 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2789 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/772 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2787 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->