### PR TITLE
[UI-side compositing] Create RemoteScrollbarsController for plumbing web process events to the scrolling coordinator

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2738,33 +2738,19 @@ void EventHandler::notifyScrollableAreasOfMouseEvents(const AtomString& eventTyp
 
     auto scrollableAreaForLastNode = enclosingScrollableArea(lastElementUnderMouse);
     auto scrollableAreaForNodeUnderMouse = enclosingScrollableArea(elementUnderMouse);
-    auto scrollingCoordinator = m_frame.page()->scrollingCoordinator();
 
     if (!!lastElementUnderMouse != !!elementUnderMouse) {
         if (elementUnderMouse) {
-            if (scrollableAreaForNodeUnderMouse != frameView) {
+            if (scrollableAreaForNodeUnderMouse != frameView)
                 frameView->mouseEnteredContentArea();
-                if (scrollingCoordinator)
-                    scrollingCoordinator->setMouseIsOverContentArea(frameView.get(), true);
-            }
-
-            if (scrollableAreaForNodeUnderMouse) {
+            if (scrollableAreaForNodeUnderMouse)
                 scrollableAreaForNodeUnderMouse->mouseEnteredContentArea();
-                if (scrollingCoordinator)
-                    scrollingCoordinator->setMouseIsOverContentArea(scrollableAreaForNodeUnderMouse, true);
-            }
         } else {
-            if (scrollableAreaForLastNode) {
+            if (scrollableAreaForLastNode)
                 scrollableAreaForLastNode->mouseExitedContentArea();
-                if (scrollingCoordinator)
-                    scrollingCoordinator->setMouseIsOverContentArea(scrollableAreaForLastNode, false);
-            }
 
-            if (scrollableAreaForLastNode != frameView) {
+            if (scrollableAreaForLastNode != frameView)
                 frameView->mouseExitedContentArea();
-                if (scrollingCoordinator)
-                    scrollingCoordinator->setMouseIsOverContentArea(frameView.get(), false);
-            }
         }
         return;
     }
@@ -2777,30 +2763,19 @@ void EventHandler::notifyScrollableAreasOfMouseEvents(const AtomString& eventTyp
     bool movedBetweenScrollableaAreas = scrollableAreaForLastNode && scrollableAreaForNodeUnderMouse && (scrollableAreaForLastNode != scrollableAreaForNodeUnderMouse);
     if (eventType == eventNames().mousemoveEvent) {
         frameView->mouseMovedInContentArea();
-        if (scrollingCoordinator)
-            scrollingCoordinator->setMouseMovedInContentArea(frameView.get());
 
-        if (!movedBetweenScrollableaAreas && scrollableAreaForNodeUnderMouse && scrollableAreaForNodeUnderMouse != frameView) {
+        if (!movedBetweenScrollableaAreas && scrollableAreaForNodeUnderMouse && scrollableAreaForNodeUnderMouse != frameView)
             scrollableAreaForNodeUnderMouse->mouseMovedInContentArea();
-            if (scrollingCoordinator)
-                scrollingCoordinator->setMouseMovedInContentArea(scrollableAreaForNodeUnderMouse);
-        }
     }
 
     if (!movedBetweenScrollableaAreas)
         return;
 
-    if (scrollableAreaForLastNode && scrollableAreaForLastNode != frameView) {
+    if (scrollableAreaForLastNode && scrollableAreaForLastNode != frameView)
         scrollableAreaForLastNode->mouseExitedContentArea();
-        if (scrollingCoordinator)
-            scrollingCoordinator->setMouseIsOverContentArea(scrollableAreaForLastNode, false);
-    }
 
-    if (scrollableAreaForNodeUnderMouse && scrollableAreaForNodeUnderMouse != frameView) {
+    if (scrollableAreaForNodeUnderMouse && scrollableAreaForNodeUnderMouse != frameView)
         scrollableAreaForNodeUnderMouse->mouseEnteredContentArea();
-        if (scrollingCoordinator)
-            scrollingCoordinator->setMouseIsOverContentArea(scrollableAreaForNodeUnderMouse, true);
-    }
 }
 
 bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetNode, int clickCount, const PlatformMouseEvent& platformMouseEvent, FireMouseOverOut fireMouseOverOut)
