### PR TITLE
[GTK] Unreviewed, build fix for Debian Stable after 262488@main

### DIFF
--- a/Source/WebKit/UIProcess/gtk/PointerLockManagerWayland.cpp
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManagerWayland.cpp
@@ -32,6 +32,7 @@
 #include "pointer-constraints-unstable-v1-client-protocol.h"
 #include <WebCore/WlUniquePtr.h>
 #include <gtk/gtk.h>
+#include <wtf/glib/GRefPtr.h>
 
 #if USE(GTK4)
 #include <gdk/wayland/gdkwayland.h>

--- a/Source/WebKit/UIProcess/gtk/PointerLockManagerX11.cpp
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManagerX11.cpp
@@ -31,6 +31,7 @@
 #include "WebPageProxy.h"
 #include <X11/Xlib.h>
 #include <gtk/gtk.h>
+#include <wtf/glib/GRefPtr.h>
 
 #if USE(GTK4)
 #include <gdk/x11/gdkx.h>


### PR DESCRIPTION
#### 0728ac2727f4b6ae90456f7903f2e93db924d28d
<pre>
[GTK] Unreviewed, build fix for Debian Stable after 262488@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=253964">https://bugs.webkit.org/show_bug.cgi?id=253964</a>

Add missing header &apos;GRefPtr.h&apos;.

* Source/WebKit/UIProcess/gtk/PointerLockManagerWayland.cpp:
* Source/WebKit/UIProcess/gtk/PointerLockManagerX11.cpp:

Canonical link: <a href="https://commits.webkit.org/262807@main">https://commits.webkit.org/262807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2168169365c1aec0fdbdbb81bd0554f8f636bae2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4092 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2783 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2710 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3857 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/2387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2768 "Built successfully") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/2390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2428 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/311 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->