### PR TITLE
[JSC] Expose $addressBits to skip tests than need a lot of virtual address space

### DIFF
--- a/JSTests/stress/big-wasm-memory-grow-no-max.js
+++ b/JSTests/stress/big-wasm-memory-grow-no-max.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
+//@ skip if $memoryLimited or $addressBits <= 32
 //@ runDefault()
 
 function test() {

--- a/JSTests/stress/big-wasm-memory-grow.js
+++ b/JSTests/stress/big-wasm-memory-grow.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
+//@ skip if $memoryLimited or $addressBits <= 32
 //@ runDefault()
 
 function test() {

--- a/JSTests/stress/big-wasm-memory.js
+++ b/JSTests/stress/big-wasm-memory.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
+//@ skip if $memoryLimited or $addressBits <= 32
 //@ runDefault()
 
 function test() {

--- a/JSTests/stress/typed-array-always-large.js
+++ b/JSTests/stress/typed-array-always-large.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
+//@ skip if $memoryLimited or $addressBits <= 32
 //@ runDefault()
 
 function getArrayLength(array)

--- a/JSTests/stress/typed-array-eventually-large.js
+++ b/JSTests/stress/typed-array-eventually-large.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
+//@ skip if $memoryLimited or $addressBits <= 32
 //@ runDefault()
 
 function getArrayLength(array)

--- a/JSTests/stress/typed-array-large-eventually-oob.js
+++ b/JSTests/stress/typed-array-large-eventually-oob.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
+//@ skip if $memoryLimited or $addressBits <= 32
 //@ runDefault()
 function getArrayLength(array)
 {

--- a/JSTests/stress/typed-array-large-slice.js
+++ b/JSTests/stress/typed-array-large-slice.js
@@ -1,4 +1,4 @@
-//@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
+//@ skip if $memoryLimited or $addressBits <= 32
 
 let giga = 1024 * 1024 * 1024;
 

--- a/JSTests/wasm/regress/llint-callee-saves-with-fast-memory.js
+++ b/JSTests/wasm/regress/llint-callee-saves-with-fast-memory.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture == "arm"
+//@ skip if $addressBits <= 32
 //@ requireOptions("--useWebAssemblyFastMemory=true")
 
 import * as assert from '../assert.js';

--- a/JSTests/wasm/stress/externref-result-tuple.js
+++ b/JSTests/wasm/stress/externref-result-tuple.js
@@ -1,4 +1,4 @@
-//@ skip if $architecture == "arm" or $memoryLimited
+//@ skip if $addressBits <= 32 or $memoryLimited
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/wasm/v8/huge-memory.js
+++ b/JSTests/wasm/v8/huge-memory.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
+//@ skip if $memoryLimited or $addressBits <= 32
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/huge-typedarray.js
+++ b/JSTests/wasm/v8/huge-typedarray.js
@@ -1,5 +1,5 @@
 //@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
+//@ skip if $memoryLimited or $addressBits <= 32
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -589,6 +589,22 @@ $isFTLPlatform = !($architecture == "x86" || $architecture == "arm" || $architec
 $isWasmPlatform = $isFTLPlatform || $architecture == "arm"
 $isSIMDPlatform = $architecture == "arm64" || $architecture == "x86_64"
 
+# This is meant for skipping execution of tests than require a lot of address
+# space. Cf. $memoryLimited, which is meant for tests that actually make use of
+# a lot of memory.
+# Technically, this should be the bits available in userspace, but right now we
+# don't need to be this precise.
+$addressBits = case $architecture
+               when /.*64.*/
+                   # We only have 36 bits on iOS. We'll need to differentiate
+                   # between iOS and other 64-bit systems (possibly by adding an
+                   # --address-bits flag to this script) when we acquire tests
+                   # that require > 36 bits of address space.
+                   36
+               else
+                   32
+               end
+
 if $architecture == "x86"
     # The JIT is temporarily disabled on this platform since
     # https://trac.webkit.org/changeset/237547


### PR DESCRIPTION
#### e04108fd6a039c9d936017a0ce4cd7907d7ea4ed
<pre>
[JSC] Expose $addressBits to skip tests than need a lot of virtual address space
<a href="https://bugs.webkit.org/show_bug.cgi?id=255144">https://bugs.webkit.org/show_bug.cgi?id=255144</a>

Reviewed by Justin Michaud.

This achieves the same effect, while making the skip self-explanatory.
Also, the list of architectures that need or don&apos;t need to skip a test
because of VA limitations can be managed in one place.

* JSTests/stress/big-wasm-memory-grow-no-max.js:
* JSTests/stress/big-wasm-memory-grow.js:
* JSTests/stress/big-wasm-memory.js:
* JSTests/stress/typed-array-always-large.js:
* JSTests/stress/typed-array-eventually-large.js:
* JSTests/stress/typed-array-large-eventually-oob.js:
* JSTests/stress/typed-array-large-slice.js:
* JSTests/wasm/regress/242294.js:
* JSTests/wasm/regress/llint-callee-saves-with-fast-memory.js:
* JSTests/wasm/stress/externref-result-tuple.js:
* JSTests/wasm/stress/only-referenced.js:
* JSTests/wasm/v8/huge-memory.js:
* JSTests/wasm/v8/huge-typedarray.js:
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/262824@main">https://commits.webkit.org/262824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d750dabe510d1913c923612d43fd50f5d105efe3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4107 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3069 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2376 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3879 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2263 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2261 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2782 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2416 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3632 "260 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2580 "Built successfully and passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2448 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2230 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2776 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2400 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/655 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/671 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2442 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2837 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2595 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/770 "Passed tests") | 
<!--EWS-Status-Bubble-End-->