### PR TITLE
Adopt strict coding of PKPaymentSetupConfiguration

### DIFF
--- a/Source/WebKit/Shared/ApplePay/PaymentSetupConfiguration.mm
+++ b/Source/WebKit/Shared/ApplePay/PaymentSetupConfiguration.mm
@@ -67,13 +67,14 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     return configuration;
 }
 
-PaymentSetupConfiguration::PaymentSetupConfiguration(const WebCore::ApplePaySetupConfiguration& configuration, const URL& url)
-    : m_configuration { toPlatformConfiguration(configuration, url) }
+RetainPtr<PKPaymentSetupConfiguration> PaymentSetupConfiguration::platformConfiguration() const
 {
+    return toPlatformConfiguration(m_configuration, m_url);
 }
 
-PaymentSetupConfiguration::PaymentSetupConfiguration(RetainPtr<PKPaymentSetupConfiguration>&& configuration)
-    : m_configuration { WTFMove(configuration) }
+PaymentSetupConfiguration::PaymentSetupConfiguration(const WebCore::ApplePaySetupConfiguration& configuration, const URL& url)
+    : m_configuration(configuration)
+    , m_url(url)
 {
 }
 

--- a/Source/WebKit/Shared/ApplePay/PaymentSetupConfiguration.serialization.in
+++ b/Source/WebKit/Shared/ApplePay/PaymentSetupConfiguration.serialization.in
@@ -24,7 +24,8 @@
 
 header: "PaymentSetupConfigurationWebKit.h"
 [CustomHeader] class WebKit::PaymentSetupConfiguration {
-    [SecureCodingAllowed=[PAL::getPKPaymentSetupConfigurationClass()]] RetainPtr<PKPaymentSetupConfiguration> m_configuration;
+    WebCore::ApplePaySetupConfiguration configuration()
+    URL url()
 };
 
 #endif

--- a/Source/WebKit/Shared/ApplePay/PaymentSetupConfigurationWebKit.h
+++ b/Source/WebKit/Shared/ApplePay/PaymentSetupConfigurationWebKit.h
@@ -27,34 +27,26 @@
 
 #if ENABLE(APPLE_PAY)
 
-#include <wtf/Forward.h>
+#include <WebCore/ApplePaySetupConfiguration.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/URL.h>
 
 OBJC_CLASS PKPaymentSetupConfiguration;
-
-namespace IPC {
-class Decoder;
-class Encoder;
-}
-
-namespace WebCore {
-struct ApplePaySetupConfiguration;
-}
 
 namespace WebKit {
 
 class PaymentSetupConfiguration {
 public:
-    PaymentSetupConfiguration() = default;
     PaymentSetupConfiguration(const WebCore::ApplePaySetupConfiguration&, const URL&);
 
-    PKPaymentSetupConfiguration *platformConfiguration() const { return m_configuration.get(); }
+    RetainPtr<PKPaymentSetupConfiguration> platformConfiguration() const;
+
+    const WebCore::ApplePaySetupConfiguration& configuration() const { return m_configuration; }
+    const URL& url() const { return m_url; }
 
 private:
-    friend struct IPC::ArgumentCoder<PaymentSetupConfiguration, void>;
-    explicit PaymentSetupConfiguration(RetainPtr<PKPaymentSetupConfiguration>&&);
-
-    RetainPtr<PKPaymentSetupConfiguration> m_configuration;
+    WebCore::ApplePaySetupConfiguration m_configuration;
+    URL m_url;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -437,7 +437,7 @@ void WebPaymentCoordinatorProxy::getSetupFeatures(const PaymentSetupConfiguratio
     });
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    [PAL::getPKPaymentSetupControllerClass() paymentSetupFeaturesForConfiguration:configuration.platformConfiguration() completion:completion.get()];
+    [PAL::getPKPaymentSetupControllerClass() paymentSetupFeaturesForConfiguration:configuration.platformConfiguration().get() completion:completion.get()];
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 }
 
