### PR TITLE
[ews-build] Split iOS layout test queue into no-WPT / only-WPT configurations

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -189,18 +189,18 @@
     },
     {
       "name": "iOS-16-Simulator-WK2-Tests-EWS", "shortname": "ios-wk2", "icon": "testOnly",
-      "factory": "iOSTestsNoWPTFactory", "platform": "ios-simulator-16",
+      "factory": "iOSTestsFactory", "platform": "ios-simulator-16",
       "configuration": "release", "architectures": ["arm64"],
       "triggered_by": ["ios-16-sim-build-ews"],
-      "additionalArguments": ["--child-process=5"],
+      "additionalArguments": ["--child-process=5", "--exclude-tests", "imported/w3c/web-platform-tests"],
       "workernames": ["ews121", "ews122", "ews123", "ews124", "ews125", "ews126", "ews184", "ews185"]
     },
     {
       "name": "iOS-16-Simulator-WPT-WK2-Tests-EWS", "shortname": "ios-wk2-wpt", "icon": "testOnly",
-      "factory": "iOSTestsOnlyWPTFactory", "platform": "ios-simulator-16",
+      "factory": "iOSTestsFactory", "platform": "ios-simulator-16",
       "configuration": "release", "architectures": ["arm64"],
       "triggered_by": ["ios-16-sim-build-ews"],
-      "additionalArguments": ["--child-process=5"],
+      "additionalArguments": ["--child-process=5", "imported/w3c/web-platform-tests"],
       "workernames": ["ews191", "ews192", "ews193", "ews194", "ews195", "ews196", "ews197", "ews198"]
     },
     {

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -32,7 +32,7 @@ from steps import (AddReviewerToCommitMessage, ApplyPatch, ApplyWatchList, Canon
                    MapBranchAlias, RunAPITests, RunBindingsTests, RunBuildWebKitOrgUnitTests, RunBuildbotCheckConfigForBuildWebKit, RunBuildbotCheckConfigForEWS,
                    RunEWSUnitTests, RunResultsdbpyTests, RunJavaScriptCoreTests, RunWebKit1Tests, RunWebKitPerlTests, RunWebKitPyPython2Tests,
                    RunWebKitPyPython3Tests, RunWebKitTests, RunWebKitTestsRedTree, RunWebKitTestsInStressMode, RunWebKitTestsInStressGuardmallocMode,
-                   RunWebKitTestsNoWPT, RunWebKitTestsOnlyWPT, SetBuildSummary, ShowIdentifier, TriggerCrashLogSubmission, UpdateWorkingDirectory, UpdatePullRequest,
+                   SetBuildSummary, ShowIdentifier, TriggerCrashLogSubmission, UpdateWorkingDirectory, UpdatePullRequest,
                    ValidateCommitMessage, ValidateChange, ValidateCommitterAndReviewer, WaitForCrashCollection,
                    InstallBuiltProduct, ValidateRemote, ValidateSquashed)
 
@@ -217,16 +217,6 @@ class iOSEmbeddedBuildFactory(BuildFactory):
 
 class iOSTestsFactory(TestFactory):
     LayoutTestClass = RunWebKitTests
-    willTriggerCrashLogSubmission = True
-
-
-class iOSTestsNoWPTFactory(TestFactory):
-    LayoutTestClass = RunWebKitTestsNoWPT
-    willTriggerCrashLogSubmission = True
-
-
-class iOSTestsOnlyWPTFactory(TestFactory):
-    LayoutTestClass = RunWebKitTestsOnlyWPT
     willTriggerCrashLogSubmission = True
 
 

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -139,7 +139,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'find-modified-layout-tests',
             'run-layout-tests-in-stress-mode',
-            'layout-tests-no-wpt',
+            'layout-tests',
             'trigger-crash-log-submission',
             'set-build-summary'
         ],
@@ -160,7 +160,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'find-modified-layout-tests',
             'run-layout-tests-in-stress-mode',
-            'layout-tests-only-wpt',
+            'layout-tests',
             'trigger-crash-log-submission',
             'set-build-summary'
         ],

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -37,9 +37,8 @@ from twisted.internet import defer
 from factories import (APITestsFactory, BindingsFactory, BuildFactory, CommitQueueFactory, Factory, GTKBuildFactory,
                        GTKTestsFactory, JSCBuildFactory, JSCBuildAndTestsFactory, JSCTestsFactory, MergeQueueFactory, StressTestFactory,
                        StyleFactory, TestFactory, tvOSBuildFactory, WPEBuildFactory, WPETestsFactory, WebKitPerlFactory, WebKitPyFactory,
-                       WinCairoFactory, iOSBuildFactory, iOSEmbeddedBuildFactory, iOSTestsFactory, iOSTestsNoWPTFactory,
-                       iOSTestsOnlyWPTFactory, macOSBuildFactory, macOSBuildOnlyFactory, macOSWK1Factory, macOSWK2Factory,
-                       ServicesFactory, UnsafeMergeQueueFactory, WatchListFactory, watchOSBuildFactory)
+                       WinCairoFactory, iOSBuildFactory, iOSEmbeddedBuildFactory, iOSTestsFactory, macOSBuildFactory, macOSBuildOnlyFactory,
+                       macOSWK1Factory, macOSWK2Factory, ServicesFactory, UnsafeMergeQueueFactory, WatchListFactory, watchOSBuildFactory)
 
 BUILDER_NAME_LENGTH_LIMIT = 70
 STEP_NAME_LENGTH_LIMIT = 50

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3337,6 +3337,9 @@ class RunWebKitTests(shell.Test, AddToLogMixin):
             self.setCommand(self.command + ['--enable-core-dumps-nolimit'])
 
         if additionalArguments:
