### PR TITLE
Accessing null RemoteScrollingCoordinatorProxy in [WKWebViewIOS _didFinishScrolling]

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1818,11 +1818,11 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 #if ENABLE(ASYNC_SCROLLING)
     // FIXME: We will want to detect whether snapping will occur before beginning to drag. See WebPageProxy::didCommitLayerTree.
-    auto* coordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy());
     ASSERT(scrollView == _scrollView.get());
-    [_scrollView _setDecelerationRateInternal:(coordinator && coordinator->shouldSetScrollViewDecelerationRateFast()) ? UIScrollViewDecelerationRateFast : UIScrollViewDecelerationRateNormal];
-
-    coordinator->setRootNodeIsInUserScroll(true);
+    if (auto* coordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy())) {
+        [_scrollView _setDecelerationRateInternal:(coordinator->shouldSetScrollViewDecelerationRateFast()) ? UIScrollViewDecelerationRateFast : UIScrollViewDecelerationRateNormal];
+        coordinator->setRootNodeIsInUserScroll(true);
+    }
 #endif
 }
 
@@ -1838,7 +1838,8 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     [_contentView didFinishScrolling];
 
 #if ENABLE(ASYNC_SCROLLING)
-    _page->scrollingCoordinatorProxy()->setRootNodeIsInUserScroll(false);
+    if (auto* coordinator = _page->scrollingCoordinatorProxy())
+        coordinator->setRootNodeIsInUserScroll(false);
 #endif
 }
 


### PR DESCRIPTION
#### 2aa252bfd9f1edb9b20d8c4ec897890fd284a036
<pre>
Accessing null RemoteScrollingCoordinatorProxy in [WKWebViewIOS _didFinishScrolling]
<a href="https://bugs.webkit.org/show_bug.cgi?id=255162">https://bugs.webkit.org/show_bug.cgi?id=255162</a>
rdar://106894608

Reviewed by Wenson Hsieh.

We&apos;re seeing null derefs of a `RemoteScrollingCoordinatorProxy` at
[WKWebViewIOS _didFinishScrolling] in situations where a web view is
closed out during a scroll operation.

This regression surfaced from <a href="https://commits.webkit.org/260975@main">https://commits.webkit.org/260975@main</a>
because it (correctly) changed the relative order of destruction between
the `DrawingAreaProxy` and the `RemoteScrollingCoordinatorProxy` (and
the `RemoteScrollingTree` it encompasses), which meant that there could
be situations where closing or switching out a web view in the middle of
a scroll operation would lead to a null deref of the
`RemoteScrollingCoordinatorProxy` held by the `WebPageProxy`.

In this patch, we add a null check on the
`RemoteScrollingCoordinatorProxy` instance held by `WebPageProxy` in two
different places:

- In `_didFinishScrolling`. This is OK to do because the web view has
  closed out by this point anyway (and `RemoteScrollingTree` instance
  has been destructed), so the `setRootNodeIsInUserScroll` method call
  would be a no-op anyway.
- In `scrollViewWillBeginDragging`. This is OK for much the same reason.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollViewWillBeginDragging:]):
(-[WKWebView _didFinishScrolling:]):

Canonical link: <a href="https://commits.webkit.org/262748@main">https://commits.webkit.org/262748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df06269c9833e989801086e5b4d008ab5e966d5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3781 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2482 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2164 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3580 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2044 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2306 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2202 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3365 "261 api tests failed or timed out") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2230 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2022 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/613 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->