### PR TITLE
Create scaffolding for Shape Detection API

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -14,6 +14,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WebCore_DERIVED_SOURCES_DIR}"
     "${WEBCORE_DIR}"
     "${WEBCORE_DIR}/Modules/ShapeDetection"
+    "${WEBCORE_DIR}/Modules/ShapeDetection/Interfaces"
     "${WEBCORE_DIR}/Modules/WebGPU"
     "${WEBCORE_DIR}/Modules/airplay"
     "${WEBCORE_DIR}/Modules/applepay"

--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "BarcodeDetectorInterface.h"
+#include "ExceptionOr.h"
 #include "ImageBitmap.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include <wtf/Ref.h>
@@ -38,18 +40,20 @@ struct DetectedBarcode;
 
 class BarcodeDetector : public RefCounted<BarcodeDetector> {
 public:
-    static Ref<BarcodeDetector> create(const BarcodeDetectorOptions&);
+    static ExceptionOr<Ref<BarcodeDetector>> create(const BarcodeDetectorOptions&);
 
     ~BarcodeDetector();
 
-    using GetSupportedFormatsPromise = DOMPromiseDeferred<IDLSequence<IDLInterface<BarcodeFormat>>>;
+    using GetSupportedFormatsPromise = DOMPromiseDeferred<IDLSequence<IDLEnumeration<BarcodeFormat>>>;
     static void getSupportedFormats(GetSupportedFormatsPromise&&);
 
     using DetectPromise = DOMPromiseDeferred<IDLSequence<IDLDictionary<DetectedBarcode>>>;
     void detect(const ImageBitmap::Source&, DetectPromise&&);
 
 private:
-    BarcodeDetector(const BarcodeDetectorOptions&);
+    BarcodeDetector(Ref<ShapeDetection::BarcodeDetector>&&);
+
+    Ref<ShapeDetection::BarcodeDetector> m_backing;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetectorOptions.h
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetectorOptions.h
@@ -25,14 +25,32 @@
 
 #pragma once
 
+#include "BarcodeDetectorOptionsInterface.h"
+#include "BarcodeFormat.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
-enum class BarcodeFormat : uint8_t;
-
 struct BarcodeDetectorOptions {
+    ShapeDetection::BarcodeDetectorOptions convertToBacking() const
+    {
+        return {
+            formats.map([] (auto format) {
+                return WebCore::convertToBacking(format);
+            }),
+        };
+    }
+
     Vector<BarcodeFormat> formats;
 };
+
+inline BarcodeDetectorOptions convertFromBacking(const ShapeDetection::BarcodeDetectorOptions& barcodeDetectorOptions)
+{
+    return {
+        barcodeDetectorOptions.formats.map([] (auto format) {
+            return WebCore::convertFromBacking(format);
+        }),
+    };
+}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/ShapeDetection/BarcodeFormat.h
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeFormat.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BarcodeFormatInterface.h"
 #include <cstdint>
 
 namespace WebCore {
@@ -45,5 +46,75 @@ enum class BarcodeFormat : uint8_t {
     Upc_a,
     Upc_e,
 };
+
+inline ShapeDetection::BarcodeFormat convertToBacking(BarcodeFormat barcodeFormat)
+{
+    switch (barcodeFormat) {
+    case BarcodeFormat::Aztec:
+        return ShapeDetection::BarcodeFormat::Aztec;
+    case BarcodeFormat::Code_128:
+        return ShapeDetection::BarcodeFormat::Code_128;
+    case BarcodeFormat::Code_39:
+        return ShapeDetection::BarcodeFormat::Code_39;
+    case BarcodeFormat::Code_93:
+        return ShapeDetection::BarcodeFormat::Code_93;
+    case BarcodeFormat::Codabar:
+        return ShapeDetection::BarcodeFormat::Codabar;
+    case BarcodeFormat::Data_matrix:
+        return ShapeDetection::BarcodeFormat::Data_matrix;
+    case BarcodeFormat::Ean_13:
+        return ShapeDetection::BarcodeFormat::Ean_13;
+    case BarcodeFormat::Ean_8:
+        return ShapeDetection::BarcodeFormat::Ean_8;
+    case BarcodeFormat::Itf:
+        return ShapeDetection::BarcodeFormat::Itf;
+    case BarcodeFormat::Pdf417:
+        return ShapeDetection::BarcodeFormat::Pdf417;
+    case BarcodeFormat::Qr_code:
+        return ShapeDetection::BarcodeFormat::Qr_code;
+    case BarcodeFormat::Unknown:
+        return ShapeDetection::BarcodeFormat::Unknown;
+    case BarcodeFormat::Upc_a:
+        return ShapeDetection::BarcodeFormat::Upc_a;
+    case BarcodeFormat::Upc_e:
+        return ShapeDetection::BarcodeFormat::Upc_e;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+inline BarcodeFormat convertFromBacking(ShapeDetection::BarcodeFormat barcodeFormat)
+{
+    switch (barcodeFormat) {
+    case ShapeDetection::BarcodeFormat::Aztec:
+        return BarcodeFormat::Aztec;
+    case ShapeDetection::BarcodeFormat::Code_128:
+        return BarcodeFormat::Code_128;
+    case ShapeDetection::BarcodeFormat::Code_39:
+        return BarcodeFormat::Code_39;
+    case ShapeDetection::BarcodeFormat::Code_93:
+        return BarcodeFormat::Code_93;
+    case ShapeDetection::BarcodeFormat::Codabar:
+        return BarcodeFormat::Codabar;
+    case ShapeDetection::BarcodeFormat::Data_matrix:
+        return BarcodeFormat::Data_matrix;
+    case ShapeDetection::BarcodeFormat::Ean_13:
+        return BarcodeFormat::Ean_13;
+    case ShapeDetection::BarcodeFormat::Ean_8:
+        return BarcodeFormat::Ean_8;
+    case ShapeDetection::BarcodeFormat::Itf:
+        return BarcodeFormat::Itf;
+    case ShapeDetection::BarcodeFormat::Pdf417:
+        return BarcodeFormat::Pdf417;
+    case ShapeDetection::BarcodeFormat::Qr_code:
+        return BarcodeFormat::Qr_code;
+    case ShapeDetection::BarcodeFormat::Unknown:
+        return BarcodeFormat::Unknown;
+    case ShapeDetection::BarcodeFormat::Upc_a:
+        return BarcodeFormat::Upc_a;
+    case ShapeDetection::BarcodeFormat::Upc_e:
+        return BarcodeFormat::Upc_e;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/ShapeDetection/DetectedBarcode.idl
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedBarcode.idl
@@ -26,7 +26,8 @@
 // https://wicg.github.io/shape-detection-api/#dictdef-detectedbarcode
 
 [
-    EnabledBySetting=ShapeDetection
+    EnabledBySetting=ShapeDetection,
+    JSGenerateToJSObject
 ]
 dictionary DetectedBarcode {
     required DOMRectReadOnly boundingBox;

--- a/Source/WebCore/Modules/ShapeDetection/DetectedFace.idl
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedFace.idl
@@ -26,7 +26,8 @@
 // https://wicg.github.io/shape-detection-api/#dictdef-detectedface
 
 [
-    EnabledBySetting=ShapeDetection
+    EnabledBySetting=ShapeDetection,
+    JSGenerateToJSObject
 ]
 dictionary DetectedFace {
     required DOMRectReadOnly boundingBox;

--- a/Source/WebCore/Modules/ShapeDetection/DetectedText.h
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedText.h
@@ -25,19 +25,49 @@
 
 #pragma once
 
+#include "DOMRectReadOnly.h"
+#include "DetectedTextInterface.h"
+#include "Point2D.h"
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class DOMRectReadOnly;
 struct Point2D;
 
 struct DetectedText {
+    ShapeDetection::DetectedText convertToBacking() const
+    {
+        ASSERT(boundingBox);
+        return {
+            {
+                static_cast<float>(boundingBox->x()),
+                static_cast<float>(boundingBox->y()),
+                static_cast<float>(boundingBox->width()),
+                static_cast<float>(boundingBox->height()),
+            },
+            rawValue,
+            cornerPoints.map([] (const auto& cornerPoint) {
+                return cornerPoint.convertToBacking();
+            }),
+        };
+    }
+
     RefPtr<DOMRectReadOnly> boundingBox;
     String rawValue;
     Vector<Point2D> cornerPoints;
 };
+
+inline DetectedText convertFromBacking(const ShapeDetection::DetectedText& detectedText)
+{
+    return {
+        DOMRectReadOnly::create(detectedText.boundingBox.x(), detectedText.boundingBox.y(), detectedText.boundingBox.width(), detectedText.boundingBox.height()),
+        detectedText.rawValue,
+        detectedText.cornerPoints.map([] (const auto& cornerPoint) {
+            return Point2D { cornerPoint.x(), cornerPoint.y() };
+        }),
+    };
+}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/ShapeDetection/DetectedText.idl
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedText.idl
@@ -26,7 +26,8 @@
 // https://wicg.github.io/shape-detection-api/text.html#dictdef-detectedtext
 
 [
-    EnabledBySetting=ShapeDetection
+    EnabledBySetting=ShapeDetection,
+    JSGenerateToJSObject
 ]
 dictionary DetectedText {
     required DOMRectReadOnly boundingBox;

--- a/Source/WebCore/Modules/ShapeDetection/FaceDetector.h
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetector.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "ExceptionOr.h"
+#include "FaceDetectorInterface.h"
 #include "ImageBitmap.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include <wtf/Ref.h>
@@ -37,7 +39,7 @@ struct DetectedFace;
 
 class FaceDetector : public RefCounted<FaceDetector> {
 public:
-    static Ref<FaceDetector> create(const FaceDetectorOptions&);
+    static ExceptionOr<Ref<FaceDetector>> create(const FaceDetectorOptions&);
 
     ~FaceDetector();
 
@@ -45,7 +47,9 @@ public:
     void detect(const ImageBitmap::Source&, DetectPromise&&);
 
 private:
-    FaceDetector(const FaceDetectorOptions&);
+    FaceDetector(Ref<ShapeDetection::FaceDetector>&&);
+
+    Ref<ShapeDetection::FaceDetector> m_backing;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/ShapeDetection/FaceDetectorOptions.h
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetectorOptions.h
@@ -25,13 +25,31 @@
 
 #pragma once
 
+#include "FaceDetectorOptionsInterface.h"
+#include <cstdint>
 #include <limits>
 
 namespace WebCore {
 
 struct FaceDetectorOptions {
+    ShapeDetection::FaceDetectorOptions convertToBacking() const
+    {
+        return {
+            maxDetectedFaces,
+            fastMode,
+        };
+    }
+
     uint16_t maxDetectedFaces { std::numeric_limits<uint16_t>::max() };
     bool fastMode { true };
 };
+
+inline FaceDetectorOptions convertFromBacking(const ShapeDetection::FaceDetectorOptions& faceDetectorOptions)
+{
+    return {
+        faceDetectorOptions.maxDetectedFaces,
+        faceDetectorOptions.fastMode,
+    };
+}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.h
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.h
@@ -25,29 +25,33 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include "BarcodeDetectorInterface.h"
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
+struct BarcodeDetectorOptions;
+
+class BarcodeDetectorImpl final : public BarcodeDetector {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<BarcodeDetectorImpl> create(const BarcodeDetectorOptions& barcodeDetectorOptions)
     {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
+        return adoptRef(*new BarcodeDetectorImpl(barcodeDetectorOptions));
     }
 
-    double x { 0 };
-    double y { 0 };
+    virtual ~BarcodeDetectorImpl();
+
+    static void getSupportedFormats(CompletionHandler<void(Vector<BarcodeFormat>&&)>&&);
+
+private:
+    BarcodeDetectorImpl(const BarcodeDetectorOptions&);
+
+    BarcodeDetectorImpl(const BarcodeDetectorImpl&) = delete;
+    BarcodeDetectorImpl(BarcodeDetectorImpl&&) = delete;
+    BarcodeDetectorImpl& operator=(const BarcodeDetectorImpl&) = delete;
+    BarcodeDetectorImpl& operator=(BarcodeDetectorImpl&&) = delete;
+
+    void detect(CompletionHandler<void(Vector<DetectedBarcode>&&)>&&) final;
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
@@ -23,31 +23,28 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "BarcodeDetectorImplementation.h"
 
-#include "FloatPoint.h"
+#include "BarcodeFormatInterface.h"
+#include "DetectedBarcodeInterface.h"
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
-
-    double x { 0 };
-    double y { 0 };
-};
-
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
+BarcodeDetectorImpl::BarcodeDetectorImpl(const BarcodeDetectorOptions&)
 {
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
 }
 
-} // namespace WebCore
+BarcodeDetectorImpl::~BarcodeDetectorImpl() = default;
+
+void BarcodeDetectorImpl::getSupportedFormats(CompletionHandler<void(Vector<BarcodeFormat>&&)>&& completionHandler)
+{
+    completionHandler({ });
+}
+
+void BarcodeDetectorImpl::detect(CompletionHandler<void(Vector<DetectedBarcode>&&)>&& completionHandler)
+{
+    completionHandler({ });
+}
+
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.h
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.h
@@ -25,29 +25,31 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include "FaceDetectorInterface.h"
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
+struct FaceDetectorOptions;
+
+class FaceDetectorImpl final : public FaceDetector {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<FaceDetectorImpl> create(const FaceDetectorOptions& faceDetectorOptions)
     {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
+        return adoptRef(*new FaceDetectorImpl(faceDetectorOptions));
     }
 
-    double x { 0 };
-    double y { 0 };
+    virtual ~FaceDetectorImpl();
+
+private:
+    FaceDetectorImpl(const FaceDetectorOptions&);
+
+    FaceDetectorImpl(const FaceDetectorImpl&) = delete;
+    FaceDetectorImpl(FaceDetectorImpl&&) = delete;
+    FaceDetectorImpl& operator=(const FaceDetectorImpl&) = delete;
+    FaceDetectorImpl& operator=(FaceDetectorImpl&&) = delete;
+
+    void detect(CompletionHandler<void(Vector<DetectedFace>&&)>&&) final;
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
@@ -23,31 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "FaceDetectorImplementation.h"
 
-#include "FloatPoint.h"
+#include "DetectedFaceInterface.h"
+#include "LandmarkInterface.h"
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
-
-    double x { 0 };
-    double y { 0 };
-};
-
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
+FaceDetectorImpl::FaceDetectorImpl(const FaceDetectorOptions&)
 {
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
 }
 
-} // namespace WebCore
+FaceDetectorImpl::~FaceDetectorImpl() = default;
+
+void FaceDetectorImpl::detect(CompletionHandler<void(Vector<DetectedFace>&&)>&& completionHandler)
+{
+    completionHandler({ });
+}
+
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.h
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.h
@@ -25,29 +25,29 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include "TextDetectorInterface.h"
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
+class TextDetectorImpl final : public TextDetector {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<TextDetectorImpl> create()
     {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
+        return adoptRef(*new TextDetectorImpl);
     }
 
-    double x { 0 };
-    double y { 0 };
+    virtual ~TextDetectorImpl();
+
+private:
+    TextDetectorImpl();
+
+    TextDetectorImpl(const TextDetectorImpl&) = delete;
+    TextDetectorImpl(TextDetectorImpl&&) = delete;
+    TextDetectorImpl& operator=(const TextDetectorImpl&) = delete;
+    TextDetectorImpl& operator=(TextDetectorImpl&&) = delete;
+
+    void detect(CompletionHandler<void(Vector<DetectedText>&&)>&&) final;
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
@@ -23,31 +23,20 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "TextDetectorImplementation.h"
 
-#include "FloatPoint.h"
+#include "DetectedTextInterface.h"
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
+TextDetectorImpl::TextDetectorImpl() = default;
 
-    double x { 0 };
-    double y { 0 };
-};
+TextDetectorImpl::~TextDetectorImpl() = default;
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
+void TextDetectorImpl::detect(CompletionHandler<void(Vector<DetectedText>&&)>&& completionHandler)
 {
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
+    completionHandler({ });
 }
 
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorInterface.h
@@ -25,29 +25,30 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/Vector.h>
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
+enum class BarcodeFormat : uint8_t;
+struct DetectedBarcode;
 
-    double x { 0 };
-    double y { 0 };
+class BarcodeDetector : public RefCounted<BarcodeDetector> {
+public:
+    virtual ~BarcodeDetector() = default;
+
+    virtual void detect(CompletionHandler<void(Vector<DetectedBarcode>&&)>&&) = 0;
+
+protected:
+    BarcodeDetector() = default;
+
+private:
+    BarcodeDetector(const BarcodeDetector&) = delete;
+    BarcodeDetector(BarcodeDetector&&) = delete;
+    BarcodeDetector& operator=(const BarcodeDetector&) = delete;
+    BarcodeDetector& operator=(BarcodeDetector&&) = delete;
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorOptionsInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorOptionsInterface.h
@@ -25,29 +25,14 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include <wtf/Vector.h>
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
+enum class BarcodeFormat : uint8_t;
 
-    double x { 0 };
-    double y { 0 };
+struct BarcodeDetectorOptions {
+    Vector<BarcodeFormat> formats;
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeFormatInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeFormatInterface.h
@@ -25,29 +25,25 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include <cstdint>
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
-
-    double x { 0 };
-    double y { 0 };
+enum class BarcodeFormat : uint8_t {
+    Aztec,
+    Code_128,
+    Code_39,
+    Code_93,
+    Codabar,
+    Data_matrix,
+    Ean_13,
+    Ean_8,
+    Itf,
+    Pdf417,
+    Qr_code,
+    Unknown,
+    Upc_a,
+    Upc_e,
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/DetectedBarcodeInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/DetectedBarcodeInterface.h
@@ -25,29 +25,22 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include "BarcodeFormat.h"
+#include "FloatRect.h"
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
-
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
-
-    double x { 0 };
-    double y { 0 };
-};
-
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
+class FloatPoint;
 }
 
-} // namespace WebCore
+namespace WebCore::ShapeDetection {
+
+struct DetectedBarcode {
+    FloatRect boundingBox;
+    String rawValue;
+    BarcodeFormat format { BarcodeFormat::Unknown };
+    Vector<FloatPoint> cornerPoints;
+};
+
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/DetectedFaceInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/DetectedFaceInterface.h
@@ -25,29 +25,17 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include "FloatRect.h"
+#include <optional>
+#include <wtf/Vector.h>
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
+struct Landmark;
 
-    double x { 0 };
-    double y { 0 };
+struct DetectedFace {
+    FloatRect boundingBox;
+    std::optional<Vector<Landmark>> landmarks;
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/DetectedTextInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/DetectedTextInterface.h
@@ -25,29 +25,20 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include "FloatRect.h"
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
-
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
-
-    double x { 0 };
-    double y { 0 };
-};
-
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
+class FloatPoint;
 }
 
-} // namespace WebCore
+namespace WebCore::ShapeDetection {
+
+struct DetectedText {
+    FloatRect boundingBox;
+    String rawValue;
+    Vector<FloatPoint> cornerPoints;
+};
+
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorInterface.h
@@ -25,29 +25,29 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/Vector.h>
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
+struct DetectedFace;
 
-    double x { 0 };
-    double y { 0 };
+class FaceDetector : public RefCounted<FaceDetector> {
+public:
+    virtual ~FaceDetector() = default;
+
+    virtual void detect(CompletionHandler<void(Vector<DetectedFace>&&)>&&) = 0;
+
+protected:
+    FaceDetector() = default;
+
+private:
+    FaceDetector(const FaceDetector&) = delete;
+    FaceDetector(FaceDetector&&) = delete;
+    FaceDetector& operator=(const FaceDetector&) = delete;
+    FaceDetector& operator=(FaceDetector&&) = delete;
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorOptionsInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorOptionsInterface.h
@@ -25,29 +25,14 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include <cstdint>
+#include <limits>
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
-
-    double x { 0 };
-    double y { 0 };
+struct FaceDetectorOptions {
+    uint16_t maxDetectedFaces { std::numeric_limits<uint16_t>::max() };
+    bool fastMode { true };
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkInterface.h
@@ -25,29 +25,18 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include "LandmarkType.h"
+#include <wtf/Vector.h>
 
 namespace WebCore {
-
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
-
-    double x { 0 };
-    double y { 0 };
-};
-
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
+class FloatPoint;
 }
 
-} // namespace WebCore
+namespace WebCore::ShapeDetection {
+
+struct Landmark {
+    Vector<FloatPoint> locations;
+    LandmarkType type { LandmarkType::Eye };
+};
+
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkTypeInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkTypeInterface.h
@@ -25,29 +25,14 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include <cstdint>
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
-
-    double x { 0 };
-    double y { 0 };
+enum class LandmarkType : uint8_t {
+    Mouth,
+    Eye,
+    Nose,
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/TextDetectorInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/TextDetectorInterface.h
@@ -25,29 +25,29 @@
 
 #pragma once
 
-#include "FloatPoint.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/Vector.h>
 
-namespace WebCore {
+namespace WebCore::ShapeDetection {
 
-struct Point2D {
-    FloatPoint convertToBacking() const
-    {
-        return {
-            static_cast<float>(x),
-            static_cast<float>(y),
-        };
-    }
+struct DetectedText;
 
-    double x { 0 };
-    double y { 0 };
+class TextDetector : public RefCounted<TextDetector> {
+public:
+    virtual ~TextDetector() = default;
+
+    virtual void detect(CompletionHandler<void(Vector<DetectedText>&&)>&&) = 0;
+
+protected:
+    TextDetector() = default;
+
+private:
+    TextDetector(const TextDetector&) = delete;
+    TextDetector(TextDetector&&) = delete;
+    TextDetector& operator=(const TextDetector&) = delete;
+    TextDetector& operator=(TextDetector&&) = delete;
 };
 
-inline Point2D convertFromBacking(const FloatPoint& floatPoint)
-{
-    return {
-        floatPoint.x(),
-        floatPoint.y(),
-    };
-}
-
-} // namespace WebCore
+} // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Landmark.h
+++ b/Source/WebCore/Modules/ShapeDetection/Landmark.h
@@ -25,16 +25,36 @@
 
 #pragma once
 
+#include "LandmarkInterface.h"
 #include "LandmarkType.h"
+#include "Point2D.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
-struct Point2D;
-
 struct Landmark {
+    ShapeDetection::Landmark convertToBacking() const
+    {
+        return {
+            locations.map([] (const auto& location) {
+                return location.convertToBacking();
+            }),
+            WebCore::convertToBacking(type),
+        };
+    }
+
     Vector<Point2D> locations;
     LandmarkType type { LandmarkType::Eye };
 };
+
+inline Landmark convertFromBacking(const ShapeDetection::Landmark& landmark)
+{
+    return {
+        landmark.locations.map([] (const auto& location) {
+            return Point2D { location.x(), location.y() };
+        }),
+        convertFromBacking(landmark.type),
+    };
+}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/ShapeDetection/Landmark.idl
+++ b/Source/WebCore/Modules/ShapeDetection/Landmark.idl
@@ -26,7 +26,8 @@
 // https://wicg.github.io/shape-detection-api/#dictdef-landmark
 
 [
-    EnabledBySetting=ShapeDetection
+    EnabledBySetting=ShapeDetection,
+    JSGenerateToJSObject
 ]
 dictionary Landmark {
     required FrozenArray<Point2D> locations;

--- a/Source/WebCore/Modules/ShapeDetection/LandmarkType.h
+++ b/Source/WebCore/Modules/ShapeDetection/LandmarkType.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LandmarkTypeInterface.h"
 #include <cstdint>
 
 namespace WebCore {
@@ -34,5 +35,31 @@ enum class LandmarkType : uint8_t {
     Eye,
     Nose,
 };
+
+inline ShapeDetection::LandmarkType convertToBacking(LandmarkType landmarkType)
+{
+    switch (landmarkType) {
+    case LandmarkType::Mouth:
+        return ShapeDetection::LandmarkType::Mouth;
+    case LandmarkType::Eye:
+        return ShapeDetection::LandmarkType::Eye;
+    case LandmarkType::Nose:
+        return ShapeDetection::LandmarkType::Nose;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+inline LandmarkType convertFromBacking(ShapeDetection::LandmarkType landmarkType)
+{
+    switch (landmarkType) {
+    case ShapeDetection::LandmarkType::Mouth:
+        return LandmarkType::Mouth;
+    case ShapeDetection::LandmarkType::Eye:
+        return LandmarkType::Eye;
+    case ShapeDetection::LandmarkType::Nose:
+        return LandmarkType::Nose;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/ShapeDetection/Point2D.idl
+++ b/Source/WebCore/Modules/ShapeDetection/Point2D.idl
@@ -25,6 +25,9 @@
 
 // https://w3c.github.io/mediacapture-image/#dictdef-point2d
 
+[
+    JSGenerateToJSObject
+]
 dictionary Point2D {
     double x = 0.0;
     double y = 0.0;

--- a/Source/WebCore/Modules/ShapeDetection/TextDetector.h
+++ b/Source/WebCore/Modules/ShapeDetection/TextDetector.h
@@ -25,8 +25,10 @@
 
 #pragma once
 
+#include "ExceptionOr.h"
 #include "ImageBitmap.h"
 #include "JSDOMPromiseDeferredForward.h"
+#include "TextDetectorInterface.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
@@ -36,7 +38,7 @@ struct DetectedText;
 
 class TextDetector : public RefCounted<TextDetector> {
 public:
-    static Ref<TextDetector> create();
+    static ExceptionOr<Ref<TextDetector>> create();
 
     ~TextDetector();
 
@@ -44,7 +46,9 @@ public:
     void detect(const ImageBitmap::Source&, DetectPromise&&);
 
 private:
-    TextDetector();
+    TextDetector(Ref<ShapeDetection::TextDetector>&&);
+
+    Ref<ShapeDetection::TextDetector> m_backing;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #if USE(SYSTEM_PREVIEW)
 
+#include "Image.h"
 #include "NativeImage.h"
 #include "SystemImage.h"
 #include <optional>

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +35,7 @@
 #import "IOSurfacePool.h"
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreImage/CoreImage.h>
+#import <dlfcn.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RetainPtr.h>
 

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -80,6 +80,9 @@ JSSpeechSynthesisErrorCode.cpp
 JSSpeechSynthesisErrorEvent.cpp
 JSSpeechSynthesisErrorEventInit.cpp
 JSSpeechSynthesisEventInit.cpp
+Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
+Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
+Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
 Modules/airplay/WebMediaSessionManager.cpp
 Modules/applepay/ApplePayCouponCodeChangedEvent.cpp
 Modules/applepay/ApplePayCancelEvent.cpp


### PR DESCRIPTION
#### a132303fd6a0c4b8ee96b6cc986723477ffefb98
<pre>
Create scaffolding for Shape Detection API
<a href="https://bugs.webkit.org/show_bug.cgi?id=255215">https://bugs.webkit.org/show_bug.cgi?id=255215</a>
rdar://107821288

Reviewed by Mike Wyrzykowski.

The implementation of the Shape Detection API needs to run in the GPU process. However, in
WebKitLegacy, it can run in-process. Therefore, we&apos;re going to have to have 2 different
implementations: one that implements the functionality directly (that the GPU process and
WebKitLegacy will use) and another one that uses IPC to forward the calls across processes.

This patch implements this by creating a virtual interface for the API. This interface will
have 2 concrete implementations, and this patch stubs out one of them. The IPC implementation
will be implemented in another patch. This virtual interface is in
Source/WebCore/Modules/ShapeDetection/Interfaces, and the stubs for the first implementation
are in Source/WebCore/Modules/ShapeDetection/Implementation.

The original classes inside Source/WebCore/Modules/ShapeDetection, which are what the IDL
files target, delegate to this virtual interface. Each one of these classes has a Ref to a
&quot;backing&quot; object which is an implementation of this virtual interface.

No tests because there is no behavior change.

* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp:
(WebCore::BarcodeDetector::create):
(WebCore::BarcodeDetector::BarcodeDetector):
(WebCore::BarcodeDetector::getSupportedFormats):
(WebCore::BarcodeDetector::detect):
* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h:
* Source/WebCore/Modules/ShapeDetection/BarcodeDetectorOptions.h:
(WebCore::BarcodeDetectorOptions::convertToBacking const):
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/BarcodeFormat.h:
(WebCore::convertToBacking):
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/DetectedBarcode.h:
(WebCore::DetectedBarcode::convertToBacking const):
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/DetectedBarcode.idl:
* Source/WebCore/Modules/ShapeDetection/DetectedFace.h:
(WebCore::DetectedFace::convertToBacking const):
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/DetectedFace.idl:
* Source/WebCore/Modules/ShapeDetection/DetectedText.h:
(WebCore::DetectedText::convertToBacking const):
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/DetectedText.idl:
* Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp:
(WebCore::FaceDetector::create):
(WebCore::FaceDetector::FaceDetector):
(WebCore::FaceDetector::detect):
* Source/WebCore/Modules/ShapeDetection/FaceDetector.h:
* Source/WebCore/Modules/ShapeDetection/FaceDetectorOptions.h:
(WebCore::FaceDetectorOptions::convertToBacking const):
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.h: Copied from Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h.
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm: Copied from Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp.
(WebCore::ShapeDetection::BarcodeDetectorImpl::BarcodeDetectorImpl):
(WebCore::ShapeDetection::BarcodeDetectorImpl::getSupportedFormats):
(WebCore::ShapeDetection::BarcodeDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.h: Copied from Source/WebCore/Modules/ShapeDetection/FaceDetector.h.
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm: Copied from Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp.
(WebCore::ShapeDetection::FaceDetectorImpl::FaceDetectorImpl):
(WebCore::ShapeDetection::FaceDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.h: Copied from Source/WebCore/Modules/ShapeDetection/FaceDetector.h.
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm: Copied from Source/WebCore/Modules/ShapeDetection/TextDetector.cpp.
(WebCore::ShapeDetection::TextDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h.
* Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorOptionsInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/BarcodeDetectorOptions.h.
* Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeFormatInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/BarcodeFormat.h.
* Source/WebCore/Modules/ShapeDetection/Interfaces/DetectedBarcodeInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/DetectedBarcode.h.
* Source/WebCore/Modules/ShapeDetection/Interfaces/DetectedFaceInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/DetectedFace.h.
* Source/WebCore/Modules/ShapeDetection/Interfaces/DetectedTextInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/DetectedText.h.
* Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/FaceDetector.h.
* Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorOptionsInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/FaceDetectorOptions.h.
* Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/Landmark.h.
* Source/WebCore/Modules/ShapeDetection/Interfaces/LandmarkTypeInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/LandmarkType.h.
* Source/WebCore/Modules/ShapeDetection/Interfaces/TextDetectorInterface.h: Copied from Source/WebCore/Modules/ShapeDetection/TextDetector.h.
* Source/WebCore/Modules/ShapeDetection/Landmark.h:
(WebCore::Landmark::convertToBacking const):
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/Landmark.idl:
* Source/WebCore/Modules/ShapeDetection/LandmarkType.h:
(WebCore::convertToBacking):
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/Point2D.h:
(WebCore::Point2D::convertToBacking const):
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/Point2D.idl:
* Source/WebCore/Modules/ShapeDetection/TextDetector.cpp:
(WebCore::TextDetector::create):
(WebCore::TextDetector::TextDetector):
(WebCore::TextDetector::detect):
* Source/WebCore/Modules/ShapeDetection/TextDetector.h:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/262994@main">https://commits.webkit.org/262994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a1ca8b64275ec50cf5e1a167c671e3a93656ac0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4641 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3317 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3259 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4453 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2875 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2927 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4197 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3303 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2876 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/794 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2871 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->