### PR TITLE
CanvasRenderingContext2D::drawImage() doesn't work correctly with transform when copying from self

### DIFF
--- a/LayoutTests/fast/canvas/canvas-self-drawImage-scaled-context-expected.html
+++ b/LayoutTests/fast/canvas/canvas-self-drawImage-scaled-context-expected.html
@@ -1,0 +1,25 @@
+<body>
+    <p>Test that the source rectangle of drawImage() is in the canvas backend coordinates.</p>
+    <canvas></canvas>
+    <script>
+        function drawTriangle(ctx, x1, y1, x2, y2, x3, y3) {
+            ctx.beginPath();
+            ctx.moveTo(x1, y1);
+            ctx.lineTo(x2, y2);
+            ctx.lineTo(x3, y3);
+            ctx.fill();
+        }
+
+        const ctx = document.querySelector('canvas').getContext('2d');
+        ctx.canvas.width = 200;
+        ctx.canvas.height = 100;
+
+        ctx.scale(2, 2);
+
+        ctx.fillStyle = "green";
+        ctx.imageSmoothingEnabled = false;
+
+        // Draw a triangle to the left side.
+        drawTriangle(ctx, 25, 0, 50, 50, 0, 50);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-self-drawImage-scaled-context.html
+++ b/LayoutTests/fast/canvas/canvas-self-drawImage-scaled-context.html
@@ -1,0 +1,31 @@
+<body>
+    <p>Test that the source rectangle of drawImage() is in the canvas backend coordinates.</p>
+    <canvas></canvas>
+    <script>
+        function drawTriangle(ctx, x1, y1, x2, y2, x3, y3) {
+            ctx.beginPath();
+            ctx.moveTo(x1, y1);
+            ctx.lineTo(x2, y2);
+            ctx.lineTo(x3, y3);
+            ctx.fill();
+        }
+
+        const ctx = document.querySelector('canvas').getContext('2d');
+        ctx.canvas.width = 200;
+        ctx.canvas.height = 100;
+
+        ctx.scale(2, 2);
+
+        ctx.fillStyle = "green";
+        ctx.globalCompositeOperation = 'copy';
+        ctx.imageSmoothingEnabled = false;
+
+        // Draw a triangle to the right side.
+        drawTriangle(ctx, 75, 0, 100, 50, 50, 50);
+
+        // Move the image from right to left via drawImage+global composite copy operation.
+        ctx.drawImage(ctx.canvas,
+            100, 0, 100, 100,   // source rect in pixels of the canvas (200x100)
+              0, 0,  50,  50);  // dest in current scaled transform (100x50)
+    </script>
+</body>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1736,7 +1736,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
         repaintEntireCanvas = true;
     } else if (state().globalComposite == CompositeOperator::Copy) {
         if (&sourceCanvas == &canvasBase()) {
-            if (auto copy = c->createAlignedImageBuffer(normalizedSrcRect.size(), colorSpace())) {
+            if (auto copy = c->createImageBuffer(normalizedSrcRect.size(), 1, colorSpace())) {
                 copy->context().drawImageBuffer(*buffer, -normalizedSrcRect.location());
                 clearCanvas();
                 c->drawImageBuffer(*copy, normalizedDstRect, { { }, normalizedSrcRect.size() }, { state().globalComposite, state().globalBlend });


### PR DESCRIPTION
#### aa025e46a961480b60e856a371d639bd874b74a7
<pre>
CanvasRenderingContext2D::drawImage() doesn&apos;t work correctly with transform when copying from self
<a href="https://bugs.webkit.org/show_bug.cgi?id=255208">https://bugs.webkit.org/show_bug.cgi?id=255208</a>
rdar://107844963

Reviewed by Kimmo Kinnunen.

drawImage() creates a temporary ImageBuffer to get the srcRect of the canvas.
This ImageBuffer is not for drawing. It should not inherit the current scaleFactor
and it should just hold the pixels of the canvas in the non-scaled coordinates. We
should use GraphicsContext::createImageBuffer() to create the temporary ImageBuffer.

* LayoutTests/fast/canvas/canvas-self-drawImage-scaled-context-expected.html: Added.
* LayoutTests/fast/canvas/canvas-self-drawImage-scaled-context.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):

Canonical link: <a href="https://commits.webkit.org/262841@main">https://commits.webkit.org/262841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7682e93c450a2819f60ebd0814c95c0b64c33fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4153 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2414 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3923 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2295 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2490 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3671 "261 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2824 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2442 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/685 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->