### PR TITLE
SourceBufferPrivate::ResetParserState shouldn't synchronously dispatch tasks

### DIFF
--- a/LayoutTests/media/media-source/media-mp4-h264-partial-abort-expected.txt
+++ b/LayoutTests/media/media-source/media-mp4-h264-partial-abort-expected.txt
@@ -53,5 +53,10 @@ RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, 45000)))
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
 EXPECTED (sourceBuffer.buffered.end(0) >= '0.708') OK
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, 45000)))
+EXPECTED (sourceBuffer.updating == 'true') OK
+RUN(sourceBuffer.abort())
+EVENT(abort)
+EXPECTED (sourceBuffer.updating == 'false') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-mp4-h264-partial-abort.html
+++ b/LayoutTests/media/media-source/media-mp4-h264-partial-abort.html
@@ -93,7 +93,14 @@
             testExpected('sourceBuffer.buffered.length', '1');
             testExpected('sourceBuffer.buffered.end(0)', '0.708', '>=');
 
-            endTest();
+            // Ensure that abort() will fire the abort event if `updating` attribute is true.
+            run('sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, 45000))');
+            testExpected('sourceBuffer.updating', true);
+            run('sourceBuffer.abort()');
+            await waitFor(sourceBuffer, 'abort');
+            testExpected('sourceBuffer.updating', false);
+            // The update event shouldn't be fired when we aborted.
+            waitForEventWithTimeout(sourceBuffer, 'update', 1000).then(failTest, endTest);
         } catch (e) {
             failTest(`Caught exception: "${e}"`);
         }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -159,9 +159,9 @@ private:
     bool isMediaSampleAllowed(const MediaSample&) const final;
 
     // SourceBufferPrivate overrides
-    void append(Ref<SharedBuffer>&&) final;
+    void appendInternal(Ref<SharedBuffer>&&) final;
     void abort() final;
-    void resetParserState() final;
+    void resetParserStateInternal() final;
     void removedFromMediaSource() final;
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.h
@@ -47,7 +47,7 @@ class ContentType;
 class MediaSampleAVFObjC;
 class SharedBuffer;
 
