### PR TITLE
Remove bot641, 682, 673 from config

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -56,12 +56,9 @@
                   { "name": "bot307", "platform": "ios-simulator-16" },
                   { "name": "bot308", "platform": "ios-simulator-16" },
                   { "name": "bot600", "platform": "ios-simulator-16" },
-                  { "name": "bot673", "platform": "ios-16" },
                   { "name": "bot651", "platform": "ios-simulator-16" },
                   { "name": "bot652", "platform": "ios-simulator-16" },
                   { "name": "bot653", "platform": "ios-simulator-16" },
-                  { "name": "bot641", "platform": "ios-simulator-16" },
-                  { "name": "bot682", "platform": "ios-simulator-16" },
                   { "name": "bot667", "platform": "ios-simulator-16"},
                   { "name": "bot664", "platform": "ios-simulator-16"},
 
@@ -285,13 +282,13 @@
                   {
                     "name": "Apple-iOS-16-Release-Build", "factory": "BuildFactory",
                     "platform": "ios-16", "configuration": "release", "architectures": ["arm64"],
-                    "workernames": ["bot673", "bot304"]
+                    "workernames": ["bot304"]
                   },
                   {
                     "name": "Apple-iOS-16-Simulator-Release-Build", "factory": "BuildFactory",
                     "platform": "ios-simulator-16", "configuration": "release", "architectures": ["x86_64", "arm64"],
                     "triggers": ["ios-simulator-16-release-gpuprocess-tests-wk2", "ios-simulator-16-release-tests-wk2", "ipados-simulator-16-release-tests-wk2"],
-                    "workernames": ["bot641", "bot682", "bot303", "bot305", "bot306"]
+                    "workernames": ["bot303", "bot305", "bot306"]
                   },
                   {
                     "name": "Apple-iOS-16-Simulator-Debug-Build", "factory": "BuildFactory",


### PR DESCRIPTION
#### 86439a3764d2b1232aeb261134cc2edd7d9da88c
<pre>
Remove bot641, 682, 673 from config
<a href="https://bugs.webkit.org/show_bug.cgi?id=255167">https://bugs.webkit.org/show_bug.cgi?id=255167</a>
rdar://problem/107206847

Unreviewed config modifcation.

Removing three no longer needed bots from config.

* Tools/CISupport/build-webkit-org/config.json:

Canonical link: <a href="https://commits.webkit.org/262729@main">https://commits.webkit.org/262729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2f5a51dd309c5f78d2f975ae28fc76b951139be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/2411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2410 "Failed to checkout and rebase branch from PR 12525") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2530 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/3640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/2455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/2383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/2557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/2500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/3640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/2433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/2557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/3455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/2557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/2151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/3455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/2261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/2557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/3455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/2500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/2387 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/2153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/276 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->