@@ -461,7 +461,7 @@ void WebPaymentCoordinatorProxy::platformBeginApplePaySetup(const PaymentSetupCo
     }
 
     auto request = adoptNS([PAL::allocPKPaymentSetupRequestInstance() init]);
-    [request setConfiguration:configuration.platformConfiguration()];
+    [request setConfiguration:configuration.platformConfiguration().get()];
     [request setPaymentSetupFeatures:features.platformFeatures()];
 
     auto completion = makeBlockPtr([reply = WTFMove(reply)](BOOL success) mutable {
@@ -492,7 +492,7 @@ void WebPaymentCoordinatorProxy::platformBeginApplePaySetup(const PaymentSetupCo
     }
 
     auto request = adoptNS([PAL::allocPKPaymentSetupRequestInstance() init]);
-    [request setConfiguration:configuration.platformConfiguration()];
+    [request setConfiguration:configuration.platformConfiguration().get()];
     [request setPaymentSetupFeatures:features.platformFeatures()];
 
     auto paymentSetupViewController = adoptNS([PAL::allocPKPaymentSetupViewControllerInstance() initWithPaymentSetupRequest:request.get()]);

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -593,9 +593,6 @@ static bool shouldEnableStrictMode(Decoder& decoder, NSArray<Class> *allowedClas
             ) && isInWebProcess()
         )
 #endif
-#if ENABLE(APPLE_PAY)
-        || (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentSetupConfigurationClass()]) // rdar://107553429, Don't re-introduce rdar://107626990
-#endif
 #if ENABLE(DATA_DETECTION)
         || (supportsDataDetectorsCore && [allowedClasses containsObject:PAL::getDDScannerResultClass()]) // rdar://107553330 - relying on NSMutableArray re-write, don't re-introduce rdar://107676726
 #if PLATFORM(MAC)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -643,6 +643,13 @@ struct WebCore::ApplePayDateComponentsRange {
 #endif // ENABLE(APPLE_PAY_SHIPPING_METHOD_DATE_COMPONENTS_RANGE)
 
 #if ENABLE(APPLE_PAY)
+struct WebCore::ApplePaySetupConfiguration {
+    String merchantIdentifier;
+    String referrerIdentifier;
+    String signature;
+    Vector<String> signedFields;
+};
+
 [Nested] enum class WebCore::ApplePayLineItem::Type : bool;
 
 struct WebCore::ApplePayLineItem {


### PR DESCRIPTION
#### 35ab5c9c5aa3a7d2e95c5dc6efede4e714983151
<pre>
Adopt strict coding of PKPaymentSetupConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=255190">https://bugs.webkit.org/show_bug.cgi?id=255190</a>
rdar://107553429

Reviewed by Andy Estes.

Rather than serialize WebKit::PaymentSetupConfiguration as a PKPaymentSetupConfiguration,
serialize its components as WTF::Strings and WTF::URLs.

* Source/WebKit/Shared/ApplePay/PaymentSetupConfiguration.mm:
(WebKit::PaymentSetupConfiguration::platformConfiguration const):
(WebKit::PaymentSetupConfiguration::PaymentSetupConfiguration):
* Source/WebKit/Shared/ApplePay/PaymentSetupConfiguration.serialization.in:
* Source/WebKit/Shared/ApplePay/PaymentSetupConfigurationWebKit.h:
(WebKit::PaymentSetupConfiguration::configuration const):
(WebKit::PaymentSetupConfiguration::url const):
(WebKit::PaymentSetupConfiguration::platformConfiguration const): Deleted.
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::getSetupFeatures):
(WebKit::WebPaymentCoordinatorProxy::platformBeginApplePaySetup):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::shouldEnableStrictMode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/262891@main">https://commits.webkit.org/262891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe0766bf16fc7af251925f179105208ea26570e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4335 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3033 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2958 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4127 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2599 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2650 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2405 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2602 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/344 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->