### PR TITLE
Correct PDF Plugin descriptions returned by navigator.plugins[x].description

### DIFF
--- a/LayoutTests/dom/html/navigator-plugins-expected.txt
+++ b/LayoutTests/dom/html/navigator-plugins-expected.txt
@@ -1,0 +1,21 @@
+Check that navigator.plugins contains only the expected items
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS navigator.plugins.length == 5 is true
+PASS plugin.name == validPluginNames[i] is true
+PASS plugin.description == 'Portable Document Format' is true
+PASS plugin.name == validPluginNames[i] is true
+PASS plugin.description == 'Portable Document Format' is true
+PASS plugin.name == validPluginNames[i] is true
+PASS plugin.description == 'Portable Document Format' is true
+PASS plugin.name == validPluginNames[i] is true
+PASS plugin.description == 'Portable Document Format' is true
+PASS plugin.name == validPluginNames[i] is true
+PASS plugin.description == 'Portable Document Format' is true
+PASS hasInvalidPlugin is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/dom/html/navigator-plugins.html
+++ b/LayoutTests/dom/html/navigator-plugins.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<script>
+description("Check that navigator.plugins contains only the expected items");
+
+shouldBeTrue("navigator.plugins.length == 5");
+
+var validPluginNames = [ 'PDF Viewer', 'Chrome PDF Viewer', 'Chromium PDF Viewer', 'Microsoft Edge PDF Viewer', 'WebKit built-in PDF' ];
+
+var hasInvalidPlugin = false;
+
+for (var i = 0; i < navigator.plugins.length; ++i) {
+    var plugin = navigator.plugins[i];
+    if (!plugin.description || !plugin.name || !plugin.filename) {
+        hasInvalidPlugin = true;
+        break;
+    }
+    shouldBeTrue("plugin.name == validPluginNames[i]");
+    shouldBeTrue("plugin.description == 'Portable Document Format'");
+}
+
+shouldBeFalse("hasInvalidPlugin");
+
+successfullyParsed = true;
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -284,11 +284,14 @@ void Navigator::initializePluginAndMimeTypeArrays()
 
     // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewing-support
     // Section 8.9.1.6 states that if pdfViewerEnabled is true, we must return a list
-    // of exactly five PDF view plugins, in a particular order.
+    // of exactly five PDF view plugins, in a particular order. They also must return
+    // a specific plain English string for 'Navigator.plugins[x].description':
+    constexpr auto navigatorPDFDescription = "Portable Document Format"_s;
     for (auto& currentDummyName : dummyPDFPluginNames()) {
         pdfPluginInfo.name = currentDummyName;
+        pdfPluginInfo.desc = navigatorPDFDescription;
         domPlugins.append(DOMPlugin::create(*this, pdfPluginInfo));
-
+        
         // Register the copy of the PluginInfo using the generic 'PDF Viewer' name
         // as the handler for PDF MIME type to match the specification.
         if (currentDummyName == genericPDFViewerName)


### PR DESCRIPTION
#### 1cc30ed20c2570c0d4b67c6c71a9b92d2a21c85c
<pre>
Correct PDF Plugin descriptions returned by navigator.plugins[x].description
<a href="https://bugs.webkit.org/show_bug.cgi?id=255155">https://bugs.webkit.org/show_bug.cgi?id=255155</a>
&lt;rdar://problem/107756651&gt;

Reviewed by Geoffrey Garen.

In Bug 254189 we corrected a bug where the name of the WebKit Built-in PDF plugin was localized
for the user&apos;s settings, which confused some anti-fraud software because the specification requires
the name to be in plain English text.

While that issue was fixed, the specification also requires a consistent English label, &quot;Portable
Document Format&quot; be returned by the &apos;description&apos; property of the plugin. This is currently localized
in Safari, leading to some anti-fraud software failing.

This patch modifies only the return value from Navigator.plugins[].description, so that other
elements of the Browser UI can correctly localize the description.

* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::initializePluginAndMimeTypeArrays):

Canonical link: <a href="https://commits.webkit.org/262779@main">https://commits.webkit.org/262779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81a578a986f8d8a8e685316583a4c787a74b78ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3975 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2275 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2597 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3740 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2153 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2628 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2313 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3505 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2339 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2122 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2292 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/635 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2328 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->