### PR TITLE
[WGSL] Add type declarations for trigonometric functions

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -84,3 +84,11 @@ operator :max, {
     [T < Number].(T, T) => T,
     [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
 }
+
+# Trigonometric
+["acos", "asin", "atan", "cos", "sin", "tan"].each do |op|
+    operator :"#{op}", {
+        [T < Float].(T) => T,
+        [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    }
+end

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -241,3 +241,47 @@ fn testMax() {
    let x6 = max(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
    let x7 = max(vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0));
 }
+
+fn testTrigonometric() {
+  {
+    let x = acos(0.0);
+    let x1 = acos(vec2(0.0, 0.0));
+    let x2 = acos(vec3(0.0, 0.0, 0.0));
+    let x3 = acos(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = asin(0.0);
+    let x1 = asin(vec2(0.0, 0.0));
+    let x2 = asin(vec3(0.0, 0.0, 0.0));
+    let x3 = asin(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = atan(0.0);
+    let x1 = atan(vec2(0.0, 0.0));
+    let x2 = atan(vec3(0.0, 0.0, 0.0));
+    let x3 = atan(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = cos(0.0);
+    let x1 = cos(vec2(0.0, 0.0));
+    let x2 = cos(vec3(0.0, 0.0, 0.0));
+    let x3 = cos(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = sin(0.0);
+    let x1 = sin(vec2(0.0, 0.0));
+    let x2 = sin(vec3(0.0, 0.0, 0.0));
+    let x3 = sin(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = tan(0.0);
+    let x1 = tan(vec2(0.0, 0.0));
+    let x2 = tan(vec3(0.0, 0.0, 0.0));
+    let x3 = tan(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+}


### PR DESCRIPTION
#### e5ac16cb40c1585281c6a874adfb36d205e5ff82
<pre>
[WGSL] Add type declarations for trigonometric functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=255158">https://bugs.webkit.org/show_bug.cgi?id=255158</a>
rdar://problem/107759133

Reviewed by Tadeu Zagallo.

Add all the possible overloads for standard library trigonometric functions:
acos, asin, atan, cos, sin, tan.

* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/262720@main">https://commits.webkit.org/262720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e72ee3e85a6086b6650ba53b92fad2bc097f9640

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2398 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2463 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3268 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2116 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/1987 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2203 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3310 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2164 "Passed tests") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2122 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/596 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->