### PR TITLE
Cache lowercase version of the localName in QualifiedName

### DIFF
--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -266,7 +266,6 @@ struct PossiblyQuotedIdentifier {
         const AtomString& value() const;
         const AtomString& serializingValue() const;
         const QualifiedName& attribute() const;
-        const AtomString& attributeCanonicalLocalName() const;
         const AtomString& argument() const { return m_hasRareData ? m_data.rareData->argument : nullAtom(); }
         bool attributeValueMatchingIsCaseInsensitive() const;
         const FixedVector<PossiblyQuotedIdentifier>* argumentList() const { return m_hasRareData ? &m_data.rareData->argumentList : nullptr; }
@@ -276,7 +275,7 @@ struct PossiblyQuotedIdentifier {
         void setValue(const AtomString&, bool matchLowerCase = false);
 
         enum AttributeMatchType { CaseSensitive, CaseInsensitive };
-        void setAttribute(const QualifiedName&, bool convertToLowercase, AttributeMatchType);
+        void setAttribute(const QualifiedName&, AttributeMatchType);
         void setNth(int a, int b);
         void setArgument(const AtomString&);
         void setArgumentList(FixedVector<PossiblyQuotedIdentifier>);
@@ -334,7 +333,6 @@ struct PossiblyQuotedIdentifier {
         unsigned m_isFirstInTagHistory : 1 { true };
         unsigned m_isLastInTagHistory : 1 { true };
         unsigned m_hasRareData : 1 { false };
-        unsigned m_hasNameWithCase : 1 { false };
         unsigned m_isForPage : 1 { false };
         unsigned m_tagIsForNamespaceRule : 1 { false };
         unsigned m_caseInsensitiveAttributeValueMatching : 1 { false };
@@ -364,7 +362,6 @@ struct PossiblyQuotedIdentifier {
             int a { 0 }; // Used for :nth-*
             int b { 0 }; // Used for :nth-*
             QualifiedName attribute; // used for attribute selector
-            AtomString attributeCanonicalLocalName;
             AtomString argument; // Used for :contains and :nth-*
             FixedVector<PossiblyQuotedIdentifier> argumentList; // Used for :lang and ::part arguments.
             std::unique_ptr<CSSSelectorList> selectorList; // Used for :is(), :matches(), and :not().
@@ -377,23 +374,10 @@ struct PossiblyQuotedIdentifier {
         };
         void createRareData();
 
-        struct NameWithCase : public RefCounted<NameWithCase> {
-            NameWithCase(const QualifiedName& originalName, const AtomString& lowercaseName)
-                : originalName(originalName)
-                , lowercaseLocalName(lowercaseName)
-            {
-                ASSERT(originalName.localName() != lowercaseName);
-            }
-
-            const QualifiedName originalName;
-            const AtomString lowercaseLocalName;
-        };
-
         union DataUnion {
             AtomStringImpl* value { nullptr };
             QualifiedName::QualifiedNameImpl* tagQName;
             RareData* rareData;
-            NameWithCase* nameWithCase;
         } m_data;
     };
 
@@ -407,13 +391,6 @@ inline const QualifiedName& CSSSelector::attribute() const
     ASSERT(isAttributeSelector());
     ASSERT(m_hasRareData);
     return m_data.rareData->attribute;
-}
-
-inline const AtomString& CSSSelector::attributeCanonicalLocalName() const
-{
-    ASSERT(isAttributeSelector());
-    ASSERT(m_hasRareData);
-    return m_data.rareData->attributeCanonicalLocalName;
 }
 
 inline bool CSSSelector::matchesPseudoElement() const
@@ -521,10 +498,6 @@ inline CSSSelector::~CSSSelector()
         m_data.rareData->deref();
         m_data.rareData = nullptr;
         m_hasRareData = false;
-    } else if (m_hasNameWithCase) {
-        m_data.nameWithCase->deref();
-        m_data.nameWithCase = nullptr;
-        m_hasNameWithCase = false;
     } else if (match() == Tag) {
         m_data.tagQName->deref();
         m_data.tagQName = nullptr;
@@ -537,17 +510,12 @@ inline CSSSelector::~CSSSelector()
 
 inline const QualifiedName& CSSSelector::tagQName() const
 {
-    ASSERT(match() == Tag);
-    if (m_hasNameWithCase)
-        return m_data.nameWithCase->originalName;
     return *reinterpret_cast<const QualifiedName*>(&m_data.tagQName);
 }
 
 inline const AtomString& CSSSelector::tagLowercaseLocalName() const
 {
-    if (m_hasNameWithCase)
-        return m_data.nameWithCase->lowercaseLocalName;
-    return m_data.tagQName->m_localName;
+    return tagQName().localNameLowercase();
 }
 
 inline const AtomString& CSSSelector::value() const

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -560,8 +560,9 @@ static bool attributeValueMatches(const Attribute& attribute, CSSSelector::Match
 static bool anyAttributeMatches(const Element& element, const CSSSelector& selector, const QualifiedName& selectorAttr, bool caseSensitive)
 {
     ASSERT(element.hasAttributesWithoutUpdate());
+    bool isHTML = element.isHTMLElement() && element.document().isHTMLDocument();
     for (const Attribute& attribute : element.attributesIterator()) {
-        if (!attribute.matches(selectorAttr.prefix(), element.isHTMLElement() ? selector.attributeCanonicalLocalName() : selectorAttr.localName(), selectorAttr.namespaceURI()))
+        if (!attribute.matches(selectorAttr.prefix(), isHTML ? selectorAttr.localNameLowercase() : selectorAttr.localName(), selectorAttr.namespaceURI()))
             continue;
 
         if (attributeValueMatches(attribute, selector.match(), selector.value(), caseSensitive))
@@ -575,7 +576,8 @@ bool SelectorChecker::attributeSelectorMatches(const Element& element, const Qua
 {
     ASSERT(selector.isAttributeSelector());
     auto& selectorAttribute = selector.attribute();
-    auto& selectorName = element.isHTMLElement() ? selector.attributeCanonicalLocalName() : selectorAttribute.localName();
+    bool isHTML = element.isHTMLElement() && element.document().isHTMLDocument();
+    auto& selectorName = isHTML ? selectorAttribute.localNameLowercase() : selectorAttribute.localName();
     if (!Attribute::nameMatchesFilter(attributeName, selectorAttribute.prefix(), selectorName, selectorAttribute.namespaceURI()))
         return false;
     bool caseSensitive = true;

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -46,18 +46,9 @@ static bool isExcludedAttribute(const AtomString& name)
     return name == HTMLNames::classAttr->localName() || name == HTMLNames::idAttr->localName() || name == HTMLNames::styleAttr->localName();
 }
 
-static inline bool localNameIsKnownToBeLowercase(const Element& element)
-{
-    // Known HTML element always return a localName() that is defined inside HTMLNames.h. All known HTML
-    // tags are lowercase.
-    return element.isHTMLElement() && !element.isUnknownElement();
-}
-
 void SelectorFilter::collectElementIdentifierHashes(const Element& element, Vector<unsigned, 4>& identifierHashes)
 {
-    AtomString tagLowercaseLocalName = LIKELY(localNameIsKnownToBeLowercase(element)) ? element.localName() : element.localName().convertToASCIILowercase();
-    ASSERT(tagLowercaseLocalName == tagLowercaseLocalName.convertToASCIILowercase());
-    identifierHashes.append(tagLowercaseLocalName.impl()->existingHash() * TagNameSalt);
+    identifierHashes.append(element.localNameLowercase().impl()->existingHash() * TagNameSalt);
 
     auto& id = element.idForStyleResolution();
     if (!id.isNull())
@@ -72,7 +63,7 @@ void SelectorFilter::collectElementIdentifierHashes(const Element& element, Vect
     
     if (element.hasAttributesWithoutUpdate()) {
         for (auto& attribute : element.attributesIterator()) {
-            auto attributeName = element.isHTMLElement() ? attribute.localName() : attribute.localName().convertToASCIILowercase();
+            auto attributeName = element.isHTMLElement() ? attribute.localName() : attribute.localNameLowercase();
             if (isExcludedAttribute(attributeName))
                 continue;
             identifierHashes.append(attributeName.impl()->existingHash() * AttributeSalt);
@@ -168,7 +159,7 @@ void SelectorFilter::collectSimpleSelectorHash(CollectedSelectorHashes& collecte
     case CSSSelector::Contain:
     case CSSSelector::Begin:
     case CSSSelector::End: {
-        auto attributeName = selector.attributeCanonicalLocalName().convertToASCIILowercase();
+        auto attributeName = selector.attribute().localNameLowercase();
         if (!isExcludedAttribute(attributeName))
             collectedHashes.attributes.append(attributeName.impl()->existingHash() * AttributeSalt);
         break;

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -53,7 +53,7 @@ public:
 
     void setValue(const AtomString& value, bool matchLowerCase = false) { m_selector->setValue(value, matchLowerCase); }
 
-    void setAttribute(const QualifiedName& value, bool convertToLowercase, CSSSelector::AttributeMatchType type) { m_selector->setAttribute(value, convertToLowercase, type); }
+    void setAttribute(const QualifiedName& value, CSSSelector::AttributeMatchType type) { m_selector->setAttribute(value, type); }
     
     void setArgument(const AtomString& value) { m_selector->setArgument(value); }
     void setNth(int a, int b) { m_selector->setNth(a, b); }

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -46,7 +46,6 @@ static bool consumeANPlusB(CSSParserTokenRange&, std::pair<int, int>&);
 
 CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& context)
     : mode(context.mode)
-    , isHTMLDocument(context.isHTMLDocument)
     , cssNestingEnabled(context.cssNestingEnabled)
     , focusVisibleEnabled(context.focusVisibleEnabled)
     , hasPseudoClassEnabled(context.hasPseudoClassEnabled)
@@ -55,7 +54,6 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
 
 CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     : mode(document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode)
-    , isHTMLDocument(document.isHTMLDocument())
     , cssNestingEnabled(document.settings().cssNestingEnabled())
     , focusVisibleEnabled(document.settings().focusVisibleEnabled())
     , hasPseudoClassEnabled(document.settings().hasPseudoClassEnabled())
@@ -65,7 +63,6 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
 bool CSSSelectorParserContext::operator==(const CSSSelectorParserContext& other) const
 {
     return mode == other.mode
-        || isHTMLDocument == other.isHTMLDocument
         || cssNestingEnabled == other.cssNestingEnabled
         || focusVisibleEnabled == other.focusVisibleEnabled
         || hasPseudoClassEnabled == other.hasPseudoClassEnabled;
@@ -75,7 +72,6 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
 {
     add(hasher,
         context.mode,
-        context.isHTMLDocument,
         context.cssNestingEnabled,
         context.focusVisibleEnabled,
         context.hasPseudoClassEnabled
@@ -696,7 +692,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeAttribute(CSSParser
     auto selector = makeUnique<CSSParserSelector>();
 
     if (block.atEnd()) {
-        selector->setAttribute(qualifiedName, m_context.isHTMLDocument, CSSSelector::CaseSensitive);
+        selector->setAttribute(qualifiedName, CSSSelector::CaseSensitive);
         selector->setMatch(CSSSelector::Set);
         return selector;
     }
@@ -708,7 +704,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeAttribute(CSSParser
         return nullptr;
     selector->setValue(attributeValue.value().toAtomString());
     
-    selector->setAttribute(qualifiedName, m_context.isHTMLDocument, consumeAttributeFlags(block));
+    selector->setAttribute(qualifiedName, consumeAttributeFlags(block));
 
     if (!block.atEnd())
         return nullptr;

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -47,7 +47,6 @@ class StyleRule;
 
 struct CSSSelectorParserContext {
     CSSParserMode mode { CSSParserMode::HTMLStandardMode };
-    bool isHTMLDocument { false };
     bool cssNestingEnabled { false };
     bool focusVisibleEnabled { false };
     bool hasPseudoClassEnabled { false };

--- a/Source/WebCore/dom/Attribute.h
+++ b/Source/WebCore/dom/Attribute.h
@@ -48,6 +48,7 @@ public:
     static ptrdiff_t valueMemoryOffset() { return OBJECT_OFFSETOF(Attribute, m_value); }
     const AtomString& prefix() const { return m_name.prefix(); }
     const AtomString& localName() const { return m_name.localName(); }
+    const AtomString& localNameLowercase() const { return m_name.localNameLowercase(); }
     const AtomString& namespaceURI() const { return m_name.namespaceURI(); }
 
     const QualifiedName& name() const { return m_name; }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -332,7 +332,7 @@ bool Element::isNonceable() const
         static constexpr auto styleString = "<style"_s;
 
         for (const auto& attribute : attributesIterator()) {
-            auto name = attribute.localName().convertToASCIILowercase();
+            auto name = attribute.localNameLowercase();
             auto value = attribute.value().convertToASCIILowercase();
             if (name.contains(scriptString)
                 || name.contains(styleString)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -281,6 +281,8 @@ public:
     const AtomString& prefix() const final { return m_tagName.prefix(); }
     const AtomString& namespaceURI() const final { return m_tagName.namespaceURI(); }
 
+    const AtomString& localNameLowercase() const { return m_tagName.localNameLowercase(); }
+
     ElementName elementName() const { return m_tagName.elementName(); }
     Namespace nodeNamespace() const { return m_tagName.nodeNamespace(); }
 

--- a/Source/WebCore/dom/QualifiedName.cpp
+++ b/Source/WebCore/dom/QualifiedName.cpp
@@ -81,7 +81,7 @@ const QualifiedName& nullQName()
     return nullName;
 }
 
-const AtomString& QualifiedName::localNameUpper() const
+const AtomString& QualifiedName::localNameUppercase() const
 {
     if (!m_impl->m_localNameUpper)
         m_impl->m_localNameUpper = m_impl->m_localName.convertToASCIIUppercase();

--- a/Source/WebCore/dom/QualifiedName.h
+++ b/Source/WebCore/dom/QualifiedName.h
@@ -66,6 +66,7 @@ public:
         const AtomString m_prefix;
         const AtomString m_localName;
         const AtomString m_namespaceURI;
+        AtomString m_localNameLower;
         mutable AtomString m_localNameUpper;
 
 #if ENABLE(JIT)
@@ -96,7 +97,8 @@ public:
     const AtomString& prefix() const { return m_impl->m_prefix; }
     const AtomString& localName() const { return m_impl->m_localName; }
     const AtomString& namespaceURI() const { return m_impl->m_namespaceURI; }
-    const AtomString& localNameUpper() const;
+    const AtomString& localNameLowercase() const { return m_impl->m_localNameLower; }
+    const AtomString& localNameUppercase() const;
 
     ElementName elementName() const { return m_impl->m_elementName; }
     Namespace nodeNamespace() const { return m_impl->m_namespace; }

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -115,7 +115,7 @@ String HTMLElement::nodeName() const
     // ASCII characters that does not have to copy the string on a hit in the hash.
     if (document().isHTMLDocument()) {
         if (LIKELY(!tagQName().hasPrefix()))
-            return tagQName().localNameUpper();
+            return tagQName().localNameUppercase();
         return Element::nodeName().convertToASCIIUppercase();
     }
     return Element::nodeName();

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -556,11 +556,8 @@ static MemoryCompactLookupOnlyRobinHoodHashMap<AtomString, QualifiedName> create
         SVGNames::zoomAndPanAttr,
     };
 
-    for (auto name : svgAttrs) {
-        const AtomString& localName = name.localName();
-        AtomString loweredLocalName = localName.convertToASCIILowercase();
-        map.add(loweredLocalName, name);
-    }
+    for (auto name : svgAttrs)
+        map.add(name.localNameLowercase(), name);
 
     return map;
 }

--- a/Source/WebCore/style/AttributeChangeInvalidation.cpp
+++ b/Source/WebCore/style/AttributeChangeInvalidation.cpp
@@ -35,7 +35,7 @@ namespace Style {
 
 static bool mayBeAffectedByAttributeChange(const RuleFeatureSet& features, bool isHTML, const QualifiedName& attributeName)
 {
-    auto& nameSet = isHTML ? features.attributeCanonicalLocalNamesInRules : features.attributeLocalNamesInRules;
+    auto& nameSet = isHTML ? features.attributeLowercaseLocalNamesInRules : features.attributeLocalNamesInRules;
     return nameSet.contains(attributeName.localName());
 }
 
@@ -44,12 +44,12 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
     if (newValue == oldValue)
         return;
 
-    bool isHTML = m_element.isHTMLElement();
+    bool isHTML = m_element.isHTMLElement() && m_element.document().isHTMLDocument();
 
     bool shouldInvalidateCurrent = false;
     bool mayAffectStyleInShadowTree = false;
 
-    auto attributeNameForLookups = attributeName.localName().convertToASCIILowercase();
+    auto attributeNameForLookups = attributeName.localNameLowercase();
 
     traverseRuleFeatures(m_element, [&] (const RuleFeatureSet& features, bool mayAffectShadowTree) {
         if (mayAffectShadowTree && mayBeAffectedByAttributeChange(features, isHTML, attributeName))

--- a/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
@@ -46,7 +46,7 @@ Vector<PseudoClassInvalidationKey, 4> makePseudoClassInvalidationKeys(CSSSelecto
             keys.append(makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Class, element.classNames()[i]));
     }
 
-    keys.append(makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Tag, element.localName().convertToASCIILowercase()));
+    keys.append(makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Tag, element.localNameLowercase()));
     keys.append(makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Universal));
 
     return keys;

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -229,10 +229,8 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
         } else if (selector->match() == CSSSelector::Class)
             selectorFeatures.classes.append({ selector, matchElement, isNegation });
         else if (selector->isAttributeSelector()) {
-            auto& canonicalLocalName = selector->attributeCanonicalLocalName();
-            auto& localName = selector->attribute().localName();
-            attributeCanonicalLocalNamesInRules.add(canonicalLocalName);
-            attributeLocalNamesInRules.add(localName);
+            attributeLowercaseLocalNamesInRules.add(selector->attribute().localNameLowercase());
+            attributeLocalNamesInRules.add(selector->attribute().localName());
             selectorFeatures.attributes.append({ selector, matchElement, isNegation });
         } else if (selector->match() == CSSSelector::PseudoElement) {
             switch (selector->pseudoElementType()) {
@@ -349,11 +347,11 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData)
 
     for (auto& entry : selectorFeatures.attributes) {
         auto& [selector, matchElement, isNegation] = entry;
-        attributeRules.ensure(selector->attribute().localName().convertToASCIILowercase(), [] {
+        attributeRules.ensure(selector->attribute().localNameLowercase(), [] {
             return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();
         }).iterator->value->append({ ruleData, matchElement, isNegation, selector });
         if (matchElement == MatchElement::Host)
-            attributesAffectingHost.add(selector->attribute().localName().convertToASCIILowercase());
+            attributesAffectingHost.add(selector->attribute().localNameLowercase());
         setUsesMatchElement(matchElement);
     }
 
@@ -385,7 +383,7 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
 {
     idsInRules.add(other.idsInRules.begin(), other.idsInRules.end());
     idsMatchingAncestorsInRules.add(other.idsMatchingAncestorsInRules.begin(), other.idsMatchingAncestorsInRules.end());
-    attributeCanonicalLocalNamesInRules.add(other.attributeCanonicalLocalNamesInRules.begin(), other.attributeCanonicalLocalNamesInRules.end());
+    attributeLowercaseLocalNamesInRules.add(other.attributeLowercaseLocalNamesInRules.begin(), other.attributeLowercaseLocalNamesInRules.end());
     attributeLocalNamesInRules.add(other.attributeLocalNamesInRules.begin(), other.attributeLocalNamesInRules.end());
     contentAttributeNamesInRules.add(other.contentAttributeNamesInRules.begin(), other.contentAttributeNamesInRules.end());
     siblingRules.appendVector(other.siblingRules);
@@ -423,7 +421,7 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
 void RuleFeatureSet::registerContentAttribute(const AtomString& attributeName)
 {
     contentAttributeNamesInRules.add(attributeName.convertToASCIILowercase());
-    attributeCanonicalLocalNamesInRules.add(attributeName);
+    attributeLowercaseLocalNamesInRules.add(attributeName);
     attributeLocalNamesInRules.add(attributeName);
 }
 
@@ -431,7 +429,7 @@ void RuleFeatureSet::clear()
 {
     idsInRules.clear();
     idsMatchingAncestorsInRules.clear();
-    attributeCanonicalLocalNamesInRules.clear();
+    attributeLowercaseLocalNamesInRules.clear();
     attributeLocalNamesInRules.clear();
     contentAttributeNamesInRules.clear();
     siblingRules.clear();

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -101,7 +101,7 @@ struct RuleFeatureSet {
 
     HashSet<AtomString> idsInRules;
     HashSet<AtomString> idsMatchingAncestorsInRules;
-    HashSet<AtomString> attributeCanonicalLocalNamesInRules;
+    HashSet<AtomString> attributeLowercaseLocalNamesInRules;
     HashSet<AtomString> attributeLocalNamesInRules;
     HashSet<AtomString> contentAttributeNamesInRules;
     Vector<RuleAndSelector> siblingRules;

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -91,7 +91,7 @@ static bool isHostSelectorMatchingInShadowTree(const CSSSelector& startSelector)
 static bool shouldHaveBucketForAttributeName(const CSSSelector& attributeSelector)
 {
     // Don't make buckets for lazy attributes since we don't want to synchronize.
-    if (attributeSelector.attributeCanonicalLocalName() == HTMLNames::styleAttr->localName())
+    if (attributeSelector.attribute().localNameLowercase() == HTMLNames::styleAttr->localName())
         return false;
     if (SVGElement::animatableAttributeForName(attributeSelector.attribute().localName()) != nullQName())
         return false;
@@ -279,7 +279,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
 
     if (attributeSelector) {
         addToRuleSet(attributeSelector->attribute().localName(), m_attributeLocalNameRules, ruleData);
-        addToRuleSet(attributeSelector->attributeCanonicalLocalName(), m_attributeCanonicalLocalNameRules, ruleData);
+        addToRuleSet(attributeSelector->attribute().localNameLowercase(), m_attributeLowercaseLocalNameRules, ruleData);
         return;
     }
 
@@ -324,7 +324,7 @@ void RuleSet::traverseRuleDatas(Function&& function)
     traverseMap(m_idRules);
     traverseMap(m_classRules);
     traverseMap(m_attributeLocalNameRules);
-    traverseMap(m_attributeCanonicalLocalNameRules);
+    traverseMap(m_attributeLowercaseLocalNameRules);
     traverseMap(m_tagLocalNameRules);
     traverseMap(m_tagLowercaseLocalNameRules);
     traverseMap(m_shadowPseudoElementRules);
@@ -418,7 +418,7 @@ void RuleSet::shrinkToFit()
     shrinkMapVectorsToFit(m_idRules);
     shrinkMapVectorsToFit(m_classRules);
     shrinkMapVectorsToFit(m_attributeLocalNameRules);
-    shrinkMapVectorsToFit(m_attributeCanonicalLocalNameRules);
+    shrinkMapVectorsToFit(m_attributeLowercaseLocalNameRules);
     shrinkMapVectorsToFit(m_tagLocalNameRules);
     shrinkMapVectorsToFit(m_tagLowercaseLocalNameRules);
     shrinkMapVectorsToFit(m_shadowPseudoElementRules);

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -174,7 +174,7 @@ private:
     AtomRuleMap m_idRules;
     AtomRuleMap m_classRules;
     AtomRuleMap m_attributeLocalNameRules;
-    AtomRuleMap m_attributeCanonicalLocalNameRules;
+    AtomRuleMap m_attributeLowercaseLocalNameRules;
     AtomRuleMap m_tagLocalNameRules;
     AtomRuleMap m_tagLowercaseLocalNameRules;
     AtomRuleMap m_shadowPseudoElementRules;
@@ -208,7 +208,7 @@ private:
 
 inline const RuleSet::RuleDataVector* RuleSet::attributeRules(const AtomString& key, bool isHTMLName) const
 {
-    auto& rules = isHTMLName ? m_attributeCanonicalLocalNameRules : m_attributeLocalNameRules;
+    auto& rules = isHTMLName ? m_attributeLowercaseLocalNameRules : m_attributeLocalNameRules;
     return rules.get(key);
 }
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -672,6 +672,20 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
         m_matchedDeclarationsCache.add(style, parentStyle, state.userAgentAppearanceStyle(), cacheHash, matchResult);
 }
 
+bool Resolver::hasSelectorForAttribute(const Element& element, const AtomString& attributeName) const
+{
+    ASSERT(!attributeName.isEmpty());
+    if (element.isHTMLElement() && element.document().isHTMLDocument())
+        return m_ruleSets.features().attributeLowercaseLocalNamesInRules.contains(attributeName);
+    return m_ruleSets.features().attributeLocalNamesInRules.contains(attributeName);
+}
+
+bool Resolver::hasSelectorForId(const AtomString& idValue) const
+{
+    ASSERT(!idValue.isEmpty());
+    return m_ruleSets.features().idsInRules.contains(idValue);
+}
+
 bool Resolver::hasViewportDependentMediaQueries() const
 {
     return m_ruleSets.hasViewportDependentMediaQueries();

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -182,19 +182,5 @@ private:
     bool m_isSharedBetweenShadowTrees { false };
 };
 
-inline bool Resolver::hasSelectorForAttribute(const Element& element, const AtomString &attributeName) const
-{
-    ASSERT(!attributeName.isEmpty());
-    if (element.isHTMLElement())
-        return m_ruleSets.features().attributeCanonicalLocalNamesInRules.contains(attributeName);
-    return m_ruleSets.features().attributeLocalNamesInRules.contains(attributeName);
-}
-
-inline bool Resolver::hasSelectorForId(const AtomString& idValue) const
-{
-    ASSERT(!idValue.isEmpty());
-    return m_ruleSets.features().idsInRules.contains(idValue);
-}
-
 } // namespace Style
 } // namespace WebCore


### PR DESCRIPTION
#### e154df3cee52425f8b218d270d812ee0af5fc06c
<pre>
Cache lowercase version of the localName in QualifiedName
<a href="https://bugs.webkit.org/show_bug.cgi?id=255123">https://bugs.webkit.org/show_bug.cgi?id=255123</a>
rdar://problem/107757119

Reviewed by Ryosuke Niwa and Chris Dumez.

This allows significant simplification of CSSSelector and some other things.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::CSSSelector):
(WebCore::CSSSelector::createRareData):
(WebCore::CSSSelector::setAttribute):
(WebCore::CSSSelector::RareData::RareData):

No need to save the lowercase version of the attribute in the rare data anymore.
This shrinks and simplifies the type.

* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::~CSSSelector):
(WebCore::CSSSelector::tagQName const):
(WebCore::CSSSelector::tagLowercaseLocalName const):
(WebCore::CSSSelector::NameWithCase::NameWithCase): Deleted.
(WebCore::CSSSelector::attributeCanonicalLocalName const): Deleted.
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::anyAttributeMatches):
(WebCore::SelectorChecker::attributeSelectorMatches):

Use lowercase versions for HTML elements in a HTML document.

* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectElementIdentifierHashes):
(WebCore::SelectorFilter::collectSimpleSelectorHash):
(WebCore::localNameIsKnownToBeLowercase): Deleted.
* Source/WebCore/css/parser/CSSParserSelector.h:
(WebCore::CSSParserSelector::setAttribute):

We now pick whether to use lowercase or original version of the localName during selector matching,
similar to how tags are handled. This means selector parsing no longer depends on knowing if the document
is HTML or not.

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::CSSSelectorParserContext::operator== const):
(WebCore::add):
(WebCore::CSSSelectorParser::consumeAttribute):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::canMatchStyleAttribute):
(WebCore::SelectorCompiler::canMatchAnimatableSVGAttribute):
(WebCore::SelectorCompiler::testIsHTMLClassOnDocument):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementAndDocumentIsHTML):

Use lowercase versions for HTML elements in a HTML document.
Share code generation between tag and attribute matching. These are now handled the same way.

(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementAttributeMatching):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementAttributeValueExactMatching):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementHasTagName):
* Source/WebCore/dom/Attribute.h:
(WebCore::Attribute::localNameLowercase const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isNonceable const):
* Source/WebCore/dom/Element.h:
(WebCore::Element::localNameLowercase const):
* Source/WebCore/dom/QualifiedName.cpp:
(WebCore::QualifiedName::QualifiedNameImpl::QualifiedNameImpl):
* Source/WebCore/dom/QualifiedName.h:
* Source/WebCore/dom/QualifiedNameCache.cpp:
(WebCore::updateImplWithNamespaceAndElementName):
(WebCore::QualifiedNameCache::getOrCreate):

Cache the lowercase localName. HTML names are always lowercase.

(WebCore::QualifiedName::localNameUppercase const):
(WebCore::QualifiedName::localNameUpper const): Deleted.
* Source/WebCore/dom/QualifiedName.h:
(WebCore::QualifiedName::localNameLowercase const):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::nodeName const):
* Source/WebCore/style/AttributeChangeInvalidation.cpp:
(WebCore::Style::mayBeAffectedByAttributeChange):
(WebCore::Style::AttributeChangeInvalidation::invalidateStyle):
* Source/WebCore/style/PseudoClassChangeInvalidation.cpp:
(WebCore::Style::makePseudoClassInvalidationKeys):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):
(WebCore::Style::RuleFeatureSet::add):
(WebCore::Style::RuleFeatureSet::registerContentAttribute):
(WebCore::Style::RuleFeatureSet::clear):
* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::shouldHaveBucketForAttributeName):
(WebCore::Style::RuleSet::addRule):
(WebCore::Style::RuleSet::traverseRuleDatas):
(WebCore::Style::RuleSet::shrinkToFit):
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::attributeRules const):

Replace &quot;canonical&quot; with &quot;lowercase&quot; similar to the tag case. Which name is used is decided at matching time.

* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::hasSelectorForAttribute const):
(WebCore::Style::Resolver::hasSelectorForId const):
* Source/WebCore/style/StyleResolver.h:
(WebCore::Style::Resolver::hasSelectorForAttribute const): Deleted.
(WebCore::Style::Resolver::hasSelectorForId const): Deleted.

Canonical link: <a href="https://commits.webkit.org/262722@main">https://commits.webkit.org/262722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75cf53b59bef97303ef8a37049ac01e30e4c5235

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3418 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2126 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3242 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/107 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Uploaded test results; layout-tests (failure); Compiled WebKit (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2115 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1991 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 55 flakes 174 failures; Uploaded test results; 14 flakes 151 failures; Compiled WebKit (cancelled)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2198 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3315 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2163 "Passed tests") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/598 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->