### PR TITLE
Vimeo video goes black if you hit the in-website play button while the video is open in PiP

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1373,6 +1373,25 @@ bool Quirks::blocksReturnToFullscreenFromPictureInPictureQuirk() const
 #endif
 }
 
+bool Quirks::blocksEnteringStandardFullscreenFromPictureInPictureQuirk() const
+{
+#if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
+    // Vimeo enters fullscreen when starting playback from the inline play button while already in PIP.
+    // This behavior is revealing a bug in the fullscreen handling. See rdar://107592139.
+    if (!needsQuirks())
+        return false;
+
+    if (!m_blocksEnteringStandardFullscreenFromPictureInPictureQuirk) {
+        auto domain = RegistrableDomain { m_document->topDocument().url() };
+        m_blocksEnteringStandardFullscreenFromPictureInPictureQuirk = domain == "vimeo.com"_s;
+    }
+
+    return *m_blocksEnteringStandardFullscreenFromPictureInPictureQuirk;
+#else
+    return false;
+#endif
+}
+
 bool Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -136,6 +136,7 @@ public:
     bool requiresUserGestureToLoadInPictureInPicture() const;
 
     WEBCORE_EXPORT bool blocksReturnToFullscreenFromPictureInPictureQuirk() const;
+    WEBCORE_EXPORT bool blocksEnteringStandardFullscreenFromPictureInPictureQuirk() const;
     bool shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk() const;
 
 #if ENABLE(TRACKING_PREVENTION)
@@ -210,6 +211,7 @@ private:
     mutable std::optional<bool> m_shouldEnableLegacyGetUserMediaQuirk;
 #endif
     mutable std::optional<bool> m_blocksReturnToFullscreenFromPictureInPictureQuirk;
+    mutable std::optional<bool> m_blocksEnteringStandardFullscreenFromPictureInPictureQuirk;
     mutable std::optional<bool> m_shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk;
 #if PLATFORM(IOS)
     mutable std::optional<bool> m_allowLayeredFullscreenVideos;

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -1088,7 +1088,6 @@ void VideoFullscreenInterfaceAVKit::didStopPictureInPicture()
         m_enteringPictureInPicture = false;
         if (m_videoFullscreenModel)
             m_videoFullscreenModel->didExitPictureInPicture();
-        returnToStandby();
 
         return;
     }
@@ -1146,9 +1145,6 @@ void VideoFullscreenInterfaceAVKit::prepareForPictureInPictureStopWithCompletion
 
         return;
     }
-
-    if (m_standby)
-        m_returningToStandby = true;
 
     prepareForPictureInPictureStop([protectedThis = Ref { *this }, strongCompletionHandler = adoptNS([completionHandler copy])](bool restored)  {
         LOG(Fullscreen, "VideoFullscreenInterfaceAVKit::prepareForPictureInPictureStopWithCompletionHandler lambda(%p) - restored(%s)", protectedThis.ptr(), boolString(restored));

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -29,6 +29,7 @@
 
 #include "Connection.h"
 #include "Logging.h"
+#include "VideoFullscreenManager.h"
 #include "WebCoreArgumentCoders.h"
 #include "WebFrame.h"
 #include "WebFullScreenManagerProxyMessages.h"
@@ -197,6 +198,9 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element)
     bool isVideoElement = false;
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
     isVideoElement = is<HTMLVideoElement>(element);
+
+    if (m_page->videoFullscreenManager().videoElementInPictureInPicture() && m_element->document().quirks().blocksEnteringStandardFullscreenFromPictureInPictureQuirk())
+        return;
 
     if (auto* currentPlaybackControlsElement = m_page->playbackSessionManager().currentPlaybackControlsElement())
         currentPlaybackControlsElement->prepareForVideoFullscreenStandby();

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
@@ -144,6 +144,8 @@ public:
     void setTextTrackRepresentationContentScaleForVideoElement(WebCore::HTMLVideoElement&, float scale);
     void setTextTrackRepresentationIsHiddenForVideoElement(WebCore::HTMLVideoElement&, bool hidden);
 
+    bool videoElementInPictureInPicture() const { return !!m_videoElementInPictureInPicture; }
+
 protected:
     friend class VideoFullscreenInterfaceContext;
 


### PR DESCRIPTION
#### 12441d93d8c3ea03464c5473548dd6c98203bba9
<pre>
Vimeo video goes black if you hit the in-website play button while the video is open in PiP
<a href="https://bugs.webkit.org/show_bug.cgi?id=255163">https://bugs.webkit.org/show_bug.cgi?id=255163</a>
rdar://107592139

Reviewed by Simon Fraser.

Vimeo enters fullscreen when starting playback from the inline play button while already in PIP.
This behavior is revealing a bug in the fullscreen handling. This patch introduces a quirk to
work around this issue. This patch also reverts &lt;<a href="https://commits.webkit.org/262703@main">https://commits.webkit.org/262703@main</a>&gt; since
it did not resolve the issue.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::blocksEnteringStandardFullscreenFromPictureInPictureQuirk const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(VideoFullscreenInterfaceAVKit::didStopPictureInPicture):
(VideoFullscreenInterfaceAVKit::prepareForPictureInPictureStopWithCompletionHandler):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h:
(WebKit::VideoFullscreenManager::videoElementInPictureInPicture const):

Canonical link: <a href="https://commits.webkit.org/262723@main">https://commits.webkit.org/262723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d4718b6e2badbc36407bfc0f499830361ecd131

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2393 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/2509 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/3522 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/2412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/2366 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Skipping applying patch since patch_id isn't provided; Checked out pull request; bindings-tests (cancelled)") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2538 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/2483 "Build was cancelled. Recent messages:OS: Ventura (13.2), Xcode: 14.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/3522 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2416 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/2164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/2509 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/3348 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/2509 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/3348 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2222 "Built successfully") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/3348 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/2509 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/2483 "Build was cancelled. Recent messages:OS: Ventura (13.2), Xcode: 14.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/2509 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/599 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Checked out pull request; Reviewed by Simon Fraser; Compiled WebKit (cancelled)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2129 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/272 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->