### PR TITLE
[SOUP] Do not handle HSTS upgrade as a redirection in case of redirection

### DIFF
--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1620,8 +1620,14 @@ bool NetworkDataTaskSoup::shouldAllowHSTSProtocolUpgrade() const
 
 void NetworkDataTaskSoup::protocolUpgradedViaHSTS(SoupMessage* soupMessage)
 {
-    m_response = ResourceResponse::syntheticRedirectResponse(m_currentRequest.url(), soupURIToURL(soup_message_get_uri(soupMessage)));
-    continueHTTPRedirection();
+    if (!m_response.isNull() && !m_response.httpHeaderField(HTTPHeaderName::Location).isEmpty()) {
+        // We handle HSTS upgrades as a redirection to let Web and UI processes know about the URL change, but in
+        // case of redirection, the new request is originated in the network process, so we can just update the URL.
+        m_currentRequest.setURL(soupURIToURL(soup_message_get_uri(m_soupMessage.get())));
+    } else {
+        m_response = ResourceResponse::syntheticRedirectResponse(m_currentRequest.url(), soupURIToURL(soup_message_get_uri(soupMessage)));
+        continueHTTPRedirection();
+    }
 }
 
 #if USE(SOUP2)


### PR DESCRIPTION
#### cebc10654f3cbebbc8defbf4bdb4b97cff316c39
<pre>
[SOUP] Do not handle HSTS upgrade as a redirection in case of redirection
<a href="https://bugs.webkit.org/show_bug.cgi?id=255218">https://bugs.webkit.org/show_bug.cgi?id=255218</a>

Reviewed by Adrian Perez de Castro.

We handle HSTS upgrades as a redirection to let Web and UI processes
know about the URL change, but in case of redirection, the new request
is originated in the network process, so we can just update the URL.

* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::protocolUpgradedViaHSTS):

Canonical link: <a href="https://commits.webkit.org/262817@main">https://commits.webkit.org/262817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f23e0cb9e5db32421d8dd21b73699399841c36c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3961 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2954 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2261 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3726 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2277 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2139 "2 flakes 147 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2587 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3488 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2327 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2110 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2280 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2314 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/318 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->