### PR TITLE
Remove `PKApplePayLaterMode` staging code

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -300,6 +300,21 @@ typedef NS_ENUM(NSInteger, PKPaymentSetupFeatureType) {
 @end
 #endif
 
+#if HAVE(PASSKIT_APPLE_PAY_LATER_MODE)
+
+typedef NS_ENUM(NSUInteger, PKApplePayLaterMode) {
+    PKApplePayLaterModeEnabled,
+    PKApplePayLaterModeDisabledMerchantIneligible,
+    PKApplePayLaterModeDisabledItemIneligible,
+    PKApplePayLaterModeDisabledRecurringTransaction,
+};
+
+@interface PKPaymentRequest ()
+@property (nonatomic, assign) PKApplePayLaterMode applePayLaterMode;
+@end
+
+#endif
+
 NS_ASSUME_NONNULL_END
 
 #endif // USE(APPLE_INTERNAL_SDK)
@@ -340,23 +355,6 @@ typedef void(^PKCanMakePaymentsCompletion)(BOOL isValid, NSError *);
 @interface PKDeferredPaymentRequest (Staging_104652810)
 @property (nonatomic, strong, nullable) NSTimeZone *freeCancellationDateTimeZone;
 @end
-#endif
-
-#if HAVE(PASSKIT_APPLE_PAY_LATER_MODE)
-
-// FIXME: rdar://106983272 Remove staging code.
-
-typedef NS_ENUM(NSUInteger, PKApplePayLaterMode);
-
-#define PKApplePayLaterModeEnabled 0
-#define PKApplePayLaterModeDisabledMerchantIneligible 1
-#define PKApplePayLaterModeDisabledItemIneligible 2
-#define PKApplePayLaterModeDisabledRecurringTransaction 3
-
-@interface PKPaymentRequest (Staging_105877661)
-@property (nonatomic, assign) PKApplePayLaterMode applePayLaterMode;
-@end
-
 #endif
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -238,19 +238,18 @@ static PKShippingContactEditingMode toPKShippingContactEditingMode(WebCore::Appl
 
 static PKApplePayLaterMode toPKApplePayLaterMode(WebCore::ApplePayLaterMode applePayLaterMode)
 {
-    // FIXME: rdar://106983272 Remove staging code.
     switch (applePayLaterMode) {
     case WebCore::ApplePayLaterMode::Enabled:
-        return (PKApplePayLaterMode)PKApplePayLaterModeEnabled;
+        return PKApplePayLaterModeEnabled;
 
     case WebCore::ApplePayLaterMode::DisabledMerchantIneligible:
-        return (PKApplePayLaterMode)PKApplePayLaterModeDisabledMerchantIneligible;
+        return PKApplePayLaterModeDisabledMerchantIneligible;
 
     case WebCore::ApplePayLaterMode::DisabledItemIneligible:
-        return (PKApplePayLaterMode)PKApplePayLaterModeDisabledItemIneligible;
+        return PKApplePayLaterModeDisabledItemIneligible;
 
     case WebCore::ApplePayLaterMode::DisabledRecurringTransaction:
-        return (PKApplePayLaterMode)PKApplePayLaterModeDisabledRecurringTransaction;
+        return PKApplePayLaterModeDisabledRecurringTransaction;
     }
 }
 
@@ -361,11 +360,8 @@ RetainPtr<PKPaymentRequest> WebPaymentCoordinatorProxy::platformPaymentRequest(c
 #endif
 
 #if HAVE(PASSKIT_APPLE_PAY_LATER_MODE)
-    if (auto& applePayLaterMode = paymentRequest.applePayLaterMode()) {
-        // FIXME: rdar://106983272 Remove staging code.
-        if ([result respondsToSelector:@selector(setApplePayLaterMode:)])
-            [result setApplePayLaterMode:toPKApplePayLaterMode(*applePayLaterMode)];
-    }
+    if (auto& applePayLaterMode = paymentRequest.applePayLaterMode())
+        [result setApplePayLaterMode:toPKApplePayLaterMode(*applePayLaterMode)];
 #endif
 
 #if HAVE(PASSKIT_RECURRING_PAYMENTS)


### PR DESCRIPTION
#### 8341e05c8d34293c67159d11612f7175d0f451e5
<pre>
Remove `PKApplePayLaterMode` staging code
<a href="https://bugs.webkit.org/show_bug.cgi?id=255189">https://bugs.webkit.org/show_bug.cgi?id=255189</a>
rdar://106983272

Reviewed by Wenson Hsieh.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::toPKApplePayLaterMode):
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):

Canonical link: <a href="https://commits.webkit.org/262747@main">https://commits.webkit.org/262747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/943748d07ebc50f1b019f212f8f0a531f2a50cb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2552 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2486 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/2279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3613 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/2200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2061 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2362 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2219 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2245 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/2203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2217 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/287 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->