### PR TITLE
[Ui-side compositing] Fix mouse position reporting to AppKit in WebScrollerImpPairDelegateMac

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -384,7 +384,13 @@ void AsyncScrollingCoordinator::setMouseMovedInContentArea(ScrollableArea& scrol
     auto stateNode = dynamicDowncast<ScrollingStateScrollingNode>(m_scrollingStateTree->stateNodeForID(scrollingNodeID));
     if (!stateNode)
         return;
-    stateNode->setMouseMovedInContentArea();
+    
+    auto mousePosition = scrollableArea.lastKnownMousePositionInView();
+    auto horizontalScrollbar = scrollableArea.horizontalScrollbar();
+    auto verticalScrollbar = scrollableArea.verticalScrollbar();
+    
+    MouseLocationState state = { horizontalScrollbar ? horizontalScrollbar->convertFromContainingView(mousePosition) : IntPoint(), verticalScrollbar ? verticalScrollbar->convertFromContainingView(mousePosition) : IntPoint() };
+    stateNode->setMouseMovedInContentArea(state);
 }
 
 bool AsyncScrollingCoordinator::requestAnimatedScrollToPosition(ScrollableArea& scrollableArea, const ScrollPosition& scrollPosition, ScrollClamping clamping)

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -49,6 +49,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(const ScrollingStateScr
     , m_snapOffsetsInfo(stateNode.m_snapOffsetsInfo)
 #if PLATFORM(MAC)
     , m_scrollbarHoverState(stateNode.scrollbarHoverState())
+    , m_mouseLocationState(stateNode.mouseLocationState())
     , m_verticalScrollerImp(stateNode.verticalScrollerImp())
     , m_horizontalScrollerImp(stateNode.horizontalScrollerImp())
 #endif
@@ -286,8 +287,9 @@ void ScrollingStateScrollingNode::setMouseIsOverContentArea(bool flag)
     setPropertyChanged(Property::ContentAreaHoverState);
 }
 
-void ScrollingStateScrollingNode::setMouseMovedInContentArea()
+void ScrollingStateScrollingNode::setMouseMovedInContentArea(const MouseLocationState& mouseLocationState)
 {
+    m_mouseLocationState = mouseLocationState;
     setPropertyChanged(Property::MouseActivityState);
 }
     

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -53,6 +53,11 @@ struct ScrollbarHoverState {
     }
 };
 
+struct MouseLocationState {
+    IntPoint locationInHorizontalScrollbar;
+    IntPoint locationInVerticalScrollbar;
+};
+
 class ScrollingStateScrollingNode : public ScrollingStateNode {
 public:
     virtual ~ScrollingStateScrollingNode();
@@ -128,7 +133,8 @@ public:
     WEBCORE_EXPORT void setMouseIsOverContentArea(bool);
     bool mouseIsOverContentArea() const { return m_mouseIsOverContentArea; }
 
-    WEBCORE_EXPORT void setMouseMovedInContentArea();
+    WEBCORE_EXPORT void setMouseMovedInContentArea(const MouseLocationState&);
+    const MouseLocationState& mouseLocationState() const { return m_mouseLocationState; }
 
 protected:
     ScrollingStateScrollingNode(ScrollingStateTree&, ScrollingNodeType, ScrollingNodeID);
@@ -154,6 +160,7 @@ private:
     LayerRepresentation m_verticalScrollbarLayer;
     
     ScrollbarHoverState m_scrollbarHoverState;
+    MouseLocationState m_mouseLocationState;
 
 #if PLATFORM(MAC)
     RetainPtr<NSScrollerImp> m_verticalScrollerImp;

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -48,7 +48,6 @@ public:
     virtual void updateFromStateNode(const ScrollingStateScrollingNode&) { }
     
     virtual void handleWheelEventPhase(const PlatformWheelEventPhase) { }
-    virtual bool handleMouseEventForScrollbars(const PlatformMouseEvent&) { return false; }
     
     virtual void viewWillStartLiveResize() { }
     virtual void viewWillEndLiveResize() { }

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -61,18 +61,19 @@ public:
     void updateScrollbarStyle();
     void updatePairScrollerImps();
 
-    FloatPoint convertFromContent(const FloatPoint&) const;
-
     void updateValues();
     
     String scrollbarState() const;
     
     void mouseEnteredScrollbar();
     void mouseExitedScrollbar();
-
+    
+    void setLastKnownMousePositionInScrollbar(IntPoint position) { m_lastKnownMousePositionInScrollbar = position; }
+    IntPoint lastKnownMousePositionInScrollbar() const;
 private:
     ScrollerPairMac& m_pair;
     const ScrollbarOrientation m_orientation;
+    IntPoint m_lastKnownMousePositionInScrollbar;
 
     RetainPtr<CALayer> m_hostLayer;
     RetainPtr<NSScrollerImp> m_scrollerImp;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -30,6 +30,7 @@
 
 #import "ScrollTypesMac.h"
 #import "ScrollerPairMac.h"
+#import "ScrollingTreeScrollingNode.h"
 #import <QuartzCore/CALayer.h>
 #import <WebCore/FloatPoint.h>
 #import <WebCore/IntRect.h>
@@ -181,7 +182,7 @@ enum class FeatureToAnimate {
 
     ASSERT_UNUSED(scrollerImp, scrollerImp == _scroller->scrollerImp());
 
-    return _scroller->convertFromContent(_scroller->pair().lastKnownMousePosition());
+    return _scroller->lastKnownMousePositionInScrollbar();
 }
 
 - (NSRect)convertRectToLayer:(NSRect)rect
@@ -367,11 +368,6 @@ void ScrollerMac::updateScrollbarStyle()
     updatePairScrollerImps();
 }
 