+            for argument in ["--child-process=5", "--exclude-tests", "imported/w3c/web-platform-tests"]:
+                if argument in additionalArguments:
+                    additionalArguments.remove(argument)
             self.setCommand(self.command + additionalArguments)
 
         if self.ENABLE_GUARD_MALLOC:
@@ -3558,22 +3561,6 @@ class RunWebKitTestsInStressGuardmallocMode(RunWebKitTestsInStressMode):
     name = 'run-layout-tests-in-guard-malloc-stress-mode'
     suffix = 'guard-malloc'
     ENABLE_GUARD_MALLOC = True
-
-
-class RunWebKitTestsNoWPT(RunWebKitTests):
-    name = 'layout-tests-no-wpt'
-
-    def setLayoutTestCommand(self):
-        RunWebKitTests.setLayoutTestCommand(self)
-        self.setCommand(self.command + ['--exclude-tests', 'imported/w3c/web-platform-tests'])
-
-
-class RunWebKitTestsOnlyWPT(RunWebKitTests):
-    name = 'layout-tests-only-wpt'
-
-    def setLayoutTestCommand(self):
-        RunWebKitTests.setLayoutTestCommand(self)
-        self.setCommand(self.command + ['imported/w3c/web-platform-tests'])
 
 
 class ReRunWebKitTests(RunWebKitTests):

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -57,7 +57,7 @@ from steps import (AddReviewerToCommitMessage, AnalyzeAPITestsResults, AnalyzeCo
                    RunBuildbotCheckConfigForBuildWebKit, RunBuildbotCheckConfigForEWS, RunEWSUnitTests, RunResultsdbpyTests,
                    RunJavaScriptCoreTests, RunJSCTestsWithoutChange, RunWebKit1Tests, RunWebKitPerlTests, RunWebKitPyPython2Tests,
                    RunWebKitPyPython3Tests, RunWebKitTests, RunWebKitTestsInStressMode, RunWebKitTestsInStressGuardmallocMode,
-                   RunWebKitTestsNoWPT, RunWebKitTestsOnlyWPT, RunWebKitTestsWithoutChange, RunWebKitTestsRedTree, RunWebKitTestsRepeatFailuresRedTree,
+                   RunWebKitTestsWithoutChange, RunWebKitTestsRedTree, RunWebKitTestsRepeatFailuresRedTree,
                    RunWebKitTestsRepeatFailuresWithoutChangeRedTree, RunWebKitTestsWithoutChangeRedTree, AnalyzeLayoutTestsResultsRedTree, TestWithFailureCount,
                    ShowIdentifier, Trigger, TransferToS3, TwistedAdditions, UnApplyPatch, UpdatePullRequest, UpdateWorkingDirectory, UploadBuiltProduct,
                    UploadTestResults, ValidateCommitMessage, ValidateCommitterAndReviewer, ValidateChange, ValidateRemote, ValidateSquashed)
@@ -2230,25 +2230,11 @@ class TestRunWebKitTestsInStressMode(BuildStepMixinAdditions, unittest.TestCase)
         self.assertEqual(self.getProperty('build_summary'), 'Found test failures')
         return rc
 
-
-class TestRunWebKitTestsNoWPT(BuildStepMixinAdditions, unittest.TestCase):
-    def setUp(self):
-        self.longMessage = True
-        self.jsonFileName = 'layout-test-results/full_results.json'
-        return self.setUpBuildStep()
-
-    def tearDown(self):
-        return self.tearDownBuildStep()
-
-    def configureStep(self):
-        self.setupStep(RunWebKitTestsNoWPT())
-        self.property_exceed_failure_limit = 'first_results_exceed_failure_limit'
-        self.property_failures = 'first_run_failures'
-
     def test_success(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'ios-simulator')
         self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test1', 'test2'])
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         logfiles={'json': self.jsonFileName},
@@ -2257,33 +2243,20 @@ class TestRunWebKitTestsNoWPT(BuildStepMixinAdditions, unittest.TestCase):
                                  'Tools/Scripts/run-webkit-tests',
                                  '--no-build', '--no-show-results', '--no-new-test-results', '--clobber-old-results',
                                  '--release', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
