### PR TITLE
Add WTF::exitProcess and WTF::terminateProcess

### DIFF
--- a/Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp
+++ b/Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp
@@ -33,6 +33,7 @@
 #include <wtf/CPUTime.h>
 #include <wtf/Condition.h>
 #include <wtf/Lock.h>
+#include <wtf/Process.h>
 #include <wtf/Threading.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -203,12 +204,12 @@ int testExecutionTimeLimit()
                 printf("PASS: %s script timed out as expected.\n", tierName);
             else {
                 printf("FAIL: %s script timeout callback was not called.\n", tierName);
-                exit(1);
+                exitProcess(1);
             }
 
             if (!exception) {
                 printf("FAIL: %s TerminationException was not thrown.\n", tierName);
-                exit(1);
+                exitProcess(1);
             }
 
             thread->waitForCompletion();

--- a/Source/JavaScriptCore/API/tests/testapi.mm
+++ b/Source/JavaScriptCore/API/tests/testapi.mm
@@ -39,6 +39,7 @@
 #import "JSWrapperMapTests.h"
 #import "Regress141275.h"
 #import "Regress141809.h"
+#import <wtf/Process.h>
 #import <wtf/SafeStrerror.h>
 #import <wtf/spi/darwin/DataVaultSPI.h>
 
@@ -2462,7 +2463,7 @@ static NSURL *resolvePathToScripts()
         char cwd[maxLength];
         if (!getcwd(cwd, maxLength)) {
             NSLog(@"getcwd errored with code: %s", safeStrerror(errno).data());
-            exit(1);
+            exitProcess(1);
         }
         NSURL *cwdURL = [NSURL fileURLWithPath:[NSString stringWithFormat:@"%s", cwd]];
         base = [NSURL fileURLWithPath:arg0 isDirectory:NO relativeToURL:cwdURL];

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -39,6 +39,7 @@
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/NumberOfCores.h>
+#include <wtf/Process.h>
 #include <wtf/PtrTag.h>
 #include <wtf/Threading.h>
 #include <wtf/text/StringCommon.h>
@@ -50,7 +51,7 @@ static void usage()
 {
     dataLog("Usage: testmasm [<filter>]\n");
     if (hiddenTruthBecauseNoReturnIsStupid())
-        exit(1);
+        exitProcess(1);
 }
 
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -45,6 +45,7 @@
 #include <wtf/DataLog.h>
 #include <wtf/Lock.h>
 #include <wtf/NumberOfCores.h>
+#include <wtf/Process.h>
 #include <wtf/StdMap.h>
 #include <wtf/Threading.h>
 #include <wtf/text/StringCommon.h>
@@ -56,7 +57,7 @@ static void usage()
 {
     dataLog("Usage: testair [<filter>]\n");
     if (hiddenTruthBecauseNoReturnIsStupid())
-        exit(1);
+        exitProcess(1);
 }
 
 #if ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -77,6 +77,7 @@
 #include <wtf/ListDump.h>
 #include <wtf/Lock.h>
 #include <wtf/NumberOfCores.h>
+#include <wtf/Process.h>
 #include <wtf/StdList.h>
 #include <wtf/Threading.h>
 #include <wtf/text/StringCommon.h>
@@ -88,7 +89,7 @@ inline void usage()
 {
     dataLog("Usage: testb3 [<filter>]\n");
     if (hiddenTruthBecauseNoReturnIsStupid())
-        exit(1);
+        exitProcess(1);
 }
 
 #if ENABLE(B3_JIT) && !CPU(ARM)

--- a/Source/JavaScriptCore/dfg/testdfg.cpp
+++ b/Source/JavaScriptCore/dfg/testdfg.cpp
@@ -30,6 +30,7 @@
 #include "DFGAbstractValue.h"
 #include "InitializeThreading.h"
 #include <wtf/DataLog.h>
+#include <wtf/Process.h>
 #include <wtf/text/StringCommon.h>
 
 // We don't have a NO_RETURN_DUE_TO_EXIT, nor should we. That's ridiculous.
@@ -39,7 +40,7 @@ static void usage()
 {
     dataLog("Usage: testdfg [<filter>]\n");
     if (hiddenTruthBecauseNoReturnIsStupid())
-        exit(1);
+        exitProcess(1);
 }
 
 #if ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -92,6 +92,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/Process.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/Scope.h>
 #include <wtf/Span.h>
@@ -194,11 +195,7 @@ NO_RETURN_WITH_VALUE static void jscExit(int status)
         }
     }
 #endif // ENABLE(DFG_JIT)
-#if OS(WINDOWS)
-    TerminateProcess(GetCurrentProcess(), status);
-#else
-    exit(status);
-#endif
+    exitProcess(status);
 }
 
 static unsigned asyncTestPasses { 0 };
@@ -2321,7 +2318,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentStart, (JSGlobalObject* globalObject
                         result = evaluationException->value();
                     checkException(globalObject, true, evaluationException, result, commandLine, success);
                     if (!success)
-                        exit(1);
+                        exitProcess(EXIT_FAILURE);
                 });
         })->detach();
     
@@ -3146,7 +3143,7 @@ static void startTimeoutTimer(Seconds duration)
                 Seconds hardTimeout { hardTimeoutInDouble };
                 sleep(hardTimeout);
                 dataLogLn("HARD TIMEOUT after ", hardTimeout);
