### PR TITLE
[UI-side compositing] Tab thumbnail sometimes offset by top content inset when entering tab overview

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
@@ -36,6 +36,7 @@
 #import "WKWebViewInternal.h"
 #import "WebPageProxy.h"
 #import <pal/spi/cg/CoreGraphicsSPI.h>
+#import <wtf/MathExtras.h>
 #import <wtf/NakedPtr.h>
 #import <wtf/SystemTracing.h>
 
@@ -62,7 +63,8 @@
     RetainPtr<NSColor> _overrideBackgroundColor;
 }
 
-@synthesize _waitingForSnapshot = _waitingForSnapshot;
+@synthesize _waitingForSnapshot;
+@synthesize _sublayerVerticalTranslationAmount;
 
 - (instancetype)initWithFrame:(NSRect)frame
 {
@@ -174,6 +176,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_viewWasUnparented
 {
     if (!_exclusivelyUsesSnapshot) {
+        self._sublayerVerticalTranslationAmount = 0;
         if (_wkView) {
             [_wkView _setThumbnailView:nil];
             [_wkView _setIgnoresAllEvents:NO];
@@ -205,6 +208,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _requestSnapshotIfNeeded];
 
     if (!_exclusivelyUsesSnapshot) {
+        self._sublayerVerticalTranslationAmount = -_webPageProxy->topContentInset();
         if (_wkView) {
             [_wkView _setThumbnailView:self];
             [_wkView _setIgnoresAllEvents:YES];
@@ -260,7 +264,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self _requestSnapshotIfNeeded];
 
-    self.layer.sublayerTransform = CATransform3DMakeScale(_scale, _scale, 1);
+    auto scaleTransform = CATransform3DMakeScale(_scale, _scale, 1);
+    self.layer.sublayerTransform = CATransform3DTranslate(scaleTransform, 0, _sublayerVerticalTranslationAmount, 0);
+}
+
+- (void)_setSublayerVerticalTranslationAmount:(CGFloat)amount
+{
+    if (WTF::areEssentiallyEqual(_sublayerVerticalTranslationAmount, amount))
+        return;
+
+    self.layer.sublayerTransform = CATransform3DTranslate(self.layer.sublayerTransform, 0, amount - _sublayerVerticalTranslationAmount, 0);
+    _sublayerVerticalTranslationAmount = amount;
 }
 
 - (void)setMaximumSnapshotSize:(CGSize)maximumSnapshotSize

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailViewInternal.h
@@ -31,6 +31,7 @@
 
 @property (nonatomic, assign, setter=_setThumbnailLayer:) CALayer *_thumbnailLayer;
 @property (nonatomic, assign, setter=_setWaitingForSnapshot:) BOOL _waitingForSnapshot;
+@property (nonatomic, assign, setter=_setSublayerVerticalTranslationAmount:) CGFloat _sublayerVerticalTranslationAmount;
 
 @end
 


### PR DESCRIPTION
#### 6cd098bb14207f0c94b6dfa91bea70c12ba6b904
<pre>
[UI-side compositing] Tab thumbnail sometimes offset by top content inset when entering tab overview
<a href="https://bugs.webkit.org/show_bug.cgi?id=255152">https://bugs.webkit.org/show_bug.cgi?id=255152</a>

Reviewed by Tim Horton.

Even after the fixes in 262649@main, the temporary root layer reparenting in `_WKThumbnailView`
results in the page content being vertically offset by an amount equal to the web view&apos;s top content
inset, in the case where the web view has `_automaticallyAdjustsContentInsets` set to `NO`, as well
as a non-zero top content inset. This appears to affect both UI-side compositing and non-UI-side
compositing (I verified this by artificially deferring the call to `-[_WKThumbnailView
_didTakeSnapshot:]`).

This patch fixes this by offsetting the root layer&apos;s sublayer transform by the top content inset,
such that the reparented layers are visually consistent with the final `_WKThumbnailView`&apos;s contents
once the snapshot image arrives.

Test: WebKit.WKThumbnailViewLayerReparentingWithUISideCompositingAndTopContentInset

* Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm:
(-[_WKThumbnailView _viewWasUnparented]):
(-[_WKThumbnailView _viewWasParented]):

Set the vertical translation amount when the layer is parented.

(-[_WKThumbnailView setScale:]):
(-[_WKThumbnailView _setSublayerVerticalTranslationAmount:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailViewInternal.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm:
(TestWebKitAPI::leftCornerColorsForThumbnailView):
(TestWebKitAPI::checkThumbnailViewSnapshotConsistency):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262778@main">https://commits.webkit.org/262778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/283a96b2b401bdfe81923de78d1677f744bde831

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2382 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2114 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3187 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2104 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1977 "23 flakes 140 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2185 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3298 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2152 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1943 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/633 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2093 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2284 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->