### PR TITLE
[JSC] Make StructureTransitionTable link half-weak

### DIFF
--- a/JSTests/microbenchmarks/object-assign-multiple.js
+++ b/JSTests/microbenchmarks/object-assign-multiple.js
@@ -1,0 +1,33 @@
+function extend1(source) {
+    source.checked = 22;
+    source.onChanged = 44;
+}
+
+function test() {
+    var target = {
+        type: 42,
+        step: 31,
+        min: 33,
+        max: 42,
+    };
+
+    var source1 = {
+        className: "string",
+        type: 41,
+    };
+    extend1(source1);
+
+    var source2 = {
+        defaultChecked: 44,
+        defaultValue: 22,
+        value: 33,
+        checked: 44,
+        onChange: 55
+    };
+
+    return Object.assign(target, source1, source2);
+}
+
+
+for (var i = 0; i < 1e6; ++i)
+    test();

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -262,7 +262,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
     return functionExecutable;
 }
 
-void BuiltinExecutables::finalizeUnconditionally()
+void BuiltinExecutables::finalizeUnconditionally(CollectionScope)
 {
     for (auto*& unlinkedExecutable : m_unlinkedExecutables) {
         if (unlinkedExecutable && !m_vm.heap.isMarked(unlinkedExecutable))

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.h
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.h
@@ -62,7 +62,7 @@ SourceCode name##Source();
 
     static UnlinkedFunctionExecutable* createExecutable(VM&, const SourceCode&, const Identifier&, ImplementationVisibility, ConstructorKind, ConstructAbility, NeedsClassFieldInitializer, PrivateBrandRequirement = PrivateBrandRequirement::None);
 
-    void finalizeUnconditionally();
+    void finalizeUnconditionally(CollectionScope);
 
 private:
     VM& m_vm;

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -1617,7 +1617,7 @@ void CodeBlock::finalizeJITInlineCaches()
 }
 #endif
 
-void CodeBlock::finalizeUnconditionally(VM& vm)
+void CodeBlock::finalizeUnconditionally(VM& vm, CollectionScope)
 {
     UNUSED_PARAM(vm);
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -203,7 +203,7 @@ public:
 
     static size_t estimatedSize(JSCell*, VM&);
     static void destroy(JSCell*);
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
 
     void notifyLexicalBindingUpdate();
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -296,7 +296,7 @@ void UnlinkedFunctionExecutable::setInvalidTypeProfilingOffsets()
     m_typeProfilingEndOffset = std::numeric_limits<unsigned>::max();
 }
 
-void UnlinkedFunctionExecutable::finalizeUnconditionally(VM& vm)
+void UnlinkedFunctionExecutable::finalizeUnconditionally(VM& vm, CollectionScope)
 {
     if (codeBlockEdgeMayBeWeak()) {
         bool isCleared = false;

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -215,7 +215,7 @@ public:
         ensureRareData().m_sourceMappingURLDirective = sourceMappingURL;
     }
 
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
 
     struct RareData {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -693,7 +693,7 @@ private:
     void harvestWeakReferences();
 
     template<typename CellType, typename CellSet>
-    void finalizeMarkedUnconditionalFinalizers(CellSet&);
+    void finalizeMarkedUnconditionalFinalizers(CellSet&, CollectionScope);
 
     void finalizeUnconditionalFinalizers();
 

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -60,6 +60,8 @@ public:
         return JSValue::decode(slotFor(i));
     }
 
+    const EncodedJSValue* data() const { return m_buffer; }
+
     void clear()
     {
         ASSERT(!m_needsOverflowCheck);

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -206,7 +206,7 @@ String ErrorInstance::sanitizedToString(JSGlobalObject* globalObject)
     return makeString(nameString, nameString.isEmpty() || messageString.isEmpty() ? ""_s : ": "_s, messageString);
 }
 
-void ErrorInstance::finalizeUnconditionally(VM& vm)
+void ErrorInstance::finalizeUnconditionally(VM& vm, CollectionScope)
 {
     if (!m_stackTrace)
         return;

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -95,7 +95,7 @@ public:
     bool materializeErrorInfoIfNeeded(VM&);
     bool materializeErrorInfoIfNeeded(VM&, PropertyName);
 
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
 
 protected:
     explicit ErrorInstance(VM&, Structure*, ErrorType);

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.h
@@ -278,7 +278,7 @@ public:
 
     TemplateObjectMap& ensureTemplateObjectMap(VM&);
 
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
 
     JSString* toString(JSGlobalObject*);
     JSString* asStringConcurrently() const

--- a/Source/JavaScriptCore/runtime/FunctionExecutableInlines.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutableInlines.h
@@ -31,9 +31,9 @@
 
 namespace JSC {
 
-inline void FunctionExecutable::finalizeUnconditionally(VM& vm)
+inline void FunctionExecutable::finalizeUnconditionally(VM& vm, CollectionScope collectionScope)
 {
-    m_singleton.finalizeUnconditionally(vm);
+    m_singleton.finalizeUnconditionally(vm, collectionScope);
     finalizeCodeBlockEdge(vm, m_codeBlockForCall);
     finalizeCodeBlockEdge(vm, m_codeBlockForConstruct);
     vm.heap.functionExecutableSpaceAndSet.outputConstraintsSet.remove(this);

--- a/Source/JavaScriptCore/runtime/GlobalExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/GlobalExecutable.cpp
@@ -77,7 +77,7 @@ CodeBlock* GlobalExecutable::replaceCodeBlockWith(VM& vm, CodeBlock* newCodeBloc
     return oldCodeBlock;
 }
 
-void GlobalExecutable::finalizeUnconditionally(VM& vm)
+void GlobalExecutable::finalizeUnconditionally(VM& vm, CollectionScope)
 {
     finalizeCodeBlockEdge(vm, m_codeBlock);
     Heap::ScriptExecutableSpaceAndSets::outputConstraintsSetFor(*subspace()).remove(this);

--- a/Source/JavaScriptCore/runtime/GlobalExecutable.h
+++ b/Source/JavaScriptCore/runtime/GlobalExecutable.h
@@ -50,7 +50,7 @@ public:
     DECLARE_VISIT_CHILDREN;
     DECLARE_VISIT_OUTPUT_CONSTRAINTS;
 
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
 
 protected:
     friend class ScriptExecutable;

--- a/Source/JavaScriptCore/runtime/InferredValue.h
+++ b/Source/JavaScriptCore/runtime/InferredValue.h
@@ -123,7 +123,7 @@ public:
         notifyWriteSlow(vm, owner, value, reason);
     }
     
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
 
 private:
     class InferredValueWatchpointSet final : public WatchpointSet {

--- a/Source/JavaScriptCore/runtime/InferredValueInlines.h
+++ b/Source/JavaScriptCore/runtime/InferredValueInlines.h
@@ -30,7 +30,7 @@
 namespace JSC {
 
 template<typename JSCellType>
-void InferredValue<JSCellType>::finalizeUnconditionally(VM& vm)
+void InferredValue<JSCellType>::finalizeUnconditionally(VM& vm, CollectionScope)
 {
     JSCellType* value = inferredValue();
 

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
@@ -97,7 +97,7 @@ void JSFinalizationRegistry::destroy(JSCell* table)
     static_cast<JSFinalizationRegistry*>(table)->~JSFinalizationRegistry();
 }
 
-void JSFinalizationRegistry::finalizeUnconditionally(VM& vm)
+void JSFinalizationRegistry::finalizeUnconditionally(VM& vm, CollectionScope)
 {
     Locker locker { cellLock() };
 

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
@@ -69,7 +69,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
     DECLARE_VISIT_CHILDREN;
     static void destroy(JSCell*);
     static constexpr bool needsDestruction = true;

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -816,6 +816,8 @@ public:
     // This is used by JSLexicalEnvironment.
     bool putOwnDataProperty(VM&, PropertyName, JSValue, PutPropertySlot&);
     bool putOwnDataPropertyMayBeIndex(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+
+    void putOwnDataPropertyBatching(VM&, const RefPtr<UniquedStringImpl>*, const EncodedJSValue*, unsigned size);
 private:
     void validatePutOwnDataProperty(VM&, PropertyName, JSValue);
 public:

--- a/Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp
+++ b/Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp
@@ -54,7 +54,7 @@ void JSWeakObjectRef::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 DEFINE_VISIT_CHILDREN(JSWeakObjectRef);
 
-void JSWeakObjectRef::finalizeUnconditionally(VM& vm)
+void JSWeakObjectRef::finalizeUnconditionally(VM& vm, CollectionScope)
 {
     if (m_value && !vm.heap.isMarked(m_value.get()))
         m_value.clear();

--- a/Source/JavaScriptCore/runtime/JSWeakObjectRef.h
+++ b/Source/JavaScriptCore/runtime/JSWeakObjectRef.h
@@ -64,7 +64,7 @@ public:
         return vm.weakObjectRefSpace<mode>();
     }
 
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
     DECLARE_VISIT_CHILDREN;
 
 private:

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -63,12 +63,7 @@ ALWAYS_INLINE bool objectAssignFast(VM& vm, JSObject* target, JSObject* source, 
     if (!canUseFastPath)
         return false;
 
-    for (size_t i = 0; i < properties.size(); ++i) {
-        // FIXME: We could put properties in a batching manner to accelerate Object.assign more.
-        // https://bugs.webkit.org/show_bug.cgi?id=185358
-        PutPropertySlot putPropertySlot(target, true);
-        target->putOwnDataProperty(vm, properties[i].get(), values.at(i), putPropertySlot);
-    }
+    target->putOwnDataPropertyBatching(vm, properties.data(), values.data(), properties.size());
     return true;
 }
 

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -35,6 +35,7 @@
 #include "Structure.h"
 #include "StructureChain.h"
 #include "StructureRareDataInlines.h"
+#include "SuperSampler.h"
 #include "Watchpoint.h"
 #include <wtf/CompactRefPtr.h>
 #include <wtf/Threading.h>
@@ -711,10 +712,16 @@ inline Structure* Structure::addPropertyTransitionToExistingStructureImpl(Struct
     if (structure->hasBeenDictionary())
         return nullptr;
 
-    if (Structure* existingTransition = structure->m_transitionTable.get(uid, attributes, TransitionKind::PropertyAddition)) {
-        validateOffset(existingTransition->transitionOffset(), existingTransition->inlineCapacity());
-        offset = existingTransition->transitionOffset();
-        return existingTransition;
+    Structure* existingTransition = nullptr;
+    {
+        {
+            existingTransition = structure->m_transitionTable.get(uid, attributes, TransitionKind::PropertyAddition);
+        }
+        if (existingTransition) {
+            validateOffset(existingTransition->transitionOffset(), existingTransition->inlineCapacity());
+            offset = existingTransition->transitionOffset();
+            return existingTransition;
+        }
     }
 
     return nullptr;
@@ -732,23 +739,30 @@ ALWAYS_INLINE Structure* Structure::addPropertyTransitionToExistingStructureConc
     return addPropertyTransitionToExistingStructureImpl(structure, uid, attributes, offset);
 }
 
-inline Structure* StructureTransitionTable::singleTransition() const
+inline Structure* StructureTransitionTable::trySingleTransition() const
 {
-    ASSERT(isUsingSingleSlot());
-    if (WeakImpl* impl = this->weakImpl()) {
-        if (impl->state() == WeakImpl::Live)
-            return jsCast<Structure*>(impl->jsValue().asCell());
-    }
+    uintptr_t pointer = m_data;
+    if (pointer & UsingSingleSlotFlag)
+        return bitwise_cast<Structure*>(pointer & ~UsingSingleSlotFlag);
     return nullptr;
 }
 
 inline Structure* StructureTransitionTable::get(UniquedStringImpl* rep, unsigned attributes, TransitionKind transitionKind) const
 {
     if (isUsingSingleSlot()) {
-        Structure* transition = singleTransition();
+        auto* transition = trySingleTransition();
         return (transition && transition->m_transitionPropertyName == rep && transition->transitionPropertyAttributes() == attributes && transition->transitionKind() == transitionKind) ? transition : nullptr;
     }
     return map()->get(StructureTransitionTable::Hash::Key(rep, attributes, transitionKind));
+}
+
+inline void StructureTransitionTable::finalizeUnconditionally(VM& vm, CollectionScope)
+{
+    if (isUsingSingleSlot()) {
+        auto* transition = trySingleTransition();
+        if (transition && !vm.heap.isMarked(transition))
+            m_data = UsingSingleSlotFlag;
+    }
 }
 
 inline void Structure::clearCachedPrototypeChain()

--- a/Source/JavaScriptCore/runtime/StructureRareData.cpp
+++ b/Source/JavaScriptCore/runtime/StructureRareData.cpp
@@ -225,7 +225,7 @@ void StructureRareData::clearCachedSpecialProperty(CachedSpecialPropertyKey key)
         cache.m_value.clear();
 }
 
-void StructureRareData::finalizeUnconditionally(VM& vm)
+void StructureRareData::finalizeUnconditionally(VM& vm, CollectionScope)
 {
     if (m_specialPropertyCache) {
         auto clearCacheIfInvalidated = [&](CachedSpecialPropertyKey key) {

--- a/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -123,7 +123,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
 
     static constexpr uintptr_t cachedPropertyNameEnumeratorIsValidatedViaTraversingFlag = 1;
     static constexpr uintptr_t cachedPropertyNameEnumeratorMask = ~static_cast<uintptr_t>(1);

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -742,7 +742,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
     void dump(PrintStream&) const;
 
     struct SymbolTableRareData {

--- a/Source/JavaScriptCore/runtime/SymbolTableInlines.h
+++ b/Source/JavaScriptCore/runtime/SymbolTableInlines.h
@@ -30,9 +30,9 @@
 
 namespace JSC {
 
-inline void SymbolTable::finalizeUnconditionally(VM& vm)
+inline void SymbolTable::finalizeUnconditionally(VM& vm, CollectionScope collectionScope)
 {
-    m_singleton.finalizeUnconditionally(vm);
+    m_singleton.finalizeUnconditionally(vm, collectionScope);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.h
@@ -287,7 +287,7 @@ public:
     }
 
     template<typename Visitor> static void visitOutputConstraints(JSCell*, Visitor&);
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
 
 private:
     template<typename Visitor>

--- a/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
@@ -72,7 +72,7 @@ ALWAYS_INLINE void WeakMapImpl<WeakMapBucket>::add(VM& vm, JSCell* key, JSValue 
 
 // Note that this function can be executed in parallel as long as the mutator stops.
 template<typename WeakMapBucket>
-void WeakMapImpl<WeakMapBucket>::finalizeUnconditionally(VM& vm)
+void WeakMapImpl<WeakMapBucket>::finalizeUnconditionally(VM& vm, CollectionScope)
 {
     auto* buffer = this->buffer();
     for (uint32_t index = 0; index < m_capacity; ++index) {

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
@@ -141,7 +141,7 @@ void JSWebAssemblyModule::clearJSCallICs(VM& vm)
         callLinkInfo.unlink(vm);
 }
 
-void JSWebAssemblyModule::finalizeUnconditionally(VM& vm)
+void JSWebAssemblyModule::finalizeUnconditionally(VM& vm, CollectionScope)
 {
     for (auto& callLinkInfo : m_callLinkInfos)
         callLinkInfo.visitWeak(vm);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
@@ -75,7 +75,7 @@ public:
     CodePtr<WasmEntryPtrTag> importFunctionStub(size_t importFunctionNum) { return m_wasmToJSExitStubs[importFunctionNum].code(); }
 
     void clearJSCallICs(VM&);
-    void finalizeUnconditionally(VM&);
+    void finalizeUnconditionally(VM&, CollectionScope);
 
     JS_EXPORT_PRIVATE Wasm::Module& module();
 


### PR DESCRIPTION
#### e5a9344fbb6d6e72bf8250e8215b50da8528ffe5
<pre>
[JSC] Make StructureTransitionTable link half-weak
<a href="https://bugs.webkit.org/show_bug.cgi?id=255137">https://bugs.webkit.org/show_bug.cgi?id=255137</a>
rdar://107739562

Reviewed by Mark Lam.

This patch optimizes Object.assign by doing two things.

1. Add putOwnDataPropertyBatching. We batch the property additions by just tracing structure transitions.
   This offers a chance to remove unnecessary intermediate butterfly allocations.
2. We found that now the hottest code in Object.assign is Structure transition itself. This patch optimizes
   this by rearchitect structure transition table mechanism. Previously we were having Weak&lt;Structure&gt; for
   single transition. But this is (1) too costly, Weak is generic and not so efficient abstraction. Every
   access to this field becomes double-pointer loading. And (2) too aggressive. Most of Structure lives for
   a long time while instances die quickly. We should allow keeping this structure chain alive at least during
   Eden collections. To make both work, this patch changes this link &quot;half-weak&quot;. During Eden collection, we
   always mark it. But in full collection, we ignore this link, and GC End phase clears it if this Structure
   is collected. This way allows us to have good balance of Structure book-keeping, plain simple field access
   for structure transition, and not doing GC End phase clearing for Structures in each Eden GC.

Object.assign gets 30% better.
                                         ToT                     Patched

    object-assign-multiple        134.7853+-0.4586     ^    103.1172+-0.1968        ^ definitely 1.3071x faster

* JSTests/microbenchmarks/object-assign-multiple.js: Added.
(extend1):
(test):
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::finalizeUnconditionally):
* Source/JavaScriptCore/builtins/BuiltinExecutables.h:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finalizeUnconditionally):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::UnlinkedFunctionExecutable::finalizeUnconditionally):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::finalizeMarkedUnconditionalFinalizers):
(JSC::Heap::finalizeUnconditionalFinalizers):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/ArgList.h:
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/ErrorInstance.h:
* Source/JavaScriptCore/runtime/FunctionExecutable.h:
* Source/JavaScriptCore/runtime/FunctionExecutableInlines.h:
(JSC::FunctionExecutable::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/GlobalExecutable.cpp:
(JSC::GlobalExecutable::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/GlobalExecutable.h:
* Source/JavaScriptCore/runtime/InferredValue.h:
* Source/JavaScriptCore/runtime/InferredValueInlines.h:
(JSC::InferredValue&lt;JSCellType&gt;::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp:
(JSC::JSFinalizationRegistry::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.h:
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::putOwnDataPropertyBatching):
* Source/JavaScriptCore/runtime/JSObject.h:
* Source/JavaScriptCore/runtime/JSWeakObjectRef.cpp:
(JSC::JSWeakObjectRef::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/JSWeakObjectRef.h:
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::objectAssignFast):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::StructureTransitionTable::setSingleTransition):
(JSC::StructureTransitionTable::contains const):
(JSC::StructureTransitionTable::add):
(JSC::Structure::addNewPropertyTransition):
(JSC::Structure::removeNewPropertyTransition):
(JSC::Structure::attributeChangeTransition):
(JSC::Structure::nonPropertyTransitionSlow):
(JSC::Structure::visitChildrenImpl):
(JSC::Structure::setBrandTransition):
(JSC::Structure::finalizeUnconditionally):
(): Deleted.
(JSC::singleSlotTransitionWeakOwner): Deleted.
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::shouldDoCacheableDictionaryTransitionForAdd):
(JSC::Structure::transitionCountEstimate const):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::addPropertyTransitionToExistingStructureImpl):
(JSC::StructureTransitionTable::trySingleTransition const):
(JSC::StructureTransitionTable::get const):
(JSC::StructureTransitionTable::finalizeUnconditionally):
(JSC::StructureTransitionTable::singleTransition const): Deleted.
* Source/JavaScriptCore/runtime/StructureRareData.cpp:
(JSC::StructureRareData::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/StructureRareData.h:
* Source/JavaScriptCore/runtime/StructureTransitionTable.h:
(JSC::StructureTransitionTable::~StructureTransitionTable):
(JSC::StructureTransitionTable::setMap):
(JSC::StructureTransitionTable::StructureTransitionTable): Deleted.
(JSC::StructureTransitionTable::weakImpl const): Deleted.
* Source/JavaScriptCore/runtime/SymbolTable.h:
* Source/JavaScriptCore/runtime/SymbolTableInlines.h:
(JSC::SymbolTable::finalizeUnconditionally):
* Source/JavaScriptCore/runtime/WeakMapImpl.h:
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::finalizeUnconditionally):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp:
(JSC::JSWebAssemblyModule::finalizeUnconditionally):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h:

Canonical link: <a href="https://commits.webkit.org/262809@main">https://commits.webkit.org/262809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bda6e735ac366c60c78079a5c52492d17f6e393

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4074 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3045 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2349 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3837 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2231 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2223 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2750 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3592 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2549 "Built successfully and passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2421 "Passed tests") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2744 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2373 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/642 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2410 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2803 "Built successfully") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/313 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2564 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/757 "Passed tests") | 
<!--EWS-Status-Bubble-End-->