-                exit(EXIT_FAILURE);
+                exitProcess(EXIT_FAILURE);
             }
         }
     });
@@ -3680,7 +3677,7 @@ void CommandLine::parseArguments(int argc, char** argv)
 
             SignalAction (*exit)(Signal, SigInfo&, PlatformRegisters&) = [] (Signal, SigInfo&, PlatformRegisters&) {
                 dataLogLn("Signal handler hit. Exiting with status 0");
-                _exit(0);
+                terminateProcess(EXIT_SUCCESS);
                 return SignalAction::ForceDefault;
             };
 

--- a/Source/JavaScriptCore/testRegExp.cpp
+++ b/Source/JavaScriptCore/testRegExp.cpp
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wtf/Process.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -495,7 +496,7 @@ static NO_RETURN void printUsageStatement(bool help = false)
     fprintf(stderr, "  -h|--help  Prints this help message\n");
     fprintf(stderr, "  -v|--verbose  Verbose output\n");
 
-    exit(help ? EXIT_SUCCESS : EXIT_FAILURE);
+    exitProcess(help ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
 static void parseArguments(int argc, char** argv, CommandLine& options)

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <wtf/DataLog.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/Process.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
@@ -185,7 +186,7 @@ bool FunctionOverrides::initializeOverrideFor(const SourceCode& origCode, Functi
     do { \
         dataLog("functionOverrides ", error, ": "); \
         dataLog errorMessageInBrackets; \
-        exit(EXIT_FAILURE); \
+        exitProcess(EXIT_FAILURE); \
     } while (false)
 
 static bool hasDisallowedCharacters(const char* str, size_t length)

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -64,6 +64,7 @@
 #include <wtf/CPUTime.h>
 #include <wtf/DataLog.h>
 #include <wtf/Language.h>
+#include <wtf/Process.h>
 #include <wtf/ProcessID.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
@@ -2287,12 +2288,12 @@ JSC_DEFINE_HOST_FUNCTION(functionBreakpoint, (JSGlobalObject* globalObject, Call
     return encodedJSUndefined();
 }
 
-// Executes exit(EXIT_SUCCESS).
+// Executes exitProcess(EXIT_SUCCESS).
 // Usage: $vm.exit()
 JSC_DEFINE_HOST_FUNCTION(functionExit, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
-    exit(EXIT_SUCCESS);
+    exitProcess(EXIT_SUCCESS);
 }
 
 // Returns true if the current frame is a DFG frame.

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0F0C03D029981BEB0064230A /* EmbeddedFixedVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0C03CF29981BEB0064230A /* EmbeddedFixedVector.cpp */; };
 		0F0C03D8299820EB0064230A /* WeakPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0C03D7299820EB0064230A /* WeakPtr.cpp */; };
 		0F0C03E7299828E60064230A /* BloomFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0C03E6299828E50064230A /* BloomFilter.cpp */; };
-		0F0C03D029981BEB0064230A /* EmbeddedFixedVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0C03CF29981BEB0064230A /* EmbeddedFixedVector.cpp */; };
 		0F30BA901E78708E002CA847 /* GlobalVersion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F30BA8A1E78708E002CA847 /* GlobalVersion.cpp */; };
 		0F30CB5A1FCDF134004B5323 /* ConcurrentPtrHashSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F30CB581FCDF133004B5323 /* ConcurrentPtrHashSet.cpp */; };
 		0F3492D722AF431C004F85FC /* TextStreamCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F3492D622AF42F1004F85FC /* TextStreamCocoa.mm */; };
@@ -444,7 +444,6 @@
 		DD3DC96027A4BF8E007E5B61 /* Algorithms.h in Headers */ = {isa = PBXBuildFile; fileRef = CD6D9FCD1EEF3AD4008B0671 /* Algorithms.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC96127A4BF8E007E5B61 /* NoTailCalls.h in Headers */ = {isa = PBXBuildFile; fileRef = 526AEC911F6B4E5C00695F5D /* NoTailCalls.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC96227A4BF8E007E5B61 /* NakedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = FE8225301B2A1E5B00BA68FD /* NakedPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		DDA35E4B29CA9B68006C1018 /* PlatformEnableWinCairo.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C98CDC923E7AFC80012F232 /* PlatformEnableWinCairo.h */; };
 		DD3DC96427A4BF8E007E5B61 /* CrossThreadTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 515F794D1CFC9F4A00CCED93 /* CrossThreadTask.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC96527A4BF8E007E5B61 /* FixedVector.h in Headers */ = {isa = PBXBuildFile; fileRef = E3E0F04F26197157004640FC /* FixedVector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC96627A4BF8E007E5B61 /* IndexSparseSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 2684D4351C000D400081D663 /* IndexSparseSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -503,11 +502,12 @@
 		DD3DC99D27A4BF8E007E5B61 /* ConcurrentPtrHashSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F30CB591FCDF133004B5323 /* ConcurrentPtrHashSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD403D5628EB93BE009B4684 /* libbmalloc.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DD403D5528EB93BE009B4684 /* libbmalloc.a */; };
 		DD4901E727B4748A00D7E50D /* ParallelJobsGeneric.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4901E027B4748A00D7E50D /* ParallelJobsGeneric.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		DDA35E4A29CA9B68006C1018 /* PlatformEnablePlayStation.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4901E127B4748A00D7E50D /* PlatformEnablePlayStation.h */; };
 		DD4901E927B4748A00D7E50D /* DataMutex.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4901E227B4748A00D7E50D /* DataMutex.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4901EA27B4748A00D7E50D /* WindowsExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4901E327B4748A00D7E50D /* WindowsExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4901EB27B4748A00D7E50D /* ParallelJobsOpenMP.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4901E427B4748A00D7E50D /* ParallelJobsOpenMP.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4901EC27B4748A00D7E50D /* MainThreadData.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4901E527B4748A00D7E50D /* MainThreadData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DDA35E4A29CA9B68006C1018 /* PlatformEnablePlayStation.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4901E127B4748A00D7E50D /* PlatformEnablePlayStation.h */; };
