### PR TITLE
[WGSL] Distinguish between abstract and concrete float literals

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -144,7 +144,11 @@ Token Lexer<T>::lex()
         std::optional<int64_t> exponent = parseDecimalFloatExponent();
         if (exponent)
             literalValue *= pow(10, exponent.value());
-        return makeLiteralToken(TokenType::DecimalFloatLiteral, literalValue);
+        if (m_current == 'f') {
+            shift();
+            return makeLiteralToken(TokenType::FloatLiteral, literalValue);
+        }
+        return makeLiteralToken(TokenType::AbstractFloatLiteral, literalValue);
     }
     case '-':
         shift();
@@ -212,12 +216,12 @@ Token Lexer<T>::lex()
                 }
                 if (m_current == 'f') {
                     shift();
-                    return makeLiteralToken(TokenType::DecimalFloatLiteral, literalValue);
+                    return makeLiteralToken(TokenType::FloatLiteral, literalValue);
                 }
             }
             if (std::optional<int64_t> exponent = parseDecimalFloatExponent()) {
+                isFloatingPoint = true;
                 literalValue *= pow(10, exponent.value());
-                return makeLiteralToken(TokenType::DecimalFloatLiteral, literalValue);
             }
             // Decimal integers are not allowed to start with 0.
             if (!isFloatingPoint)
@@ -225,10 +229,10 @@ Token Lexer<T>::lex()
         }
         if (m_current == 'f') {
             shift();
-            return makeLiteralToken(TokenType::DecimalFloatLiteral, literalValue);
+            return makeLiteralToken(TokenType::FloatLiteral, literalValue);
         }
         if (isFloatingPoint)
-            return makeLiteralToken(TokenType::DecimalFloatLiteral, literalValue);
+            return makeLiteralToken(TokenType::AbstractFloatLiteral, literalValue);
         return parseIntegerLiteralSuffix(literalValue);
     }
     case '~':
@@ -253,16 +257,16 @@ Token Lexer<T>::lex()
                 }
             }
             if (std::optional<int64_t> exponent = parseDecimalFloatExponent()) {
+                isFloatingPoint = true;
                 literalValue *= pow(10, exponent.value());
-                return makeLiteralToken(TokenType::DecimalFloatLiteral, literalValue);
             }
             if (m_current == 'f') {
                 shift();
-                return makeLiteralToken(TokenType::DecimalFloatLiteral, literalValue);
+                return makeLiteralToken(TokenType::FloatLiteral, literalValue);
             }
             if (!isFloatingPoint)
                 return parseIntegerLiteralSuffix(literalValue);
-            return makeLiteralToken(TokenType::DecimalFloatLiteral, literalValue);
+            return makeLiteralToken(TokenType::AbstractFloatLiteral, literalValue);
         } else if (isIdentifierStart(m_current)) {
             const T* startOfToken = m_code;
             shift();

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -1091,13 +1091,13 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePrimaryExpression()
         CONSUME_TYPE_NAMED(lit, IntegerLiteralUnsigned);
         RETURN_NODE_UNIQUE_REF(Unsigned32Literal, lit.literalValue);
     }
