### PR TITLE
REGRESSION (261912@main): [macOS WK2] imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-035.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1710,8 +1710,6 @@ webkit.org/b/245010 imported/w3c/web-platform-tests/html/browsers/browsing-the-w
 
 webkit.org/b/245140 http/wpt/webrtc/video-script-transform-keyframe-only.html [ Pass Failure ]
 
-webkit.org/b/254745 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-035.html [ Pass ImageOnlyFailure ]
-
 # Will pass once accelerated drawing is enabled on macOS tests.
 webkit.org/b/246285 compositing/canvas/accelerated-canvas-compositing-size-limit.html [ Failure ]
 


### PR DESCRIPTION
#### ad969c4574b63f2db67a03018ff1f3c41dbe80d6
<pre>
REGRESSION (261912@main): [macOS WK2] imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-035.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=254745">https://bugs.webkit.org/show_bug.cgi?id=254745</a>
rdar://107423870

Reviewed by Dean Jackson.

Whether we show the elapsed or remaining time label to the right of the scrubber depends on the visibility of the elapsed time label.
Showing the remaining time label will show the &quot;-&quot; symbol prior to the duration while the elapsed time label will not.

To determine whether the elapsed time label should show, we run an &quot;ideal&quot; layout. However, we would account for the existing
state of the elapsed time label&apos;s visibility to determine whether to show the elapsed or remaining time label, whereas an ideal
layout should always assume we&apos;d manage to show the elapsed time label.

We re-organize the code to make _performIdealLayout() not account for any elapsed time label visibility state and refactor
the code that performs the layout of the scrubber and time label to the right of the scrubber (duration or remaining) in
a specific _performLayoutWithRightTimeLabel() method which will take in an explicit label parameter.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Modules/modern-media-controls/controls/time-control.js:
(TimeControl.prototype.get minimumWidth):
(TimeControl.prototype.get idealMinimumWidth):
(TimeControl.prototype.layout):
(TimeControl.prototype.get _scrubberMargin):
(TimeControl.prototype._performIdealLayout):
(TimeControl.prototype._performLayoutWithRightTimeLabel):

Canonical link: <a href="https://commits.webkit.org/262829@main">https://commits.webkit.org/262829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5e61f44a61c8a5f42af56912a6c1d02e76c2920

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3071 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2377 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3875 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2258 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2784 "Built successfully") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2418 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3626 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2450 "Passed tests") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2232 "5 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2402 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2444 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/319 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->