### PR TITLE
Pull back some upstream css-backgrounds changes based on WPT team review

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-image-repeat-space-8.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-image-repeat-space-8.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://www.w3.org/TR/css3-background/#the-border-image-repeat">
 <link rel="match" href="border-image-repeat-space-8-ref.html">
 <meta name="assert" content="An explicit 'border-image-width' which is exactly the same size as 'border-width' should render the same as 'border-image-width:1' (the initial value).">
-<meta name="fuzzy" content="maxDifference=110; totalPixels=10540" />
+<meta name="fuzzy" content="maxDifference=0-110; totalPixels=0-10540" />
 
 <style>
   div {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-image-space-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-image-space-001.html
@@ -6,7 +6,7 @@
   <link rel="author" title="Levi Weintraub" href="mailto:leviw@chromium.org">
   <link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-image-repeat">
   <meta name="assert" content="border-image-repeat: space property spaces out background image that doesn't fit an even number of times.">
-  <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-3895">
+  <meta name="fuzzy" content="maxDifference=0-80; totalPixels=0-1728">
   <link rel="match" href="reference/border-image-space-001-ref.html">
   <style>
    .borderContainer {


### PR DESCRIPTION
#### 893e62e7ce3b46b03b3be8f47236f481fe817e6a
<pre>
Pull back some upstream css-backgrounds changes based on WPT team review
<a href="https://bugs.webkit.org/show_bug.cgi?id=255301">https://bugs.webkit.org/show_bug.cgi?id=255301</a>

Reviewed by Tim Nguyen.

Revert the very wide fuzzy factor added in <a href="https://commits.webkit.org/262031@main">https://commits.webkit.org/262031@main</a>, and correct
a new fuzzy factor based on feedback from the WPT project reviewers.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-image-repeat-space-8.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-image-space-001.html:

Canonical link: <a href="https://commits.webkit.org/262881@main">https://commits.webkit.org/262881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/397455ec533c3de9ec4fa1233ec85d5199af04c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3126 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2441 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3960 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2460 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2325 "18 flakes 168 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3708 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2848 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2284 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2463 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/719 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->