-class WEBCORE_EXPORT SourceBufferParser : public ThreadSafeRefCounted<SourceBufferParser> {
+class WEBCORE_EXPORT SourceBufferParser : public ThreadSafeRefCounted<SourceBufferParser, WTF::DestructionThread::Main> {
 public:
     static MediaPlayerEnums::SupportsType isContentTypeSupported(const ContentType&);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h
@@ -58,9 +58,8 @@ public:
 
     void clearMediaSource() { m_mediaSource = nullptr; }
 
-    void append(Vector<unsigned char>&&) final;
-    void abort() final;
-    void resetParserState() final;
+    void appendInternal(Ref<SharedBuffer>&&) final;
+    void resetParserStateInternal() final;
     void removedFromMediaSource() final;
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -133,9 +133,9 @@ MockSourceBufferPrivate::MockSourceBufferPrivate(MockMediaSourcePrivate* parent)
 
 MockSourceBufferPrivate::~MockSourceBufferPrivate() = default;
 
-void MockSourceBufferPrivate::append(Vector<uint8_t>&& data)
+void MockSourceBufferPrivate::appendInternal(Ref<SharedBuffer>&& data)
 {
-    m_inputBuffer.appendVector(WTFMove(data));
+    m_inputBuffer.appendVector(data->extractData());
     bool parsingSucceeded = true;
 
     while (m_inputBuffer.size() && parsingSucceeded) {
@@ -201,7 +201,7 @@ void MockSourceBufferPrivate::didReceiveSample(const MockSampleBox& sampleBox)
     SourceBufferPrivate::didReceiveSample(MockMediaSample::create(sampleBox));
 }
 
-void MockSourceBufferPrivate::abort()
+void MockSourceBufferPrivate::resetParserStateInternal()
 {
 }
 

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -52,8 +52,8 @@ private:
     explicit MockSourceBufferPrivate(MockMediaSourcePrivate*);
 
     // SourceBufferPrivate overrides
-    void append(Vector<uint8_t>&&) final;
-    void abort() final;
+    void appendInternal(Ref<SharedBuffer>&&) final;
+    void resetParserStateInternal() final;
     void removedFromMediaSource() final;
     MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState) final;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -110,6 +110,16 @@ void SourceBufferPrivateRemote::resetParserState()
     m_gpuProcessConnection->connection().send(Messages::RemoteSourceBufferProxy::ResetParserState(), m_remoteSourceBufferIdentifier);
 }
 
+void SourceBufferPrivateRemote::appendInternal(Ref<SharedBuffer>&&)
+{
+    ASSERT_NOT_REACHED();
+}
+
+void SourceBufferPrivateRemote::resetParserStateInternal()
+{
+    ASSERT_NOT_REACHED();
+}
+
 void SourceBufferPrivateRemote::removedFromMediaSource()
 {
     if (!isGPURunning())

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -74,6 +74,8 @@ private:
     // SourceBufferPrivate overrides
     void setActive(bool) final;
     void append(Ref<WebCore::SharedBuffer>&&) final;
+    void appendInternal(Ref<WebCore::SharedBuffer>&&) final;
+    void resetParserStateInternal() final;
     void abort() final;
     void resetParserState() final;
     void removedFromMediaSource() final;


### PR DESCRIPTION
#### e448a8292b724c70d880956c2bc56c647070d287
<pre>
SourceBufferPrivate::ResetParserState shouldn&apos;t synchronously dispatch tasks
<a href="https://bugs.webkit.org/show_bug.cgi?id=255120">https://bugs.webkit.org/show_bug.cgi?id=255120</a>
rdar://107729258

Reviewed by Youenn Fablet.

The MSE&apos;s Reset Parser State algorithm [1] alongside the `abort()` [2]
operation is racy at best and leads to a non-deterministicc behaviour as
the buffer append algorithm started by the `appendBuffer()` [3] operation
runs asynchronously.

As such, having parsed the entire input buffer when the `abort()` method
is called is a valid behaviour, and we make this behaviour the default.

We now consider all operations to be sequential and we queue them to run
sequentially.
We actually abort and reset the parser only once the previous operations
have completed, all while allowing `appendBuffer()` to be called immediately
after `abort()`
As `abort()` use case is designed to be able to append a new buffer regardless
of the operation that was run before (such as a partial init or media segment)
and we continue to fullfill this requirement.

This allows to remove the need to actually abort a currently running append
operation.
This will also help when we implement MSE in a worker as the possibility
of the race allowed by the spec does no longer exists.

[1] <a href="https://w3c.github.io/media-source/#sourcebuffer-reset-parser-state">https://w3c.github.io/media-source/#sourcebuffer-reset-parser-state</a>
[2] <a href="https://w3c.github.io/media-source/#dom-sourcebuffer-abort">https://w3c.github.io/media-source/#dom-sourcebuffer-abort</a>
[3] <a href="https://w3c.github.io/media-source/#dom-sourcebuffer-appendbuffer">https://w3c.github.io/media-source/#dom-sourcebuffer-appendbuffer</a>

* LayoutTests/media/media-source/media-mp4-h264-partial-abort-expected.txt:
* LayoutTests/media/media-source/media-mp4-h264-partial-abort.html: Ensure that if abort is called
then `update` event isn&apos;t fired.

* LayoutTests/media/media-source/media-mp4-h264-partial-abort-expected.txt:
* LayoutTests/media/media-source/media-mp4-h264-partial-abort.html:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::advanceOperationState):
(WebCore::SourceBufferPrivate::rewindOperationState):
(WebCore::SourceBufferPrivate::appendCompleted):
(WebCore::SourceBufferPrivate::processOperation):
(WebCore::SourceBufferPrivate::didReceiveInitializationSegment):
(WebCore::SourceBufferPrivate::didReceiveSample):
(WebCore::SourceBufferPrivate::append):
(WebCore::SourceBufferPrivate::queueOperation):
(WebCore::SourceBufferPrivate::processPendingOperations):
(WebCore::SourceBufferPrivate::abortPendingOperations):
(WebCore::SourceBufferPrivate::processError):
(WebCore::SourceBufferPrivate::abort):
(WebCore::SourceBufferPrivate::resetParserState):
(WebCore::SourceBufferPrivate::processInitOperation): Deleted.
(WebCore::SourceBufferPrivate::processMediaSamples): Deleted.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::~SourceBufferPrivateAVFObjC):
(WebCore::SourceBufferPrivateAVFObjC::didParseInitializationData):
(WebCore::SourceBufferPrivateAVFObjC::appendInternal):
(WebCore::SourceBufferPrivateAVFObjC::abort):
(WebCore::SourceBufferPrivateAVFObjC::resetParserStateInternal):
(WebCore::SourceBufferPrivateAVFObjC::append): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::resetParserState): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::appendInternal):
(WebCore::SourceBufferPrivateGStreamer::resetParserStateInternal):
(WebCore::SourceBufferPrivateGStreamer::append): Deleted.
(WebCore::SourceBufferPrivateGStreamer::abort): Deleted.
(WebCore::SourceBufferPrivateGStreamer::resetParserState): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::appendInternal):
(WebCore::MockSourceBufferPrivate::resetParserStateInternal):
(WebCore::MockSourceBufferPrivate::append): Deleted.
(WebCore::MockSourceBufferPrivate::abort): Deleted.
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::appendInternal):
(WebKit::SourceBufferPrivateRemote::resetParserStateInternal):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/262746@main">https://commits.webkit.org/262746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a396740f5d8d71dfaac0343dbd6f583064023c17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3693 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2152 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3517 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2032 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2289 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3351 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2213 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2009 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2165 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/611 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->