-FloatPoint ScrollerMac::convertFromContent(const FloatPoint& point) const
-{
-    return FloatPoint { [m_hostLayer convertPoint:point fromLayer:[m_hostLayer superlayer]] };
-}
-
 void ScrollerMac::updatePairScrollerImps()
 {
     NSScrollerImp *scrollerImp = m_hostLayer ? m_scrollerImp.get() : nil;
@@ -407,6 +403,15 @@ void ScrollerMac::mouseExitedScrollbar()
 
         [m_scrollerImp mouseExitedScroller];
     });
+}
+
+IntPoint ScrollerMac::lastKnownMousePositionInScrollbar() const
+{
+    // When we dont have an update from the Web Process, return
+    // a point outside of the scrollbars
+    if (!m_pair.mouseInContentArea())
+        return { -1, -1 };
+    return m_lastKnownMousePositionInScrollbar;
 }
 
 String ScrollerMac::scrollbarState() const

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -40,7 +40,6 @@ OBJC_CLASS NSScrollerImpPair;
 OBJC_CLASS WebScrollerImpPairDelegateMac;
 
 namespace WebCore {
-class PlatformMouseEvent;
 class PlatformWheelEvent;
 class ScrollingTreeScrollingNode;
 }
@@ -62,7 +61,6 @@ public:
     ~ScrollerPairMac();
 
     void handleWheelEventPhase(PlatformWheelEventPhase);
-    bool handleMouseEvent(const PlatformMouseEvent&);
 
     void setUsePresentationValues(bool);
     bool isUsingPresentationValues() const { return m_usingPresentationValues; }
@@ -73,7 +71,6 @@ public:
     void updateValues();
 
     FloatSize visibleSize() const;
-    IntPoint lastKnownMousePosition() const { return m_lastKnownMousePosition; }
     bool useDarkAppearance() const;
 
     struct Values {
@@ -105,12 +102,14 @@ public:
     
     void mouseEnteredContentArea();
     void mouseExitedContentArea();
-    void mouseMovedInContentArea();
+    void mouseMovedInContentArea(const MouseLocationState&);
     void mouseIsInScrollbar(ScrollbarHoverState);
 
     NSScrollerImpPair *scrollerImpPair() const { return m_scrollerImpPair.get(); }
     void ensureOnMainThreadWithProtectedThis(Function<void()>&&);
-
+    ScrollingTreeScrollingNode& node() const { return m_scrollingNode; }
+    
+    bool mouseInContentArea() const { return m_mouseInContentArea; }
 private:
     ScrollerPairMac(ScrollingTreeScrollingNode&);
 
@@ -125,7 +124,6 @@ private:
     ScrollerMac m_verticalScroller;
     ScrollerMac m_horizontalScroller;
 
-    IntPoint m_lastKnownMousePosition;
     std::optional<FloatPoint> m_lastScrollOffset;
 
     RetainPtr<NSScrollerImpPair> m_scrollerImpPair;
@@ -134,6 +132,7 @@ private:
     std::atomic<bool> m_usingPresentationValues { false };
     std::atomic<ScrollbarStyle> m_scrollbarStyle { ScrollbarStyle::AlwaysVisible };
     bool m_inLiveResize { false };
+    bool m_mouseInContentArea { false };
 };
 
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -30,10 +30,10 @@
 
 #import "Logging.h"
 #import "ScrollTypesMac.h"