-                                 '--exit-after-n-failures', '60', '--skip-failing-tests',
-                                 '--exclude-tests', 'imported/w3c/web-platform-tests'],
+                                 '--exit-after-n-failures', '10', '--skip-failing-tests',
+                                 '--iterations', 100, 'test1', 'test2'],
                         )
             + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='Passed layout tests')
         return self.runStep()
 
-
-class TestRunWebKitTestsOnlyWPT(BuildStepMixinAdditions, unittest.TestCase):
-    def setUp(self):
-        self.longMessage = True
-        self.jsonFileName = 'layout-test-results/full_results.json'
-        return self.setUpBuildStep()
-
-    def tearDown(self):
-        return self.tearDownBuildStep()
-
-    def configureStep(self):
-        self.setupStep(RunWebKitTestsOnlyWPT())
-        self.property_exceed_failure_limit = 'first_results_exceed_failure_limit'
-        self.property_failures = 'first_run_failures'
-
-    def test_success(self):
+    def test_success_additional_arguments(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'ios-simulator')
         self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test1', 'test2'])
+        self.setProperty('additionalArguments', ['--child-process=5', '--exclude-tests', 'imported/w3c/web-platform-tests'])
         self.expectRemoteCommands(
             ExpectShell(workdir='wkdir',
                         logfiles={'json': self.jsonFileName},
@@ -2292,8 +2265,8 @@ class TestRunWebKitTestsOnlyWPT(BuildStepMixinAdditions, unittest.TestCase):
                                  'Tools/Scripts/run-webkit-tests',
                                  '--no-build', '--no-show-results', '--no-new-test-results', '--clobber-old-results',
                                  '--release', '--results-directory', 'layout-test-results', '--debug-rwt-logging',
-                                 '--exit-after-n-failures', '60', '--skip-failing-tests',
-                                 'imported/w3c/web-platform-tests'],
+                                 '--exit-after-n-failures', '10', '--skip-failing-tests',
+                                 '--iterations', 100, 'test1', 'test2'],
                         )
             + 0,
         )


### PR DESCRIPTION
#### 3b1f649acd18a6ac92fca48689c95faf5de23ebe
<pre>
[ews-build] Split iOS layout test queue into no-WPT / only-WPT configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=254559">https://bugs.webkit.org/show_bug.cgi?id=254559</a>
rdar://107291888

Reviewed by Jonathan Bedard.

The first iteration of this commit used new steps and factories to accomplish the
no-WPT / only-WPT split, but if retries were required to determine if a failure was
pre-existing the bots ended up running the whole suite.

Using the additional arguments approach instead will make sure the no-WPT / only-WPT queues
behave as expected even in the retry case. These specific additional arguments will be
removed in the RunWebKitTestsInStressMode so they don&apos;t interfere with the intent of this
step running only the new or modified tests.

* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/factories.py:
(iOSTestsFactory):
(iOSTestsNoWPTFactory): Deleted.
(iOSTestsOnlyWPTFactory): Deleted.
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/ews-build/loadConfig.py:
* Tools/CISupport/ews-build/steps.py:
(RunWebKitTestsInStressMode):
(RunWebKitTestsNoWPT): Deleted.
(RunWebKitTestsNoWPT.setLayoutTestCommand): Deleted.
(RunWebKitTestsOnlyWPT): Deleted.
(RunWebKitTestsOnlyWPT.setLayoutTestCommand): Deleted.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestRunWebKitTestsInStressMode.test_success_additional_arguments): Add new unit test.
(TestRunWebKitTestsNoWPT): Deleted.
(TestRunWebKitTestsNoWPT.setUp): Deleted.
(TestRunWebKitTestsNoWPT.tearDown): Deleted.
(TestRunWebKitTestsNoWPT.configureStep): Deleted.
(TestRunWebKitTestsNoWPT.test_success): Deleted.
(TestRunWebKitTestsOnlyWPT): Deleted.
(TestRunWebKitTestsOnlyWPT.setUp): Deleted.
(TestRunWebKitTestsOnlyWPT.tearDown): Deleted.
(TestRunWebKitTestsOnlyWPT.configureStep): Deleted.
(TestRunWebKitTestsOnlyWPT.test_success): Deleted.

Canonical link: <a href="https://commits.webkit.org/262714@main">https://commits.webkit.org/262714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a8e61ba8f77d436b201063c89cfc3db5ef8c313

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2361 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/2369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2475 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/3359 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2389 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2451 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/3359 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2383 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/2120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3201 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/99 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/2108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2192 "Built successfully") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/2338 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2167 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/2114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2100 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/267 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2291 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->