### PR TITLE
[WGSL] Implement if statement codegen

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -307,6 +307,22 @@ void StringDumper::visit(CompoundStatement& block)
     m_out.print("}\n");
 }
 
+void StringDumper::visit(IfStatement& statement)
+{
+    m_out.print(m_indent, "if ");
+    visit(statement.test());
+    m_out.print("\n");
+    visit(statement.trueBody());
+    if (statement.maybeFalseBody()) {
+        m_out.print(m_indent, "else");
+        if (is<IfStatement>(*statement.maybeFalseBody()))
+            m_out.print(" ");
+        else
+            m_out.print("\n");
+        visit(*statement.maybeFalseBody());
+    }
+}
+
 void StringDumper::visit(ReturnStatement& statement)
 {
     m_out.print(m_indent, "return");

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -78,6 +78,7 @@ public:
     // Statement
     void visit(AssignmentStatement&) override;
     void visit(CompoundStatement&) override;
+    void visit(IfStatement&) override;
     void visit(ReturnStatement&) override;
     void visit(VariableStatement&) override;
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -54,6 +54,7 @@ public:
 
     // Statements
     void visit(AST::AssignmentStatement&) override;
+    void visit(AST::IfStatement&) override;
     void visit(AST::ReturnStatement&) override;
     void visit(AST::CompoundStatement&) override;
 
@@ -224,6 +225,18 @@ void TypeChecker::visit(AST::AssignmentStatement& statement)
     auto* rhs = infer(statement.rhs());
     if (!unify(lhs, rhs))
         typeError(InferBottom::No, statement.span(), "cannot assign value of type '", *rhs, "' to '", *lhs, "'");
+}
+
+void TypeChecker::visit(AST::IfStatement& statement)
+{
+    auto* test = infer(statement.test());
+
+    if (!unify(test, m_types.boolType()))
+        typeError(statement.test().span(), "expected 'bool', found ", *test);
+
+    AST::Visitor::visit(statement.trueBody());
+    if (statement.maybeFalseBody())
+        AST::Visitor::visit(*statement.maybeFalseBody());
 }
 
 void TypeChecker::visit(AST::ReturnStatement& statement)

--- a/Source/WebGPU/WGSL/tests/valid/if.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/if.wgsl
@@ -1,0 +1,9 @@
+fn testIfStmt() -> i32 {
+    if true {
+        return 42;
+    } else if false {
+        return -1;
+    } else {
+        return 0;
+    }
+}


### PR DESCRIPTION
#### 42bb0c9d8cd6a9f358091ab7079db850d87177fd
<pre>
[WGSL] Implement if statement codegen
<a href="https://bugs.webkit.org/show_bug.cgi?id=255267">https://bugs.webkit.org/show_bug.cgi?id=255267</a>
rdar://problem/107862445

Reviewed by Tadeu Zagallo.

Implement type-checking and codegen for if statements.

Minor cleanup of indentation handling in FunctionDefinitionWriter to allow `else
if` to format nicely.

* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
Map WGSL if statement to C if statement.
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
Type check if statement but checking that the type of the test expression is
boolean.
* Source/WebGPU/WGSL/tests/valid/if.wgsl: Added.
Test for parsing, type-checking and codegen of if statements.

Canonical link: <a href="https://commits.webkit.org/262862@main">https://commits.webkit.org/262862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b3ad8604e237e9c7a917edda78ebe92bc8eac71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3259 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2928 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2848 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3251 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4015 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2501 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2506 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2552 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2316 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2504 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/700 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->