### PR TITLE
Make data eviction based on user interaction time when ITP is enabled

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp
@@ -2024,6 +2024,19 @@ Vector<RegistrableDomain> ResourceLoadStatisticsDatabaseStore::allDomains() cons
     return domains;
 }
 
+HashMap<RegistrableDomain, WallTime> ResourceLoadStatisticsDatabaseStore::allDomainsWithLastAccessedTime() const
+{
+    ASSERT(!RunLoop::isMain());
+
+    HashMap<RegistrableDomain, WallTime> result;
+    for (auto& domainData : domains()) {
+        auto lastAccessedTime = std::max(domainData.mostRecentUserInteractionTime, domainData.mostRecentWebPushInteractionTime);
+        result.add(WTFMove(domainData.registrableDomain), lastAccessedTime);
+    }
+
+    return result;
+}
+
 void ResourceLoadStatisticsDatabaseStore::clear(CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(!RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
@@ -116,6 +116,7 @@ public:
     void setIsNewResourceLoadStatisticsDatabaseFile(bool isNewResourceLoadStatisticsDatabaseFile) { m_isNewResourceLoadStatisticsDatabaseFile = isNewResourceLoadStatisticsDatabaseFile; }
     void removeDataForDomain(const RegistrableDomain&) override;
     Vector<RegistrableDomain> allDomains() const final;
+    HashMap<RegistrableDomain, WallTime> allDomainsWithLastAccessedTime() const final;
     bool domainIDExistsInDatabase(int);
     std::optional<Vector<String>> checkForMissingTablesInSchema();
     void insertExpiredStatisticForTesting(const RegistrableDomain&, unsigned numberOfOperatingDaysPassed, bool hasUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent) override;

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -194,6 +194,7 @@ public:
     virtual void removeDataForDomain(const RegistrableDomain&) = 0;
 
     virtual Vector<RegistrableDomain> allDomains() const = 0;
+    virtual HashMap<RegistrableDomain, WallTime> allDomainsWithLastAccessedTime() const = 0;
 
     void didCreateNetworkProcess();
 

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -1432,6 +1432,25 @@ void WebResourceLoadStatisticsStore::registrableDomains(CompletionHandler<void(V
     });
 }
 
+void WebResourceLoadStatisticsStore::registrableDomainsWithLastAccessedTime(CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>)>&& completionHandler)
+{
+    ASSERT(RunLoop::isMain());
+
+    if (isEphemeral()) {
+        completionHandler(std::nullopt);
+        return;
+    }
+
+    postTask([this, completionHandler = WTFMove(completionHandler)]() mutable {
+        std::optional<HashMap<RegistrableDomain, WallTime>> result;
+        if (m_statisticsStore)
+            result = m_statisticsStore->allDomainsWithLastAccessedTime();
+        postTaskReply([result = crossThreadCopy(WTFMove(result)), completionHandler = WTFMove(completionHandler)]() mutable {
+            completionHandler(WTFMove(result));
+        });
+    });
+}
+
 void WebResourceLoadStatisticsStore::deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType> dataTypes, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&& domainsToDeleteAndRestrictWebsiteDataFor, bool shouldNotifyPage, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -158,6 +158,7 @@ public:
     void removeDataForDomain(const RegistrableDomain, CompletionHandler<void()>&&);
     void deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType>, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&&, bool shouldNotifyPage, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&&);
     void registrableDomains(CompletionHandler<void(Vector<RegistrableDomain>&&)>&&);
+    void registrableDomainsWithLastAccessedTime(CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>)>&&);
     void registrableDomainsWithWebsiteData(OptionSet<WebsiteDataType>, bool shouldNotifyPage, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&&);
     StorageAccessWasGranted grantStorageAccessInStorageSession(const SubFrameDomain&, const TopFrameDomain&, std::optional<WebCore::FrameIdentifier>, WebCore::PageIdentifier, StorageAccessScope);
     void hasHadUserInteraction(RegistrableDomain&&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -595,6 +595,19 @@ void NetworkProcess::destroySession(PAL::SessionID sessionID)
     m_sessionsControlledByAutomation.remove(sessionID);
 }
 
