### PR TITLE
REGRESSION(262572@main): [GTK] No contents renderer after process swap for navigation

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -57,7 +57,6 @@ DrawingAreaCoordinatedGraphics::DrawingAreaCoordinatedGraphics(WebPage& webPage,
     : DrawingArea(DrawingAreaType::CoordinatedGraphics, parameters.drawingAreaIdentifier, webPage)
     , m_exitCompositingTimer(RunLoop::main(), this, &DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode)
     , m_discardPreviousLayerTreeHostTimer(RunLoop::main(), this, &DrawingAreaCoordinatedGraphics::discardPreviousLayerTreeHost)
-    , m_supportsAsyncScrolling(parameters.store.getBoolValueForKey(WebPreferencesKey::threadedScrollingEnabledKey()))
     , m_displayTimer(RunLoop::main(), this, &DrawingAreaCoordinatedGraphics::displayTimerFired)
 {
 #if USE(GLIB_EVENT_LOOP)
@@ -67,13 +66,13 @@ DrawingAreaCoordinatedGraphics::DrawingAreaCoordinatedGraphics(WebPage& webPage,
 #endif
 #endif
 
-#if ENABLE(DEVELOPER_MODE)
-    if (m_supportsAsyncScrolling) {
-        auto* disableAsyncScrolling = getenv("WEBKIT_DISABLE_ASYNC_SCROLLING");
-        if (disableAsyncScrolling && strcmp(disableAsyncScrolling, "0"))
-            m_supportsAsyncScrolling = false;
+    updatePreferences(parameters.store);
+
+    if (m_alwaysUseCompositing) {
+        enterAcceleratedCompositingMode(nullptr);
+        if (!parameters.isProcessSwap)
+            sendEnterAcceleratedCompositingModeIfNeeded();
     }
-#endif
 }
 
 DrawingAreaCoordinatedGraphics::~DrawingAreaCoordinatedGraphics() = default;
@@ -98,9 +97,6 @@ void DrawingAreaCoordinatedGraphics::setNeedsDisplayInRect(const IntRect& rect)
         return;
     }
 
-    if (!m_isPaintingEnabled)
-        return;
-
     IntRect dirtyRect = rect;
     dirtyRect.intersect(m_webPage.bounds());
     if (dirtyRect.isEmpty())
@@ -112,9 +108,6 @@ void DrawingAreaCoordinatedGraphics::setNeedsDisplayInRect(const IntRect& rect)
 
 void DrawingAreaCoordinatedGraphics::scroll(const IntRect& scrollRect, const IntSize& scrollDelta)
 {
-    if (!m_isPaintingEnabled)
-        return;
-
     if (m_layerTreeHost) {
         ASSERT(m_scrollRect.isEmpty());
         ASSERT(m_scrollOffset.isEmpty());
@@ -180,10 +173,8 @@ void DrawingAreaCoordinatedGraphics::forceRepaint()
 
     if (!m_layerTreeHost) {
         m_isWaitingForDidUpdate = false;
-        if (m_isPaintingEnabled) {
-            m_dirtyRegion = m_webPage.bounds();
-            display();
-        }
+        m_dirtyRegion = m_webPage.bounds();
+        display();
         return;
     }
 
@@ -258,20 +249,21 @@ void DrawingAreaCoordinatedGraphics::updatePreferences(const WebPreferencesStore
 
     m_alwaysUseCompositing = settings.acceleratedCompositingEnabled() && settings.forceCompositingMode();
 
+    m_supportsAsyncScrolling = store.getBoolValueForKey(WebPreferencesKey::threadedScrollingEnabledKey());
+#if ENABLE(DEVELOPER_MODE)
+    if (m_supportsAsyncScrolling) {
+        auto* disableAsyncScrolling = getenv("WEBKIT_DISABLE_ASYNC_SCROLLING");
+        if (disableAsyncScrolling && strcmp(disableAsyncScrolling, "0"))
+            m_supportsAsyncScrolling = false;
+    }
+#endif
+
     // If async scrolling is disabled, we have to force-disable async frame and overflow scrolling
     // to keep the non-async scrolling on those elements working.
     if (!m_supportsAsyncScrolling) {
         settings.setAsyncFrameScrollingEnabled(false);
         settings.setAsyncOverflowScrollingEnabled(false);
     }
-}
-
-void DrawingAreaCoordinatedGraphics::enablePainting()
-{
-    m_isPaintingEnabled = true;
-
-    if (m_alwaysUseCompositing && !m_layerTreeHost)
-        enterAcceleratedCompositingMode(nullptr);
 }
 
 void DrawingAreaCoordinatedGraphics::mainFrameContentSizeChanged(const IntSize& size)
@@ -659,13 +651,15 @@ void DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode(GraphicsLay
         if (!m_layerTreeStateIsFrozen)
             m_layerTreeHost->setLayerFlushSchedulingEnabled(true);
     } else {
-#if USE(COORDINATED_GRAPHICS) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
+#if USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
         m_layerTreeHost = makeUnique<LayerTreeHost>(m_webPage);
-        changeWindowScreen();
+#elif USE(COORDINATED_GRAPHICS)
+        m_layerTreeHost = makeUnique<LayerTreeHost>(m_webPage, std::numeric_limits<uint32_t>::max() - m_identifier.toUInt64());
 #else
         m_layerTreeHost = nullptr;
         return;
 #endif
+        changeWindowScreen();
         if (m_layerTreeStateIsFrozen)
             m_layerTreeHost->setLayerFlushSchedulingEnabled(false);
         if (m_isPaintingSuspended)
@@ -677,8 +671,8 @@ void DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode(GraphicsLay
 
     m_layerTreeHost->setRootCompositingLayer(graphicsLayer);
 
-    send(Messages::DrawingAreaProxy::EnterAcceleratedCompositingMode(m_backingStoreStateID, m_layerTreeHost->layerTreeContext()));
-    m_compositingAccordingToProxyMessages = true;
+    if (m_shouldSendEnterAcceleratedCompositingMode)
+        sendEnterAcceleratedCompositingModeIfNeeded();
 
     // Non-composited content will now be handled exclusively by the layer tree host.
     m_dirtyRegion = WebCore::Region();
@@ -686,6 +680,20 @@ void DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode(GraphicsLay
     m_scrollOffset = IntSize();
     m_displayTimer.stop();
     m_isWaitingForDidUpdate = false;
+}
+
+void DrawingAreaCoordinatedGraphics::sendEnterAcceleratedCompositingModeIfNeeded()
+{
+    if (m_compositingAccordingToProxyMessages)
+        return;
+
+    if (!m_layerTreeHost) {
+        m_shouldSendEnterAcceleratedCompositingMode = true;
+        return;
+    }
+
+    send(Messages::DrawingAreaProxy::EnterAcceleratedCompositingMode(m_backingStoreStateID, m_layerTreeHost->layerTreeContext()));
+    m_compositingAccordingToProxyMessages = true;
 }
 
 void DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -57,8 +57,8 @@ private:
     bool layerTreeStateIsFrozen() const override { return m_layerTreeStateIsFrozen; }
 
     void updatePreferences(const WebPreferencesStore&) override;
-    void enablePainting() override;
     void mainFrameContentSizeChanged(const WebCore::IntSize&) override;
+    void sendEnterAcceleratedCompositingModeIfNeeded() override;
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     void deviceOrPageScaleFactorChanged() override;
@@ -111,9 +111,6 @@ private:
 
     uint64_t m_backingStoreStateID { 0 };
 
-    // Whether painting is enabled. If painting is disabled, any calls to setNeedsDisplay and scroll are ignored.
-    bool m_isPaintingEnabled { false };
-
     // Whether we're currently processing an UpdateBackingStoreState message.
     bool m_inUpdateBackingStoreState { false };
 
@@ -156,6 +153,7 @@ private:
     bool m_alwaysUseCompositing { false };
     bool m_supportsAsyncScrolling { true };
     bool m_forceRepaintAfterBackingStoreStateUpdate { false };
+    bool m_shouldSendEnterAcceleratedCompositingMode { false };
 
     RunLoop::Timer m_displayTimer;
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -51,12 +51,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-LayerTreeHost::LayerTreeHost(WebPage& webPage)
+LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displayID)
     : m_webPage(webPage)
     , m_surface(AcceleratedSurface::create(webPage, *this))
     , m_viewportController(webPage.size())
     , m_layerFlushTimer(RunLoop::main(), this, &LayerTreeHost::layerFlushTimerFired)
     , m_coordinator(webPage, *this)
+    , m_displayID(displayID)
 {
 #if USE(GLIB_EVENT_LOOP)
     m_layerFlushTimer.setPriority(RunLoopSourcePriority::LayerFlushTimer);
@@ -78,8 +79,6 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage)
     if (m_surface->shouldPaintMirrored())
         paintFlags |= TextureMapper::PaintingMirrored;
 
-    ASSERT(m_webPage.drawingArea());
-    m_displayID = std::numeric_limits<uint32_t>::max() - m_webPage.drawingArea()->identifier().toUInt64();
     m_compositor = ThreadedCompositor::create(*this, *this, m_displayID, scaledSize, scaleFactor, paintFlags);
     m_layerTreeContext.contextID = m_surface->surfaceID();
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -65,7 +65,7 @@ class LayerTreeHost
 {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit LayerTreeHost(WebPage&);
+    LayerTreeHost(WebPage&, WebCore::PlatformDisplayID);
     ~LayerTreeHost();
 
     const LayerTreeContext& layerTreeContext() const { return m_layerTreeContext; }

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -96,7 +96,6 @@ public:
     virtual bool layerTreeStateIsFrozen() const { return false; }
 
     virtual void updatePreferences(const WebPreferencesStore&) { }
-    virtual void enablePainting() { }
     virtual void mainFrameContentSizeChanged(const WebCore::IntSize&) { }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -875,8 +875,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     if (!parameters.itemStates.isEmpty())
         restoreSessionInternal(parameters.itemStates, parameters.itemStatesWereRestoredByAPIRequest ? WasRestoredByAPIRequest::Yes : WasRestoredByAPIRequest::No, WebBackForwardListProxy::OverwriteExistingItem::No);
 
-    m_drawingArea->enablePainting();
-    
     setMediaVolume(parameters.mediaVolume);
 
     setMuted(parameters.muted, [] { });
@@ -1093,7 +1091,6 @@ void WebPage::reinitializeWebPage(WebPageCreationParameters&& parameters)
         m_drawingArea = DrawingArea::create(*this, parameters);
         m_drawingArea->setShouldScaleViewToFitDocument(parameters.shouldScaleViewToFitDocument);
         m_drawingArea->updatePreferences(parameters.store);
-        m_drawingArea->enablePainting();
 
         m_drawingArea->adoptLayersFromDrawingArea(*oldDrawingArea);
         m_drawingArea->adoptDisplayRefreshMonitorsFromDrawingArea(*oldDrawingArea);

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
@@ -58,8 +58,6 @@ void AcceleratedSurfaceDMABuf::didCreateGLContext()
 {
     glGenFramebuffers(1, &m_fbo);
     glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
-
-    clientResize(m_size);
 }
 
 void AcceleratedSurfaceDMABuf::willDestroyGLContext()


### PR DESCRIPTION
#### f938f81c9a7b341437e118fbd333f32da73875a2
<pre>
REGRESSION(262572@main): [GTK] No contents renderer after process swap for navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=255221">https://bugs.webkit.org/show_bug.cgi?id=255221</a>

Reviewed by Žan Doberšek.

In case of process swap current drawing area is destroyed causing the AC
mode to be exited, and the new drawing area sends the enter AC message
before the UI process has switched drawing areas, so the message is just
ignored. To be able to enter AC mode from the DrawingArea constructor
this patch removes the enablePainting methods, since it&apos;s always called
right after the drawing area is crewated and only used by coordinated
graphics drawing area.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::DrawingAreaCoordinatedGraphics): Enter AC mode here when always compositing.
(WebKit::DrawingAreaCoordinatedGraphics::setNeedsDisplayInRect): Remove painting enabled check.
(WebKit::DrawingAreaCoordinatedGraphics::scroll): Ditto.
(WebKit::DrawingAreaCoordinatedGraphics::forceRepaint): Ditto.
(WebKit::DrawingAreaCoordinatedGraphics::updatePreferences): Update async scrolling enabled here.
(WebKit::DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode): Create the LayerTreeHost with the display ID
so that LayerTreeHost doesn&apos;t need to access the page drawing area that is being created.
(WebKit::DrawingAreaCoordinatedGraphics::sendEnterAcceleratedCompositingModeIfNeeded): Implement this.
(WebKit::DrawingAreaCoordinatedGraphics::enablePainting): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost): Use the given display ID.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::enablePainting): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::reinitializeWebPage): Remove enablePainting calls.
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didCreateGLContext): Do not resize
here that is too early in some cases, wait for the first frame to do the
resize.

Canonical link: <a href="https://commits.webkit.org/262812@main">https://commits.webkit.org/262812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1afb5afc88a1a2f8b375a3cb14f8e107f4592e7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3968 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2961 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2268 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/2990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3733 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2149 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2612 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3500 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2332 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2117 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2285 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2321 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/316 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2472 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->