### PR TITLE
[WTF][GLib] Rework FileSystem::openFile()

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -41,11 +41,6 @@
 #include <unistd.h>
 #endif
 
-#if USE(GLIB)
-#include <gio/gfiledescriptorbased.h>
-#include <gio/gio.h>
-#endif
-
 #if HAVE(STD_FILESYSTEM) || HAVE(STD_EXPERIMENTAL_FILESYSTEM)
 #include <wtf/StdFilesystem.h>
 #endif
@@ -329,13 +324,7 @@ bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openM
     if (!isHandleValid(handle))
         return false;
 
-    int fd;
-#if USE(GLIB)
-    auto* inputStream = g_io_stream_get_input_stream(G_IO_STREAM(handle));
-    fd = g_file_descriptor_based_get_fd(G_FILE_DESCRIPTOR_BASED(inputStream));
-#else
-    fd = handle;
-#endif
+    int fd = posixFileDescriptor(handle);
 
     struct stat fileStat;
     if (fstat(fd, &fileStat)) {

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -54,7 +54,7 @@ typedef void *HANDLE;
 #endif
 
 #if USE(GLIB)
-typedef struct _GFileIOStream GFileIOStream;
+typedef struct _GSeekable GSeekable;
 #endif
 
 namespace WTF {
@@ -63,7 +63,7 @@ namespace FileSystemImpl {
 
 // PlatformFileHandle
 #if USE(GLIB) && !OS(WINDOWS)
-typedef GFileIOStream* PlatformFileHandle;
+typedef GSeekable* PlatformFileHandle;
 const PlatformFileHandle invalidPlatformFileHandle = nullptr;
 #elif OS(WINDOWS)
 typedef HANDLE PlatformFileHandle;
@@ -200,6 +200,10 @@ WTF_EXPORT_PRIVATE String encodeForFileName(const String&);
 WTF_EXPORT_PRIVATE String decodeFromFilename(const String&);
 
 WTF_EXPORT_PRIVATE bool filesHaveSameVolume(const String&, const String&);
+
+#if !OS(WINDOWS)
+WTF_EXPORT_PRIVATE int posixFileDescriptor(PlatformFileHandle);
+#endif
 
 #if USE(CF)
 WTF_EXPORT_PRIVATE RetainPtr<CFURLRef> pathAsURL(const String&);

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -94,6 +94,11 @@ void closeFile(PlatformFileHandle& handle)
     }
 }
 
+int posixFileDescriptor(PlatformFileHandle handle)
+{
+    return handle;
+}
+
 long long seekFile(PlatformFileHandle handle, long long offset, FileSeekOrigin origin)
 {
     int whence = SEEK_SET;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
@@ -142,8 +142,7 @@ RefPtr<SharedMemory> Data::tryCreateSharedMemory() const
     if (isNull() || !isMap())
         return nullptr;
 
-    GInputStream* inputStream = g_io_stream_get_input_stream(G_IO_STREAM(m_fileDescriptor));
-    int fd = g_file_descriptor_based_get_fd(G_FILE_DESCRIPTOR_BASED(inputStream));
+    int fd = FileSystem::posixFileDescriptor(m_fileDescriptor);
     gsize length;
     const auto* data = g_bytes_get_data(m_buffer.get(), &length);
     return SharedMemory::wrapMap(const_cast<void*>(data), length, fd);


### PR DESCRIPTION
#### 78d2561b2bf73ecfc596b303f3321e6789c1f659
<pre>
[WTF][GLib] Rework FileSystem::openFile()
<a href="https://bugs.webkit.org/show_bug.cgi?id=254813">https://bugs.webkit.org/show_bug.cgi?id=254813</a>

Reviewed by Michael Catanzaro and Adrian Perez de Castro.

Fixes REGRESSION(259689@main). The previous implementation failed when
asked to create a file in ReadWrite mode.

This patch also increases the test coverage for FileSystem::openFile().
Previously, few argument combinations where tested, which caused the
regression to go unnoticed.

Read requests no longer create a read-write stream.

To accomodate that, PlatformFileHandle in GLib is now the generic
GSeekable* rather than GFileIOStream* (which implies a read-write file
handle).

This patch also introduces WTF::FileSystem::posixFileDescriptor() for
non-Windows platforms, which allows decoupling of the GIO API in a few
places in WebKit.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::MappedFileData::mapFileHandle):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/glib/FileSystemGlib.cpp:
(WTF::FileSystemImpl::genericGIOFileClose):
(WTF::FileSystemImpl::genericGIOFileQueryInfo):
(WTF::FileSystemImpl::genericGIOGetInputStream):
(WTF::FileSystemImpl::genericGIOGetOutputStream):
(WTF::FileSystemImpl::genericGIOGetFileDescriptorBased):
(WTF::FileSystemImpl::posixFileDescriptor):
(WTF::FileSystemImpl::fileSize):
(WTF::FileSystemImpl::fileID):
(WTF::FileSystemImpl::openTemporaryFile):
(WTF::FileSystemImpl::openFile):
(WTF::FileSystemImpl::closeFile):
(WTF::FileSystemImpl::seekFile):
(WTF::FileSystemImpl::truncateFile):
(WTF::FileSystemImpl::flushFile):
(WTF::FileSystemImpl::writeToFile):
(WTF::FileSystemImpl::readFromFile):
(WTF::FileSystemImpl::lockFile):
(WTF::FileSystemImpl::unlockFile):
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::posixFileDescriptor):
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp:
(WebKit::NetworkCache::Data::tryCreateSharedMemory const):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/263367@main">https://commits.webkit.org/263367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b3d5f4af3e2d5a17427b6d283d3feeb82e2a58e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5837 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4577 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4445 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5837 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3901 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/7302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3624 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3899 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4146 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3560 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4460 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3899 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1110 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1080 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7954 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4562 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4253 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1216 "Passed tests") | 
<!--EWS-Status-Bubble-End-->