### PR TITLE
Handle vary headers appropriately for DOMCache opaque response

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any-expected.txt
@@ -23,5 +23,5 @@ PASS Cache produces large Responses that can be cloned and read correctly.
 PASS cors-exposed header should be stored correctly.
 PASS MIME type should be set from content-header correctly.
 FAIL MIME type should reflect Content-Type headers of response. assert_equals: mime type can be overridden expected "text/plain" but got "text/html"
-FAIL Cache.match ignores vary headers on opaque response. assert_not_equals: got disallowed value undefined
+PASS Cache.match ignores vary headers on opaque response.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.serviceworker-expected.txt
@@ -23,5 +23,5 @@ PASS Cache produces large Responses that can be cloned and read correctly.
 PASS cors-exposed header should be stored correctly.
 PASS MIME type should be set from content-header correctly.
 FAIL MIME type should reflect Content-Type headers of response. assert_equals: mime type can be overridden expected "text/plain" but got "text/html"
-FAIL Cache.match ignores vary headers on opaque response. assert_not_equals: got disallowed value undefined
+PASS Cache.match ignores vary headers on opaque response.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.sharedworker-expected.txt
@@ -23,5 +23,5 @@ PASS Cache produces large Responses that can be cloned and read correctly.
 PASS cors-exposed header should be stored correctly.
 PASS MIME type should be set from content-header correctly.
 FAIL MIME type should reflect Content-Type headers of response. assert_equals: mime type can be overridden expected "text/plain" but got "text/html"
-FAIL Cache.match ignores vary headers on opaque response. assert_not_equals: got disallowed value undefined
+PASS Cache.match ignores vary headers on opaque response.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.worker-expected.txt
@@ -23,5 +23,5 @@ PASS Cache produces large Responses that can be cloned and read correctly.
 PASS cors-exposed header should be stored correctly.
 PASS MIME type should be set from content-header correctly.
 FAIL MIME type should reflect Content-Type headers of response. assert_equals: mime type can be overridden expected "text/plain" but got "text/html"
-FAIL Cache.match ignores vary headers on opaque response. assert_not_equals: got disallowed value undefined
+PASS Cache.match ignores vary headers on opaque response.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/serviceworker/cache-match.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/serviceworker/cache-match.https-expected.txt
@@ -24,5 +24,5 @@ PASS Cache produces large Responses that can be cloned and read correctly.
 PASS cors-exposed header should be stored correctly.
 PASS MIME type should be set from content-header correctly.
 FAIL MIME type should reflect Content-Type headers of response. assert_equals: mime type can be overridden expected "text/plain" but got "text/html"
-FAIL Cache.match ignores vary headers on opaque response. assert_not_equals: got disallowed value undefined
+PASS Cache.match ignores vary headers on opaque response.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/window/cache-match.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/window/cache-match.https-expected.txt
@@ -23,5 +23,5 @@ PASS Cache produces large Responses that can be cloned and read correctly.
 PASS cors-exposed header should be stored correctly.
 PASS MIME type should be set from content-header correctly.
 FAIL MIME type should reflect Content-Type headers of response. assert_equals: mime type can be overridden expected "text/plain" but got "text/html"
-FAIL Cache.match ignores vary headers on opaque response. assert_not_equals: got disallowed value undefined
+PASS Cache.match ignores vary headers on opaque response.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/worker/cache-match.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/worker/cache-match.https-expected.txt
@@ -23,5 +23,5 @@ PASS Cache produces large Responses that can be cloned and read correctly.
 PASS cors-exposed header should be stored correctly.
 PASS MIME type should be set from content-header correctly.
 FAIL MIME type should reflect Content-Type headers of response. assert_equals: mime type can be overridden expected "text/plain" but got "text/html"
