### PR TITLE
REGRESSION(259818@main...259759@main?): CSS variables are not applied to the SVG use element's shadow tree

### DIFF
--- a/LayoutTests/http/tests/svg/resources/st-search.svg
+++ b/LayoutTests/http/tests/svg/resources/st-search.svg
@@ -1,0 +1,6 @@
+<svg id="icon-import" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+        d="M15 14.899C16.2372 13.6364 17 11.9073 17 10C17 6.13401 13.866 3 10 3C6.13401 3 3 6.13401 3 10C3 13.866 6.13401 17 10 17C11.9587 17 13.7295 16.1955 15 14.899ZM15 14.899L19.5 19.5"
+        stroke="var(--stroke-color, black)" stroke-width="var(--stroke-width, 1.5)"
+        vector-effect="non-scaling-stroke" stroke-linecap="square" />
+</svg>

--- a/LayoutTests/http/tests/svg/use-custom-property-inheritance-expected.html
+++ b/LayoutTests/http/tests/svg/use-custom-property-inheritance-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <style>
+        body {
+          --stroke-color: red;
+        }
+        svg {
+          border: 1px solid black;
+          width: 50px;
+          height: 50px;
+        }
+    </style>
+  </head>
+  <body>
+    <div>
+        <svg id="icon-import" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M15 14.899C16.2372 13.6364 17 11.9073 17 10C17 6.13401 13.866 3 10 3C6.13401 3 3 6.13401 3 10C3 13.866 6.13401 17 10 17C11.9587 17 13.7295 16.1955 15 14.899ZM15 14.899L19.5 19.5"
+                stroke="var(--stroke-color, black)" stroke-width="var(--stroke-width, 1.5)"
+                vector-effect="non-scaling-stroke" stroke-linecap="square" />
+        </svg>
+    </div>
+  </body>
+</html>
+

--- a/LayoutTests/http/tests/svg/use-custom-property-inheritance.html
+++ b/LayoutTests/http/tests/svg/use-custom-property-inheritance.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <style>
+        body {
+          --stroke-color: red;
+        }
+        svg {
+          border: 1px solid black;
+          width: 50px;
+          height: 50px;
+        }
+    </style>
+  </head>
+  <body>
+    <div>
+      <svg>
+        <use href="resources/st-search.svg#icon-import" />
+      </svg>
+    </div>
+  </body>
+</html>

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -244,7 +244,7 @@ ResolvedStyle Resolver::styleForElement(const Element& element, const Resolution
 
     if (state.parentStyle()) {
         state.setStyle(RenderStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry()));
-        if (&element == document().documentElement()) {
+        if (&element == document().documentElement() && !context.isSVGUseTreeRoot) {
             // Initial values for custom properties are inserted to the document element style. Don't overwrite them.
             state.style()->inheritIgnoringCustomPropertiesFrom(*state.parentStyle());
         } else

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -82,6 +82,7 @@ struct ResolutionContext {
     // This needs to be provided during style resolution when up-to-date document element style is not available via DOM.
     const RenderStyle* documentElementStyle { nullptr };
     SelectorMatchingState* selectorMatchingState { nullptr };
+    bool isSVGUseTreeRoot { false };
 };
 
 class Resolver : public RefCounted<Resolver> {

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -711,6 +711,7 @@ std::optional<Style::ResolvedStyle> SVGElement::resolveCustomStyle(const Style::
         auto styleElementResolutionContext = resolutionContext;
         // Can't use the state since we are going to another part of the tree.
         styleElementResolutionContext.selectorMatchingState = nullptr;
+        styleElementResolutionContext.isSVGUseTreeRoot = true;
         auto resolvedStyle = styleElement->resolveStyle(styleElementResolutionContext);
         Style::Adjuster::adjustSVGElementStyle(*resolvedStyle.style, *this);
         return resolvedStyle;


### PR DESCRIPTION
#### abf098f7f5b062eb6853824155c2c6d3711e0996
<pre>
REGRESSION(259818@main...259759@main?): CSS variables are not applied to the SVG use element&apos;s shadow tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=254549">https://bugs.webkit.org/show_bug.cgi?id=254549</a>
rdar://107295588

Reviewed by Ryosuke Niwa.

We fail to inherit custom properties to &lt;use&gt; element shadow tree in the specific case where
the targeted element is the root element of an external SVG document.

* LayoutTests/http/tests/svg/resources/st-search.svg: Added.
* LayoutTests/http/tests/svg/use-custom-property-inheritance-expected.html: Added.
* LayoutTests/http/tests/svg/use-custom-property-inheritance.html: Added.
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForElement):

Don&apos;t suppress property inheritance for the document element in the case we are resolving a &lt;use&gt; tree root.

* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::resolveCustomStyle):

Canonical link: <a href="https://commits.webkit.org/262698@main">https://commits.webkit.org/262698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d977ed7d505bcc4e212f830b6b1962921272b9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2298 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/2314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3236 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2068 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2319 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/2027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3099 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1929 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2129 "Built successfully") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3239 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2100 "Passed tests") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2058 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/573 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2229 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->