### PR TITLE
[Base system] Crash when accessing soft-linked Objective-C classes while decoding IPC

### DIFF
--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -537,6 +537,44 @@ static void encodeSecureCodingInternal(Encoder& encoder, id <NSObject, NSSecureC
 
 static bool shouldEnableStrictMode(Decoder& decoder, NSArray<Class> *allowedClasses)
 {
+    static bool supportsPassKitCore = false;
+    static bool supportsDataDetectorsCore = false;
+    static bool supportsDataDetectors = false;
+    static bool supportsVisionKitCore = false;
+    static bool supportsRevealCore = false;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+#if ENABLE(APPLE_PAY)
+        supportsPassKitCore = PAL::isPassKitCoreFrameworkAvailable();
+#else
+        UNUSED_PARAM(supportsPassKitCore);
+#endif
+
+#if ENABLE(DATA_DETECTION)
+        supportsDataDetectorsCore = PAL::isDataDetectorsCoreFrameworkAvailable();
+#else
+        UNUSED_PARAM(supportsDataDetectorsCore);
+#endif
+
+#if ENABLE(DATA_DETECTION) && PLATFORM(MAC)
+        supportsDataDetectors = PAL::isDataDetectorsFrameworkAvailable();
+#else
+        UNUSED_PARAM(supportsDataDetectors);
+#endif
+
+#if HAVE(VK_IMAGE_ANALYSIS)
+        supportsVisionKitCore = PAL::isVisionKitCoreFrameworkAvailable();
+#else
+        UNUSED_PARAM(supportsVisionKitCore);
+#endif
+
+#if ENABLE(REVEAL)
+        supportsRevealCore = PAL::isRevealCoreFrameworkAvailable();
+#else
+        UNUSED_PARAM(supportsRevealCore);
+#endif
+    });
+
     if (([allowedClasses containsObject:NSURLProtectionSpace.class]
             && (
                 decoder.messageName() == IPC::MessageName::DownloadProxy_DidReceiveAuthenticationChallenge // NP -> UIP
@@ -546,9 +584,9 @@ static bool shouldEnableStrictMode(Decoder& decoder, NSArray<Class> *allowedClas
                 || decoder.messageName() == IPC::MessageName::AuthenticationManager_CompleteAuthenticationChallenge // UIP -> NP
             )
         )
-#if HAVE(VK_IMAGE_ANALYSIS) && ENABLE(IMAGE_ANALYSIS)
+#if HAVE(VK_IMAGE_ANALYSIS)
         || (
-            [allowedClasses containsObject:PAL::getVKCImageAnalysisClass()]
+            (supportsVisionKitCore && [allowedClasses containsObject:PAL::getVKCImageAnalysisClass()])
             && (
                 decoder.messageName() == IPC::MessageName::WebPage_UpdateWithTextRecognitionResult // UIP -> WCP
                 || decoder.messageName() == IPC::MessageName::WebPageProxy_RequestTextRecognitionReply // UIP -> WCP
@@ -556,12 +594,12 @@ static bool shouldEnableStrictMode(Decoder& decoder, NSArray<Class> *allowedClas
         )
 #endif
 #if ENABLE(APPLE_PAY)
-        || [allowedClasses containsObject:PAL::getPKPaymentSetupConfigurationClass()] // rdar://107553429, Don't re-introduce rdar://107626990
+        || (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentSetupConfigurationClass()]) // rdar://107553429, Don't re-introduce rdar://107626990
 #endif
 #if ENABLE(DATA_DETECTION)
-        || [allowedClasses containsObject:PAL::getDDScannerResultClass()] // rdar://107553330 - relying on NSMutableArray re-write, don't re-introduce rdar://107676726
+        || (supportsDataDetectorsCore && [allowedClasses containsObject:PAL::getDDScannerResultClass()]) // rdar://107553330 - relying on NSMutableArray re-write, don't re-introduce rdar://107676726
 #if PLATFORM(MAC)
-        || [allowedClasses containsObject:PAL::getDDActionContextClass()] // rdar://107553348 - relying on NSMutableArray re-write, don't re-introduce rdar://107676726
+        || (supportsDataDetectors && [allowedClasses containsObject:PAL::getDDActionContextClass()]) // rdar://107553348 - relying on NSMutableArray re-write, don't re-introduce rdar://107676726
 #endif // PLATFORM(MAC)
 #endif // ENABLE(DATA_DETECTION)
     ) {
@@ -574,14 +612,14 @@ static bool shouldEnableStrictMode(Decoder& decoder, NSArray<Class> *allowedClas
         || [allowedClasses containsObject:NSShadow.class] // rdar://107553244
         || [allowedClasses containsObject:NSTextAttachment.class] // rdar://107553273
 #if ENABLE(REVEAL)
-        || [allowedClasses containsObject:PAL::getRVItemClass()] // rdar://107553310
+        || (supportsRevealCore && [allowedClasses containsObject:PAL::getRVItemClass()]) // rdar://107553310
 #endif // ENABLE(REVEAL)
 #if ENABLE(APPLE_PAY)
-        || [allowedClasses containsObject:PAL::getPKPaymentSetupFeatureClass()] // rdar://107553409
-        || [allowedClasses containsObject:PAL::getPKPaymentMerchantSessionClass()] // rdar://107553452
-        || ([allowedClasses containsObject:PAL::getPKPaymentClass()] && isInWebProcess())
-        || ([allowedClasses containsObject:PAL::getPKPaymentInstallmentConfigurationClass()] && isInWebProcess())
-        || [allowedClasses containsObject:PAL::getPKPaymentMethodClass()] // rdar://107553480
+        || (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentSetupFeatureClass()]) // rdar://107553409
+        || (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentMerchantSessionClass()]) // rdar://107553452
+        || (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentClass()] && isInWebProcess())
+        || (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentInstallmentConfigurationClass()] && isInWebProcess())
+        || (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentMethodClass()]) // rdar://107553480
 #endif // ENABLE(APPLE_PAY)
         || (
             [allowedClasses containsObject:NSURLCredential.class] // rdar://107553367 relying on NSMutableDictionary re-write


### PR DESCRIPTION
#### 353fc00c0bdac42276df534f3459ded656e362eb
<pre>
[Base system] Crash when accessing soft-linked Objective-C classes while decoding IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=255240">https://bugs.webkit.org/show_bug.cgi?id=255240</a>
rdar://107838765

Reviewed by Aditya Keerthi.

Add relevant runtime framework availability checks for the following system frameworks:

- PassKitCore
- DataDetectorsCore
- DataDetectors
- VisionKitCore
- Reveal

...before attempting to soft link Objective-C objects from those respective frameworks.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::shouldEnableStrictMode):

Also remove an extraneous `ENABLE(IMAGE_ANALYSIS)` here; `ENABLE(IMAGE_ANALYSIS)` is true as long as
`HAVE(VK_IMAGE_ANALYSIS)` is true, so there&apos;s no need to check both.

Canonical link: <a href="https://commits.webkit.org/262783@main">https://commits.webkit.org/262783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f32a893d3b41abed280fe2ac8a28e7ed8e7a4b1d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/2992 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2295 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2623 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3768 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2308 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2670 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3534 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2358 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2145 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2311 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/638 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->