+#import "ScrollingTreeFrameScrollingNode.h"
 #import <WebCore/FloatPoint.h>
 #import <WebCore/IntRect.h>
 #import <WebCore/NSScrollerImpDetails.h>
-#import <WebCore/PlatformMouseEvent.h>
 #import <WebCore/PlatformWheelEvent.h>
 #import <WebCore/ScrollTypes.h>
 #import <WebCore/ScrollableArea.h>
@@ -81,15 +81,15 @@
 - (NSPoint)mouseLocationInContentAreaForScrollerImpPair:(NSScrollerImpPair *)scrollerImpPair
 {
     UNUSED_PARAM(scrollerImpPair);
-    if (!_scrollerPair)
-        return NSZeroPoint;
-
-    return _scrollerPair->lastKnownMousePosition();
+    // This location is only used when calling mouseLocationInScrollerForScrollerImp,
+    // where we will use the converted mouse position from the Web Process
+    return NSZeroPoint;
 }
 
 - (NSPoint)scrollerImpPair:(NSScrollerImpPair *)scrollerImpPair convertContentPoint:(NSPoint)pointInContentArea toScrollerImp:(NSScrollerImp *)scrollerImp
 {
     UNUSED_PARAM(scrollerImpPair);
+    UNUSED_PARAM(pointInContentArea);
 
     if (!_scrollerPair || !scrollerImp)
         return NSZeroPoint;
@@ -102,7 +102,7 @@
 
     ASSERT(scrollerImp == scroller->scrollerImp());
 
-    return scroller->convertFromContent(WebCore::IntPoint(pointInContentArea));
+    return scroller->lastKnownMousePositionInScrollbar();
 }
 
 - (void)scrollerImpPair:(NSScrollerImpPair *)scrollerImpPair setContentAreaNeedsDisplayInRect:(NSRect)rect
@@ -211,21 +211,6 @@ void ScrollerPairMac::contentsSizeChanged()
 
         [m_scrollerImpPair contentAreaDidResize];
     });
-}
-
-bool ScrollerPairMac::handleMouseEvent(const PlatformMouseEvent& event)
-{
-    if (event.type() != PlatformEvent::Type::MouseMoved)
-        return false;
-
-    m_lastKnownMousePosition = event.position();
-
-    ensureOnMainThreadWithProtectedThis([this] {
-        [m_scrollerImpPair mouseMovedInContentArea];
-    });
-
-    // FIXME: this needs to return whether the event was handled.
-    return true;
 }
 
 void ScrollerPairMac::setUsePresentationValues(bool inMomentumPhase)
@@ -362,6 +347,7 @@ void ScrollerPairMac::mouseEnteredContentArea()
 
 void ScrollerPairMac::mouseExitedContentArea()
 {
+    m_mouseInContentArea = false;
     LOG_WITH_STREAM(OverlayScrollbars, stream << "ScrollerPairMac for [" << m_scrollingNode.scrollingNodeID() << "] mouseExitedContentArea");
     
     ensureOnMainThreadWithProtectedThis([this] {
@@ -372,8 +358,12 @@ void ScrollerPairMac::mouseExitedContentArea()
     });
 }
 
