### PR TITLE
[iPad] Vimeo video goes black navigating from PiP back to full screen

### DIFF
--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -1088,6 +1088,7 @@ void VideoFullscreenInterfaceAVKit::didStopPictureInPicture()
         m_enteringPictureInPicture = false;
         if (m_videoFullscreenModel)
             m_videoFullscreenModel->didExitPictureInPicture();
+        returnToStandby();
 
         return;
     }
@@ -1145,6 +1146,9 @@ void VideoFullscreenInterfaceAVKit::prepareForPictureInPictureStopWithCompletion
 
         return;
     }
+
+    if (m_standby)
+        m_returningToStandby = true;
 
     prepareForPictureInPictureStop([protectedThis = Ref { *this }, strongCompletionHandler = adoptNS([completionHandler copy])](bool restored)  {
         LOG(Fullscreen, "VideoFullscreenInterfaceAVKit::prepareForPictureInPictureStopWithCompletionHandler lambda(%p) - restored(%s)", protectedThis.ptr(), boolString(restored));


### PR DESCRIPTION
#### dc8a2c99f4be79db635a93727b0a1532a5edfc81
<pre>
[iPad] Vimeo video goes black navigating from PiP back to full screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=255145">https://bugs.webkit.org/show_bug.cgi?id=255145</a>
rdar://107592139

Reviewed by Per Arne Vollan.

Vimeo gets into a state where it attempts to enter Element Fullscreen while the video
is in picture-in-picture, which causes PiP mode to exit, returning the video to the newly
fullscreened page. This video is simultaneously made &quot;standby&quot;, i.e., it will enter PiP
when the browser is &quot;swiped&quot; to the background. This causes the state machine of the
VideoFullscreenInterfaceAVKit to get confused, as it&apos;s exiting one mode (PiP) at the
same time as it&apos;s entering another (standby).

This is the most minimal change which will un-break this path, however there remain
a few usability issues afterward. Because the WebContent process issues both a enter-
fullscreen and exit-fullscreen command, it gets stuck in a state where it thinks its
still animating into (or out of) fullscreen and doesn&apos;t allow any new fullscreen mode
changes to be issued. This has the effect of preventing the video element from going
into PiP or native fullscreen mode again.

* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(VideoFullscreenInterfaceAVKit::didStopPictureInPicture):
(VideoFullscreenInterfaceAVKit::prepareForPictureInPictureStopWithCompletionHandler):

Canonical link: <a href="https://commits.webkit.org/262703@main">https://commits.webkit.org/262703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84cbb7c99470dd759b0d69e64f241e49feb05e2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2093 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3153 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/56 "21 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1955 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2160 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2094 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3270 "260 api tests failed or timed out") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2132 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1920 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2090 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2068 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/262 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->