### PR TITLE
ManagedMediaSource: remove BufferingPolicy attribute and add event listener.

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -52,11 +52,6 @@ ManagedMediaSource::ManagedMediaSource(ScriptExecutionContext& context)
 
 ManagedMediaSource::~ManagedMediaSource() = default;
 
-ExceptionOr<ManagedMediaSource::BufferingPolicy> ManagedMediaSource::buffering() const
-{
-    return BufferingPolicy::Medium;
-}
-
 ExceptionOr<ManagedMediaSource::PreferredQuality> ManagedMediaSource::quality() const
 {
     return PreferredQuality::High;

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -38,9 +38,6 @@ public:
     static Ref<ManagedMediaSource> create(ScriptExecutionContext&);
     ~ManagedMediaSource();
 
-    enum class BufferingPolicy { Low, Medium, High };
-    ExceptionOr<BufferingPolicy> buffering() const;
-
     enum class PreferredQuality { Low, Medium, High };
     ExceptionOr<PreferredQuality> quality() const;
 

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
@@ -23,12 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-enum BufferingPolicy {
-    "low",
-    "medium",
-    "high"
-};
-
 enum PreferredQuality {
     "low",
     "medium",
@@ -43,8 +37,8 @@ enum PreferredQuality {
 ] interface ManagedMediaSource : MediaSource {
     [CallWith=CurrentScriptExecutionContext] constructor();
 
-    readonly attribute BufferingPolicy buffering;
     readonly attribute PreferredQuality quality;
+    attribute EventHandler onqualitychange;
 
     readonly attribute boolean streaming;
     attribute EventHandler onstartstreaming;

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -230,6 +230,7 @@ namespace WebCore {
     macro(progress) \
     macro(push) \
     macro(pushsubscriptionchange) \
+    macro(qualitychange) \
     macro(ratechange) \
     macro(readystatechange) \
     macro(rejectionhandled) \


### PR DESCRIPTION
#### d919543062296cc72d676d656d4257404a1b8dff
<pre>
ManagedMediaSource: remove BufferingPolicy attribute and add event listener.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255262">https://bugs.webkit.org/show_bug.cgi?id=255262</a>
rdar://107862766

Reviewed by Jer Noble.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::buffering const): Deleted.
* Source/WebCore/Modules/mediasource/ManagedMediaSource.h:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.idl:
* Source/WebCore/dom/EventNames.h:

Canonical link: <a href="https://commits.webkit.org/262815@main">https://commits.webkit.org/262815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07ae3ef3b675fa8b0e00612997320005f3bfdbf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3061 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2788 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3862 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2389 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2251 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2773 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2408 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2440 "Passed tests") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2392 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/660 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2433 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->