-void ScrollerPairMac::mouseMovedInContentArea()
+void ScrollerPairMac::mouseMovedInContentArea(const MouseLocationState& state)
 {
+    m_mouseInContentArea = true;
+    horizontalScroller().setLastKnownMousePositionInScrollbar(state.locationInHorizontalScrollbar);
+    verticalScroller().setLastKnownMousePositionInScrollbar(state.locationInVerticalScrollbar);
+
     ensureOnMainThreadWithProtectedThis([this] {
         if ([m_scrollerImpPair overlayScrollerStateIsLocked])
             return;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -61,7 +61,6 @@ public:
     void updateScrollbarLayers() final;
     
     void handleWheelEventPhase(const PlatformWheelEventPhase) final;
-    bool handleMouseEventForScrollbars(const PlatformMouseEvent&) final;
     void viewWillStartLiveResize() final;
     void viewWillEndLiveResize() final;
     void viewSizeDidChange() final;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -92,7 +92,7 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
     }
     
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::MouseActivityState))
-        m_scrollerPair->mouseMovedInContentArea();
+        m_scrollerPair->mouseMovedInContentArea(scrollingStateNode.mouseLocationState());
 
     m_scrollerPair->updateValues();
 
@@ -326,11 +326,6 @@ void ScrollingTreeScrollingNodeDelegateMac::updateScrollbarLayers()
 void ScrollingTreeScrollingNodeDelegateMac::handleWheelEventPhase(const PlatformWheelEventPhase wheelEventPhase)
 {
     m_scrollerPair->handleWheelEventPhase(wheelEventPhase);
-}
-
-bool ScrollingTreeScrollingNodeDelegateMac::handleMouseEventForScrollbars(const PlatformMouseEvent& mouseEvent)
-{
-    return m_scrollerPair->handleMouseEvent(mouseEvent);
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::viewWillStartLiveResize()

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -171,6 +171,12 @@ void ArgumentCoder<ScrollingStateScrollingNode>::encode(Encoder& encoder, const 
         encoder << mouseIsInScrollbar.mouseIsOverHorizontalScrollbar;
         encoder << mouseIsInScrollbar.mouseIsOverVerticalScrollbar;
     }
+    
+    if (node.hasChangedProperty(ScrollingStateNode::Property::MouseActivityState)) {
+        auto mouseLocationState = node.mouseLocationState();
+        encoder << mouseLocationState.locationInHorizontalScrollbar;
+        encoder << mouseLocationState.locationInVerticalScrollbar;
+    }
 }
 
 void ArgumentCoder<ScrollingStateFrameScrollingNode>::encode(Encoder& encoder, const ScrollingStateFrameScrollingNode& node)
@@ -264,7 +270,7 @@ bool ArgumentCoder<ScrollingStateScrollingNode>::decode(Decoder& decoder, Scroll
         node.setRequestedScrollData(WTFMove(requestedScrollData), ScrollingStateScrollingNode::CanMergeScrollData::No);
     }
     SCROLLING_NODE_DECODE(ScrollingStateNode::Property::KeyboardScrollData, RequestedKeyboardScrollData, setKeyboardScrollData);
