### PR TITLE
[JSC] Mark Weak in parallel

### DIFF
--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -74,6 +74,7 @@ public:
 
     // Block size must be at least as large as the system page size.
     static constexpr size_t blockSize = std::max(16 * KB, CeilingOnPageSize);
+    static_assert((WeakBlock::blockSize * 16) == 16 * KB);
 
     static constexpr size_t blockMask = ~(blockSize - 1); // blockSize must be a power of two.
 

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -273,22 +273,6 @@ void MarkedSpace::enablePreciseAllocationTracking()
         m_preciseAllocationSet->add(allocation->cell());
 }
 
-template<typename Visitor>
-void MarkedSpace::visitWeakSets(Visitor& visitor)
-{
-    auto visit = [&] (WeakSet* weakSet) {
-        weakSet->visit(visitor);
-    };
-    
-    m_newActiveWeakSets.forEach(visit);
-    
-    if (heap().collectionScope() == CollectionScope::Full)
-        m_activeWeakSets.forEach(visit);
-}
-
-template void MarkedSpace::visitWeakSets(AbstractSlotVisitor&);
-template void MarkedSpace::visitWeakSets(SlotVisitor&);
-
 void MarkedSpace::reapWeakSets()
 {
     auto visit = [&] (WeakSet* weakSet) {

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -105,8 +105,10 @@ public:
     
     void prepareForAllocation();
 
-    template<typename Visitor> void visitWeakSets(Visitor&);
     void reapWeakSets();
+
+    template<typename Visitor>
+    Ref<SharedTask<void(Visitor&)>> forEachWeakInParallel();
 
     MarkedBlockSet& blocks() { return m_blocks; }
 

--- a/Source/JavaScriptCore/heap/WeakBlock.h
+++ b/Source/JavaScriptCore/heap/WeakBlock.h
@@ -41,7 +41,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WeakBlock);
 class WeakBlock : public DoublyLinkedListNode<WeakBlock> {
 public:
     friend class WTF::DoublyLinkedListNode<WeakBlock>;
-    static constexpr size_t blockSize = 256; // 1/16 of MarkedBlock size
+    static constexpr size_t blockSize = 1024; // 1/16 of MarkedBlock size
 
     struct FreeCell {
         FreeCell* next;

--- a/Source/JavaScriptCore/heap/WeakSet.cpp
+++ b/Source/JavaScriptCore/heap/WeakSet.cpp
@@ -123,7 +123,4 @@ void WeakSet::removeAllocator(WeakBlock* block)
     WeakBlock::destroy(*heap(), block);
 }
 
-template void WeakSet::visit(AbstractSlotVisitor&);
-template void WeakSet::visit(SlotVisitor&);
-
 } // namespace JSC


### PR DESCRIPTION
#### 25d6b13a31b0ac57d35ccf5e540e35c60ab54608
<pre>
[JSC] Mark Weak in parallel
<a href="https://bugs.webkit.org/show_bug.cgi?id=255219">https://bugs.webkit.org/show_bug.cgi?id=255219</a>
rdar://107824755

Reviewed by Justin Michaud.

This patch extends WeakImpl visiting to make it happen in parallel.
We define parallel task visiting WeakImpl with multiple threads, and make
marking constraint for that ConstraintParallelism::Parallel.
We also fixes WeakBlock size from 256 to 1024. As comment says, it was originally
1/16 of MarkedBlock size. But this was because MarkedBlock was 4KB. And after it
gets 16KB, still WeakBlock is not extended. 256 is too small since it only holds
9 elements of WeakImpl.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::addCoreConstraints):
* Source/JavaScriptCore/heap/IsoCellSetInlines.h:
(JSC::IsoCellSet::forEachMarkedCellInParallel):
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::visitWeakSets): Deleted.
* Source/JavaScriptCore/heap/MarkedSpace.h:
* Source/JavaScriptCore/heap/MarkedSpaceInlines.h:
(JSC::MarkedSpace::forEachWeakInParallel):
* Source/JavaScriptCore/heap/SubspaceInlines.h:
(JSC::Subspace::forEachMarkedCellInParallel):
* Source/JavaScriptCore/heap/WeakSet.cpp:
* Source/JavaScriptCore/heap/WeakSet.h:
(JSC::WeakSet::head):
(JSC::WeakSet::forEachBlock):
(JSC::WeakSet::lastChanceToFinalize):
(JSC::WeakSet::reap):
(JSC::WeakSet::visit): Deleted.

Canonical link: <a href="https://commits.webkit.org/262849@main">https://commits.webkit.org/262849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd92ce005ab9be9e8374d98d6e25f1cf051110ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2786 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/2859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4201 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2883 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2812 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3229 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3975 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2473 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2317 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2524 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2652 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/2871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2856 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2476 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/679 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2925 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/326 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/801 "Passed tests") | 
<!--EWS-Status-Bubble-End-->