### PR TITLE
[Cocoa] "Pop" of bad audio heard at the start of certain YouTube videos

### DIFF
--- a/LayoutTests/media/media-source/media-webm-opus-partial-abort-expected.txt
+++ b/LayoutTests/media/media-source/media-webm-opus-partial-abort-expected.txt
@@ -21,7 +21,7 @@ EXPECTED (sourceBuffer.buffered.end(0) == '7.401') OK
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, loader.mediaSegmentSize(0)/2)))
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '2') OK
-EXPECTED (sourceBuffer.buffered.end(0) == '3.961') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '3.96') OK
 EXPECTED (sourceBuffer.buffered.end(1) == '7.401') OK
 Clean sourcebuffer of all content.
 RUN(sourceBuffer.remove(0, 100))
@@ -41,7 +41,7 @@ EVENT(update)
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, loader.mediaSegmentSize(0)/2)))
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '2') OK
-EXPECTED (sourceBuffer.buffered.end(0) == '3.961') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '3.96') OK
 EXPECTED (sourceBuffer.buffered.end(1) == '7.401') OK
 Clean sourcebuffer of all content.
 RUN(sourceBuffer.abort())
@@ -56,6 +56,6 @@ EVENT(update)
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, loader.mediaSegmentSize(0)/2)))
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
-EXPECTED (sourceBuffer.buffered.end(0) == '3.961') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '3.96') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-webm-opus-partial-abort.html
+++ b/LayoutTests/media/media-source/media-webm-opus-partial-abort.html
@@ -23,6 +23,13 @@
 
     window.addEventListener('load', async event => {
         try {
+            // NOTE: A bug in ffmpeg causes a 1ms mismatch between the Opus
+            // packet duration of the first WebM block, and the start time of
+            // the subsequent block. Until all ports agree on whether to use
+            // the packet duration or the block timestamps, this tolerance
+            // value allows this to continue passing normally.
+            const OpusBufferedTolerance = 0.001;
+
             findMediaElement();
             loader = new MediaSourceLoader('content/test-opus-manifest.json');
             await loaderPromise(loader);
@@ -58,7 +65,7 @@
             run('sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, loader.mediaSegmentSize(0)/2))');
             await waitFor(sourceBuffer, 'update');
             testExpected('sourceBuffer.buffered.length', '2');
-            testExpected('sourceBuffer.buffered.end(0)', '3.961');
+            testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', '3.96', OpusBufferedTolerance);
             testExpected('sourceBuffer.buffered.end(1)', '7.401');
 
             consoleWrite('Clean sourcebuffer of all content.');
@@ -80,7 +87,7 @@
             run('sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, loader.mediaSegmentSize(0)/2))');
             await waitFor(sourceBuffer, 'update');
             testExpected('sourceBuffer.buffered.length', '2');
-            testExpected('sourceBuffer.buffered.end(0)', '3.961');
+            testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', '3.96', OpusBufferedTolerance);
             testExpected('sourceBuffer.buffered.end(1)', '7.401');
 
             consoleWrite('Clean sourcebuffer of all content.');
@@ -97,7 +104,7 @@
             run('sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, loader.mediaSegmentSize(0)/2))');
             await waitFor(sourceBuffer, 'update');
             testExpected('sourceBuffer.buffered.length', '1');
-            testExpected('sourceBuffer.buffered.end(0)', '3.961');
+            testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', '3.96', OpusBufferedTolerance);
 
             endTest();
         } catch (e) {

--- a/LayoutTests/media/media-source/media-webm-opus-partial-expected.txt
+++ b/LayoutTests/media/media-source/media-webm-opus-partial-expected.txt
@@ -11,12 +11,12 @@ Append a partial media segment.
 RUN(sourceBuffer.appendBuffer(partial1))
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
-EXPECTED (sourceBuffer.buffered.end(0) == '3.961') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '3.96') OK
 Complete the partial media segment.
 RUN(sourceBuffer.appendBuffer(partial2))
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
-EXPECTED (sourceBuffer.buffered.end(0) == '4.981') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '4.98') OK
 Clean sourcebuffer of all content.
 RUN(sourceBuffer.remove(0, 100))
 EVENT(update)
@@ -24,12 +24,12 @@ Append the two media segment in reverse order.
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
-EXPECTED (sourceBuffer.buffered.start(0) == '4.981') OK
-EXPECTED (sourceBuffer.buffered.end(0) == '9.981') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '4.98') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '9.98') OK
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
 EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
