### PR TITLE
Ignore fully disabled RuleSets

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -187,6 +187,9 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
 {
     ASSERT_WITH_MESSAGE(!(m_mode == SelectorChecker::Mode::CollectingRulesIgnoringVirtualPseudoElements && m_pseudoElementRequest.pseudoId != PseudoId::None), "When in StyleInvalidation or SharingRules, SelectorChecker does not try to match the pseudo ID. While ElementRuleCollector supports matching a particular pseudoId in this case, this would indicate a error at the call site since matching a particular element should be unnecessary.");
 
+    if (!matchRequest.ruleSet.hasEnabledRules())
+        return;
+
     auto& element = this->element();
     auto* shadowRoot = element.containingShadowRoot();
     if (shadowRoot && shadowRoot->mode() == ShadowRootMode::UserAgent)

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -397,11 +397,14 @@ RuleSet::CollectedMediaQueryChanges RuleSet::evaluateDynamicMediaQueryRules(cons
     if (affectedRulePositionsAndResults.isEmpty())
         return collectedChanges;
 
+    m_hasEnabledRules = false;
+
     traverseRuleDatas([&](RuleData& ruleData) {
         auto it = affectedRulePositionsAndResults.find(ruleData.position());
-        if (it == affectedRulePositionsAndResults.end())
-            return;
-        ruleData.setEnabled(it->value);
+        if (it != affectedRulePositionsAndResults.end())
+            ruleData.setEnabled(it->value);
+        if (ruleData.isEnabled())
+            m_hasEnabledRules = true;
     });
 
     return collectedChanges;

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -118,6 +118,8 @@ public:
     bool hasContainerQueries() const { return !m_containerQueries.isEmpty(); }
     Vector<const CQ::ContainerQuery*> containerQueriesFor(const RuleData&) const;
 
+    bool hasEnabledRules() const { return m_hasEnabledRules; }
+
 private:
     friend class RuleSetBuilder;
 
@@ -192,6 +194,7 @@ private:
     Vector<DynamicMediaQueryRules> m_dynamicMediaQueryRules;
     HashMap<Vector<size_t>, Ref<const RuleSet>> m_mediaQueryInvalidationRuleSetCache;
     unsigned m_ruleCount { 0 };
+    bool m_hasEnabledRules { true };
 
     Vector<CascadeLayer> m_cascadeLayers;
     // This is a side vector to hold layer identifiers without bloating RuleData.


### PR DESCRIPTION
#### 01bb77c1529ccebb4927a761e8ff108eaa9bd1b1
<pre>
Ignore fully disabled RuleSets
<a href="https://bugs.webkit.org/show_bug.cgi?id=255165">https://bugs.webkit.org/show_bug.cgi?id=255165</a>
rdar://problem/107766483

Reviewed by NOBODY (OOPS!).

Avoid unnecessary hash lookups if all rules are disabled. This case is common with dynamic UA sheet media query rules.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):

Bail out if no rules are enabled.

* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::evaluateDynamicMediaQueryRules):

Check if we disable all the rules.

* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::hasEnabledRules const):
</pre>