### PR TITLE
Avoid scenarios where every element automatically gets an interaction region

### DIFF
--- a/LayoutTests/interaction-region/ignore-catch-all-body-expected.txt
+++ b/LayoutTests/interaction-region/ignore-catch-all-body-expected.txt
@@ -1,0 +1,21 @@
+an actual link
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (-4,196) width=95 height=27)
+        (borderRadius 8.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/ignore-catch-all-body.html
+++ b/LayoutTests/interaction-region/ignore-catch-all-body.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body {
+        margin: 0;
+        cursor: pointer;
+    }
+
+    div {
+        width: 100px;
+        height: 100px;
+        background-color: gray;
+    }
+</style>
+<body>
+<div></div>
+<div></div>
+<a href="#">an actual link</a>
+<div></div>
+
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -69,22 +69,12 @@
                                       (type interaction)
                                       (layer bounds [x: 0 y: 0 width: 284 height: 192])
                                       (layer position [x: 152 y: 152])
-                                      (layer cornerRadius 8)
-                                      (sublayers
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 284 height: 192])
-                                          (layer position [x: 142 y: 142])
-                                          (layer opacity 0))))
+                                      (layer cornerRadius 8))
                                     (
                                       (type interaction)
                                       (layer bounds [x: 0 y: 0 width: 59 height: 20])
                                       (layer position [x: 29.5 y: 29.5])
-                                      (layer cornerRadius 9)
-                                      (sublayers
-                                        (
-                                          (layer bounds [x: 0 y: 0 width: 59 height: 20])
-                                          (layer position [x: 29.5 y: 29.5])
-                                          (layer opacity 0))))
+                                      (layer cornerRadius 9))
                                     (
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (sublayers
@@ -104,12 +94,7 @@
                                               (type interaction)
                                               (layer bounds [x: 0 y: 0 width: 76 height: 27])
                                               (layer position [x: 34 y: 34])
-                                              (layer cornerRadius 8)
-                                              (sublayers
-                                                (
-                                                  (layer bounds [x: 0 y: 0 width: 76 height: 27])
-                                                  (layer position [x: 38 y: 38])
-                                                  (layer opacity 0))))))
+                                              (layer cornerRadius 8))))
                                         (
                                           (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                           (layer position [x: 400 y: 400])
@@ -123,12 +108,7 @@
                                               (type interaction)
                                               (layer bounds [x: 0 y: 0 width: 33 height: 27])
                                               (layer position [x: 12.5 y: 12.5])
-                                              (layer cornerRadius 8)
-                                              (sublayers
-                                                (
-                                                  (layer bounds [x: 0 y: 0 width: 33 height: 27])
-                                                  (layer position [x: 16.5 y: 16.5])
-                                                  (layer opacity 0))))
+                                              (layer cornerRadius 8))
                                             (
                                               (layer bounds [x: 0 y: 0 width: 800 height: 20])
                                               (layer position [x: 400 y: 400]))))))))))))))))))

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -583,6 +583,12 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
 
         style.setEventListenerRegionTypes(computeEventListenerRegionTypes(m_document, style, *m_element, m_parentStyle.eventListenerRegionTypes()));
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+        // Every element will automatically get an interaction region which is not useful, ignoring the `cursor: pointer;` on the body.
+        if (is<HTMLBodyElement>(*m_element) && style.cursor() == CursorType::Pointer && style.eventListenerRegionTypes().contains(EventListenerRegionType::MouseClick))
+            style.setCursor(CursorType::Auto);
+#endif
+
 #if ENABLE(TEXT_AUTOSIZING)
         if (m_document.settings().textAutosizingUsesIdempotentMode())
             adjustForTextAutosizing(style, *m_element);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -94,10 +94,13 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     };
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if ([layer valueForKey:@"WKInteractionRegionGroupName"])
+    if ([layer valueForKey:@"WKInteractionRegionGroupName"]) {
         ts.dumpProperty("type", "interaction");
-    else if ([layer valueForKey:@"WKInteractionRegionType"])
+        traverse = false;
+    } else if ([layer valueForKey:@"WKInteractionRegionType"]) {
         ts.dumpProperty("type", "occlusion");
+        traverse = false;
+    }
 #endif
 
     ts.dumpProperty("layer bounds", rectToString(layer.bounds));


### PR DESCRIPTION
#### fbf81751af85bcc9401029fd025e51ed03dfa91c
<pre>
Avoid scenarios where every element automatically gets an interaction region
<a href="https://bugs.webkit.org/show_bug.cgi?id=255220">https://bugs.webkit.org/show_bug.cgi?id=255220</a>
&lt;rdar://100421682&gt;

Reviewed by Tim Horton.

We have a corner case where every element on the page gets an
interaction region regardless of its own properties: a body element that
both does event delegation _and_ sets `cursor: pointer;`.
Work around this issue by ignoring the `pointer` in this specific case.

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
Detect the corner case and ignore `pointer` on the body.

* LayoutTests/interaction-region/ignore-catch-all-body-expected.txt: Added.
* LayoutTests/interaction-region/ignore-catch-all-body.html: Added.
Add a test case.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(dumpCALayer):
* LayoutTests/interaction-region/layer-tree-expected.txt:
Fix test flakiness by not dumping InteractionRegion layers&apos; sublayers.

Canonical link: <a href="https://commits.webkit.org/263077@main">https://commits.webkit.org/263077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8283af7d6c3bb4a9084b66be10a83d86a28df22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4686 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3246 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2840 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4508 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2833 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3345 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2671 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2913 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/860 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2907 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->