+void NetworkProcess::registrableDomainsWithLastAccessedTime(PAL::SessionID sessionID, CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>)>&& completionHandler)
+{
+#if ENABLE(TRACKING_PREVENTION)
+    if (auto* session = networkSession(sessionID)) {
+        if (auto* resourceLoadStatistics = session->resourceLoadStatistics()) {
+            resourceLoadStatistics->registrableDomainsWithLastAccessedTime(WTFMove(completionHandler));
+            return;
+        }
+    }
+#endif
+    completionHandler(std::nullopt);
+}
+
 #if ENABLE(TRACKING_PREVENTION)
 void NetworkProcess::dumpResourceLoadStatistics(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
 {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -203,6 +203,7 @@ public:
 
     void addWebsiteDataStore(WebsiteDataStoreParameters&&);
 
+    void registrableDomainsWithLastAccessedTime(PAL::SessionID, CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>)>&&);
 #if ENABLE(TRACKING_PREVENTION)
     void clearPrevalentResource(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
     void clearUserInteraction(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -77,15 +77,14 @@ enum class BackgroundFetchChange : uint8_t;
 enum class UnifiedOriginStorageLevel : uint8_t;
 class FileSystemStorageHandleRegistry;
 class IDBStorageRegistry;
-class NetworkQuotaManager;
-
+class NetworkProcess;
 class ServiceWorkerStorageManager;
 class StorageAreaBase;
 class StorageAreaRegistry;
 
 class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver {
 public:
-    static Ref<NetworkStorageManager> create(PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
+    static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);
     static OptionSet<WebsiteDataType> allManagedTypes();
 
@@ -128,14 +127,12 @@ public:
 #endif // ENABLE(SERVICE_WORKER)
 
 private:
-    NetworkStorageManager(PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
+    NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     ~NetworkStorageManager();
-    NetworkQuotaManager& quotaManager();
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
     OriginStorageManager& originStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);
     bool removeOriginStorageManagerIfPossible(const WebCore::ClientOrigin&);
-    void updateOriginModificationTime(const WebCore::ClientOrigin&);
 
     void forEachOriginDirectory(const Function<void(const String&)>&);
     HashSet<WebCore::ClientOrigin> getAllOrigins();
@@ -225,8 +222,22 @@ private:
     Vector<WebCore::ServiceWorkerScripts> updateServiceWorkerRegistrationsByOrigin(Vector<WebCore::ServiceWorkerContextData>&&, Vector<WebCore::ServiceWorkerRegistrationKey>&&);
 #endif
 
+    void spaceGrantedForOrigin(const WebCore::ClientOrigin&, uint64_t amount);
+    void prepareForEviction();
+    void donePrepareForEviction(const std::optional<HashMap<WebCore::RegistrableDomain, WallTime>>&);
+    WallTime lastModificationTimeForOrigin(const WebCore::ClientOrigin&, OriginStorageManager&) const;
+    void updateLastModificationTimeForOrigin(const WebCore::ClientOrigin&);
+    void schedulePerformEviction();
+    struct AccessRecord {
+        bool isActive { false };
+        uint64_t usage { 0 };
+        WallTime lastAccessTime;
+        Vector<WebCore::SecurityOriginData> clientOrigins;
+    };
+    void performEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&&);
     SuspendableWorkQueue& workQueue() WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
 
+    WeakPtr<NetworkProcess> m_process;
     PAL::SessionID m_sessionID;
     String m_queueName;
     Ref<SuspendableWorkQueue> m_queue;
@@ -247,7 +258,9 @@ private:
     std::optional<double> m_originQuotaRatio;
     std::optional<double> m_totalQuotaRatio;
     std::optional<uint64_t> m_volumeCapacityOverride;
-    std::unique_ptr<NetworkQuotaManager> m_quotaManager;
+    std::optional<uint64_t> m_totalUsage;
+    uint64_t m_totalQuota;
+    bool m_isEvictionScheduled { false };
     UnifiedOriginStorageLevel m_unifiedOriginStorageLevel;
     IPC::Connection::UniqueID m_parentConnection;
     HashMap<IPC::Connection::UniqueID, HashSet<String>> m_temporaryBlobPathsByConnection WTF_GUARDED_BY_CAPABILITY(workQueue());

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
@@ -37,8 +37,8 @@ class OriginQuotaManager : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPt
 public:
     using GetUsageFunction = Function<uint64_t()>;
     using IncreaseQuotaFunction = Function<void(QuotaIncreaseRequestIdentifier, uint64_t currentQuota, uint64_t currentUsage, uint64_t requestedIncrease)>;
-    using NotifyUsageUpdateFunction = Function<void(uint64_t)>;
-    static Ref<OriginQuotaManager> create(uint64_t quota, uint64_t standardReportedQuota, GetUsageFunction&&, IncreaseQuotaFunction&& = { }, NotifyUsageUpdateFunction&& = { });
+    using NotifySpaceGrantedFunction = Function<void(uint64_t)>;
+    static Ref<OriginQuotaManager> create(uint64_t quota, uint64_t standardReportedQuota, GetUsageFunction&&, IncreaseQuotaFunction&& = { }, NotifySpaceGrantedFunction&& = { });
     uint64_t reportedQuota() const;
     uint64_t usage();
     enum class Decision : bool { Deny, Grant };
@@ -50,11 +50,11 @@ public:
     void resetQuotaForTesting();
 
 private:
-    OriginQuotaManager(uint64_t quota, uint64_t standardReportedQuota, GetUsageFunction&&, IncreaseQuotaFunction&&, NotifyUsageUpdateFunction&&);
+    OriginQuotaManager(uint64_t quota, uint64_t standardReportedQuota, GetUsageFunction&&, IncreaseQuotaFunction&&, NotifySpaceGrantedFunction&&);
     void handleRequests();
     bool grantWithCurrentQuota(uint64_t spaceRequested);
     bool grantFastPath(uint64_t spaceRequested);
-    void usageUpdated(uint64_t newUsage);
+    void spaceGranted(uint64_t amount);
 
     struct Request {
         uint64_t spaceRequested;
@@ -71,7 +71,7 @@ private:
     std::optional<uint64_t> m_usage;
     GetUsageFunction m_getUsageFunction;
     IncreaseQuotaFunction m_increaseQuotaFunction;
-    NotifyUsageUpdateFunction m_notifyUsageUpdateFunction;
+    NotifySpaceGrantedFunction m_notifySpaceGrantedFunction;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -664,10 +664,10 @@ Ref<OriginQuotaManager> OriginStorageManager::createQuotaManager()
         }
         return IDBStorageManager::idbStorageSize(idbStoragePath) + CacheStorageManager::cacheStorageSize(cacheStoragePath) + fileSystemStorageSize;
     };
-    return OriginQuotaManager::create(m_quota, m_standardReportedQuota, WTFMove(getUsageFunction), std::exchange(m_increaseQuotaFunction, { }), std::exchange(m_notifyUsageUpdateFunction, { }));
+    return OriginQuotaManager::create(m_quota, m_standardReportedQuota, WTFMove(getUsageFunction), std::exchange(m_increaseQuotaFunction, { }), std::exchange(m_notifySpaceGrantedFunction, { }));
 }
 
-OriginStorageManager::OriginStorageManager(uint64_t quota, uint64_t standardReportedQuota, OriginQuotaManager::IncreaseQuotaFunction&& increaseQuotaFunction, OriginQuotaManager::NotifyUsageUpdateFunction&& notifyUsageUpdateFunction, String&& path, String&& customLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel level)
+OriginStorageManager::OriginStorageManager(uint64_t quota, uint64_t standardReportedQuota, OriginQuotaManager::IncreaseQuotaFunction&& increaseQuotaFunction, OriginQuotaManager::NotifySpaceGrantedFunction&& notifySpaceGrantedFunction, String&& path, String&& customLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel level)
     : m_path(WTFMove(path))
     , m_customLocalStoragePath(WTFMove(customLocalStoragePath))
     , m_customIDBStoragePath(WTFMove(customIDBStoragePath))
@@ -675,7 +675,7 @@ OriginStorageManager::OriginStorageManager(uint64_t quota, uint64_t standardRepo
     , m_quota(quota)
     , m_standardReportedQuota(standardReportedQuota)
     , m_increaseQuotaFunction(WTFMove(increaseQuotaFunction))
-    , m_notifyUsageUpdateFunction(WTFMove(notifyUsageUpdateFunction))
+    , m_notifySpaceGrantedFunction(WTFMove(notifySpaceGrantedFunction))
     , m_level(level)
 {
     ASSERT(!RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -58,7 +58,7 @@ class OriginStorageManager : public CanMakeWeakPtr<OriginStorageManager> {
 public:
     static String originFileIdentifier();
 
-    OriginStorageManager(uint64_t quota, uint64_t standardReportedQuota, OriginQuotaManager::IncreaseQuotaFunction&&, OriginQuotaManager::NotifyUsageUpdateFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel);
+    OriginStorageManager(uint64_t quota, uint64_t standardReportedQuota, OriginQuotaManager::IncreaseQuotaFunction&&, OriginQuotaManager::NotifySpaceGrantedFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel);
     ~OriginStorageManager();
 
     void connectionClosed(IPC::Connection::UniqueID);
@@ -113,7 +113,7 @@ private:
     uint64_t m_quota;
     uint64_t m_standardReportedQuota;
     OriginQuotaManager::IncreaseQuotaFunction m_increaseQuotaFunction;
-    OriginQuotaManager::NotifyUsageUpdateFunction m_notifyUsageUpdateFunction;
+    OriginQuotaManager::NotifySpaceGrantedFunction m_notifySpaceGrantedFunction;
     RefPtr<OriginQuotaManager> m_quotaManager;
     bool m_persisted { false };
     UnifiedOriginStorageLevel m_level;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1604,7 +1604,6 @@
 		93B631E527ABA62800443A44 /* IDBStorageConnectionToClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B631E427ABA62700443A44 /* IDBStorageConnectionToClient.h */; };
 		93B631E827ABA65D00443A44 /* IDBStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B631E627ABA65C00443A44 /* IDBStorageManager.h */; };
 		93B631ED27ABA6B400443A44 /* IDBStorageRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B631EB27ABA6B300443A44 /* IDBStorageRegistry.h */; };
-		93B631F127ABACA900443A44 /* QuotaManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B631EF27ABACA900443A44 /* QuotaManager.h */; };
 		93B631F327ABAD8000443A44 /* QuotaIncreaseRequestIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B631F227ABAD7F00443A44 /* QuotaIncreaseRequestIdentifier.h */; };
 		93BDEB01171DD7AF00BFEE1B /* WKPageLoadTypesPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BDEB00171DD7AF00BFEE1B /* WKPageLoadTypesPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93D1EEF529669D74009B31D6 /* UnifiedOriginStorageLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D1EEF429669D73009B31D6 /* UnifiedOriginStorageLevel.h */; };
