### PR TITLE
[iOS] Pan gestures immediately after tap do not scroll a page with an unresponsive viewport

### DIFF
--- a/LayoutTests/fast/events/touch/ios/swipe-after-tap-scrolls-web-view-in-non-responsive-viewport-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/swipe-after-tap-scrolls-web-view-in-non-responsive-viewport-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that a pan gesture that immediately follows a tap still results in the web view being scrolled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Observed scrolling after a tap
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/touch/ios/swipe-after-tap-scrolls-web-view-in-non-responsive-viewport.html
+++ b/LayoutTests/fast/events/touch/ios/swipe-after-tap-scrolls-web-view-in-non-responsive-viewport.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<meta name="viewport" content="width=500">
+<head>
+<script src="../../../../resources/ui-helper.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+<style>
+html, body {
+    margin: 0;
+    height: 10000px;
+}
+
+#console {
+    position: fixed;
+}
+</style>
+</head>
+<body>
+<div id="console"></div>
+<script>
+jsTestIsAsync = true;
+description("This test verifies that a pan gesture that immediately follows a tap still results in the web view being scrolled.");
+
+let handledClick;
+document.body.addEventListener("click", () => handledClick = true);
+
+async function attemptTest() {
+    scrollTo(0, 0);
+    handledClick = false;
+
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(100, 100)
+        .wait(0.1)
+        .end()
+        .takeResult());
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(250, 800)
+        .move(250, 50, 0.25)
+        .end()
+        .takeResult());
+
+    await UIHelper.ensureStablePresentationUpdate();
+    return handledClick && pageYOffset > 0;
+}
+
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    const maximumNumberOfAttempts = 10;
+    for (let i = 0; i < maximumNumberOfAttempts; ++i) {
+        if (await attemptTest()) {
+            testPassed("Observed scrolling after a tap");
+            finishJSTest();
+            return;
+        }
+    }
+    testFailed(`Failed ${maximumNumberOfAttempts} attempts to scroll after tapping`);
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2566,6 +2566,9 @@ static inline bool isSamePair(UIGestureRecognizer *a, UIGestureRecognizer *b, UI
         return ![self shouldDeferGestureDueToImageAnalysis:gestureRecognizer];
 #endif
 
+    if (gestureRecognizer == _singleTapGestureRecognizer && [otherGestureRecognizer isKindOfClass:UIPanGestureRecognizer.class])
+        return YES;
+
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _highlightLongPressGestureRecognizer.get(), _longPressGestureRecognizer.get()))
         return YES;
 


### PR DESCRIPTION
#### f9672dbf09d92cbcc1ce47ee959a7ff55ed27f9e
<pre>
[iOS] Pan gestures immediately after tap do not scroll a page with an unresponsive viewport
<a href="https://bugs.webkit.org/show_bug.cgi?id=255300">https://bugs.webkit.org/show_bug.cgi?id=255300</a>
rdar://106010038

Reviewed by Megan Gardner.

Currently, in a page with an unresponsive viewport, attempting to scroll the web view with a pan
gesture immediately after performing a tap does not actually result in any scrolling, since the
scroll view&apos;s pan gesture recognizer does not begin. This happens because while the pan gesture is
immediately reset to `Possible` state after the tap, it then transitions to `Failed` state right
away when subsequently panning the web view, since it&apos;s excluded by the synthetic tap (single click)
gesture which is still in `Ended` state because it hasn&apos;t been reset yet (due to the double click
gesture still being `Possible`).

To avoid this, we allow both the synthetic tap gesture to recognize simultaneously alongside pan
gestures by adding logic to `-gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:`.
This means that instead of transitioning to `Failed` state right away when panning the web view, we
instead remain in `Possible` state, which then allows us to recognize the gesture if the user begins
to actually pan the view.

Test: fast/events/touch/ios/swipe-after-tap-scrolls-web-view-in-non-responsive-viewport.html

* LayoutTests/fast/events/touch/ios/swipe-after-tap-scrolls-web-view-in-non-responsive-viewport-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/swipe-after-tap-scrolls-web-view-in-non-responsive-viewport.html: Added.

Add a layout test to exercise the fix. This test preemptively tries to mitigate any potential
flakiness as a result of either the tap or swipe gesture not getting recognized by automatically
retrying itself several times, until it&apos;s successful.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):

Canonical link: <a href="https://commits.webkit.org/262853@main">https://commits.webkit.org/262853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da4d5052ba2169cca1cee22d99c1d639f72f6628

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4189 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3130 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2444 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3962 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2328 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3711 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2852 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/693 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2503 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2667 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->