### PR TITLE
TextureMapperGL: Support painting to a BitmapTexture instead of the default frame buffer

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -76,6 +76,7 @@ public:
 
     // makes a surface the target for the following drawTexture calls.
     virtual void bindSurface(BitmapTexture* surface) = 0;
+    virtual BitmapTexture* currentSurface() = 0;
     virtual void beginClip(const TransformationMatrix&, const FloatRoundedRect&) = 0;
     virtual void endClip() = 0;
     virtual IntRect clipBounds() = 0;
@@ -83,7 +84,7 @@ public:
     virtual Ref<BitmapTexture> createTexture(int internalFormat) = 0;
     virtual void setDepthRange(double zNear, double zFar) = 0;
 
-    virtual void beginPainting(PaintFlags = 0) { }
+    virtual void beginPainting(PaintFlags = 0, BitmapTexture* = nullptr) { }
     virtual void endPainting() { }
 
     void setMaskMode(bool m) { m_isMaskMode = m; }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGL.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGL.h
@@ -74,9 +74,9 @@ public:
     void clearColor(const Color&) override;
 
     void bindSurface(BitmapTexture* surface) override;
-    BitmapTexture* currentSurface();
+    BitmapTexture* currentSurface() override;
     void beginClip(const TransformationMatrix&, const FloatRoundedRect&) override;
-    void beginPainting(PaintFlags = 0) override;
+    void beginPainting(PaintFlags = 0, BitmapTexture* = nullptr) override;
     void endPainting() override;
     void endClip() override;
     IntRect clipBounds() override;
@@ -102,6 +102,8 @@ private:
     void bindDefaultSurface();
     ClipStack& clipStack();
     inline TextureMapperGLData& data() { return *m_data; }
+
+    void updateProjectionMatrix();
 
     TextureMapperContextAttributes m_contextAttributes;
     TextureMapperGLData* m_data;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -174,8 +174,7 @@ void TextureMapperLayer::paint(TextureMapper& textureMapper)
     textureMapper.setDepthRange(data.zNear, data.zFar);
 
     TextureMapperPaintOptions options(textureMapper);
-    options.textureMapper.bindSurface(0);
-
+    options.surface = textureMapper.currentSurface();
     paintRecursive(options);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -221,7 +221,14 @@ std::optional<UpdateInfo> WCScene::update(WCUpateInfo&& update)
     WebCore::IntSize windowSize = expandedIntSize(rootLayer->size());
     glViewport(0, 0, windowSize.width(), windowSize.height());
 
-    m_textureMapper->beginPainting(m_usesOffscreenRendering ? WebCore::TextureMapper::PaintingMirrored : 0);
+    WebCore::BitmapTexture* surface = nullptr;
+    RefPtr<WebCore::BitmapTexture> texture;
+    if (m_usesOffscreenRendering) {
+        texture = m_textureMapper->acquireTextureFromPool(windowSize);
+        surface = texture.get();
+    }
+
+    m_textureMapper->beginPainting(0, surface);
     rootLayer->paint(*m_textureMapper);
     m_fpsCounter.updateFPSAndDisplay(*m_textureMapper);
     m_textureMapper->endPainting();


### PR DESCRIPTION
#### 8d6126fe8b505e74482ab5583385b01d45d5f9dd
<pre>
TextureMapperGL: Support painting to a BitmapTexture instead of the default frame buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=255213">https://bugs.webkit.org/show_bug.cgi?id=255213</a>

Reviewed by Don Olmstead.

TextureMapperGL was supporting to paint only to the default frame
buffer. This change added the support of painting to a BitmapTexture.
Changed TextureMapperGL::beginPainting to take an optional
BitmapTexture to paint.

This is used for the offscreen rendering mode of Windows port.
Previously it was using the back buffer of the frame buffer.
WCScene::update allocates a BitmapTextureGL and paints a layer tree to
it.

* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
(WebCore::TextureMapper::beginPainting):
* Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp:
(WebCore::TextureMapperGL::beginPainting):
(WebCore::TextureMapperGL::bindDefaultSurface):
(WebCore::TextureMapperGL::bindSurface):
(WebCore::TextureMapperGL::setDepthRange):
(WebCore::TextureMapperGL::updateProjectionMatrix):
* Source/WebCore/platform/graphics/texmap/TextureMapperGL.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paint):
* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
(WebKit::WCScene::update):

Canonical link: <a href="https://commits.webkit.org/262781@main">https://commits.webkit.org/262781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c13dca98f9cee8aef20f9e4101f879a2ae4822e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4007 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/2996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2696 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2628 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3773 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/2320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/2681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/2323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2359 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/299 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->