### PR TITLE
imported/w3c/web-platform-tests/preload/modulepreload.html is a flaky failure

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6169,8 +6169,6 @@ imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text
 imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing/text-spacing-valid.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing [ Skip ]
 
-webkit.org/b/252942 imported/w3c/web-platform-tests/preload/modulepreload.html [ Pass Failure ]
-
 # This test is checking that WebContent is terminated when performing an invalid IPC operation
 ipc/restrictedendpoints/no-test-only-ipc-expected-crash.html [ Crash ]
 ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html [ Crash ]

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -50,7 +50,7 @@ void ResourceTimingInformation::addResourceTiming(CachedResource& resource, Docu
     if (!ResourceTimingInformation::shouldAddResourceTiming(resource))
         return;
 
-    auto iterator = m_initiatorMap.find(&resource);
+    auto iterator = m_initiatorMap.find(resource);
     if (iterator == m_initiatorMap.end())
         return;
 
@@ -80,7 +80,7 @@ void ResourceTimingInformation::addResourceTiming(CachedResource& resource, Docu
 
 void ResourceTimingInformation::removeResourceTiming(CachedResource& resource)
 {
-    m_initiatorMap.remove(&resource);
+    m_initiatorMap.remove(resource);
 }
 
 void ResourceTimingInformation::storeResourceTimingInitiatorInformation(const CachedResourceHandle<CachedResource>& resource, const AtomString& initiatorType, LocalFrame* frame)
@@ -92,11 +92,11 @@ void ResourceTimingInformation::storeResourceTimingInitiatorInformation(const Ca
         ASSERT(frame);
         if (frame->ownerElement()) {
             InitiatorInfo info = { frame->ownerElement()->localName(), NotYetAdded };
-            m_initiatorMap.add(resource.get(), info);
+            m_initiatorMap.add(*resource, info);
         }
     } else {
         InitiatorInfo info = { initiatorType, NotYetAdded };
-        m_initiatorMap.add(resource.get(), info);
+        m_initiatorMap.add(*resource, info);
     }
 }
 

--- a/Source/WebCore/loader/ResourceTimingInformation.h
+++ b/Source/WebCore/loader/ResourceTimingInformation.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "CachedResourceHandle.h"
-#include <wtf/HashMap.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -48,10 +48,9 @@ private:
     enum AlreadyAdded { NotYetAdded, Added };
     struct InitiatorInfo {
         AtomString type;
-        AlreadyAdded added;
+        AlreadyAdded added { NotYetAdded };
     };
-    // FIXME: This shoudn't use raw pointer as identifier (though it is not dereferenced).
-    HashMap<CachedResource*, InitiatorInfo> m_initiatorMap;
+    WeakHashMap<CachedResource, InitiatorInfo> m_initiatorMap;
 };
 
 }


### PR DESCRIPTION
#### 8096a949d5f7ae89892cb6d30bb48172e07d0af5
<pre>
imported/w3c/web-platform-tests/preload/modulepreload.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=255242">https://bugs.webkit.org/show_bug.cgi?id=255242</a>
&lt;rdar://107840455&gt;

Reviewed by Alexey Shvayka.

The flakiness was caused by ResourceTimingInformation using pointer value as its key for m_initiatorMap.
When two resources of the same document happen to be allocated at the same address (at two different times),
we erroneously conclude that the second resource&apos;s timing information had already been added in
ResourceTimingInformation::addResourceTiming because there is a matching entry in m_initiatorMap.

Fixed the bug by using WeakHashMap in ResourceTimingInformation to make the identity of CachedResource deterministic.

* LayoutTests/TestExpectations:
* Source/WebCore/loader/ResourceTimingInformation.cpp:
(WebCore::ResourceTimingInformation::addResourceTiming):
(WebCore::ResourceTimingInformation::removeResourceTiming):
(WebCore::ResourceTimingInformation::storeResourceTimingInitiatorInformation):
* Source/WebCore/loader/ResourceTimingInformation.h:

Canonical link: <a href="https://commits.webkit.org/262810@main">https://commits.webkit.org/262810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6b1578d002968b63b9864e253661da9db096a28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2363 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3853 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2238 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2764 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3606 "Passed tests") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2435 "Passed tests") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2216 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2387 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2424 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/314 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->