### PR TITLE
[WGSL] Add type declarations for hyperbolic trigonometric functions

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -86,7 +86,8 @@ operator :max, {
 }
 
 # Trigonometric
-["acos", "asin", "atan", "cos", "sin", "tan"].each do |op|
+["acos", "asin", "atan", "cos", "sin", "tan",
+ "acosh", "asinh", "atanh", "cosh", "sinh", "tanh"].each do |op|
     operator :"#{op}", {
         [T < Float].(T) => T,
         [T < Float, N].(Vector[T, N]) => Vector[T, N],

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -285,3 +285,47 @@ fn testTrigonometric() {
     let x3 = tan(vec4(0.0, 0.0, 0.0, 0.0));
   }
 }
+
+fn testTrigonometricHyperbolic() {
+  {
+    let x = acosh(0.0);
+    let x1 = acosh(vec2(0.0, 0.0));
+    let x2 = acosh(vec3(0.0, 0.0, 0.0));
+    let x3 = acosh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = asinh(0.0);
+    let x1 = asinh(vec2(0.0, 0.0));
+    let x2 = asinh(vec3(0.0, 0.0, 0.0));
+    let x3 = asinh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = atanh(0.0);
+    let x1 = atanh(vec2(0.0, 0.0));
+    let x2 = atanh(vec3(0.0, 0.0, 0.0));
+    let x3 = atanh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = cosh(0.0);
+    let x1 = cosh(vec2(0.0, 0.0));
+    let x2 = cosh(vec3(0.0, 0.0, 0.0));
+    let x3 = cosh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = sinh(0.0);
+    let x1 = sinh(vec2(0.0, 0.0));
+    let x2 = sinh(vec3(0.0, 0.0, 0.0));
+    let x3 = sinh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = tanh(0.0);
+    let x1 = tanh(vec2(0.0, 0.0));
+    let x2 = tanh(vec3(0.0, 0.0, 0.0));
+    let x3 = tanh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+}


### PR DESCRIPTION
#### a2a06f3433afdba101eb4a0644c59f9c68dc4e66
<pre>
[WGSL] Add type declarations for hyperbolic trigonometric functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=255160">https://bugs.webkit.org/show_bug.cgi?id=255160</a>
rdar://107759751

Reviewed by Tadeu Zagallo.

Add all the possible overloads for standard library hyperbolic trigonometric
functions: acosh, asinh, atanh, cosh, sinh, tanh.

* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/262724@main">https://commits.webkit.org/262724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b37b6e080a0f5778dda8be372953b71a97b47731

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2399 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/2398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2515 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/3543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/2417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2544 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/2489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2421 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/2168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3357 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/2141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/2235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/2143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/273 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->