### PR TITLE
REGRESSION(r262728): elementsFromPoint misses elements if they are in different paint passes.

### DIFF
--- a/LayoutTests/fast/dom/elementsFromPoint-z-index-expected.txt
+++ b/LayoutTests/fast/dom/elementsFromPoint-z-index-expected.txt
@@ -1,0 +1,1 @@
+SUCCESS: Hit test elements in correct order - front < middle < back < container < html

--- a/LayoutTests/fast/dom/elementsFromPoint-z-index.html
+++ b/LayoutTests/fast/dom/elementsFromPoint-z-index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html id="html">
+<head>
+<title>elementsFromPoint hit-testing with negative and positive z-index</title>
+<style>
+#container {
+    width: 200px;
+    height: 200px;
+    background: beige;
+    transform: translateZ(1px);
+    position: absolute;
+}
+
+a {
+    width: 200px;
+    height: 200px;
+    display: block;
+    position: absolute;
+}
+
+#back {
+    transform: translateZ(-10px);
+    z-index: -2;
+}
+
+#front {
+    transform: translateZ(10px);
+    z-index: 2;
+}
+
+#results {
+    position: absolute;
+    top: 250px;
+}
+
+</style>
+</head>
+<body id="body">
+<div id="container">
+    <a id="back"></a>
+    <a id="front"></a>
+    <a id="middle"></a>
+</div>
+
+<div id="results"></div>
+
+<script type="text/javascript" charset="utf-8">
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  let elements = document.elementsFromPoint(100, 100);
+  let result = "";
+  elements.forEach((elt, i) => {
+    result += elt.id;
+    if (i < elements.length - 1) {
+      result += " < ";
+    }
+  });
+  let output = document.getElementById('results');
+  if (result == "front < middle < back < container < html")
+    output.textContent = "SUCCESS: Hit test elements in correct order - " + result;
+  else
+    output.textContent = "FAIL: Hit test elements in incorrect order - " + result;
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4144,11 +4144,11 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
     {
         HitTestResult tempResult(result.hitTestLocation());
         hitLayer = hitTestList(normalFlowLayers(), rootLayer, request, tempResult, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
+        if (request.resultIsElementList())
+            result.append(tempResult, request);
         if (hitLayer.layer) {
             if (!depthSortDescendants || !using3DTransformsInterop || hitLayer.zOffset > candidateLayer.zOffset) {
-                if (request.resultIsElementList())
-                    result.append(tempResult, request);
-                else
+                if (!request.resultIsElementList())
                     result = tempResult;
                 candidateLayer = hitLayer;
             }
@@ -4197,11 +4197,11 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
     {
         HitTestResult tempResult(result.hitTestLocation());
         hitLayer = hitTestList(negativeZOrderLayers(), rootLayer, request, tempResult, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
+        if (request.resultIsElementList())
+            result.append(tempResult, request);
         if (hitLayer.layer) {
             if (!depthSortDescendants || !using3DTransformsInterop || hitLayer.zOffset > candidateLayer.zOffset) {
-                if (request.resultIsElementList())
-                    result.append(tempResult, request);
-                else
+                if (!request.resultIsElementList())
                     result = tempResult;
                 candidateLayer = hitLayer;
             }


### PR DESCRIPTION
#### 21a87c5807185504fea14651253b804a318c4c07
<pre>
REGRESSION(r262728): elementsFromPoint misses elements if they are in different paint passes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255266">https://bugs.webkit.org/show_bug.cgi?id=255266</a>
&lt;rdar://problem/107862197&gt;

Reviewed by Simon Fraser.

<a href="https://commits.webkit.org/262728@main">https://commits.webkit.org/262728@main</a> changed the behaviour such that we only write to the HitTestResult if we hit a layer in that paint behaviour pass.

For elementsFromPoint we don&apos;t record a single hit layer, and we to append to the HitTestResult for each element that we intersected.

This change always appends to the final HitTestResult if resultIsElementList(), which matches the logic in hitTestList.

This doesn&apos;t fix the problem that these appends are done in normal paint order, not 3d depth sorted order (if transform-style is preserve-3d), which is bug 255265.

* LayoutTests/fast/dom/elementsFromPoint-z-index-expected.txt: Added.
* LayoutTests/fast/dom/elementsFromPoint-z-index.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTestLayer):

Canonical link: <a href="https://commits.webkit.org/262897@main">https://commits.webkit.org/262897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/654f79ce1dd89ebecd07234c74f9aa09080fd3c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4358 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3056 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2981 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4150 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2623 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2612 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2674 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3022 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2626 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/728 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->