### PR TITLE
Finalize postMessage support to being created service worker clients

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/controlled-dedicatedworker-postMessage.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/controlled-dedicatedworker-postMessage.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Register service worker
-FAIL Verify dedicated worker gets messages if setting event listener early assert_equals: expected (number) 0 but got (string) "No message received"
+PASS Verify dedicated worker gets messages if setting event listener early
 PASS Verify dedicated worker does not get all messages if not setting event listener early
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/controlled-iframe-postMessage.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/controlled-iframe-postMessage.https-expected.txt
@@ -1,7 +1,6 @@
 
-
 PASS Register service worker
 PASS Verify frame gets early messages if setting synchronously message event listener
-FAIL Verify frame does not get all messages if not setting event listener early assert_not_equals: got disallowed value 0
-FAIL Verify frame does get messages in order assert_true: expected true got false
+PASS Verify frame does not get all messages if not setting event listener early
+PASS Verify frame does get messages in order
 

--- a/Source/WebCore/workers/service/SWClientConnection.h
+++ b/Source/WebCore/workers/service/SWClientConnection.h
@@ -143,15 +143,13 @@ public:
     using RetrieveRecordResponseBodyCallback = Function<void(Expected<RefPtr<SharedBuffer>, ResourceError>&&)>;
     virtual void retrieveRecordResponseBody(BackgroundFetchRecordIdentifier, RetrieveRecordResponseBodyCallback&&) = 0;
 
-    virtual void getServiceWorkerClientPendingMessages(ScriptExecutionContextIdentifier, CompletionHandler<void(Vector<ServiceWorkerClientPendingMessage>&&)>&&) = 0;
-
 protected:
     WEBCORE_EXPORT SWClientConnection();
 
     WEBCORE_EXPORT void jobRejectedInServer(ServiceWorkerJobIdentifier, ExceptionData&&);
     WEBCORE_EXPORT void registrationJobResolvedInServer(ServiceWorkerJobIdentifier, ServiceWorkerRegistrationData&&, ShouldNotifyWhenResolved);
     WEBCORE_EXPORT void startScriptFetchForServer(ServiceWorkerJobIdentifier, ServiceWorkerRegistrationKey&&, FetchOptions::Cache);
-    WEBCORE_EXPORT void postMessageToServiceWorkerClient(ScriptExecutionContextIdentifier destinationContextIdentifier, MessageWithMessagePorts&&, ServiceWorkerData&& source, String&& sourceOrigin, CompletionHandler<void(bool)>&&);
+    WEBCORE_EXPORT void postMessageToServiceWorkerClient(ScriptExecutionContextIdentifier destinationContextIdentifier, MessageWithMessagePorts&&, ServiceWorkerData&& source, String&& sourceOrigin);
     WEBCORE_EXPORT void updateRegistrationState(ServiceWorkerRegistrationIdentifier, ServiceWorkerRegistrationState, const std::optional<ServiceWorkerData>&);
     WEBCORE_EXPORT void updateWorkerState(ServiceWorkerIdentifier, ServiceWorkerState);
     WEBCORE_EXPORT void fireUpdateFoundEvent(ServiceWorkerRegistrationIdentifier);

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.cpp
@@ -553,11 +553,6 @@ void WorkerSWClientConnection::retrieveRecordResponseBody(BackgroundFetchRecordI
     });
 }
 