@@ -6008,8 +6007,6 @@
 		93B631E727ABA65C00443A44 /* IDBStorageManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IDBStorageManager.cpp; sourceTree = "<group>"; };
 		93B631EA27ABA6B200443A44 /* IDBStorageRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IDBStorageRegistry.cpp; sourceTree = "<group>"; };
 		93B631EB27ABA6B300443A44 /* IDBStorageRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IDBStorageRegistry.h; sourceTree = "<group>"; };
-		93B631EE27ABACA800443A44 /* QuotaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = QuotaManager.cpp; sourceTree = "<group>"; };
-		93B631EF27ABACA900443A44 /* QuotaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QuotaManager.h; sourceTree = "<group>"; };
 		93B631F227ABAD7F00443A44 /* QuotaIncreaseRequestIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QuotaIncreaseRequestIdentifier.h; sourceTree = "<group>"; };
 		93BA04DA2151ADF3007F455F /* WebSWServerConnection.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebSWServerConnection.messages.in; sourceTree = "<group>"; };
 		93BA04DB2151ADF3007F455F /* WebSWServerToContextConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSWServerToContextConnection.h; sourceTree = "<group>"; };
@@ -11601,8 +11598,6 @@
 				3AE104BE29CBC8BB00661165 /* OriginQuotaManager.h */,
 				93085DC526E1C6CF000EC6A7 /* OriginStorageManager.cpp */,
 				93085DC626E1C6CF000EC6A7 /* OriginStorageManager.h */,