-    case TokenType::DecimalFloatLiteral: {
-        CONSUME_TYPE_NAMED(lit, DecimalFloatLiteral);
+    case TokenType::AbstractFloatLiteral: {
+        CONSUME_TYPE_NAMED(lit, AbstractFloatLiteral);
         RETURN_NODE_UNIQUE_REF(AbstractFloatLiteral, lit.literalValue);
     }
-    case TokenType::HexFloatLiteral: {
-        CONSUME_TYPE_NAMED(lit, HexFloatLiteral);
-        RETURN_NODE_UNIQUE_REF(AbstractFloatLiteral, lit.literalValue);
+    case TokenType::FloatLiteral: {
+        CONSUME_TYPE_NAMED(lit, FloatLiteral);
+        RETURN_NODE_UNIQUE_REF(Float32Literal, lit.literalValue);
     }
     // TODO: bitcast expression
 

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -35,16 +35,16 @@ String toString(TokenType type)
         return "Invalid"_s;
     case TokenType::EndOfFile:
         return "EOF"_s;
+    case TokenType::AbstractFloatLiteral:
+        return "AbstractFloatLiteral"_s;
     case TokenType::IntegerLiteral:
         return "IntegerLiteral"_s;
     case TokenType::IntegerLiteralSigned:
         return "IntegerLiteralSigned"_s;
     case TokenType::IntegerLiteralUnsigned:
         return "IntegerLiteralUnsigned"_s;
-    case TokenType::DecimalFloatLiteral:
-        return "DecimalFloatLiteral"_s;
-    case TokenType::HexFloatLiteral:
-        return "HexFloatLiteral"_s;
+    case TokenType::FloatLiteral:
+        return "FloatLiteral"_s;
     case TokenType::Identifier:
         return "Identifier"_s;
     case TokenType::ReservedWord:

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -40,11 +40,11 @@ enum class TokenType: uint32_t {
 
     EndOfFile,
 
+    AbstractFloatLiteral,
     IntegerLiteral,
     IntegerLiteralSigned,
     IntegerLiteralUnsigned,
-    DecimalFloatLiteral,
-    HexFloatLiteral,
+    FloatLiteral,
 
     Identifier,
 
@@ -125,12 +125,12 @@ struct Token {
         : type(type)
         , span(position.line, position.lineOffset, position.offset, length)
     {
-        ASSERT(type != TokenType::Identifier);
-        ASSERT(type != TokenType::IntegerLiteral);
-        ASSERT(type != TokenType::IntegerLiteralSigned);
-        ASSERT(type != TokenType::IntegerLiteralUnsigned);
-        ASSERT(type != TokenType::DecimalFloatLiteral);
-        ASSERT(type != TokenType::HexFloatLiteral);
+        ASSERT(type != TokenType::AbstractFloatLiteral
+            && type != TokenType::Identifier
+            && type != TokenType::IntegerLiteral
+            && type != TokenType::IntegerLiteralSigned
+            && type != TokenType::IntegerLiteralUnsigned
+            && type != TokenType::FloatLiteral);
     }
 
     Token(TokenType type, SourcePosition position, unsigned length, double literalValue)
@@ -138,11 +138,11 @@ struct Token {
         , span(position.line, position.lineOffset, position.offset, length)
         , literalValue(literalValue)
     {
-        ASSERT(type == TokenType::IntegerLiteral
+        ASSERT(type == TokenType::AbstractFloatLiteral
+            || type == TokenType::IntegerLiteral
             || type == TokenType::IntegerLiteralSigned
             || type == TokenType::IntegerLiteralUnsigned
-            || type == TokenType::DecimalFloatLiteral
-            || type == TokenType::HexFloatLiteral);
+            || type == TokenType::FloatLiteral);
     }
 
     Token(TokenType type, SourcePosition position, unsigned length, String&& ident)
@@ -167,11 +167,11 @@ struct Token {
             new (NotNull, &ident) String();
             ident = other.ident;
             break;
+        case TokenType::AbstractFloatLiteral:
         case TokenType::IntegerLiteral:
         case TokenType::IntegerLiteralSigned:
         case TokenType::IntegerLiteralUnsigned:
-        case TokenType::DecimalFloatLiteral:
-        case TokenType::HexFloatLiteral:
+        case TokenType::FloatLiteral:
             literalValue = other.literalValue;
             break;
         default:
@@ -190,11 +190,11 @@ struct Token {
             new (NotNull, &ident) String();
             ident = other.ident;
             break;
+        case TokenType::AbstractFloatLiteral:
         case TokenType::IntegerLiteral:
         case TokenType::IntegerLiteralSigned:
         case TokenType::IntegerLiteralUnsigned:
-        case TokenType::DecimalFloatLiteral:
-        case TokenType::HexFloatLiteral:
+        case TokenType::FloatLiteral:
             literalValue = other.literalValue;
             break;
         default:

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -96,18 +96,22 @@ TEST(WGSLLexerTests, SingleTokens)
     checkSingleLiteral("1"_s, TokenType::IntegerLiteral, 1);
     checkSingleLiteral("0"_s, TokenType::IntegerLiteral, 0);
     checkSingleLiteral("142"_s, TokenType::IntegerLiteral, 142);
-    checkSingleLiteral("1.1"_s, TokenType::DecimalFloatLiteral, 1.1);
-    checkSingleLiteral("0.4"_s, TokenType::DecimalFloatLiteral, 0.4);
-    checkSingleLiteral("0123.456"_s, TokenType::DecimalFloatLiteral, 0123.456);
+    checkSingleLiteral("142f"_s, TokenType::FloatLiteral, 142.0);
+    checkSingleLiteral("1.1"_s, TokenType::AbstractFloatLiteral, 1.1);
+    checkSingleLiteral("0.4"_s, TokenType::AbstractFloatLiteral, 0.4);
+    checkSingleLiteral("0123.456"_s, TokenType::AbstractFloatLiteral, 0123.456);
     checkSingleToken("0123"_s, TokenType::Invalid);
-    checkSingleLiteral("0123."_s, TokenType::DecimalFloatLiteral, 123);
-    checkSingleLiteral(".456"_s, TokenType::DecimalFloatLiteral, 0.456);
+    checkSingleLiteral("0123."_s, TokenType::AbstractFloatLiteral, 123);
+    checkSingleLiteral(".456"_s, TokenType::AbstractFloatLiteral, 0.456);
     checkSingleToken("."_s, TokenType::Period);
-    checkSingleLiteral("42f"_s, TokenType::DecimalFloatLiteral, 42);
-    checkSingleLiteral("42e0f"_s, TokenType::DecimalFloatLiteral, 42);
-    checkSingleLiteral("042e0f"_s, TokenType::DecimalFloatLiteral, 42);
+    checkSingleLiteral("42f"_s, TokenType::FloatLiteral, 42);
+    checkSingleLiteral("42e0f"_s, TokenType::FloatLiteral, 42);
+    checkSingleLiteral("042e0f"_s, TokenType::FloatLiteral, 42);
     checkSingleToken("042f"_s, TokenType::Invalid);
-    checkSingleLiteral("42e-3"_s, TokenType::DecimalFloatLiteral, 42e-3);
+    checkSingleLiteral("0123.f"_s, TokenType::FloatLiteral, 123);
+    checkSingleLiteral(".456f"_s, TokenType::FloatLiteral, 0.456);
+    checkSingleLiteral("42e-3"_s, TokenType::AbstractFloatLiteral, 42e-3);
+    checkSingleLiteral("42e-3f"_s, TokenType::FloatLiteral, 42e-3);
     checkSingleLiteral("42e-a"_s, TokenType::IntegerLiteral, 42);
 }
 
@@ -353,13 +357,13 @@ TEST(WGSLLexerTests, GraphicsShader)
     checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Gt, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.4, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.4, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.4, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.4, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.8, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.8, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 1.0, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 1.0, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
 
@@ -437,9 +441,9 @@ TEST(WGSLLexerTests, TriangleVert)
     checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Gt, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.0, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.0, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.5, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
 
@@ -451,10 +455,10 @@ TEST(WGSLLexerTests, TriangleVert)
     checkNextTokenIs(lexer, WGSL::TokenType::Gt, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Minus, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.5, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Minus, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.5, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
 
@@ -465,10 +469,10 @@ TEST(WGSLLexerTests, TriangleVert)
     checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Gt, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.5, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Minus, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.5, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
 
     ++lineNumber;
@@ -494,14 +498,14 @@ TEST(WGSLLexerTests, TriangleVert)
     checkNextTokenIs(lexer, WGSL::TokenType::KeywordF32, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Gt, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenLeft, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.5, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.5, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.5, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 0.0, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 0.0, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Comma, lineNumber);
-    checkNextTokenIsLiteral(lexer, WGSL::TokenType::DecimalFloatLiteral, 1.0, lineNumber);
+    checkNextTokenIsLiteral(lexer, WGSL::TokenType::AbstractFloatLiteral, 1.0, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::ParenRight, lineNumber);
     checkNextTokenIs(lexer, WGSL::TokenType::Semicolon, lineNumber);
 


### PR DESCRIPTION
#### 8df3beb4ce3657173519fa4a87d1ff4db910e608
<pre>
[WGSL] Distinguish between abstract and concrete float literals
<a href="https://bugs.webkit.org/show_bug.cgi?id=255127">https://bugs.webkit.org/show_bug.cgi?id=255127</a>
rdar://problem/107732951

Reviewed by Tadeu Zagallo.

Lexing did not correctly distinguish between &quot;abstract&quot; and &quot;concrete&quot; floating
point literals. Eg. 124.0 vs 124.0f. This patch implements the distinction via
tokens AbstractFloatLiteral and FloatLiteral, allowing the parser to create
Float32Literal AST nodes.

Also, not all cases of concrete literals specified with suffix &apos;f&apos; were lexed
correctly. Added these cases and tests.

Canonical link: <a href="https://commits.webkit.org/262732@main">https://commits.webkit.org/262732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/522dd15d927b321e2f2ff4ab182fd09f0b68189a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3214 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2318 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2369 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3077 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1926 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2117 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2052 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3240 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2088 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1887 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2045 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/604 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->