+		DDA35E4B29CA9B68006C1018 /* PlatformEnableWinCairo.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C98CDC923E7AFC80012F232 /* PlatformEnableWinCairo.h */; };
 		DDCAF31D27B1E7C500C45308 /* GenericHashKey.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FD6D6627A1F6AD00935000 /* GenericHashKey.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDE99319278D08DC00F60D26 /* libWebKitAdditions.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DDE99317278D08C900F60D26 /* libWebKitAdditions.a */; };
 		DDF306D827C08654006A526F /* CFStringSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF306C127C08654006A526F /* CFStringSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -815,6 +815,8 @@
 		E361DB67289115D000B2A2B8 /* fast_table.h in Headers */ = {isa = PBXBuildFile; fileRef = E361DB5E289115D000B2A2B8 /* fast_table.h */; };
 		E361DB68289115D000B2A2B8 /* digit_comparison.h in Headers */ = {isa = PBXBuildFile; fileRef = E361DB5F289115D000B2A2B8 /* digit_comparison.h */; };
 		E361DB69289115D000B2A2B8 /* bigint.h in Headers */ = {isa = PBXBuildFile; fileRef = E361DB60289115D000B2A2B8 /* bigint.h */; };
+		E36BA9DE29E275DB00300057 /* Process.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36BA9DC29E275DB00300057 /* Process.cpp */; };
+		E36BA9DF29E275DB00300057 /* Process.h in Headers */ = {isa = PBXBuildFile; fileRef = E36BA9DD29E275DB00300057 /* Process.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E37E96542702AD0B00E1C36A /* ApproximateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E37E96522702AD0700E1C36A /* ApproximateTime.cpp */; };
 		E388886F20C9095100E632BC /* WorkerPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E388886D20C9095100E632BC /* WorkerPool.cpp */; };
 		E38C41281EB4E0680042957D /* CPUTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38C41261EB4E0680042957D /* CPUTime.cpp */; };
@@ -930,11 +932,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0F0C03D7299820EB0064230A /* WeakPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WeakPtr.cpp; sourceTree = "<group>"; };
-		0F0C03E6299828E50064230A /* BloomFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BloomFilter.cpp; sourceTree = "<group>"; };
 		077CD86A1FD9CFD200828587 /* Logger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Logger.h; sourceTree = "<group>"; };
 		077CD86B1FD9CFD300828587 /* LoggerHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoggerHelper.h; sourceTree = "<group>"; };
 		0F0C03CF29981BEB0064230A /* EmbeddedFixedVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EmbeddedFixedVector.cpp; sourceTree = "<group>"; };
+		0F0C03D7299820EB0064230A /* WeakPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WeakPtr.cpp; sourceTree = "<group>"; };
+		0F0C03E6299828E50064230A /* BloomFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BloomFilter.cpp; sourceTree = "<group>"; };
 		0F0D85B317234CB100338210 /* NoLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NoLock.h; sourceTree = "<group>"; };
 		0F0FCDDD1DD167F900CCAB53 /* LockAlgorithm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LockAlgorithm.h; sourceTree = "<group>"; };
 		0F2AC5601E89F70C0001EE3F /* Range.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Range.h; sourceTree = "<group>"; };
@@ -1717,6 +1719,8 @@
 		E361DB60289115D000B2A2B8 /* bigint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bigint.h; sourceTree = "<group>"; };
 		E36895CB23A445CD008DD4C8 /* PackedRef.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PackedRef.h; sourceTree = "<group>"; };
 		E36895CC23A445EE008DD4C8 /* PackedRefPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PackedRefPtr.h; sourceTree = "<group>"; };
+		E36BA9DC29E275DB00300057 /* Process.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Process.cpp; sourceTree = "<group>"; };
+		E36BA9DD29E275DB00300057 /* Process.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Process.h; sourceTree = "<group>"; };
 		E37E96522702AD0700E1C36A /* ApproximateTime.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ApproximateTime.cpp; sourceTree = "<group>"; };
 		E37E96532702AD0700E1C36A /* ApproximateTime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ApproximateTime.h; sourceTree = "<group>"; };
 		E38020DB2401C0930037CA9E /* CompactRefPtrTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactRefPtrTuple.h; sourceTree = "<group>"; };
@@ -2224,6 +2228,8 @@
 				0F9D335D165DBA73005AD387 /* PrintStream.cpp */,
 				0F9D335E165DBA73005AD387 /* PrintStream.h */,
 				53EC253C1E95AD30000831B9 /* PriorityQueue.h */,
+				E36BA9DC29E275DB00300057 /* Process.cpp */,
+				E36BA9DD29E275DB00300057 /* Process.h */,
 				0FC4488216FE9FE100844BE9 /* ProcessID.h */,
 				7AF023B42061E16F00A8EFD6 /* ProcessPrivilege.cpp */,
 				7AF023B32061E16C00A8EFD6 /* ProcessPrivilege.h */,