-void WorkerSWClientConnection::getServiceWorkerClientPendingMessages(ScriptExecutionContextIdentifier, CompletionHandler<void(Vector<ServiceWorkerClientPendingMessage>&&)>&& completionHandler)
-{
-    completionHandler({ });
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebCore/workers/service/WorkerSWClientConnection.h
+++ b/Source/WebCore/workers/service/WorkerSWClientConnection.h
@@ -76,7 +76,6 @@ private:
     void matchBackgroundFetch(ServiceWorkerRegistrationIdentifier, const String&, RetrieveRecordsOptions&&, MatchBackgroundFetchCallback&&) final;
     void retrieveRecordResponse(BackgroundFetchRecordIdentifier, RetrieveRecordResponseCallback&&) final;
     void retrieveRecordResponseBody(BackgroundFetchRecordIdentifier, RetrieveRecordResponseBodyCallback&&) final;
-    void getServiceWorkerClientPendingMessages(ScriptExecutionContextIdentifier, CompletionHandler<void(Vector<ServiceWorkerClientPendingMessage>&&)>&&) final;
 
     Ref<WorkerThread> m_thread;
 

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -213,7 +213,8 @@ public:
 
     WEBCORE_EXPORT static HashSet<SWServer*>& allServers();
 
-    WEBCORE_EXPORT void registerServiceWorkerClient(ClientOrigin&&, ServiceWorkerClientData&&, const std::optional<ServiceWorkerRegistrationIdentifier>&, String&& userAgent);
+    enum class IsBeingCreatedClient : bool { No, Yes };
+    WEBCORE_EXPORT void registerServiceWorkerClient(ClientOrigin&&, ServiceWorkerClientData&&, const std::optional<ServiceWorkerRegistrationIdentifier>&, String&& userAgent, IsBeingCreatedClient);
     WEBCORE_EXPORT void unregisterServiceWorkerClient(const ClientOrigin&, ScriptExecutionContextIdentifier);
 
     using RunServiceWorkerCallback = Function<void(SWServerToContextConnection*)>;
@@ -286,8 +287,9 @@ public:
     Ref<BackgroundFetchStore> createBackgroundFetchStore() { return m_delegate->createBackgroundFetchStore(); }
     WEBCORE_EXPORT BackgroundFetchEngine& backgroundFetchEngine();
 
-    WEBCORE_EXPORT void addServiceWorkerClientPendingMessage(ScriptExecutionContextIdentifier, ServiceWorkerClientPendingMessage&&);
     WEBCORE_EXPORT Vector<ServiceWorkerClientPendingMessage> releaseServiceWorkerClientPendingMessage(ScriptExecutionContextIdentifier);
+
+    WEBCORE_EXPORT void postMessageToServiceWorkerClient(ScriptExecutionContextIdentifier, const MessageWithMessagePorts&, ServiceWorkerIdentifier, const String&, const Function<void(ScriptExecutionContextIdentifier, const MessageWithMessagePorts&, const ServiceWorkerData&, const String&)>&);
 
 private:
     unsigned maxRegistrationCount();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -91,6 +91,7 @@ public:
     std::optional<WebCore::SWServer::GatheredClientData> gatherClientData(WebCore::ScriptExecutionContextIdentifier);
 
     void registerServiceWorkerClient(WebCore::ClientOrigin&&, WebCore::ServiceWorkerClientData&&, const std::optional<WebCore::ServiceWorkerRegistrationIdentifier>&, String&& userAgent);
+    void registerServiceWorkerClientInternal(WebCore::ClientOrigin&&, WebCore::ServiceWorkerClientData&&, const std::optional<WebCore::ServiceWorkerRegistrationIdentifier>&, String&& userAgent, WebCore::SWServer::IsBeingCreatedClient);
     void unregisterServiceWorkerClient(const WebCore::ScriptExecutionContextIdentifier&);
 
 private:
@@ -106,7 +107,6 @@ private:
     void setRegistrationUpdateViaCache(WebCore::ServiceWorkerRegistrationIdentifier, WebCore::ServiceWorkerUpdateViaCache) final;
     void notifyClientsOfControllerChange(const HashSet<WebCore::ScriptExecutionContextIdentifier>& contextIdentifiers, const WebCore::ServiceWorkerData& newController);
     void focusServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier, CompletionHandler<void(std::optional<WebCore::ServiceWorkerClientData>&&)>&&) final;
-    void getServiceWorkerClientPendingMessages(const WebCore::ScriptExecutionContextIdentifier&, CompletionHandler<void(Vector<WebCore::ServiceWorkerClientPendingMessage>&&)>&&);
 
     void scheduleJobInServer(WebCore::ServiceWorkerJobData&&);
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -65,6 +65,5 @@ messages -> WebSWServerConnection NotRefCounted {
     MatchBackgroundFetch(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, String backgroundFetchIdentifier, struct WebCore::RetrieveRecordsOptions options) -> (Vector<WebCore::BackgroundFetchRecordInformation> results)
     RetrieveRecordResponse(WebCore::BackgroundFetchRecordIdentifier recordIdentifier) -> (Expected<WebCore::ResourceResponse, WebCore::ExceptionData> result)
     RetrieveRecordResponseBody(WebCore::BackgroundFetchRecordIdentifier recordIdentifier, WebKit::RetrieveRecordResponseBodyCallbackIdentifier callbackIdentifier)
-    GetServiceWorkerClientPendingMessages(WebCore::ScriptExecutionContextIdentifier identifier) -> (Vector<WebCore::ServiceWorkerClientPendingMessage> messages)
 }
 #endif // ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -394,11 +394,6 @@ void WebSWClientConnection::notifyRecordResponseBodyEnd(RetrieveRecordResponseBo
         callback(makeUnexpected(WTFMove(error)));
 }
 