-				93B631EE27ABACA800443A44 /* QuotaManager.cpp */,
-				93B631EF27ABACA900443A44 /* QuotaManager.h */,
 				3A7D62D329D38DD300D57DAC /* ServiceWorkerStorageManager.cpp */,
 				3A7D62D429D38DD300D57DAC /* ServiceWorkerStorageManager.h */,
 				93E799CC2760497B0074008A /* SessionStorageManager.cpp */,
@@ -14519,7 +14514,6 @@
 				1A0C227E2451130A00ED614D /* QuickLookThumbnailingSoftLink.h in Headers */,
 				1AEE57252409F142002005D6 /* QuickLookThumbnailLoader.h in Headers */,
 				93B631F327ABAD8000443A44 /* QuotaIncreaseRequestIdentifier.h in Headers */,
-				93B631F127ABACA900443A44 /* QuotaManager.h in Headers */,
 				5CB6AE442609799C00B6ED5A /* ReasonSPI.h in Headers */,
 				7BE9326327F5C75A00D5FEFB /* ReceiverMatcher.h in Headers */,
 				950FECF4285027200002DE4E /* RecurringPaymentRequest.h in Headers */,


### PR DESCRIPTION
#### 781b9f59f164fdfb902bdbbe5c67f6472a2b8a0f
<pre>
Make data eviction based on user interaction time when ITP is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=255272">https://bugs.webkit.org/show_bug.cgi?id=255272</a>