-EXPECTED (sourceBuffer.buffered.end(0) == '9.981') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '9.98') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-webm-opus-partial.html
+++ b/LayoutTests/media/media-source/media-webm-opus-partial.html
@@ -18,6 +18,13 @@
 
     window.addEventListener('load', async event => {
         try {
+            // NOTE: A bug in ffmpeg causes a 1ms mismatch between the Opus
+            // packet duration of the first WebM block, and the start time of
+            // the subsequent block. Until all ports agree on whether to use
+            // the packet duration or the block timestamps, this tolerance
+            // value allows this to continue passing normally.
+            const OpusBufferedTolerance = 0.001;
+
             findMediaElement();
             loader = new MediaSourceLoader('content/test-opus-manifest.json');
             await loaderPromise(loader);
@@ -39,14 +46,14 @@
             run('sourceBuffer.appendBuffer(partial1)');
             await waitFor(sourceBuffer, 'update');
             testExpected('sourceBuffer.buffered.length', '1');
-            testExpected('sourceBuffer.buffered.end(0)', '3.961', '==');
+            testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', '3.96', OpusBufferedTolerance);
 
             consoleWrite('Complete the partial media segment.')
             run('sourceBuffer.appendBuffer(partial2)');
             await waitFor(sourceBuffer, 'update');
 
             testExpected('sourceBuffer.buffered.length', '1');
-            testExpected('sourceBuffer.buffered.end(0)', '4.981', '==');
+            testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', '4.98', OpusBufferedTolerance);
 
             consoleWrite('Clean sourcebuffer of all content.');
             run('sourceBuffer.remove(0, 100)');
@@ -56,14 +63,14 @@
             run('sourceBuffer.appendBuffer(loader.mediaSegment(1))');
             await waitFor(sourceBuffer, 'update');
             testExpected('sourceBuffer.buffered.length', '1');
-            testExpected('sourceBuffer.buffered.start(0)', '4.981', '==');
-            testExpected('sourceBuffer.buffered.end(0)', '9.981', '==');
+            testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', '4.98', OpusBufferedTolerance);
+            testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', '9.98', OpusBufferedTolerance);
 
             run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
             await waitFor(sourceBuffer, 'update');
             testExpected('sourceBuffer.buffered.length', '1');
             testExpected('sourceBuffer.buffered.start(0)', '0', '==');
-            testExpected('sourceBuffer.buffered.end(0)', '9.981', '==');
+            testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', '9.98', OpusBufferedTolerance);
 
             endTest();
         } catch (e) {

--- a/LayoutTests/media/video-test.js
+++ b/LayoutTests/media/video-test.js
@@ -95,6 +95,17 @@ function testExpected(testFuncString, expected, comparison)
     }
 }
 
+function testExpectedEqualWithTolerance(testFuncString, expected, tolerance)
+{
+    try {
+        let observed = eval(testFuncString);
+        let success = Math.abs(observed - expected) <= tolerance;
+        reportExpected(success, testFuncString, '==', expected, observed)
+    } catch (ex) {
+        consoleWrite(ex);
+    }
+}
+
 function sleepFor(duration) {
     return new Promise(resolve => {
         setTimeout(resolve, duration);

--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -217,6 +217,7 @@ public:
         MediaTime presentationTime;
         MediaTime decodeTime;
         MediaTime duration;
+        MediaTime trimDuration;
         MediaSampleDataType data;
         MediaSample::SampleFlags flags;
     };

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -233,10 +233,7 @@ public:
             return makeUniqueRef<AudioTrackData>(codecType, trackEntry, parser);
         }
 
-        AudioTrackData(CodecType codecType, const webm::TrackEntry& trackEntry, WebMParser& parser)
-            : TrackData { codecType, trackEntry, TrackInfo::TrackType::Audio, parser }
-        {
-        }
+        AudioTrackData(CodecType, const webm::TrackEntry&, WebMParser&);
 
     private:
         webm::Status consumeFrameData(webm::Reader&, const webm::FrameMetadata&, uint64_t*, const MediaTime&) final;
@@ -247,6 +244,9 @@ public:
         uint8_t m_framesPerPacket { 0 };
         Seconds m_frameDuration { 0_s };
         size_t mNumFramesInCompleteBlock { 0 };
+        MediaTime m_lastPresentationEndTime { MediaTime::invalidTime() };
+        MediaTime m_remainingTrimDuration;
+        MediaTime m_presentationTimeShift;
     };
 
 private:


### PR DESCRIPTION
#### 7f1bcb55362b63563bfcb60c4bbb4868c0f310d8
<pre>
[Cocoa] &quot;Pop&quot; of bad audio heard at the start of certain YouTube videos
<a href="https://bugs.webkit.org/show_bug.cgi?id=255212">https://bugs.webkit.org/show_bug.cgi?id=255212</a>
rdar://106976225

Reviewed by Eric Carlson.

Tracking addition of a test via <a href="https://bugs.webkit.org/show_bug.cgi?id=255227.">https://bugs.webkit.org/show_bug.cgi?id=255227.</a>

Two interrelated problems cause discontinuties in the audio output at the
start of certain Opus-encoded WebM files.

1) A bug in the ffmpeg muxer causes the initial block in a cluster to be 1ms
too long, which causes an audible discontinuity to be generated from
AVSampleBufferAudioRenderer.

2) Some Opus-encoded WebM files include a CodecDelay value, which requires
players to decode, but not render, the initial audio frames in a stream.

For 2), map the CodecDelay value to a kCMSampleBufferAttachmentKey_TrimDurationAtStart
attachment in the resulting CMSampleBuffer. This causes the output duration of the
sample to be reduced by the trim duration, and the output presentation time to be
increased by the trim duration, so also shift the input presentation time by the same
amount. This aligns the first audible frame with the start time of the track.

For 1), if a discontinuity is encountered, and the discontinuity is less than 15ms
simply advance the presentation time of the subsequent sample by the discontinuity
duration. Track this discontinuity cumulatively, so that if multiple discontinuities
are encountered that total greater than 15ms, a real audible discontinuity is generated
and the track is brought back in sync with the master timeline.

* Source/WebCore/platform/MediaSample.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::toCMSampleBuffer):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::VideoTrackData::consumeFrameData):
(WebCore::WebMParser::AudioTrackData::AudioTrackData):
(WebCore::WebMParser::AudioTrackData::consumeFrameData):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
(WebCore::WebMParser::AudioTrackData::AudioTrackData): Deleted.

Canonical link: <a href="https://commits.webkit.org/262837@main">https://commits.webkit.org/262837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bd00f0969d1d1cc0b55112b06c325ee083806d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2397 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3903 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2281 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3665 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2808 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2252 "6 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2423 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/680 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2621 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->