@@ -4697,16 +4672,11 @@ void EventHandler::updateLastScrollbarUnderMouse(Scrollbar* scrollbar, SetOrClea
 {
     if (m_lastScrollbarUnderMouse != scrollbar) {
         // Send mouse exited to the old scrollbar.
-        if (m_lastScrollbarUnderMouse) {
-            if (auto scrollingCoordinator = m_frame.page()->scrollingCoordinator())
-                scrollingCoordinator->setMouseIsOverScrollbar(m_lastScrollbarUnderMouse.get(), false);
+        if (m_lastScrollbarUnderMouse)
             m_lastScrollbarUnderMouse->mouseExited();
-        }
 
         // Send mouse entered if we're setting a new scrollbar.
         if (scrollbar && setOrClear == SetOrClearLastScrollbar::Set) {
-            if (auto scrollingCoordinator = m_frame.page()->scrollingCoordinator())
-                scrollingCoordinator->setMouseIsOverScrollbar(scrollbar, true);
             scrollbar->mouseEntered();
             m_lastScrollbarUnderMouse = *scrollbar;
         } else

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -359,11 +359,11 @@ bool AsyncScrollingCoordinator::requestScrollPositionUpdate(ScrollableArea& scro
     return true;
 }
 
-void AsyncScrollingCoordinator::setMouseIsOverContentArea(ScrollableArea* scrollableArea, bool isOverContentArea)
+void AsyncScrollingCoordinator::setMouseIsOverContentArea(ScrollableArea& scrollableArea, bool isOverContentArea)
 {
     ASSERT(isMainThread());
     ASSERT(m_page);
-    auto scrollingNodeID = scrollableArea->scrollingNodeID();
+    auto scrollingNodeID = scrollableArea.scrollingNodeID();
     if (!scrollingNodeID)
         return;
     
@@ -373,11 +373,11 @@ void AsyncScrollingCoordinator::setMouseIsOverContentArea(ScrollableArea* scroll
     stateNode->setMouseIsOverContentArea(isOverContentArea);
 }
 
-void AsyncScrollingCoordinator::setMouseMovedInContentArea(ScrollableArea* scrollableArea)
+void AsyncScrollingCoordinator::setMouseMovedInContentArea(ScrollableArea& scrollableArea)
 {
     ASSERT(isMainThread());
     ASSERT(m_page);
-    auto scrollingNodeID = scrollableArea->scrollingNodeID();
+    auto scrollingNodeID = scrollableArea.scrollingNodeID();
     if (!scrollingNodeID)
         return;
     

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -73,8 +73,8 @@ public:
 
     virtual void hasNodeWithAnimatedScrollChanged(bool) { };
     
-    WEBCORE_EXPORT void setMouseIsOverContentArea(ScrollableArea*, bool) override;
-    WEBCORE_EXPORT void setMouseMovedInContentArea(ScrollableArea*) override;
+    WEBCORE_EXPORT void setMouseIsOverContentArea(ScrollableArea&, bool) override;
+    WEBCORE_EXPORT void setMouseMovedInContentArea(ScrollableArea&) override;
 
 protected:
     WEBCORE_EXPORT AsyncScrollingCoordinator(Page*);

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -62,7 +62,7 @@ struct KeyboardScroll;
 using FramesPerSecond = unsigned;
 using PlatformDisplayID = uint32_t;
 
-class ScrollingCoordinator : public ThreadSafeRefCounted<ScrollingCoordinator> {
+class ScrollingCoordinator : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollingCoordinator> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<ScrollingCoordinator> create(Page*);
@@ -206,8 +206,8 @@ public:
     void deferWheelEventTestCompletionForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason);
     void removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason);
 
-    WEBCORE_EXPORT virtual void setMouseIsOverContentArea(ScrollableArea*, bool) { }
-    WEBCORE_EXPORT virtual void setMouseMovedInContentArea(ScrollableArea*) { }
+    WEBCORE_EXPORT virtual void setMouseIsOverContentArea(ScrollableArea&, bool) { }
+    WEBCORE_EXPORT virtual void setMouseMovedInContentArea(ScrollableArea&) { }
     WEBCORE_EXPORT virtual void setMouseIsOverScrollbar(Scrollbar*, bool) { }
 
 protected:

--- a/Source/WebCore/platform/ScrollbarsController.h
+++ b/Source/WebCore/platform/ScrollbarsController.h
@@ -54,42 +54,42 @@ public:
 
     virtual void notifyContentAreaScrolled(const FloatSize&) { }
 
-    virtual void cancelAnimations();
+    WEBCORE_EXPORT virtual void cancelAnimations();
 
-    virtual void didBeginScrollGesture();
-    virtual void didEndScrollGesture();
-    virtual void mayBeginScrollGesture();
+    WEBCORE_EXPORT virtual void didBeginScrollGesture();
+    WEBCORE_EXPORT virtual void didEndScrollGesture();
+    WEBCORE_EXPORT virtual void mayBeginScrollGesture();
 
-    virtual void contentAreaWillPaint() const { }
-    virtual void mouseEnteredContentArea() { }
-    virtual void mouseExitedContentArea() { }
-    virtual void mouseMovedInContentArea() { }
-    virtual void mouseEnteredScrollbar(Scrollbar*) const { }
-    virtual void mouseExitedScrollbar(Scrollbar*) const { }
-    virtual void mouseIsDownInScrollbar(Scrollbar*, bool) const { }
-    virtual void willStartLiveResize() { }
-    virtual void contentsSizeChanged() const { }
-    virtual void willEndLiveResize() { }
-    virtual void contentAreaDidShow() { }
-    virtual void contentAreaDidHide() { }
+    WEBCORE_EXPORT virtual void contentAreaWillPaint() const { }
+    WEBCORE_EXPORT virtual void mouseEnteredContentArea() { }
+    WEBCORE_EXPORT virtual void mouseExitedContentArea() { }
+    WEBCORE_EXPORT virtual void mouseMovedInContentArea() { }
+    WEBCORE_EXPORT virtual void mouseEnteredScrollbar(Scrollbar*) const { }
+    WEBCORE_EXPORT virtual void mouseExitedScrollbar(Scrollbar*) const { }
+    WEBCORE_EXPORT virtual void mouseIsDownInScrollbar(Scrollbar*, bool) const { }
+    WEBCORE_EXPORT virtual void willStartLiveResize() { }
+    WEBCORE_EXPORT virtual void contentsSizeChanged() const { }
+    WEBCORE_EXPORT virtual void willEndLiveResize() { }
+    WEBCORE_EXPORT virtual void contentAreaDidShow() { }
+    WEBCORE_EXPORT virtual void contentAreaDidHide() { }
 
-    virtual void lockOverlayScrollbarStateToHidden(bool) { }
-    virtual bool scrollbarsCanBeActive() const { return true; }
+    WEBCORE_EXPORT virtual void lockOverlayScrollbarStateToHidden(bool) { }
+    WEBCORE_EXPORT virtual bool scrollbarsCanBeActive() const { return true; }
 
-    virtual void didAddVerticalScrollbar(Scrollbar*) { }
-    virtual void willRemoveVerticalScrollbar(Scrollbar*) { }
-    virtual void didAddHorizontalScrollbar(Scrollbar*) { }
-    virtual void willRemoveHorizontalScrollbar(Scrollbar*) { }
+    WEBCORE_EXPORT virtual void didAddVerticalScrollbar(Scrollbar*) { }
+    WEBCORE_EXPORT virtual void willRemoveVerticalScrollbar(Scrollbar*) { }
+    WEBCORE_EXPORT virtual void didAddHorizontalScrollbar(Scrollbar*) { }
+    WEBCORE_EXPORT virtual void willRemoveHorizontalScrollbar(Scrollbar*) { }
 
-    virtual void invalidateScrollbarPartLayers(Scrollbar*) { }
+    WEBCORE_EXPORT virtual void invalidateScrollbarPartLayers(Scrollbar*) { }
 
-    virtual void verticalScrollbarLayerDidChange() { }
-    virtual void horizontalScrollbarLayerDidChange() { }
+    WEBCORE_EXPORT virtual void verticalScrollbarLayerDidChange() { }
+    WEBCORE_EXPORT virtual void horizontalScrollbarLayerDidChange() { }
 
-    virtual bool shouldScrollbarParticipateInHitTesting(Scrollbar*) { return true; }
+    WEBCORE_EXPORT virtual bool shouldScrollbarParticipateInHitTesting(Scrollbar*) { return true; }
 
-    virtual String horizontalScrollbarStateForTesting() const { return emptyString(); }
-    virtual String verticalScrollbarStateForTesting() const { return emptyString(); }
+    WEBCORE_EXPORT virtual String horizontalScrollbarStateForTesting() const { return emptyString(); }
+    WEBCORE_EXPORT virtual String verticalScrollbarStateForTesting() const { return emptyString(); }
 
 private:
     ScrollableArea& m_scrollableArea;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -716,6 +716,7 @@ WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm @no-unify
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.cpp
 
 // Derived Sources
 GPUConnectionToWebProcessMessageReceiver.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3223,6 +3223,8 @@
 		1ABC3DF41899E437004F0626 /* NavigationState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NavigationState.h; sourceTree = "<group>"; };
 		1ABC3DFB1899F51C004F0626 /* WKNavigationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKNavigationDelegate.h; sourceTree = "<group>"; };
 		1ABF43791A368050003FB0E6 /* WebsiteDataType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebsiteDataType.h; sourceTree = "<group>"; };
+		1AC009E129E0E28A00E696C4 /* RemoteScrollbarsController.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteScrollbarsController.cpp; sourceTree = "<group>"; };
+		1AC009E229E0E28B00E696C4 /* RemoteScrollbarsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollbarsController.h; sourceTree = "<group>"; };
 		1AC0273E196622D600C12B75 /* WebPageProxyCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPageProxyCocoa.mm; sourceTree = "<group>"; };
 		1AC1336518565B5700F3EC05 /* UserData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserData.cpp; sourceTree = "<group>"; };
 		1AC1336618565B5700F3EC05 /* UserData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserData.h; sourceTree = "<group>"; };
@@ -9042,6 +9044,8 @@
 				2D29ECCF192F2C2E00984B78 /* RemoteLayerTreeDisplayRefreshMonitor.mm */,
 				1AB16ADC1648598400290D62 /* RemoteLayerTreeDrawingArea.h */,
 				1AB16ADB1648598400290D62 /* RemoteLayerTreeDrawingArea.mm */,
+				1AC009E129E0E28A00E696C4 /* RemoteScrollbarsController.cpp */,
+				1AC009E229E0E28B00E696C4 /* RemoteScrollbarsController.h */,
 				0F59478D187B3B3A00437857 /* RemoteScrollingCoordinator.h */,
 				0F59478E187B3B3A00437857 /* RemoteScrollingCoordinator.messages.in */,
 				0F59478F187B3B3A00437857 /* RemoteScrollingCoordinator.mm */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -143,7 +143,7 @@
 #endif
 
 #if PLATFORM(MAC)
-#include <WebCore/ScrollbarsController.h>
+#include "RemoteScrollbarsController.h"
 #endif
 
 namespace WebKit {
@@ -1039,7 +1039,7 @@ bool WebChromeClient::layerTreeStateIsFrozen() const
 
 #if ENABLE(ASYNC_SCROLLING)
 
-RefPtr<ScrollingCoordinator> WebChromeClient::createScrollingCoordinator(Page& page) const
+RefPtr<WebCore::ScrollingCoordinator> WebChromeClient::createScrollingCoordinator(Page& page) const
 {
     ASSERT_UNUSED(page, m_page.corePage() == &page);
 #if PLATFORM(COCOA)
@@ -1063,7 +1063,7 @@ std::unique_ptr<ScrollbarsController> WebChromeClient::createScrollbarsControlle
     ASSERT_UNUSED(page, m_page.corePage() == &page);
     switch (m_page.drawingArea()->type()) {
     case DrawingAreaType::RemoteLayerTree:
-        return makeUnique<ScrollbarsController>(area);
+        return makeUnique<RemoteScrollbarsController>(area, page.scrollingCoordinator());
     default:
         return nullptr;
     }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteScrollbarsController.h"
+
+#if PLATFORM(MAC)
+
+#include <WebCore/ScrollableArea.h>
+#include <WebCore/ScrollingCoordinator.h>
+
+namespace WebKit {
+
+RemoteScrollbarsController::RemoteScrollbarsController(WebCore::ScrollableArea& scrollableArea, WebCore::ScrollingCoordinator* coordinator)
+    : ScrollbarsController(scrollableArea)
+    , m_coordinator(ThreadSafeWeakPtr<WebCore::ScrollingCoordinator>(coordinator))
+{
+}
+
+void RemoteScrollbarsController::mouseEnteredContentArea()
+{
+    if (auto scrollingCoordinator = m_coordinator.get())
+        scrollingCoordinator->setMouseIsOverContentArea(scrollableArea(), true);
+}
+
+void RemoteScrollbarsController::mouseExitedContentArea()
+{
+    if (auto scrollingCoordinator = m_coordinator.get())
+        scrollingCoordinator->setMouseIsOverContentArea(scrollableArea(), false);
+}
+
+void RemoteScrollbarsController::mouseMovedInContentArea()
+{
+    if (auto scrollingCoordinator = m_coordinator.get())
+        scrollingCoordinator->setMouseMovedInContentArea(scrollableArea());
+}
+
+void RemoteScrollbarsController::mouseEnteredScrollbar(WebCore::Scrollbar* scrollbar) const
+{
+    if (auto scrollingCoordinator = m_coordinator.get())
+        scrollingCoordinator->setMouseIsOverScrollbar(scrollbar, true);
+}
+
+void RemoteScrollbarsController::mouseExitedScrollbar(WebCore::Scrollbar* scrollbar) const
+{
+    if (auto scrollingCoordinator = m_coordinator.get())
+        scrollingCoordinator->setMouseIsOverScrollbar(scrollbar, false);
+}
+
+}
+#endif // PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#include <WebCore/ScrollbarsController.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+class ScrollingCoordinator;
+class Scrollbar;
+
+namespace WebKit {
+
+
+class RemoteScrollbarsController final : public WebCore::ScrollbarsController {
+public:
+    RemoteScrollbarsController(WebCore::ScrollableArea&, WebCore::ScrollingCoordinator*);
+    ~RemoteScrollbarsController() = default;
+    void mouseEnteredContentArea() final;
+    void mouseExitedContentArea()  final;
+    void mouseMovedInContentArea() final;
+    void mouseEnteredScrollbar(WebCore::Scrollbar*) const final;
+    void mouseExitedScrollbar(WebCore::Scrollbar*) const final;
+
+private:
+    ThreadSafeWeakPtr<WebCore::ScrollingCoordinator> m_coordinator;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 87496bbd2fe0644663cbe1fb501e2711eddae3c3
<pre>
[UI-side compositing] Create RemoteScrollbarsController for plumbing web process events to the scrolling coordinator
<a href="https://bugs.webkit.org/show_bug.cgi?id=255173">https://bugs.webkit.org/show_bug.cgi?id=255173</a>
rdar://107770765

Reviewed by Simon Fraser.

This patch creates RemoteScrollbarsController, for the purpose of moving the scrolling coordinator
calls out of EventHandler and into the ScrollbarController functions, which were already being
called in the EventHandler.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::notifyScrollableAreasOfMouseEvents):
(WebCore::EventHandler::updateLastScrollbarUnderMouse):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setMouseIsOverContentArea):
(WebCore::AsyncScrollingCoordinator::setMouseMovedInContentArea):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
(WebCore::ScrollingCoordinator::setMouseIsOverContentArea):
(WebCore::ScrollingCoordinator::setMouseMovedInContentArea):
* Source/WebCore/platform/ScrollbarsController.h:
(WebCore::ScrollbarsController::contentAreaWillPaint const):
(WebCore::ScrollbarsController::mouseEnteredContentArea):
(WebCore::ScrollbarsController::mouseExitedContentArea):
(WebCore::ScrollbarsController::mouseMovedInContentArea):
(WebCore::ScrollbarsController::mouseEnteredScrollbar const):
(WebCore::ScrollbarsController::mouseExitedScrollbar const):
(WebCore::ScrollbarsController::mouseIsDownInScrollbar const):
(WebCore::ScrollbarsController::willStartLiveResize):
(WebCore::ScrollbarsController::contentsSizeChanged const):
(WebCore::ScrollbarsController::willEndLiveResize):
(WebCore::ScrollbarsController::contentAreaDidShow):
(WebCore::ScrollbarsController::contentAreaDidHide):
(WebCore::ScrollbarsController::lockOverlayScrollbarStateToHidden):
(WebCore::ScrollbarsController::scrollbarsCanBeActive const):
(WebCore::ScrollbarsController::didAddVerticalScrollbar):
(WebCore::ScrollbarsController::willRemoveVerticalScrollbar):
(WebCore::ScrollbarsController::didAddHorizontalScrollbar):
(WebCore::ScrollbarsController::willRemoveHorizontalScrollbar):
(WebCore::ScrollbarsController::invalidateScrollbarPartLayers):
(WebCore::ScrollbarsController::verticalScrollbarLayerDidChange):
(WebCore::ScrollbarsController::horizontalScrollbarLayerDidChange):
(WebCore::ScrollbarsController::shouldScrollbarParticipateInHitTesting):
(WebCore::ScrollbarsController::horizontalScrollbarStateForTesting const):
(WebCore::ScrollbarsController::verticalScrollbarStateForTesting const):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createScrollingCoordinator const):
(WebKit::WebChromeClient::createScrollbarsController const):
* Source/WebKit/WebProcess/WebPage/mac/ScrollbarsControllerProxyMac.cpp: Added.
(WebKit::ScrollbarsControllerProxyMac::ScrollbarsControllerProxyMac):
(WebKit::ScrollbarsControllerProxyMac::mouseEnteredContentArea):
(WebKit::ScrollbarsControllerProxyMac::mouseExitedContentArea):
(WebKit::ScrollbarsControllerProxyMac::mouseMovedInContentArea):
(WebKit::ScrollbarsControllerProxyMac::mouseEnteredScrollbar const):
(WebKit::ScrollbarsControllerProxyMac::mouseExitedScrollbar const):
* Source/WebKit/WebProcess/WebPage/mac/ScrollbarsControllerProxyMac.h: Added.

Canonical link: <a href="https://commits.webkit.org/262744@main">https://commits.webkit.org/262744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/737aaf84e108ade09b2ee0917ce835eebe03999e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2453 "26 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2169 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2474 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/2255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3592 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2193 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2323 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2209 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3372 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2243 "Passed tests") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2196 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2205 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/284 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->