### PR TITLE
REGRESSION(262749@main) [GraphicsLayerWC] WCContentBufferIdentifier should use ObjectIdentifierThreadSafeAccessTraits

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/wc/WCContentBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCContentBuffer.h
@@ -81,7 +81,7 @@ private:
 
     WCContentBufferManager& m_manager;
     WebCore::ProcessIdentifier m_processIdentifier;
-    WCContentBufferIdentifier m_identifier { WCContentBufferIdentifier::generate() };
+    WCContentBufferIdentifier m_identifier { WCContentBufferIdentifier::generateThreadSafe() };
     WebCore::TextureMapperPlatformLayer* m_platformLayer;
     Client* m_client { nullptr };
 };

--- a/Source/WebKit/Shared/wc/WCContentBufferIdentifier.h
+++ b/Source/WebKit/Shared/wc/WCContentBufferIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum WCContentBufferIdentifierType { };
-using WCContentBufferIdentifier = ObjectIdentifier<WCContentBufferIdentifierType>;
+using WCContentBufferIdentifier = ObjectIdentifier<WCContentBufferIdentifierType, WTF::ObjectIdentifierThreadSafeAccessTraits>;
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### d3c2c894de79fc44199e1ec91ae0e1f4c6904a4f
<pre>
REGRESSION(262749@main) [GraphicsLayerWC] WCContentBufferIdentifier should use ObjectIdentifierThreadSafeAccessTraits
<a href="https://bugs.webkit.org/show_bug.cgi?id=255195">https://bugs.webkit.org/show_bug.cgi?id=255195</a>

Unreviewed crash fix.

After 262749@main (bug#254873) added an assertion checking the thread
is the main thread to generateIdentifierInternal, WinCairo was
crashing for WebGL tests.

* Source/WebKit/GPUProcess/graphics/wc/WCContentBuffer.h:
Use WCContentBufferIdentifier::generateThreadSafe.
* Source/WebKit/Shared/wc/WCContentBufferIdentifier.h:
Use ObjectIdentifierThreadSafeAccessTraits.

Canonical link: <a href="https://commits.webkit.org/262754@main">https://commits.webkit.org/262754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55c22baab9b6ae71951e34f012c3f61c5cbd681d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3892 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2530 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2582 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2516 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/2488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3656 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/2226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2424 "Built successfully") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2272 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/2229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2246 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/288 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->