-FAIL Cache.match ignores vary headers on opaque response. assert_not_equals: got disallowed value undefined
+PASS Cache.match ignores vary headers on opaque response.
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -135,7 +135,7 @@ static CacheStorageRecord toCacheStorageRecord(WebCore::DOMCacheEngine::CrossThr
 {
     NetworkCache::Key key { "record"_s, uniqueName, { }, createVersion4UUIDString(), salt };
     CacheStorageRecordInformation recordInfo { WTFMove(key), MonotonicTime::now().secondsSinceEpoch().milliseconds(), record.identifier, 0 , record.responseBodySize, record.request.url(), false, { } };
-    recordInfo.updateVaryHeaders(record.request, record.response.httpHeaderFields.get(WebCore::HTTPHeaderName::Vary));
+    recordInfo.updateVaryHeaders(record.request, record.response);
 
     return CacheStorageRecord { WTFMove(recordInfo), record.requestHeadersGuard, WTFMove(record.request), record.options, WTFMove(record.referrer), record.responseHeadersGuard, WTFMove(record.response), record.responseBodySize, WTFMove(record.responseBody) };
 }
@@ -351,7 +351,7 @@ void CacheStorageCache::putRecordsInStore(Vector<CacheStorageRecord>&& records, 
             record.request = WTFMove(existingRecord->request);
             record.options = WTFMove(existingRecord->options);
             record.referrer = WTFMove(existingRecord->referrer);
-            record.info.updateVaryHeaders(record.request, record.responseData.httpHeaderFields.get(WebCore::HTTPHeaderName::Vary));
+            record.info.updateVaryHeaders(record.request, record.responseData);
             sizeIncreased += record.info.size;
             sizeDecreased += existingRecordInfo->size;
             existingRecordInfo->size = record.info.size;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -297,7 +297,7 @@ static std::optional<StoredRecordInformation> readRecordInfoFromFileData(const F
         return std::nullopt;
 
     CacheStorageRecordInformation info { metaData->key, header->insertionTime, 0, 0, header->responseBodySize, header->request.url(), false, { } };
-    info.updateVaryHeaders(header->request, header->responseData.httpHeaderFields.get(WebCore::HTTPHeaderName::Vary));
+    info.updateVaryHeaders(header->request, header->responseData);
     return StoredRecordInformation { info, WTFMove(*metaData), WTFMove(*header) };
 }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
@@ -27,13 +27,15 @@
 #include "NetworkCacheKey.h"
 #include <WebCore/DOMCacheEngine.h>
 #include <WebCore/HTTPParsers.h>
+#include <WebCore/ResourceResponse.h>
 
 namespace WebKit {
 
 struct CacheStorageRecordInformation {
-    void updateVaryHeaders(const WebCore::ResourceRequest& request, const String& varyValue)
+    void updateVaryHeaders(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse::CrossThreadData& response)
     {
-        if (varyValue.isNull()) {
+        auto varyValue = response.httpHeaderFields.get(WebCore::HTTPHeaderName::Vary);
+        if (varyValue.isNull() || response.tainting == WebCore::ResourceResponse::Tainting::Opaque || response.tainting == WebCore::ResourceResponse::Tainting::Opaqueredirect) {
             hasVaryStar = false;
             varyHeaders = { };
             return;


### PR DESCRIPTION
#### ed3253fa0f11ee057db3a81768c5abbe8d77b2f0
<pre>
Handle vary headers appropriately for DOMCache opaque response
<a href="https://bugs.webkit.org/show_bug.cgi?id=255170">https://bugs.webkit.org/show_bug.cgi?id=255170</a>
rdar://problem/107769146

Reviewed by Sihui Liu.

For opaque responses, clear parsed vary header map as this header should not be observable.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/serviceworker/cache-match.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/window/cache-match.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/worker/cache-match.https-expected.txt:
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::toCacheStorageRecord):
(WebKit::CacheStorageCache::putRecordsInStore):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::readRecordInfoFromFileData):
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h:
(WebKit::CacheStorageRecordInformation::updateVaryHeaders):

Canonical link: <a href="https://commits.webkit.org/262813@main">https://commits.webkit.org/262813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14c762e3e030f67e680e7c7357cdaa744dba536f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2176 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3607 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2056 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2342 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3381 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2246 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2032 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2199 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/661 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->