### PR TITLE
REGRESSION (iOS 16.4 / macOS 13.3): TestWTF.TypeCastsCocoaARC.bridge_cast is a constant failure

### DIFF
--- a/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
+++ b/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
@@ -35,7 +35,7 @@ namespace WTF {
 
 #if __has_feature(objc_arc)
 #define WTF_CF_TO_NS_BRIDGE_TRANSFER(type, value) ((__bridge_transfer type)value)
-#define WTF_NS_TO_CF_BRIDGE_TRANSFER(type, value) ((__bridge_retained type)value)
+#define WTF_NS_TO_CF_BRIDGE_TRANSFER(type, value) ((type)reinterpret_cast<uintptr_t>(value))
 #else
 #define WTF_CF_TO_NS_BRIDGE_TRANSFER(type, value) ((__bridge type)value)
 #define WTF_NS_TO_CF_BRIDGE_TRANSFER(type, value) ((__bridge type)value)


### PR DESCRIPTION
#### 8b741e1d580dcc18ec14d8be401f97fab5b9d1b5
<pre>
REGRESSION (iOS 16.4 / macOS 13.3): TestWTF.TypeCastsCocoaARC.bridge_cast is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=255243">https://bugs.webkit.org/show_bug.cgi?id=255243</a>
&lt;rdar://107849758&gt;

Unreviewed partial revert of 261860@main (b6a50d258a8e):

    Use bridge instead of reinterpret_cast to convert between NS and CF objects.
    &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=253820">https://bugs.webkit.org/show_bug.cgi?id=253820</a>&gt;

* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
(WTF_NS_TO_CF_BRIDGE_TRANSFER): Revert change since this causes
leaks in macOS 13.3 and iOS 16.4 and later, and causes the
TestWTF.TypeCastsCocoaARC.bridge_cast test to fail on Release
builds.  It is the correct long-term change, but further fixes
are required to enable it.

Canonical link: <a href="https://commits.webkit.org/263639@main">https://commits.webkit.org/263639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01edf4b868edcf7f2bdbcba19c93a29a7cbec9d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5354 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5895 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6872 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4764 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/11596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4403 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6455 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4898 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4327 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5413 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4734 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1353 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8829 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5568 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/595 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5094 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1471 "Passed tests") | 
<!--EWS-Status-Bubble-End-->