### PR TITLE
REGRESSION (255086@main): Safari 16.4 and above does not render <option> label/text updates until <select> is focused

### DIFF
--- a/LayoutTests/fast/forms/select/selected-option-update-inner-html-expected.html
+++ b/LayoutTests/fast/forms/select/selected-option-update-inner-html-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<select>
+    <option>Bar</option>
+</select>
+</body>
+</html>

--- a/LayoutTests/fast/forms/select/selected-option-update-inner-html.html
+++ b/LayoutTests/fast/forms/select/selected-option-update-inner-html.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<select>
+    <option>Foo</option>
+</select>
+<script>
+
+addEventListener("load", () => {
+    let option = document.querySelector("option");
+    option.innerHTML = "Bar";
+});
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -427,6 +427,8 @@ void HTMLSelectElement::childrenChanged(const ChildChange& change)
 
 void HTMLSelectElement::optionElementChildrenChanged()
 {
+    setOptionsChangedOnRenderer();
+    invalidateStyleForSubtree();
     updateValidity();
     if (auto* cache = document().existingAXObjectCache())
         cache->childrenChanged(this);


### PR DESCRIPTION
#### d86fed1a2d3d34c612802f1e640341dd5656a665
<pre>
REGRESSION (255086@main): Safari 16.4 and above does not render &lt;option&gt; label/text updates until &lt;select&gt; is focused
<a href="https://bugs.webkit.org/show_bug.cgi?id=255230">https://bugs.webkit.org/show_bug.cgi?id=255230</a>
rdar://107838336

Reviewed by Chris Dumez.

255086@main removed the call to `HTMLSelectElement::setRecalcListItems` in
`HTMLSelectElement::optionElementChildrenChanged` so that updating the text
inside an &lt;option&gt; element does not reset the &lt;select&gt; element&apos;s selected option.

However, this broke rendering of the option&apos;s new text, since
`setRecalcListItems` contained logic to update the rendered text. Fix by
reintroducing the logic that is responsible for ensuring the displayed text
matches the &lt;option&gt; element&apos;s text.

Add a regression (reference) test which would have caught this issue.

* LayoutTests/fast/forms/select/selected-option-update-inner-html-expected.html: Added.
* LayoutTests/fast/forms/select/selected-option-update-inner-html.html: Added.
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::optionElementChildrenChanged):

Canonical link: <a href="https://commits.webkit.org/262791@main">https://commits.webkit.org/262791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb3f0fdbb3ec67a93f40cf24dda731e8c5ae865c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/3992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2288 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3758 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2305 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2168 "145 failures") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2654 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3523 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2355 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2138 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2308 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/647 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->