-    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::ContentAreaHoverState, bool, setMouseIsOverContentArea)
+    SCROLLING_NODE_DECODE(ScrollingStateNode::Property::ContentAreaHoverState, bool, setMouseIsOverContentArea);
 
     if (node.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
         std::optional<PlatformLayerIdentifier> layerID;
@@ -303,6 +309,17 @@ bool ArgumentCoder<ScrollingStateScrollingNode>::decode(Decoder& decoder, Scroll
         if (!decoder.decode(didEnterScrollbarVertical))
             return false;
         node.setScrollbarHoverState({ didEnterScrollbarHorizontal, didEnterScrollbarVertical });
+    }
+    
+    if (node.hasChangedProperty(ScrollingStateNode::Property::MouseActivityState)) {
+        IntPoint locationInHorizontalScrollbar;
+        if (!decoder.decode(locationInHorizontalScrollbar))
+            return false;
+
+        IntPoint locationInVerticalScrollbar;
+        if (!decoder.decode(locationInVerticalScrollbar))
+            return false;
+        node.setMouseMovedInContentArea({ locationInHorizontalScrollbar, locationInVerticalScrollbar });
     }
 
     return true;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -46,8 +46,6 @@ public:
     explicit RemoteScrollingTreeMac(RemoteScrollingCoordinatorProxy&);
     virtual ~RemoteScrollingTreeMac();
 
-    void handleMouseEvent(const WebCore::PlatformMouseEvent&) final;
-
 private:
     void handleWheelEventPhase(WebCore::ScrollingNodeID, WebCore::PlatformWheelEventPhase) override;
     RefPtr<WebCore::ScrollingTreeNode> scrollingNodeForPoint(WebCore::FloatPoint) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -106,13 +106,6 @@ Ref<ScrollingTreeNode> RemoteScrollingTreeMac::createScrollingTreeNode(Scrolling
     return ScrollingTreeFixedNodeCocoa::create(*this, nodeID);
 }
 
-void RemoteScrollingTreeMac::handleMouseEvent(const PlatformMouseEvent& event)
-{
-    if (!rootNode())
-        return;
-    static_cast<ScrollingTreeFrameScrollingNodeRemoteMac&>(*rootNode()).handleMouseEvent(event);
-}
-
 void RemoteScrollingTreeMac::didCommitTree()
 {
     ASSERT(isMainRunLoop());

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -59,11 +59,6 @@ void ScrollingTreeFrameScrollingNodeRemoteMac::handleWheelEventPhase(const Platf
     m_delegate->handleWheelEventPhase(phase);
 }
 
-bool ScrollingTreeFrameScrollingNodeRemoteMac::handleMouseEvent(const PlatformMouseEvent& mouseEvent)
-{
-    return m_delegate->handleMouseEventForScrollbars(mouseEvent);
-}
-
 void ScrollingTreeFrameScrollingNodeRemoteMac::viewWillStartLiveResize()
 {
     m_delegate->viewWillStartLiveResize();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
@@ -61,11 +61,6 @@ void ScrollingTreeOverflowScrollingNodeRemoteMac::handleWheelEventPhase(const Pl
     m_delegate->handleWheelEventPhase(phase);
 }
 
-bool ScrollingTreeOverflowScrollingNodeRemoteMac::handleMouseEvent(const PlatformMouseEvent& mouseEvent)
-{
-    return m_delegate->handleMouseEventForScrollbars(mouseEvent);
-}
-
 String ScrollingTreeOverflowScrollingNodeRemoteMac::scrollbarStateForOrientation(ScrollbarOrientation orientation) const
 {
     return m_delegate->scrollbarStateForOrientation(orientation);


### PR DESCRIPTION
#### caec1d312c597c37515751aedbec9433978fb627
<pre>
[Ui-side compositing] Fix mouse position reporting to AppKit in WebScrollerImpPairDelegateMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=255188">https://bugs.webkit.org/show_bug.cgi?id=255188</a>
rdar://107776583

Reviewed by Simon Fraser.

This patch aims to fix several issues with the way ScrollerPairMac and ScrollerMac handle
mouse events, with the intent of fixing hovering over overlay scrollbars in overflow scrolling
nodes. The first issue is that currently there isn&apos;t a good way to convert the frame relative
mouse position to a scrollbar relative mouse position. To work around this, bundle the scrollbar
relative mouse positions in the mouseMovedInContentArea event. When we know that we have updated
mouse positions from the WebProcess, return them in the various WebScrollerImpPairDelegateMac
functions. The second issue is that RemoteScrollingTree is only calling handleMouseEvent
on the root scroller. Since this mouse position was only being used as input to convertContentPoint,
it is ok to just return a zero point and use the converted mouse position from the Web Process.

* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::lastKnownMousePosition):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::lastKnownMousePosition const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::lastKnownMousePosition const):
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(-[WebScrollerImpDelegateMac mouseLocationInScrollerForScrollerImp:]):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
(WebCore::ScrollerPairMac::node const):
(WebCore::ScrollerPairMac::lastKnownMousePosition const): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(-[WebScrollerImpPairDelegateMac mouseLocationInContentAreaForScrollerImpPair:]):
(-[WebScrollerImpPairDelegateMac scrollerImpPair:convertContentPoint:toScrollerImp:]):
(WebCore::ScrollerPairMac::lastKnownMousePosition const):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::lastKnownMousePosition const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::lastKnownMousePosition):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::lastKnownMousePosition):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.h:

Canonical link: <a href="https://commits.webkit.org/262995@main">https://commits.webkit.org/262995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bead618f98d61ba1b4695d6c5f1789ef1edaa262

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2776 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4413 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2843 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2683 "3 flakes 147 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4167 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2610 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2845 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2843 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/379 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->