### PR TITLE
transform-style:preserve-3d has incorrect hit-testing of negative z-index ::after.

### DIFF
--- a/LayoutTests/transforms/3d/hit-testing/hit-preserves-3d-2-expected.txt
+++ b/LayoutTests/transforms/3d/hit-testing/hit-preserves-3d-2-expected.txt
@@ -1,0 +1,2 @@
+Hit Me
+Hit correct target: PASSED

--- a/LayoutTests/transforms/3d/hit-testing/hit-preserves-3d-2.html
+++ b/LayoutTests/transforms/3d/hit-testing/hit-preserves-3d-2.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<title>Hit testing preserve-3d + negative z-index ::after</title>
+<style>
+* {
+	position: relative;
+}
+
+#container {
+    width: 200px;
+    height: 200px
+	display: flex;
+	background: beige;
+    align-items: center;
+	transform-style: preserve-3d;
+}
+
+#container::after {
+    width: 200px;
+    height: 200px;
+	content: "";
+	display: block;
+	position: absolute;
+	background: aliceblue;
+	top: 0%;
+	z-index: -1;
+}
+
+#hit {
+    display: block;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<body>
+<div id="container">
+    <a id="hit" href="2">Hit Me</a>
+</div>
+
+<div id="results"></div>
+
+<script type="text/javascript" charset="utf-8">
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  var hit = document.elementFromPoint(100, 100);
+  var results = document.getElementById('results');
+  if (hit == document.getElementById('hit'))
+    results.innerHTML = 'Hit correct target: PASSED';
+  else
+    results.innerHTML = 'Failed to find correct target: FAIL';
+</script>
+</body>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4141,15 +4141,21 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
     }
 
     // Now check our overflow objects.
-    hitLayer = hitTestList(normalFlowLayers(), rootLayer, request, result, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
-    if (hitLayer.layer) {
-        if (!depthSortDescendants)
-            return hitLayer;
-        if (using3DTransformsInterop) {
-            if (hitLayer.zOffset > candidateLayer.zOffset)
+    {
+        HitTestResult tempResult(result.hitTestLocation());
+        hitLayer = hitTestList(normalFlowLayers(), rootLayer, request, tempResult, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
+        if (hitLayer.layer) {
+            if (!depthSortDescendants || !using3DTransformsInterop || hitLayer.zOffset > candidateLayer.zOffset) {
+                if (request.resultIsElementList())
+                    result.append(tempResult, request);
+                else
+                    result = tempResult;
                 candidateLayer = hitLayer;
-        } else
-            candidateLayer = hitLayer;
+            }
+
+            if (!depthSortDescendants)
+                return hitLayer;
+        }
     }
 
     // Collect the fragments. This will compute the clip rectangles for each layer fragment.
@@ -4188,15 +4194,21 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
     }
 
     // Now check our negative z-index children.
-    hitLayer = hitTestList(negativeZOrderLayers(), rootLayer, request, result, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
-    if (hitLayer.layer) {
-        if (!depthSortDescendants)
-            return hitLayer;
-        if (using3DTransformsInterop) {
-            if (hitLayer.zOffset > candidateLayer.zOffset)
+    {
+        HitTestResult tempResult(result.hitTestLocation());
+        hitLayer = hitTestList(negativeZOrderLayers(), rootLayer, request, tempResult, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
+        if (hitLayer.layer) {
+            if (!depthSortDescendants || !using3DTransformsInterop || hitLayer.zOffset > candidateLayer.zOffset) {
+                if (request.resultIsElementList())
+                    result.append(tempResult, request);
+                else
+                    result = tempResult;
                 candidateLayer = hitLayer;
-        } else
-            candidateLayer = hitLayer;
+            }
+
+            if (!depthSortDescendants)
+                return hitLayer;
+        }
     }
 
     // If we found a layer, return. Child layers, and foreground always render in front of background.


### PR DESCRIPTION
#### 048b254e9fd926c46dcfef64d9e97443953ef2b0
<pre>
transform-style:preserve-3d has incorrect hit-testing of negative z-index ::after.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255028">https://bugs.webkit.org/show_bug.cgi?id=255028</a>

Reviewed by Simon Fraser.

We call hitTestList with the intention of storing the result in the temporary object &apos;hitLayer&apos;,
and only mutate the final result &apos;candidateLayer&apos; if the depth test passes.
Unfortunately the &apos;result&apos; variable is also part of the final output, and this gets mutated
on hitTestList calls that don&apos;t pass the depth test.

This creates a temporary &apos;tempResult&apos; (like we do for the other sections of this function),
and only copies back to &apos;result&apos; if the depth test passes.

* LayoutTests/transforms/3d/hit-testing/hit-preserves-3d-2-expected.txt: Added.
* LayoutTests/transforms/3d/hit-testing/hit-preserves-3d-2.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTestLayer):

Canonical link: <a href="https://commits.webkit.org/262728@main">https://commits.webkit.org/262728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58a33cebcdfaad0e201982ad64f83380e219fc3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3454 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2400 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2466 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2128 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 12 flakes 124 failures; Uploaded test results; 5 flakes 114 failures; Compiled WebKit (cancelled)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3287 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1989 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2206 "Built successfully") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2152 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3312 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2172 "Passed tests") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/1976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2129 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/600 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->