### PR TITLE
DeviceIdHashSalt data may not be removed

### DIFF
--- a/Source/WebKit/UIProcess/DeviceIdHashSaltStorage.h
+++ b/Source/WebKit/UIProcess/DeviceIdHashSaltStorage.h
@@ -79,6 +79,7 @@ private:
     Ref<WorkQueue> m_queue;
     HashMap<String, std::unique_ptr<HashSaltForOrigin>> m_deviceIdHashSaltForOrigins;
     bool m_isLoaded { false };
+    bool m_isClosed { false };
     Vector<CompletionHandler<void()>> m_pendingCompletionHandlers;
     const String m_deviceIdHashSaltStorageDirectory;
 };

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMediaNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMediaNavigation.mm
@@ -27,6 +27,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#import "DeprecatedGlobalValues.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestWKWebView.h"
@@ -40,6 +41,16 @@
 
 static bool okToProceed = false;
 static bool shouldReleaseInEnumerate = false;
+
+@interface GetUserMeidaNavigationMessageHandler : NSObject <WKScriptMessageHandler>
+@end
+
+@implementation GetUserMeidaNavigationMessageHandler
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
+{
+    receivedScriptMessage = true;
+}
+@end
 
 @interface NavigationWhileGetUserMediaPromptDisplayedUIDelegate : NSObject<WKUIDelegate>
 - (void)webView:(WKWebView *)webView requestMediaCapturePermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame type:(WKMediaCaptureType)type decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler;
@@ -163,6 +174,56 @@ TEST(WebKit, DeviceIdHashSaltsDirectory)
     NSError *error = nil;
     [fileManager removeItemAtPath:tempDir.path error:&error];
     EXPECT_FALSE(error);
+}
+
+TEST(WebKit, DeviceIdHashSaltsRemoval)
+{
+    auto dataTypeHashSalt = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeHashSalt]]);
+    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    @autoreleasepool {
+        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        [configuration setWebsiteDataStore:websiteDataStore.get()];
+        auto messageHandler = adoptNS([[GetUserMeidaNavigationMessageHandler alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+        auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        initializeMediaCaptureConfiguration(configuration.get());
+        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+        auto delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
+        [webView setUIDelegate:delegate.get()];
+
+        NSString *htmlString = @"<script> \
+        navigator.mediaDevices.enumerateDevices().then(() => { \
+            window.webkit.messageHandlers.testHandler.postMessage('done'); \
+        }); \
+        </script>";
+        receivedScriptMessage = false;
+        [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        
+
+        done = false;
+        [websiteDataStore fetchDataRecordsOfTypes:dataTypeHashSalt.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> * records) {
+            EXPECT_GT(records.count, 0u);
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    }
+
+    // Create a new WebsiteDataStore to ensure DeviceHashSaltStorage receives delete task before storage is loaded from disk.
+    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    done = false;
+    [websiteDataStore removeDataOfTypes:dataTypeHashSalt.get() modifiedSince:[NSDate distantPast] completionHandler:^() {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    done = false;
+    [websiteDataStore fetchDataRecordsOfTypes:dataTypeHashSalt.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> * records) {
+        EXPECT_EQ(records.count, 0u);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 76179a575826b84d9e5ebf74436bb2307e1d46e4
<pre>
DeviceIdHashSalt data may not be removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=255174">https://bugs.webkit.org/show_bug.cgi?id=255174</a>
rdar://106879064

Reviewed by Youenn Fablet.

When DeviceIdHashSaltStorage performs data deletion, it checks whether target origin is present; if not, it will skip
the deletion. However, DeviceIdHashSaltStorage does not wait until m_deviceIdHashSaltForOrigins is loaded from disk
before checking. This patch fixes this by ensuring check happens after m_deviceIdHashSaltForOrigins is loaded.

API test: WebKit.DeviceIdHashSaltsRemoval

* Source/WebKit/UIProcess/DeviceIdHashSaltStorage.cpp:
(WebKit::DeviceIdHashSaltStorage::~DeviceIdHashSaltStorage):
(WebKit::DeviceIdHashSaltStorage::deleteDeviceIdHashSaltForOrigins):
(WebKit::DeviceIdHashSaltStorage::deleteDeviceIdHashSaltOriginsModifiedSince):
* Source/WebKit/UIProcess/DeviceIdHashSaltStorage.h:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMediaNavigation.mm:
(-[GetUserMeidaNavigationMessageHandler userContentController:didReceiveScriptMessage:]):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262980@main">https://commits.webkit.org/262980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bac09f015c0b5bdbbeb19922ae6c77333cd5ddd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3043 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3434 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2656 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4284 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2579 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4019 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2493 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2710 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/786 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->