### PR TITLE
Web Inspector: Console: timestamps cause objects to be shown on a separate line

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
@@ -311,8 +311,9 @@
 }
 
 .console-message .timestamp {
+    float: right;
+    margin-inline-start: 12px;
     color: var(--text-color-tertiary);
-    padding-inline-end: 5px;
 }
 
 .console-session:not(.timestamps-visible) .console-message .timestamp {

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -187,7 +187,7 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
         if (!this._timestampElement) {
             this._timestampElement = document.createElement("span");
             this._timestampElement.classList.add("timestamp");
-            this._messageBodyElement.insertBefore(this._timestampElement, this._messageBodyElement.firstChild);
+            this._element.insertBefore(this._timestampElement, this._element.firstChild);
         }
     
         let date = new Date(this._timestamp * 1000);


### PR DESCRIPTION
#### 2f8d67e3fcb5239efb5d9e4742ac7698bb88aacc
<pre>
Web Inspector: Console: timestamps cause objects to be shown on a separate line
<a href="https://bugs.webkit.org/show_bug.cgi?id=255031">https://bugs.webkit.org/show_bug.cgi?id=255031</a>
&lt;rdar://problem/107659829&gt;

Reviewed by Patrick Angle.

Move the timestamp to the end of the line and `float` it so that it doesn&apos;t participate in the normal flow.

* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js:
(WI.ConsoleMessageView.prototype.renderTimestamp):
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css:
(.console-message .timestamp):

Canonical link: <a href="https://commits.webkit.org/263263@main">https://commits.webkit.org/263263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80d763a5d42215f90d6478e7cf003145699ff34d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3274 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2348 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2087 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3145 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/38 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1950 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2120 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3263 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1910 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2078 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1002 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->