### PR TITLE
HTML fast parser fails to parse complex HTML entities

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1063,9 +1063,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     html/forms/FileIconLoader.h
 
-    html/parser/ParsingUtilities.h
+    html/parser/HTMLDocumentParserFastPath.h
     html/parser/HTMLParserIdioms.h
     html/parser/HTMLParserScriptingFlagPolicy.h
+    html/parser/ParsingUtilities.h
 
     html/track/AudioTrack.h
     html/track/AudioTrackClient.h

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -69,7 +69,7 @@ public:
     void parserRemoveChild(Node&);
     void parserInsertBefore(Node& newChild, Node& refChild);
 
-    void removeChildren();
+    WEBCORE_EXPORT void removeChildren();
 
     void takeAllChildrenFrom(ContainerNode*);
 

--- a/Source/WebCore/dom/DocumentFragment.h
+++ b/Source/WebCore/dom/DocumentFragment.h
@@ -31,7 +31,7 @@ namespace WebCore {
 class DocumentFragment : public ContainerNode {
     WTF_MAKE_ISO_ALLOCATED(DocumentFragment);
 public:
-    static Ref<DocumentFragment> create(Document&);
+    WEBCORE_EXPORT static Ref<DocumentFragment> create(Document&);
 
     void parseHTML(const String&, Element& contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
     bool parseXML(const String&, Element* contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -696,17 +696,17 @@ private:
             out.append(0xa0);
         else {
             // This handles uncommon named references.
-            String inputString { reference.data(), static_cast<unsigned>(reference.size()) };
-            SegmentedString inputSegmented { inputString };
+            // We need +1 to include the trailing semicolon. Without it, the HTMLEntityParser would think
+            // the input is incomplete and would fail parsing.
+            String inputString { reference.data(), static_cast<unsigned>(reference.size() + 1) };
+            SegmentedString inputSegmented { WTFMove(inputString) };
             bool notEnoughCharacters = false;
             if (!consumeHTMLEntity(inputSegmented, out, notEnoughCharacters) || notEnoughCharacters)
                 return didFail(HTMLFastPathResult::FailedParsingCharacterReference);
             // consumeHTMLEntity() may not have consumed all the input.
             if (auto remainingLength = inputSegmented.length()) {
-                if (*(m_parsingBuffer.position() - 1) == ';')
-                    m_parsingBuffer.setPosition(m_parsingBuffer.position() - remainingLength - 1);
-                else
-                    m_parsingBuffer.setPosition(m_parsingBuffer.position() - remainingLength);
+                ASSERT(*(m_parsingBuffer.position() - 1) == ';');
+                m_parsingBuffer.setPosition(m_parsingBuffer.position() - remainingLength);
             }
         }
     }

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
@@ -41,7 +41,7 @@ class Element;
 
 enum class ParserContentPolicy : uint8_t;
 
-bool tryFastParsingHTMLFragment(const String& source, Document&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy>);
+WEBCORE_EXPORT bool tryFastParsingHTMLFragment(const String& source, Document&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy>);
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/parser/HTMLEntityParser.cpp
+++ b/Source/WebCore/html/parser/HTMLEntityParser.cpp
@@ -79,7 +79,7 @@ public:
             consumedCharacters.append(cc);
             source.advancePastNonNewline();
         }
-        notEnoughCharacters = source.isEmpty();
+        notEnoughCharacters = source.isEmpty() && cc != ';';
         if (notEnoughCharacters) {
             // We can't decide on an entity because there might be a longer entity
             // that we could match if we had more data.

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
@@ -26,14 +26,18 @@
 #include "config.h"
 
 #include "Test.h"
+#include <WebCore/DocumentFragment.h>
+#include <WebCore/FragmentScriptingPermission.h>
 #include <WebCore/HTMLBodyElement.h>
 #include <WebCore/HTMLDivElement.h>
 #include <WebCore/HTMLDocument.h>
+#include <WebCore/HTMLDocumentParserFastPath.h>
 #include <WebCore/HTMLHtmlElement.h>
 #include <WebCore/HTMLInputElement.h>
 #include <WebCore/HTMLParserIdioms.h>
 #include <WebCore/ProcessWarming.h>
 #include <WebCore/Settings.h>
+#include <WebCore/Text.h>
 #include <wtf/text/WTFString.h>
 
 using namespace WebCore;
@@ -194,6 +198,39 @@ TEST(WebCoreHTMLParser, HTMLInputElementCheckedState)
     auto inputElement = downcast<HTMLInputElement>(div2->firstChild());
     ASSERT_TRUE(inputElement);
     EXPECT_TRUE(inputElement->checked());
+}
+
+TEST(WebCoreHTMLParser, FastPathComplexHTMLEntityParsing)
+{
+    ProcessWarming::initializeNames();
+
+    auto settings = Settings::create(nullptr);
+    auto document = HTMLDocument::create(nullptr, settings.get(), aboutBlankURL());
+    auto documentElement = HTMLHtmlElement::create(document);
+    document->appendChild(documentElement);
+    auto body = HTMLBodyElement::create(document);
+    documentElement->appendChild(body);
+
+    auto div = HTMLDivElement::create(document);
+    document->body()->appendChild(div);
+
+    auto fragment = DocumentFragment::create(document);
+    bool result = tryFastParsingHTMLFragment("Price: 12&cent; only"_s, document, fragment, div, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    EXPECT_TRUE(result);
+
+    auto textChild = dynamicDowncast<Text>(fragment->firstChild());
+    ASSERT_TRUE(textChild);
+
+    EXPECT_STREQ(textChild->data().utf8().data(), String::fromUTF8("Price: 12¢ only").utf8().data());
+
+    fragment->removeChildren();
+    result = tryFastParsingHTMLFragment("Genius Nicer Dicer Plus | 18&nbsp&hellip;"_s, document, fragment, div, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    EXPECT_TRUE(result);
+
+    textChild = dynamicDowncast<Text>(fragment->firstChild());
+    ASSERT_TRUE(textChild);
+
+    EXPECT_STREQ(textChild->data().utf8().data(), String::fromUTF8("Genius Nicer Dicer Plus | 18 …").utf8().data());
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 2e3b48b25a4dbd440e4688ba2ef9dbddc0c6b788
<pre>
HTML fast parser fails to parse complex HTML entities
<a href="https://bugs.webkit.org/show_bug.cgi?id=255302">https://bugs.webkit.org/show_bug.cgi?id=255302</a>

Reviewed by Ryosuke Niwa.

When trying to parse a non-trivial HTML entity such as `&amp;cent;`, the fast HTML
parser would call `consumeHTMLEntity()` with the string &quot;cent&quot;. This would
always fail `notEnoughCharacters` would be set to true. This is because our
parser currently requires data after the HTML entity to make sure we reached
the end of the entity.

To address the issue, the HTML fast parser now includes the trailing semicolon
when calling `consumeHTMLEntity()`. We now pass the string &quot;cent;&quot; for example.
I also tweaked the HTMLEntityParser to not fail with `notEnoughCharacters` if
the last character was a semicolon. In this case, it is safe to assume the
entity was complete, even though we don&apos;t know what comes next in the stream.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/DocumentFragment.h:
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanHTMLCharacterReference):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.h:
* Source/WebCore/html/parser/HTMLEntityParser.cpp:
(WebCore::HTMLEntityParser::consumeNamedEntity):
* Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262856@main">https://commits.webkit.org/262856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db837f7afbc590c1ff81ebb6731723252a76749e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4207 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2460 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3983 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/730 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2346 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3734 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2878 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2296 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2489 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2519 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->