### PR TITLE
Remove WebKit main thread workaround

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSWindowSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSWindowSPI.h
@@ -42,7 +42,7 @@
 @interface NSWindow ()
 
 - (id)_oldFirstResponderBeforeBecoming;
-- (id)_newFirstResponderAfterResigning;
+- (id)_newFirstResponderAfterResigning NS_RETURNS_NOT_RETAINED;
 - (void)_setCursorForMouseLocation:(NSPoint)point;
 - (void)exitFullScreenMode:(id)sender;
 - (void)enterFullScreenMode:(id)sender;

--- a/Source/WebKitLegacy/mac/WebKit.order
+++ b/Source/WebKitLegacy/mac/WebKit.order
@@ -56,7 +56,6 @@ __ZN7WebCore15FontDescriptionD2Ev
 -[WebPreferences _setStringValue:forKey:]
 -[WebPreferences _stringValueForKey:]
 -[WebView initWithCoder:]
-__ZL32needsWebViewInitThreadWorkaroundv
 -[WebView setNextKeyView:]
 -[WebView mainFrame]
 +[WebViewPrivate initialize]

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -1539,8 +1539,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _private->savedSubviews = self._subviewsIvar;
     // We need to keep the layer-hosting view in the subviews, otherwise the layers flash.
     if (_private->layerHostingView) {
-        NSMutableArray* newSubviews = [[NSMutableArray alloc] initWithObjects:_private->layerHostingView, nil];
-        self._subviewsIvar = newSubviews;
+        self._subviewsIvar = [[NSMutableArray alloc] initWithObjects:_private->layerHostingView, nil];
     } else
         self._subviewsIvar = nil;
     _private->subviewsSetAside = YES;
@@ -3400,7 +3399,6 @@ static RetainPtr<NSArray> fixMenusToSendToOldClients(NSMutableArray *defaultMenu
 
             [defaultMenuItems removeObject:secondToLastItem];
             [defaultMenuItems removeObject:lastItem];
-            defaultItemsCount -= 2;
         }
     }
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -5300,40 +5300,6 @@ IGNORE_WARNINGS_END
     return self;
 }
 
-#if !PLATFORM(IOS_FAMILY)
-static bool clientNeedsWebViewInitThreadWorkaround()
-{
-    if (WebKitLinkedOnOrAfter(WEBKIT_FIRST_VERSION_WITHOUT_WEBVIEW_INIT_THREAD_WORKAROUND))
-        return false;
-
-    NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
-
-    // Installer.
-    if ([bundleIdentifier _webkit_isCaseInsensitiveEqualToString:@"com.apple.installer"])
-        return true;
-
-    // Automator.
-    if ([bundleIdentifier _webkit_isCaseInsensitiveEqualToString:@"com.apple.Automator"])
-        return true;
-
-    // Automator Runner.
-    if ([bundleIdentifier _webkit_isCaseInsensitiveEqualToString:@"com.apple.AutomatorRunner"])
-        return true;
-
-    // Automator workflows.
-    if ([bundleIdentifier _webkit_hasCaseInsensitivePrefix:@"com.apple.Automator."])
-        return true;
-
-    return false;
-}
-
-static bool needsWebViewInitThreadWorkaround()
-{
-    static bool isOldClient = clientNeedsWebViewInitThreadWorkaround();
-    return isOldClient && !pthread_main_np();
-}
-#endif // !PLATFORM(IOS_FAMILY)
-
 - (instancetype)initWithFrame:(NSRect)f
 {
     return [self initWithFrame:f frameName:nil groupName:nil];
@@ -5341,10 +5307,6 @@ static bool needsWebViewInitThreadWorkaround()
 
 - (instancetype)initWithFrame:(NSRect)f frameName:(NSString *)frameName groupName:(NSString *)groupName
 {
-#if !PLATFORM(IOS_FAMILY)
-    if (needsWebViewInitThreadWorkaround())
-        return [[self _webkit_invokeOnMainThread] initWithFrame:f frameName:frameName groupName:groupName];
-#endif
 
     WebCoreThreadViolationCheckRoundTwo();
     return [self _initWithFrame:f frameName:frameName groupName:groupName];
@@ -5353,9 +5315,6 @@ static bool needsWebViewInitThreadWorkaround()
 #if !PLATFORM(IOS_FAMILY)
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
-    if (needsWebViewInitThreadWorkaround())
-        return [[self _webkit_invokeOnMainThread] initWithCoder:decoder];
-
     WebCoreThreadViolationCheckRoundTwo();
     WebView *result = nil;
 


### PR DESCRIPTION
<pre>
Remove WebKit main thread workaround
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

It is not needed anymore and throws off the clang static analyzers.

* Source/WebCore/PAL/pal/spi/mac/NSWindowSPI.h:
* Source/WebKitLegacy/mac/WebKit.order:
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(_setAsideSubviews):
(isPreInspectElementTagClient):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(_initWithArguments:(NSDictionary *))
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eddcc220ac06f33f24ce81ad084c969b784aba7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2215 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3665 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2233 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2095 "2 flakes 146 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2449 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3438 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2283 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2066 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2236 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2255 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->