@@ -3187,6 +3193,7 @@
 				DD3DC96F27A4BF8E007E5B61 /* PointerPreparations.h in Headers */,
 				DD3DC93227A4BF8E007E5B61 /* PrintStream.h in Headers */,
 				DD3DC95027A4BF8E007E5B61 /* PriorityQueue.h in Headers */,
+				E36BA9DF29E275DB00300057 /* Process.h in Headers */,
 				DD3DC89927A4BF8E007E5B61 /* ProcessID.h in Headers */,
 				DDF306E827C08654006A526F /* ProcessMemoryFootprint.h in Headers */,
 				DD3DC95627A4BF8E007E5B61 /* ProcessPrivilege.h in Headers */,
@@ -3749,6 +3756,7 @@
 				51F1752D1F3D486000C74950 /* PersistentEncoder.cpp in Sources */,
 				FE1E2C42224187C600F6B729 /* PlatformRegisters.cpp in Sources */,
 				0F9D3362165DBA73005AD387 /* PrintStream.cpp in Sources */,
+				E36BA9DE29E275DB00300057 /* Process.cpp in Sources */,
 				7AF023B52061E17000A8EFD6 /* ProcessPrivilege.cpp in Sources */,
 				FE1E2C3B2240C06600F6B729 /* PtrTag.cpp in Sources */,
 				143F611F1565F0F900DB514A /* RAMSize.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -212,6 +212,7 @@ set(WTF_PUBLIC_HEADERS
     PointerPreparations.h
     PrintStream.h
     PriorityQueue.h
+    Process.h
     ProcessID.h
     ProcessPrivilege.h
     PtrTag.h
@@ -482,6 +483,7 @@ set(WTF_SOURCES
     ParallelJobsGeneric.cpp
     ParkingLot.cpp
     PrintStream.cpp
+    Process.cpp
     ProcessPrivilege.cpp
     RAMSize.cpp
     RandomDevice.cpp

--- a/Source/WTF/wtf/Process.cpp
+++ b/Source/WTF/wtf/Process.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/Process.h>
+
+#include <stdlib.h>
+
+#if OS(UNIX)
+#include <unistd.h>
+#endif
+
+#if OS(WINDOWS)
+#include <windows.h>
+#endif
+
+namespace WTF {
+
+void exitProcess(int status)
+{
+#if OS(WINDOWS)
+    // Windows do not have "main thread" concept. So, shutdown of the main thread does not mean immediate process shutdown.
+    // As a result, if there is running thread, it sometimes cause deadlock.
+    //
+    // > If one of the terminated threads in the process holds a lock and the DLL detach code in one of the loaded DLLs
+    // > attempts to acquire the same lock, then calling ExitProcess results in a deadlock. In contrast, if a process
+    // > terminates by calling TerminateProcess, the DLLs that the process is attached to are not notified of the process
+    // > termination. Therefore, if you do not know the state of all threads in your process, it is better to call TerminateProcess
+    // > than ExitProcess. Note that returning from the main function of an application results in a call to ExitProcess.
+    // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-exitprocess
+    //
+    // Always use TerminateProcess since framework does not know the status of the other threads.
+    TerminateProcess(GetCurrentProcess(), status);
+
+    // The code can reach here only when very buggy anti-virus software hooks are integrated into the system. To make it safe, in that case,
+    // let the process crash explicitly.
+    CRASH();
+#else
+    exit(status);
+#endif
+}
+
+void terminateProcess(int status)
+{
+#if OS(WINDOWS)
+    // On Windows, exitProcess and terminateProcess do the same thing due to its more complicated main thread handling.
+    // See comment in exitProcess.
+    exitProcess(status);
+#else
+    _exit(status);
+#endif
+}
+
+}

--- a/Source/WTF/wtf/Process.h
+++ b/Source/WTF/wtf/Process.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,21 +23,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "ResourceExhaustion.h"
+#pragma once
 
-#include "Options.h"
-#include <wtf/Assertions.h>
-#include <wtf/Process.h>
+namespace WTF {
 
-namespace JSC {
+// Expect exit call on UNIX platforms.
+WTF_EXPORT_PRIVATE NO_RETURN void exitProcess(int status);
+// Expect _exit call on UNIX platforms.
+WTF_EXPORT_PRIVATE NO_RETURN void terminateProcess(int status);
 
-NO_RETURN_DUE_TO_CRASH void handleResourceExhaustion(const char* file, int line, const char* function, const char* assertion, ResourceExhaustionCode exitCode, const char* exitCodeAsString, const char* failureMessage)
-{
-    WTFReportAssertionFailureWithMessage(file, line, function, assertion, "%s: %s", exitCodeAsString, failureMessage);
-    if (Options::exitOnResourceExhaustion())
-        exitProcess(exitCode);
-    CRASH();
-}
+} // namespace WTF
 
-} // namespace JSC
+using WTF::exitProcess;
+using WTF::terminateProcess;

--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -31,6 +31,7 @@
 #include "Logging.h"
 #include "MessageWithMessagePorts.h"
 #include "ServiceWorkerGlobalScope.h"
+#include <wtf/Process.h>
 
 namespace WebCore {
 
@@ -233,7 +234,7 @@ void SWContextManager::serviceWorkerFailedToTerminate(ServiceWorkerIdentifier se
     UNUSED_PARAM(serviceWorkerIdentifier);
     RELEASE_LOG_ERROR(ServiceWorker, "Failed to terminate service worker with identifier %s, killing the service worker process", serviceWorkerIdentifier.loggingString().utf8().data());
     ASSERT_NOT_REACHED();
-    _exit(EXIT_FAILURE);
+    terminateProcess(EXIT_FAILURE);
 }
 
 SWContextManager::ServiceWorkerTerminationRequest::ServiceWorkerTerminationRequest(SWContextManager& manager, ServiceWorkerIdentifier serviceWorkerIdentifier, Seconds timeout)

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -30,6 +30,7 @@
 #include "WGSLShaderModule.h"
 #include <wtf/DataLog.h>
 #include <wtf/FileSystem.h>
+#include <wtf/Process.h>
 
 static NO_RETURN void printUsageStatement(bool help = false)
 {
@@ -40,7 +41,7 @@ static NO_RETURN void printUsageStatement(bool help = false)
     fprintf(stderr, "  --dump-generated-code  Dumps the generated Metal code\n");
     fprintf(stderr, "\n");
 
-    exit(help ? EXIT_SUCCESS : EXIT_FAILURE);
+    exitProcess(help ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
 struct CommandLine {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -92,6 +92,7 @@
 #include <wtf/CallbackAggregator.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/OptionSet.h>
+#include <wtf/Process.h>
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/RunLoop.h>
 #include <wtf/UUID.h>
@@ -135,12 +136,7 @@ static void callExitSoon(IPC::Connection*)
         // global destructors or atexit handlers to be called from this thread while the main thread is busy
         // doing its thing.
         RELEASE_LOG_ERROR(IPC, "Exiting process early due to unacknowledged closed-connection");
-#if OS(WINDOWS)
-        // Calling _exit in non-main threads may cause a deadlock in WTF::Thread::ThreadHolder::~ThreadHolder.
-        TerminateProcess(GetCurrentProcess(), EXIT_FAILURE);
-#else
-        _exit(EXIT_FAILURE);
-#endif
+        terminateProcess(EXIT_FAILURE);
     });
 }
 

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -36,6 +36,7 @@
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/ObjectIdentifier.h>
+#include <wtf/Process.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Scope.h>
 #include <wtf/text/WTFString.h>
@@ -1122,7 +1123,7 @@ void Connection::didFailToSendSyncMessage()
     if (!m_shouldExitOnSyncMessageSendFailure)
         return;
 
-    exit(0);
+    exitProcess(0);
 }
 
 void Connection::enqueueIncomingMessage(std::unique_ptr<Decoder> incomingMessage)

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -35,6 +35,7 @@
 #include <WebCore/LogInitialization.h>
 #include <pal/SessionID.h>
 #include <wtf/LogInitialization.h>
+#include <wtf/Process.h>
 #include <wtf/SetForScope.h>
 
 #if !OS(WINDOWS)
@@ -67,7 +68,7 @@ void AuxiliaryProcess::didClose(IPC::Connection&)
 #if PLATFORM(GTK) || PLATFORM(WPE)
     stopRunLoop();
 #else
-    _exit(EXIT_SUCCESS);
+    terminateProcess(EXIT_SUCCESS);
 #endif
 }
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -29,6 +29,7 @@
 #import "WebKit2Initialize.h"
 #import <JavaScriptCore/ExecutableAllocator.h>
 #import <wtf/OSObjectPtr.h>
+#import <wtf/Process.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
 #if !USE(RUNNINGBOARD)
@@ -131,15 +132,15 @@ void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_
     InitializeWebKit2();
 
     if (!delegate.checkEntitlements())
-        exit(EXIT_FAILURE);
+        exitProcess(EXIT_FAILURE);
 
     AuxiliaryProcessInitializationParameters parameters;
 
     if (!delegate.getConnectionIdentifier(parameters.connectionIdentifier))
-        exit(EXIT_FAILURE);
+        exitProcess(EXIT_FAILURE);
 
     if (!delegate.getClientIdentifier(parameters.clientIdentifier))
-        exit(EXIT_FAILURE);
+        exitProcess(EXIT_FAILURE);
 
     // The host process may not have a bundle identifier (e.g. a command line app), so don't require one.
     delegate.getClientBundleIdentifier(parameters.clientBundleIdentifier);
@@ -148,14 +149,14 @@ void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_
 
     WebCore::ProcessIdentifier processIdentifier;
     if (!delegate.getProcessIdentifier(processIdentifier))
-        exit(EXIT_FAILURE);
+        exitProcess(EXIT_FAILURE);
     parameters.processIdentifier = processIdentifier;
 
     if (!delegate.getClientProcessName(parameters.uiProcessName))
-        exit(EXIT_FAILURE);
+        exitProcess(EXIT_FAILURE);
 
     if (!delegate.getExtraInitializationData(parameters.extraInitializationData))
-        exit(EXIT_FAILURE);
+        exitProcess(EXIT_FAILURE);
 
     // Set the task default voucher to the current value (as propagated by XPC).
     voucher_replace_default_voucher();

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -30,6 +30,7 @@
 #import "XPCServiceEntryPoint.h"
 #import <WebCore/ProcessIdentifier.h>
 #import <signal.h>
+#import <wtf/Process.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/text/StringToIntegerConversion.h>
@@ -170,13 +171,13 @@ void setOSTransaction(OSObjectPtr<os_transaction_t>&& transaction)
     // services ourselves. However, one of the side effects of leaking this transaction is that the default SIGTERM
     // handler doesn't cleanly exit our XPC services when logging out or rebooting. This led to crashes with
     // XPC_EXIT_REASON_SIGTERM_TIMEOUT as termination reason (rdar://88940229). To address the issue, we now set our
-    // own SIGTERM handler that calls exit(0). In the future, we should likely adopt RunningBoard on macOS and
+    // own SIGTERM handler that calls exitProcess(0). In the future, we should likely adopt RunningBoard on macOS and
     // control our lifetime via process assertions instead of leaking this OS transaction.
     static dispatch_once_t flag;
     dispatch_once(&flag, ^{
         globalSource.get() = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0, dispatch_get_main_queue()));
         dispatch_source_set_event_handler(globalSource.get().get(), ^{
-            exit(0);
+            exitProcess(0);
         });
         dispatch_resume(globalSource.get().get());
     });

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -37,6 +37,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/Language.h>
 #import <wtf/OSObjectPtr.h>
+#import <wtf/Process.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/spi/cocoa/OSLogSPI.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
@@ -125,7 +126,7 @@ static void XPCServiceEventHandler(xpc_connection_t peer)
                     RELEASE_LOG_FAULT(IPC, "Exiting: Received XPC event type: %{public}s", event == XPC_ERROR_CONNECTION_INVALID ? "XPC_ERROR_CONNECTION_INVALID" : "XPC_ERROR_TERMINATION_IMMINENT");
                     // FIXME: Handle this case more gracefully.
                     [[NSRunLoop mainRunLoop] performBlock:^{
-                        exit(EXIT_FAILURE);
+                        exitProcess(EXIT_FAILURE);
                     }];
                 }
             }
@@ -164,7 +165,7 @@ static void XPCServiceEventHandler(xpc_connection_t peer)
             if (!initializerFunctionPtr) {
                 RELEASE_LOG_FAULT(IPC, "Exiting: Unable to find entry point in WebKit.framework with name: %s", [(__bridge NSString *)entryPointFunctionName UTF8String]);
                 [[NSRunLoop mainRunLoop] performBlock:^{
-                    exit(EXIT_FAILURE);
+                    exitProcess(EXIT_FAILURE);
                 }];
                 return;
             }

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "IPCStreamTester.h"
 
+#include <wtf/Process.h>
+
 #if ENABLE(IPC_TESTING_API)
 #include "Decoder.h"
 #include "IPCStreamTesterMessages.h"
@@ -93,12 +95,7 @@ void IPCStreamTester::syncCrashOnZero(int32_t value, CompletionHandler<void(int3
 {
     if (!value) {
         // Use exit so that we don't leave a crash report.
-#if OS(WINDOWS)
-        // Calling _exit in non-main threads may cause a deadlock in WTF::Thread::ThreadHolder::~ThreadHolder.
-        TerminateProcess(GetCurrentProcess(), EXIT_SUCCESS);
-#else
-        _exit(EXIT_SUCCESS);
-#endif
+        terminateProcess(EXIT_SUCCESS);
     }
     completionHandler(value);
 }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -149,6 +149,7 @@
 #include <wtf/CallbackAggregator.h>
 #include <wtf/DateMath.h>
 #include <wtf/Language.h>
+#include <wtf/Process.h>
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/RunLoop.h>
 #include <wtf/SystemTracing.h>
@@ -266,12 +267,7 @@ using namespace WebCore;
 #if !PLATFORM(GTK) && !PLATFORM(WPE)
 NO_RETURN static void callExit(IPC::Connection*)
 {
-#if OS(WINDOWS)
-    // Calling _exit in non-main threads may cause a deadlock in WTF::Thread::ThreadHolder::~ThreadHolder.
-    TerminateProcess(GetCurrentProcess(), EXIT_SUCCESS);
-#else
-    _exit(EXIT_SUCCESS);
-#endif
+    terminateProcess(EXIT_SUCCESS);
 }
 #endif
 
@@ -1159,7 +1155,7 @@ NO_RETURN inline void failedToGetNetworkProcessConnection()
     // Web process is still initializing, so we always want to exit instead of crashing. This can
     // happen when the WebView is created and then destroyed quickly.
     // See https://bugs.webkit.org/show_bug.cgi?id=183348.
-    exit(0);
+    exitProcess(0);
 #else
     CRASH();
 #endif

--- a/Source/WebKit/webpushd/WebPushDaemonMain.mm
+++ b/Source/WebKit/webpushd/WebPushDaemonMain.mm
@@ -40,6 +40,7 @@
 #import <wtf/LogInitialization.h>
 #import <wtf/MainThread.h>
 #import <wtf/OSObjectPtr.h>
+#import <wtf/Process.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 
 using WebKit::Daemon::EncodedMessage;
@@ -132,7 +133,7 @@ int WebPushDaemonMain(int argc, char** argv)
                 break;
             default:
                 fprintf(stderr, "Unknown option: %c\n", optopt);
-                exit(1);
+                exitProcess(1);
             }
         }
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -29,6 +29,7 @@
 #import <Foundation/Foundation.h>
 #import <optional>
 #import <wtf/MainThread.h>
+#import <wtf/Process.h>
 
 using WebKit::WebPushD::PushMessageForTesting;
 
@@ -56,7 +57,7 @@ static void printUsageAndTerminate(NSString *message)
     fprintf(stderr, "    Inject a test push message to the target app, push partition, and registration URL\n");
     fprintf(stderr, "\n");
 
-    exit(-1);
+    exitProcess(-1);
 }
 
 static std::unique_ptr<PushMessageForTesting> pushMessageFromArguments(NSEnumerator<NSString *> *enumerator)

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -98,6 +98,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/OSObjectPtr.h>
+#import <wtf/Process.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/Threading.h>
@@ -540,7 +541,7 @@ static void activateTestingFonts()
     if (!CTFontManagerRegisterFontsForURLs((CFArrayRef)fontURLs.get(), kCTFontManagerScopeProcess, &errors)) {
         NSLog(@"Failed to activate fonts: %@", errors);
         CFRelease(errors);
-        exit(1);
+        exitProcess(1);
     }
 }
 
@@ -557,20 +558,20 @@ static void activateFontIOS(const uint8_t* fontData, unsigned long length, std::
     auto data = adoptCF(CGDataProviderCreateWithData(nullptr, fontData, length, nullptr));
     if (!data) {
         fprintf(stderr, "Failed to create CGDataProviderRef for the %s font.\n", sectionName.c_str());
-        exit(1);
+        exitProcess(1);
     }
 
     auto cgFont = adoptCF(CGFontCreateWithDataProvider(data.get()));
     if (!cgFont) {
         fprintf(stderr, "Failed to create CGFontRef for the %s font.\n", sectionName.c_str());
-        exit(1);
+        exitProcess(1);
     }
 
     CFErrorRef error = nullptr;
     CTFontManagerRegisterGraphicsFont(cgFont.get(), &error);
     if (error) {
         fprintf(stderr, "Failed to add CGFont to CoreText for the %s font: %s.\n", sectionName.c_str(), CFStringGetCStringPtr(CFErrorCopyDescription(error), kCFStringEncodingUTF8));
-        exit(1);
+        exitProcess(1);
     }
 }
 
@@ -1028,7 +1029,7 @@ static void initializeGlobalsFromCommandLineOptions(int argc, const char *argv[]
         switch (option) {
             case '?':   // unknown or ambiguous option
             case ':':   // missing argument
-                exit(1);
+                exitProcess(1);
                 break;
             case 'a': // "allowed-host"
                 allowedHosts.insert(optarg);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -87,6 +87,7 @@
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
+#include <wtf/Process.h>
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
@@ -591,10 +592,10 @@ void TestController::initialize(int argc, const char* argv[])
 
     if (argc < 2) {
         optionsHandler.printHelp();
-        exit(1);
+        exitProcess(1);
     }
     if (!optionsHandler.parse(argc, argv))
-        exit(1);
+        exitProcess(1);
 
     platformInitialize(options);
 
@@ -2145,7 +2146,7 @@ void TestController::networkProcessDidCrash(WKProcessID processID, WKProcessTerm
     fprintf(stderr, "%s terminated (pid %ld) for reason: %s\n", networkProcessName(), static_cast<long>(processID), terminationReasonToString(reason));
     fprintf(stderr, "#CRASHED - %s (pid %ld)\n", networkProcessName(), static_cast<long>(processID));
     if (m_shouldExitWhenAuxiliaryProcessCrashes)
-        exit(1);
+        exitProcess(1);
 }
 
 void TestController::serviceWorkerProcessDidCrash(WKProcessID processID, WKProcessTerminationReason reason)
@@ -2153,7 +2154,7 @@ void TestController::serviceWorkerProcessDidCrash(WKProcessID processID, WKProce
     fprintf(stderr, "%s terminated (pid %ld) for reason: %s\n", "ServiceWorkerProcess", static_cast<long>(processID), terminationReasonToString(reason));
     fprintf(stderr, "#CRASHED - ServiceWorkerProcess (pid %ld)\n", static_cast<long>(processID));
     if (m_shouldExitWhenAuxiliaryProcessCrashes)
-        exit(1);
+        exitProcess(1);
 }
 
 void TestController::gpuProcessDidCrash(WKProcessID processID, WKProcessTerminationReason reason)
@@ -2161,7 +2162,7 @@ void TestController::gpuProcessDidCrash(WKProcessID processID, WKProcessTerminat
     fprintf(stderr, "%s terminated (pid %ld) for reason: %s\n", gpuProcessName(), static_cast<long>(processID), terminationReasonToString(reason));
     fprintf(stderr, "#CRASHED - %s (pid %ld)\n", gpuProcessName(), static_cast<long>(processID));
     if (m_shouldExitWhenAuxiliaryProcessCrashes)
-        exit(1);
+        exitProcess(1);
 }
 
 // WKPageNavigationClient
@@ -2521,7 +2522,7 @@ void TestController::webProcessDidTerminate(WKProcessTerminationReason reason)
     }
 
     if (m_shouldExitWhenAuxiliaryProcessCrashes)
-        exit(1);
+        exitProcess(1);
 }
 
 void TestController::didBeginNavigationGesture(WKPageRef)

--- a/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
@@ -32,6 +32,7 @@
 #include <WebKit/WKViewPrivate.h>
 #include <gtk/gtk.h>
 #include <wtf/Platform.h>
+#include <wtf/Process.h>
 #include <wtf/RunLoop.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
@@ -90,7 +91,7 @@ static char* getEnvironmentVariableAsUTF8String(const char* variableName)
     const char* value = g_getenv(variableName);
     if (!value) {
         fprintf(stderr, "%s environment variable not found\n", variableName);
-        exit(0);
+        exitProcess(0);
     }
     gsize bytesWritten;
     return g_filename_to_utf8(value, -1, 0, &bytesWritten, 0);

--- a/Tools/WebKitTestRunner/win/TestControllerWin.cpp
+++ b/Tools/WebKitTestRunner/win/TestControllerWin.cpp
@@ -34,6 +34,7 @@
 #include <shlwapi.h>
 #include <string>
 #include <windows.h>
+#include <wtf/Process.h>
 #include <wtf/RunLoop.h>
 
 
@@ -163,7 +164,7 @@ void TestController::platformRunUntil(bool& condition, WTF::Seconds timeout)
     bool neverSetCondition = false;
     result = runRunLoopUntil(neverSetCondition, 0, maximumWaitForWebProcessToCrash);
     ASSERT_UNUSED(result, result == TimedOut);
-    exit(1);
+    exitProcess(1);
 }
 
 void TestController::platformDidCommitLoadForFrame(WKPageRef, WKFrameRef)

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -29,6 +29,7 @@
 #include "PlatformWebView.h"
 #include <cairo.h>
 #include <glib.h>
+#include <wtf/Process.h>
 #include <wtf/RunLoop.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/Base64.h>
@@ -97,7 +98,7 @@ static char* getEnvironmentVariableAsUTF8String(const char* variableName)
     const char* value = g_getenv(variableName);
     if (!value) {
         fprintf(stderr, "%s environment variable not found\n", variableName);
-        exit(0);
+        exitProcess(0);
     }
     gsize bytesWritten;
     return g_filename_to_utf8(value, -1, 0, &bytesWritten, 0);


### PR DESCRIPTION
#### 009188ebcbd7cdc8f898c994c87f2940bd064f17
<pre>
Add WTF::exitProcess and WTF::terminateProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=255199">https://bugs.webkit.org/show_bug.cgi?id=255199</a>
rdar://107798593

Reviewed by Ross Kirsling.

Add WTF::exitProcess and WTF::terminateProcess. They are corresponding to exit(...) and _exit(...) on UNIX platforms.
We would like to have this since Windows have subtle different behavior in these functions, and WTF::exitProcess and
WTF::terminateProcess can hide these difference.

* Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp:
(testExecutionTimeLimit):
* Source/JavaScriptCore/API/tests/testapi.mm:
(resolvePathToScripts):
* Source/JavaScriptCore/assembler/testmasm.cpp:
(usage):
* Source/JavaScriptCore/b3/air/testair.cpp:
(usage):
* Source/JavaScriptCore/b3/testb3.h:
(usage):
* Source/JavaScriptCore/dfg/testdfg.cpp:
(usage):
* Source/JavaScriptCore/jsc.cpp:
(JSC::jscExit):
(JSC_DEFINE_HOST_FUNCTION):
(startTimeoutTimer):
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/ResourceExhaustion.cpp:
(JSC::handleResourceExhaustion):
* Source/JavaScriptCore/testRegExp.cpp:
(printUsageStatement):
* Source/JavaScriptCore/tools/FunctionOverrides.cpp:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/Process.cpp: Added.
(WTF::exitProcess):
(WTF::terminateProcess):
* Source/WTF/wtf/Process.h: Copied from Source/JavaScriptCore/runtime/ResourceExhaustion.cpp.
* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::serviceWorkerFailedToTerminate):
* Source/WebGPU/WGSL/wgslc.cpp:
(printUsageStatement):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::callExitSoon):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::didFailToSendSyncMessage):
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::didClose):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
(WebKit::XPCServiceInitializer):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::setOSTransaction):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::syncCrashOnZero):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::sandboxDataVaultParentDirectory):
(WebKit::populateSandboxInitializationParameters):
(WebKit::AuxiliaryProcess::initializeSandbox):
(WebKit::AuxiliaryProcess::stopNSRunLoop):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::callExit):
(WebKit::failedToGetNetworkProcessConnection):
* Source/WebKit/webpushd/WebPushDaemonMain.mm:
(WebKit::WebPushDaemonMain):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(printUsageAndTerminate):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(activateTestingFonts):
(activateFontIOS):
(initializeGlobalsFromCommandLineOptions):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::initialize):
(WTR::TestController::networkProcessDidCrash):
(WTR::TestController::serviceWorkerProcessDidCrash):
(WTR::TestController::gpuProcessDidCrash):
(WTR::TestController::webProcessDidTerminate):
* Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp:
(WTR::getEnvironmentVariableAsUTF8String):
* Tools/WebKitTestRunner/win/TestControllerWin.cpp:
(WTR::TestController::platformRunUntil):
* Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp:
(WTR::getEnvironmentVariableAsUTF8String):

Canonical link: <a href="https://commits.webkit.org/262760@main">https://commits.webkit.org/262760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39523f93ba4860da2f7146654c243503c703e126

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2552 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2224 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3682 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2101 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2098 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2470 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3448 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2412 "Built successfully and passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2296 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2079 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2594 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2249 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/596 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2271 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2649 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/289 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2422 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/709 "Passed tests") | 
<!--EWS-Status-Bubble-End-->