### PR TITLE
Images are not drawn even after they are completely loaded from a slow server

### DIFF
--- a/LayoutTests/http/tests/images/render-partial-image-load-expected.html
+++ b/LayoutTests/http/tests/images/render-partial-image-load-expected.html
@@ -1,0 +1,10 @@
+<style>
+    .box {
+        width: 400px;
+        height: 400px;
+        background-color: green;
+    }
+</style>
+<body>
+    <div class="box"></div>
+</body>

--- a/LayoutTests/http/tests/images/render-partial-image-load.html
+++ b/LayoutTests/http/tests/images/render-partial-image-load.html
@@ -1,0 +1,32 @@
+<body>
+    <script>
+        function resolvedImageSourceURL() {
+            return "http://127.0.0.1:8000/resources/load-and-stall.py"
+                 + "?name=../../../fast/images/resources/green-400x400.png"
+                 + "&mimeType=image%2Fpng"
+                 + "&stallAt=1024"
+                 + "&stallFor=1";
+        }
+
+        (function() {
+            if (window.internals && window.testRunner) {
+                internals.clearMemoryCache();
+                internals.settings.setLargeImageAsyncDecodingEnabled(true);
+                testRunner.waitUntilDone();
+            }
+
+            var image = new Image;
+            document.body.appendChild(image);
+
+            // Force async image decoding for this image.
+            if (window.internals)
+                internals.setLargeImageAsyncDecodingEnabledForTesting(image, true);
+
+            image.onload = (() => {
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+            image.src = resolvedImageSourceURL();
+        })();
+    </script>
+</body>

--- a/Source/WebCore/platform/graphics/ImageFrame.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrame.cpp
@@ -100,7 +100,7 @@ IntSize ImageFrame::size() const
 {
     return m_size;
 }
-    
+
 bool ImageFrame::hasNativeImage(const std::optional<SubsamplingLevel>& subsamplingLevel) const
 {
     return m_nativeImage && (!subsamplingLevel || *subsamplingLevel >= m_subsamplingLevel);
@@ -113,7 +113,7 @@ bool ImageFrame::hasFullSizeNativeImage(const std::optional<SubsamplingLevel>& s
 
 bool ImageFrame::hasDecodedNativeImageCompatibleWithOptions(const std::optional<SubsamplingLevel>& subsamplingLevel, const DecodingOptions& decodingOptions) const
 {
-    return hasNativeImage(subsamplingLevel) && m_decodingOptions.isCompatibleWith(decodingOptions);
+    return isComplete() && hasNativeImage(subsamplingLevel) && m_decodingOptions.isCompatibleWith(decodingOptions);
 }
 
 Color ImageFrame::singlePixelSolidColor() const
@@ -124,4 +124,4 @@ Color ImageFrame::singlePixelSolidColor() const
     return m_nativeImage->singlePixelSolidColor();
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageSource.cpp
+++ b/Source/WebCore/platform/graphics/ImageSource.cpp
@@ -246,17 +246,12 @@ void ImageSource::setNativeImage(Ref<NativeImage>&& nativeImage)
     frame.m_hasAlpha = frame.m_nativeImage->hasAlpha();
 }
 
-void ImageSource::cacheMetadataAtIndex(size_t index, SubsamplingLevel subsamplingLevel, DecodingStatus decodingStatus)
+void ImageSource::cacheMetadataAtIndex(size_t index, SubsamplingLevel subsamplingLevel)
 {
     ASSERT(index < m_frames.size());
     ImageFrame& frame = m_frames[index];
 
     ASSERT(isDecoderAvailable());
-    if (decodingStatus == DecodingStatus::Invalid)
-        frame.m_decodingStatus = m_decoder->frameIsCompleteAtIndex(index) ? DecodingStatus::Complete : DecodingStatus::Partial;
-    else
-        frame.m_decodingStatus = decodingStatus;
-
     if (frame.hasMetadata())
         return;
 
@@ -277,7 +272,7 @@ void ImageSource::cacheMetadataAtIndex(size_t index, SubsamplingLevel subsamplin
         frame.m_duration = m_decoder->frameDurationAtIndex(index);
 }
 
-void ImageSource::cachePlatformImageAtIndex(PlatformImagePtr&& platformImage, size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& decodingOptions, DecodingStatus decodingStatus)
+void ImageSource::cachePlatformImageAtIndex(PlatformImagePtr&& platformImage, size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& decodingOptions)
 {
     ASSERT(index < m_frames.size());
     ImageFrame& frame = m_frames[index];
@@ -290,16 +285,19 @@ void ImageSource::cachePlatformImageAtIndex(PlatformImagePtr&& platformImage, si
     if (!isInBounds<unsigned>(frameBytes + decodedSize()))
         return;
 
+    auto decodingStatus = m_decoder->frameIsCompleteAtIndex(index) ? DecodingStatus::Complete : DecodingStatus::Partial;
+
     // Move the new image to the cache.
     frame.m_nativeImage = NativeImage::create(WTFMove(platformImage));
     frame.m_decodingOptions = decodingOptions;
-    cacheMetadataAtIndex(index, subsamplingLevel, decodingStatus);
+    frame.m_decodingStatus = decodingStatus;
+    cacheMetadataAtIndex(index, subsamplingLevel);
 
     // Update the observer with the new image frame bytes.
     decodedSizeIncreased(frame.frameBytes());
 }
 
-void ImageSource::cachePlatformImageAtIndexAsync(PlatformImagePtr&& platformImage, size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& decodingOptions, DecodingStatus decodingStatus)
+void ImageSource::cachePlatformImageAtIndexAsync(PlatformImagePtr&& platformImage, size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& decodingOptions)
 {
     if (!isDecoderAvailable())
         return;
@@ -307,7 +305,7 @@ void ImageSource::cachePlatformImageAtIndexAsync(PlatformImagePtr&& platformImag
     ASSERT(index < m_frames.size());
 
     // Clean the old native image and set a new one
-    cachePlatformImageAtIndex(WTFMove(platformImage), index, subsamplingLevel, decodingOptions, decodingStatus);
+    cachePlatformImageAtIndex(WTFMove(platformImage), index, subsamplingLevel, decodingOptions);
     LOG(Images, "ImageSource::%s - %p - url: %s [frame %ld has been cached]", __FUNCTION__, this, sourceURL().string().utf8().data(), index);
 
     // Notify the image with the readiness of the new frame NativeImage.
@@ -378,7 +376,7 @@ void ImageSource::startAsyncDecodingQueue()
                 if (protectedDecodingQueue.ptr() == protectedThis->m_decodingQueue && protectedDecoder.ptr() == protectedThis->m_decoder) {
                     ASSERT(protectedThis->m_frameCommitQueue.first() == frameRequest);
                     protectedThis->m_frameCommitQueue.removeFirst();
-                    protectedThis->cachePlatformImageAtIndexAsync(WTFMove(platformImage), frameRequest.index, frameRequest.subsamplingLevel, frameRequest.decodingOptions, frameRequest.decodingStatus);
+                    protectedThis->cachePlatformImageAtIndexAsync(WTFMove(platformImage), frameRequest.index, frameRequest.subsamplingLevel, frameRequest.decodingOptions);
                 } else
                     LOG(Images, "ImageSource::%s - %p - url: %s [frame %ld will not cached]", __FUNCTION__, protectedThis.ptr(), sourceURL.utf8().data(), frameRequest.index);
             });
@@ -396,12 +394,11 @@ void ImageSource::requestFrameAsyncDecodingAtIndex(size_t index, SubsamplingLeve
         startAsyncDecodingQueue();
 
     ASSERT(index < m_frames.size());
-    DecodingStatus decodingStatus = m_decoder->frameIsCompleteAtIndex(index) ? DecodingStatus::Complete : DecodingStatus::Partial;
 
     LOG(Images, "ImageSource::%s - %p - url: %s [enqueuing frame %ld for decoding]", __FUNCTION__, this, sourceURL().string().utf8().data(), index);
     DecodingOptions decodingOptions = { DecodingMode::Asynchronous, sizeForDrawing };
-    m_frameRequestQueue->enqueue({ index, subsamplingLevel, decodingOptions, decodingStatus });
-    m_frameCommitQueue.append({ index, subsamplingLevel, decodingOptions, decodingStatus });
+    m_frameRequestQueue->enqueue({ index, subsamplingLevel, decodingOptions });
+    m_frameCommitQueue.append({ index, subsamplingLevel, decodingOptions });
 }
 
 bool ImageSource::isAsyncDecodingQueueIdle() const
@@ -452,8 +449,9 @@ const ImageFrame& ImageSource::frameAtIndexCacheIfNeeded(size_t index, ImageFram
 
     case ImageFrame::Caching::MetadataAndImage:
         // Cache the image and retrieve the metadata from ImageDecoder only if there was not valid image stored.
-        if (frame.hasFullSizeNativeImage(subsamplingLevel))
+        if (frame.isComplete() && frame.hasFullSizeNativeImage(subsamplingLevel))
             break;
+
         // We have to perform synchronous image decoding in this code.
         auto platformImage = m_decoder->createFrameImageAtIndex(index, subsamplingLevelValue, decodingOptions);
         // Clean the old native image and set a new one.
@@ -725,4 +723,4 @@ void ImageSource::dump(TextStream& ts)
         ts.dumpProperty("orientation", orientation);
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -162,9 +162,9 @@ private:
     void encodedDataStatusChanged(EncodedDataStatus);
 
     void setNativeImage(Ref<NativeImage>&&);
-    void cacheMetadataAtIndex(size_t, SubsamplingLevel, DecodingStatus = DecodingStatus::Invalid);
-    void cachePlatformImageAtIndex(PlatformImagePtr&&, size_t, SubsamplingLevel, const DecodingOptions&, DecodingStatus = DecodingStatus::Invalid);
-    void cachePlatformImageAtIndexAsync(PlatformImagePtr&&, size_t, SubsamplingLevel, const DecodingOptions&, DecodingStatus);
+    void cacheMetadataAtIndex(size_t, SubsamplingLevel);
+    void cachePlatformImageAtIndex(PlatformImagePtr&&, size_t, SubsamplingLevel, const DecodingOptions&);
+    void cachePlatformImageAtIndexAsync(PlatformImagePtr&&, size_t, SubsamplingLevel, const DecodingOptions&);
 
     struct ImageFrameRequest;
     static const int BufferSize = 8;
@@ -190,10 +190,9 @@ private:
         size_t index;
         SubsamplingLevel subsamplingLevel;
         DecodingOptions decodingOptions;
-        DecodingStatus decodingStatus;
         bool operator==(const ImageFrameRequest& other) const
         {
-            return index == other.index && subsamplingLevel == other.subsamplingLevel && decodingOptions == other.decodingOptions && decodingStatus == other.decodingStatus;
+            return index == other.index && subsamplingLevel == other.subsamplingLevel && decodingOptions == other.decodingOptions;
         }
     };
     using FrameRequestQueue = SynchronizedFixedQueue<ImageFrameRequest, BufferSize>;
@@ -225,4 +224,4 @@ private:
     RunLoop& m_runLoop;
 };
 
-}
+} // namespace WebCore


### PR DESCRIPTION
#### b56577295e3d7564c3f3b74f0bd6cdb7647569e0
<pre>
Images are not drawn even after they are completely loaded from a slow server
<a href="https://bugs.webkit.org/show_bug.cgi?id=249645">https://bugs.webkit.org/show_bug.cgi?id=249645</a>
rdar://103560731

Reviewed by Simon Fraser.

While loading a BitmapImage (i.e. allDataReceived is false), a partially decoded
NativeImage is created and cached in ImageFrame with DecodingStatus::Partial.

After loading the image is completed, ImageSource::cacheMetadataAtIndex() gets
called with the default DecodingStatus which is DecodingStatus::Invalid. This
forces recalculating a new DecodingStatus which will be DecodingStatus::Complete.

So the ImageFrame will have partially decoded NativeImage and DecodingStatus::
Complete. The next draw ImageFrame::hasDecodedNativeImageCompatibleWithOptions()
will return true and a stale NativeImage is drawn, which usually draws nothing
except for JPEG images.

It turns out we were setting ImageFrame::m_decodingStatus incorrectly always when
decoding an image asynchronously on GTK and WPE ports. We get the decodingStatus
of the frame when requesting it to be asynchronously decoded. This is calculated
by calling frameIsCompleteAtIndex(). ScalableImageDecoder::frameIsCompleteAtIndex()
returns false always if we have not decoded the frame yet.

The fix is to let ImageSource::cachePlatformImageAtIndex() be the only place to
set the ImageFrame::m_decodingStatus since it is the only setter for the
ImageFrame::nativeImage and we are sure at this point frameIsCompleteAtIndex()
will return the correct value for all ports.

* LayoutTests/http/tests/images/render-partial-image-load-expected.html: Added.
* LayoutTests/http/tests/images/render-partial-image-load.html: Added.
* Source/WebCore/platform/graphics/ImageFrame.cpp:
(WebCore::ImageFrame::hasDecodedNativeImageCompatibleWithOptions const):
* Source/WebCore/platform/graphics/ImageSource.cpp:
(WebCore::ImageSource::cacheMetadataAtIndex):
(WebCore::ImageSource::cachePlatformImageAtIndex):
(WebCore::ImageSource::cachePlatformImageAtIndexAsync):
(WebCore::ImageSource::startAsyncDecodingQueue):
(WebCore::ImageSource::requestFrameAsyncDecodingAtIndex):
(WebCore::ImageSource::frameAtIndexCacheIfNeeded):
* Source/WebCore/platform/graphics/ImageSource.h:

Canonical link: <a href="https://commits.webkit.org/263085@main">https://commits.webkit.org/263085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34bdc156878a98717e05fafa57e4e3219f695c10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2968 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4655 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2956 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4403 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2793 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3044 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/866 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->