Reviewed by Youenn Fablet.

Revamp data eviction from exceeding total quota. The major changes:
1. NetworkStorageManager tracks total usage and performs eviction by itself instead of relying on NetworkQuotaManager;
this is because NetworkStorageManager has a list of origins that are being used (m_originStorageManagers) and it&apos;s more
convenient to do operation on OriginStorageManager from NetworkStorageManager.
2. NetworkStorageManager uses how much space is granted to all origins as estimated total usage. It only calculates the
real usage when estimated usage is bigger than quota, and then uses real usage to decide if eviction is needed.
3. When ITP is enabled, NetworkStorageManager decides the eviction order of origins based on interaction time from ITP;
when ITP is not enabled, NetworkStorageManager decides the order based on last modification time of storage files or
directories.
4. NetworkStorageManager will update last modification time of storage files or directories of an origin when it is
granted space.

API test: WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithResourceLoadStatisticsEnabled

* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.cpp:
(WebKit::ResourceLoadStatisticsDatabaseStore::allDomainsWithLastAccessedTime const):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::registrableDomainsWithLastAccessedTime):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::registrableDomainsWithLastAccessedTime):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::createNetworkStorageManager):
(WebKit::NetworkSession::NetworkSession):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::create):
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::writeOriginToFileIfNecessary):
(WebKit::NetworkStorageManager::spaceGrantedForOrigin):
(WebKit::NetworkStorageManager::schedulePerformEviction):
(WebKit::NetworkStorageManager::prepareForEviction):
(WebKit::NetworkStorageManager::lastModificationTimeForOrigin const):
(WebKit::NetworkStorageManager::donePrepareForEviction):
(WebKit::NetworkStorageManager::performEviction):
(WebKit::NetworkStorageManager::originStorageManager):
(WebKit::NetworkStorageManager::updateLastModificationTimeForOrigin):
(WebKit::NetworkStorageManager::quotaManager): Deleted.
(WebKit::NetworkStorageManager::updateOriginModificationTime): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp:
(WebKit::OriginQuotaManager::create):
(WebKit::OriginQuotaManager::OriginQuotaManager):
(WebKit::OriginQuotaManager::usage):
(WebKit::OriginQuotaManager::grantWithCurrentQuota):
(WebKit::OriginQuotaManager::spaceGranted):
(WebKit::OriginQuotaManager::grantFastPath):
(WebKit::OriginQuotaManager::usageUpdated): Deleted.
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h:
(WebKit::OriginQuotaManager::create):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::createQuotaManager):
(WebKit::OriginStorageManager::OriginStorageManager):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262900@main">https://commits.webkit.org/262900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ccff0705765ebad640333ed0c15d90acfcf307b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2935 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4340 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2571 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2963 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3342 "2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4132 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2466 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2656 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3877 "261 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2408 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2608 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/731 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2825 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->