-void WebSWClientConnection::getServiceWorkerClientPendingMessages(ScriptExecutionContextIdentifier clientIdentifier, CompletionHandler<void(Vector<ServiceWorkerClientPendingMessage>&&)>&& completionHandler)
-{
-    sendWithAsyncReply(Messages::WebSWServerConnection::GetServiceWorkerClientPendingMessages { clientIdentifier }, WTFMove(completionHandler));
-}
-
 void WebSWClientConnection::focusServiceWorkerClient(ScriptExecutionContextIdentifier clientIdentifier, CompletionHandler<void(std::optional<ServiceWorkerClientData>&&)>&& callback)
 {
     auto* client = Document::allDocumentsMap().get(clientIdentifier);

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
@@ -115,8 +115,6 @@ private:
     void retrieveRecordResponse(WebCore::BackgroundFetchRecordIdentifier, RetrieveRecordResponseCallback&&) final;
     void retrieveRecordResponseBody(WebCore::BackgroundFetchRecordIdentifier, RetrieveRecordResponseBodyCallback&&) final;
 
-    void getServiceWorkerClientPendingMessages(WebCore::ScriptExecutionContextIdentifier clientIdentifier, CompletionHandler<void(Vector<WebCore::ServiceWorkerClientPendingMessage>&&)>&&) final;
-
     void focusServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier, CompletionHandler<void(std::optional<WebCore::ServiceWorkerClientData>&&)>&&);
     void notifyRecordResponseBodyChunk(RetrieveRecordResponseBodyCallbackIdentifier, IPC::SharedBufferReference&&);
     void notifyRecordResponseBodyEnd(RetrieveRecordResponseBodyCallbackIdentifier, WebCore::ResourceError&&);

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in
@@ -37,7 +37,7 @@ messages -> WebSWClientConnection {
 
     SetSWOriginTableIsImported()
     SetSWOriginTableSharedMemory(WebKit::SharedMemory::Handle handle)
-    PostMessageToServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier destinationContextIdentifier, struct WebCore::MessageWithMessagePorts message, struct WebCore::ServiceWorkerData source, String sourceOrigin) -> (bool success)
+    PostMessageToServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier destinationContextIdentifier, struct WebCore::MessageWithMessagePorts message, struct WebCore::ServiceWorkerData source, String sourceOrigin)
 
     SetServiceWorkerClientIsControlled(WebCore::ScriptExecutionContextIdentifier workerIdentifier, struct WebCore::ServiceWorkerRegistrationData data) -> (bool isSuccess)
 


### PR DESCRIPTION
#### 8f8c1da762686cec4b5140d95b4212945cdd75bb
<pre>
Finalize postMessage support to being created service worker clients
<a href="https://bugs.webkit.org/show_bug.cgi?id=255203">https://bugs.webkit.org/show_bug.cgi?id=255203</a>
rdar://problem/107802408

Reviewed by Chris Dumez.

We change the way service worker client postMessage is done to fully align with the spec.
Whenever posting a message to a service worker client, we go to network process.
Previously, we were directly going to the client web process.

We are now checking whether the client is a being created client.
A being created client is a client registered in network process when receiving a navigation or main script load.
The client, when fully created, is updating its data by registering itself through IPC.
At this point, the client is no longer a being created client.
A client is a being created client if SWServer:: m_clientPendingMessagesById has an entry with the client ID.

As long as the client is a being created client, we store the message until the client is created in the web process.
When the client is registering itself, we remove the entry in SWServer:: m_clientPendingMessagesById and send all pending messages.

This allows direct support of workers since we reuse the normal post message process.
This also gets us closer to spec, in  particular:
- We ensure message ordering is always preserved.
- We ensure we do not overbuffer messages.

Covered by rebased newly added WPT tests.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/controlled-dedicatedworker-postMessage.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/controlled-iframe-postMessage.https-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::m_isNonRenderedPlaceholder):
* Source/WebCore/workers/service/SWClientConnection.cpp:
(WebCore::postMessageToContainer):
(WebCore::SWClientConnection::postMessageToServiceWorkerClient):
* Source/WebCore/workers/service/SWClientConnection.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::ServiceWorkerContainer):
(WebCore::ServiceWorkerContainer::startMessages):
(WebCore::ServiceWorkerContainer::postMessage):
(WebCore::ServiceWorkerContainer::addEventListener):
* Source/WebCore/workers/service/WorkerSWClientConnection.cpp:
(WebCore::WorkerSWClientConnection::getServiceWorkerClientPendingMessages): Deleted.
* Source/WebCore/workers/service/WorkerSWClientConnection.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::registerServiceWorkerClient):
(WebCore::SWServer::postMessageToServiceWorkerClient):
(WebCore::SWServer::addServiceWorkerClientPendingMessage): Deleted.
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::controlClient):
(WebKit::WebSWServerConnection::postMessageToServiceWorkerClient):
(WebKit::WebSWServerConnection::registerServiceWorkerClient):
(WebKit::WebSWServerConnection::registerServiceWorkerClientInternal):
(WebKit::WebSWServerConnection::getServiceWorkerClientPendingMessages): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::getServiceWorkerClientPendingMessages): Deleted.
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.h:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.messages.in:

Canonical link: <a href="https://commits.webkit.org/262818@main">https://commits.webkit.org/262818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/873893021199811febba831780c80449fb321690

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2368 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2716 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3160 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3863 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2392 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2774 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3621 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2443 "Passed tests") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2395 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/663 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->