### PR TITLE
[UI-side compositing] Have RemoteScrollbarsController keep track of scrollbar visibility for hit testing

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -41,6 +41,7 @@
 #include "RenderLayerCompositor.h"
 #include "RenderView.h"
 #include "ScrollAnimator.h"
+#include "ScrollbarsController.h"
 #include "ScrollingConstraints.h"
 #include "ScrollingStateFixedNode.h"
 #include "ScrollingStateFrameHostingNode.h"
@@ -1191,6 +1192,16 @@ bool AsyncScrollingCoordinator::scrollAnimatorEnabled() const
         return false;
     auto& settings = localMainFrame->settings();
     return settings.scrollAnimatorEnabled();
+}
+
+void AsyncScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID nodeID, ScrollbarOrientation orientation, bool isVisible)
+{
+    auto* frameView = frameViewForScrollingNode(nodeID);
+    if (!frameView)
+        return;
+    
+    if (auto* scrollableArea = frameView->scrollableAreaForScrollingNodeID(nodeID))
+        scrollableArea->scrollbarsController().setScrollbarVisibilityState(orientation, isVisible);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -75,6 +75,7 @@ public:
     
     WEBCORE_EXPORT void setMouseIsOverContentArea(ScrollableArea&, bool) override;
     WEBCORE_EXPORT void setMouseMovedInContentArea(ScrollableArea&) override;
+    WEBCORE_EXPORT void scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID, ScrollbarOrientation, bool);
 
 protected:
     WEBCORE_EXPORT AsyncScrollingCoordinator(Page*);

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -242,6 +242,7 @@ public:
 
     WEBCORE_EXPORT Seconds frameDuration();
     WEBCORE_EXPORT Seconds maxAllowableRenderingUpdateDurationForSynchronization();
+    WEBCORE_EXPORT virtual void scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID, ScrollbarOrientation, bool) { };
     
 protected:
     WEBCORE_EXPORT WheelEventHandlingResult handleWheelEventWithNode(const PlatformWheelEvent&, OptionSet<WheelEventProcessingSteps>, ScrollingTreeNode*, EventTargeting = EventTargeting::Propagate);

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -492,6 +492,11 @@ ScrollPropagationInfo ScrollingTreeScrollingNode::computeScrollPropagation(const
     return propagation;
 }
 
+void ScrollingTreeScrollingNode::scrollbarVisibilityDidChange(ScrollbarOrientation orientation, bool isVisible)
+{
+    scrollingTree().scrollingTreeNodeScrollbarVisibilityDidChange(scrollingNodeID(), orientation, isVisible);
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -132,6 +132,8 @@ public:
     OverscrollBehavior verticalOverscrollBehavior() const { return m_scrollableAreaParameters.verticalOverscrollBehavior; }
     
     virtual String scrollbarStateForOrientation(ScrollbarOrientation) const { return ""_s; }
+    
+    void scrollbarVisibilityDidChange(ScrollbarOrientation, bool);
 
 protected:
     ScrollingTreeScrollingNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -66,11 +66,12 @@ public:
     String scrollbarState() const;
     
     void mouseEnteredScrollbar();
-    void mouseExitedScrollbar();
-    
+    void mouseExitedScrollbar();    
     void setLastKnownMousePositionInScrollbar(IntPoint position) { m_lastKnownMousePositionInScrollbar = position; }
     IntPoint lastKnownMousePositionInScrollbar() const;
+    void visibilityChanged(bool);
 private:
+    bool m_isVisible { false };
     ScrollerPairMac& m_pair;
     const ScrollbarOrientation m_orientation;
     IntPoint m_lastKnownMousePositionInScrollbar;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -28,14 +28,14 @@
 
 #if PLATFORM(MAC)
 
+#import "FloatPoint.h"
+#import "IntRect.h"
+#import "NSScrollerImpDetails.h"
+#import "PlatformWheelEvent.h"
 #import "ScrollTypesMac.h"
 #import "ScrollerPairMac.h"
 #import "ScrollingTreeScrollingNode.h"
 #import <QuartzCore/CALayer.h>
-#import <WebCore/FloatPoint.h>
-#import <WebCore/IntRect.h>
-#import <WebCore/NSScrollerImpDetails.h>
-#import <WebCore/PlatformWheelEvent.h>
 #import <pal/spi/mac/NSScrollerImpSPI.h>
 #import <wtf/BlockObjCExceptions.h>
 
@@ -233,6 +233,7 @@ enum class FeatureToAnimate {
         return;
 
     ASSERT_UNUSED(scrollerImp, scrollerImp == _scroller->scrollerImp());
+    _scroller->visibilityChanged(newKnobAlpha > 0);
     [self setUpAlphaAnimation:_knobAlphaAnimation featureToAnimate:FeatureToAnimate::KnobAlpha animateAlphaTo:newKnobAlpha duration:duration];
 }
 
@@ -412,6 +413,14 @@ IntPoint ScrollerMac::lastKnownMousePositionInScrollbar() const
     if (!m_pair.mouseInContentArea())
         return { -1, -1 };
     return m_lastKnownMousePositionInScrollbar;
+}
+
+void ScrollerMac::visibilityChanged(bool isVisible)
+{
+    if (m_isVisible == isVisible)
+        return;
+    m_isVisible = isVisible;
+    m_pair.node().scrollbarVisibilityDidChange(m_orientation, isVisible);
 }
 
 String ScrollerMac::scrollbarState() const

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -110,6 +110,7 @@ public:
     ScrollingTreeScrollingNode& node() const { return m_scrollingNode; }
     
     bool mouseInContentArea() const { return m_mouseInContentArea; }
+
 private:
     ScrollerPairMac(ScrollingTreeScrollingNode&);
 

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -412,4 +412,12 @@ template<> struct EnumTraits<WebCore::ScrollDirection> {
         WebCore::ScrollDirection::ScrollRight
     >;
 };
+
+template<> struct EnumTraits<WebCore::ScrollbarOrientation> {
+    using values = EnumValues<
+        WebCore::ScrollbarOrientation,
+        WebCore::ScrollbarOrientation::Horizontal,
+        WebCore::ScrollbarOrientation::Vertical
+    >;
+};
 } // namespace WTF

--- a/Source/WebCore/platform/ScrollbarsController.h
+++ b/Source/WebCore/platform/ScrollbarsController.h
@@ -35,6 +35,7 @@ namespace WebCore {
 class Scrollbar;
 class ScrollableArea;
 class ScrollingCoordinator;
+enum class ScrollbarOrientation : uint8_t;
 
 class ScrollbarsController {
     WTF_MAKE_FAST_ALLOCATED;
@@ -90,6 +91,8 @@ public:
 
     WEBCORE_EXPORT virtual String horizontalScrollbarStateForTesting() const { return emptyString(); }
     WEBCORE_EXPORT virtual String verticalScrollbarStateForTesting() const { return emptyString(); }
+    
+    WEBCORE_EXPORT virtual void setScrollbarVisibilityState(ScrollbarOrientation, bool) { }
 
 private:
     ScrollableArea& m_scrollableArea;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -777,6 +777,7 @@ def headers_for_type(type):
         'WebCore::ScriptExecutionContextIdentifier': ['<WebCore/ProcessQualified.h>', '<WebCore/ScriptExecutionContextIdentifier.h>', '<wtf/ObjectIdentifier.h>'],
         'WebCore::ScrollGranularity': ['<WebCore/ScrollTypes.h>'],
         'WebCore::ScrollPinningBehavior': ['<WebCore/ScrollTypes.h>'],
+        'WebCore::ScrollbarOrientation': ['<WebCore/ScrollTypes.h>'],
         'WebCore::SecurityPolicyViolationEventInit': ['<WebCore/SecurityPolicyViolationEvent.h>'],
         'WebCore::SelectionDirection': ['<WebCore/VisibleSelection.h>'],
         'WebCore::SelectionGeometry': ['"EditorState.h"'],

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -716,8 +716,8 @@ WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm @no-unify
+WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
-WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.cpp
 
 // Derived Sources
 GPUConnectionToWebProcessMessageReceiver.cpp

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -434,6 +434,11 @@ bool RemoteScrollingCoordinatorProxy::scrollingPerformanceTestingEnabled() const
     return m_scrollingTree->scrollingPerformanceTestingEnabled();
 }
 
+void RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID nodeID, ScrollbarOrientation orientation, bool isVisible)
+{
+    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarVisibilityDidChange(nodeID, orientation, isVisible));
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -160,6 +160,8 @@ public:
     bool overlayScrollbarsEnabled();
 
     void sendScrollingTreeNodeDidScroll();
+    
+    void scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, bool);
 
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -46,6 +46,8 @@ public:
     explicit RemoteScrollingTreeMac(RemoteScrollingCoordinatorProxy&);
     virtual ~RemoteScrollingTreeMac();
 
+    void scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID, ScrollbarOrientation, bool) override;
+
 private:
     void handleWheelEventPhase(WebCore::ScrollingNodeID, WebCore::PlatformWheelEventPhase) override;
     RefPtr<WebCore::ScrollingTreeNode> scrollingNodeForPoint(WebCore::FloatPoint) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -458,6 +458,14 @@ OptionSet<EventListenerRegionType> RemoteScrollingTreeMac::eventListenerRegionTy
 }
 #endif
 
+void RemoteScrollingTreeMac::scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID nodeID, ScrollbarOrientation orientation, bool isVisible)
+{
+    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, orientation, isVisible] {
+        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+            scrollingCoordinatorProxy->scrollingTreeNodeScrollbarVisibilityDidChange(nodeID, orientation, isVisible);
+    });
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3223,7 +3223,7 @@
 		1ABC3DF41899E437004F0626 /* NavigationState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NavigationState.h; sourceTree = "<group>"; };
 		1ABC3DFB1899F51C004F0626 /* WKNavigationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKNavigationDelegate.h; sourceTree = "<group>"; };
 		1ABF43791A368050003FB0E6 /* WebsiteDataType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebsiteDataType.h; sourceTree = "<group>"; };
-		1AC009E129E0E28A00E696C4 /* RemoteScrollbarsController.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteScrollbarsController.cpp; sourceTree = "<group>"; };
+		1AC009E129E0E28A00E696C4 /* RemoteScrollbarsController.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = RemoteScrollbarsController.mm; sourceTree = "<group>"; };
 		1AC009E229E0E28B00E696C4 /* RemoteScrollbarsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollbarsController.h; sourceTree = "<group>"; };
 		1AC0273E196622D600C12B75 /* WebPageProxyCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPageProxyCocoa.mm; sourceTree = "<group>"; };
 		1AC1336518565B5700F3EC05 /* UserData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserData.cpp; sourceTree = "<group>"; };
@@ -9048,8 +9048,8 @@
 				2D29ECCF192F2C2E00984B78 /* RemoteLayerTreeDisplayRefreshMonitor.mm */,
 				1AB16ADC1648598400290D62 /* RemoteLayerTreeDrawingArea.h */,
 				1AB16ADB1648598400290D62 /* RemoteLayerTreeDrawingArea.mm */,
-				1AC009E129E0E28A00E696C4 /* RemoteScrollbarsController.cpp */,
 				1AC009E229E0E28B00E696C4 /* RemoteScrollbarsController.h */,
+				1AC009E129E0E28A00E696C4 /* RemoteScrollbarsController.mm */,
 				0F59478D187B3B3A00437857 /* RemoteScrollingCoordinator.h */,
 				0F59478E187B3B3A00437857 /* RemoteScrollingCoordinator.messages.in */,
 				0F59478F187B3B3A00437857 /* RemoteScrollingCoordinator.mm */,

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(MAC)
 
+#include <WebCore/NSScrollerImpDetails.h>
 #include <WebCore/ScrollbarsController.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -35,7 +36,6 @@ class ScrollingCoordinator;
 class Scrollbar;
 
 namespace WebKit {
-
 
 class RemoteScrollbarsController final : public WebCore::ScrollbarsController {
 public:
@@ -46,8 +46,13 @@ public:
     void mouseMovedInContentArea() final;
     void mouseEnteredScrollbar(WebCore::Scrollbar*) const final;
     void mouseExitedScrollbar(WebCore::Scrollbar*) const final;
+    bool shouldScrollbarParticipateInHitTesting(WebCore::Scrollbar*) final;
+    
+    void setScrollbarVisibilityState(ScrollbarOrientation, bool) final;
 
 private:
+    bool m_horizontalOverlayScrollbarIsVisible { false };
+    bool m_verticalOverlayScrollbarIsVisible { false };
     ThreadSafeWeakPtr<WebCore::ScrollingCoordinator> m_coordinator;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -30,6 +30,7 @@
 
 #include <WebCore/ScrollableArea.h>
 #include <WebCore/ScrollingCoordinator.h>
+#include <pal/spi/mac/NSScrollerImpSPI.h>
 
 namespace WebKit {
 
@@ -67,6 +68,23 @@ void RemoteScrollbarsController::mouseExitedScrollbar(WebCore::Scrollbar* scroll
 {
     if (auto scrollingCoordinator = m_coordinator.get())
         scrollingCoordinator->setMouseIsOverScrollbar(scrollbar, false);
+}
+
+bool RemoteScrollbarsController::shouldScrollbarParticipateInHitTesting(WebCore::Scrollbar* scrollbar)
+{
+    // Non-overlay scrollbars should always participate in hit testing.    
+    ASSERT(scrollbar->isOverlayScrollbar());
+
+    // Overlay scrollbars should participate in hit testing whenever they are at all visible.
+    return scrollbar->orientation() == ScrollbarOrientation::Horizontal ? m_horizontalOverlayScrollbarIsVisible :  m_verticalOverlayScrollbarIsVisible;
+}
+
+void RemoteScrollbarsController::setScrollbarVisibilityState(ScrollbarOrientation orientation, bool isVisible)
+{
+    if (orientation == ScrollbarOrientation::Horizontal)
+        m_horizontalOverlayScrollbarIsVisible = isVisible;
+    else
+        m_verticalOverlayScrollbarIsVisible = isVisible;
 }
 
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -96,6 +96,7 @@ private:
     void receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase);
     void startDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
     void stopDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
+    void scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, bool);
 
     WebCore::WheelEventHandlingResult handleWheelEventForScrolling(const WebCore::PlatformWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>) override;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
@@ -31,6 +31,7 @@ messages -> RemoteScrollingCoordinator {
     ReceivedWheelEventWithPhases(enum:uint8_t WebCore::PlatformWheelEventPhase phase, enum:uint8_t WebCore::PlatformWheelEventPhase momentumPhase);
     StartDeferringScrollingTestCompletionForNode(uint64_t nodeID, WebCore::WheelEventTestMonitor::DeferReason reason);
     StopDeferringScrollingTestCompletionForNode(uint64_t nodeID, WebCore::WheelEventTestMonitor::DeferReason reason);
+    ScrollingTreeNodeScrollbarVisibilityDidChange(uint64_t nodeID, enum:uint8_t WebCore::ScrollbarOrientation orientation, bool isVisible);
 }
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -30,6 +30,7 @@
 
 #import "ArgumentCoders.h"
 #import "GraphicsLayerCARemote.h"
+#import "Logging.h"
 #import "RemoteLayerTreeDrawingArea.h"
 #import "RemoteScrollingCoordinatorMessages.h"
 #import "RemoteScrollingCoordinatorTransaction.h"
@@ -183,6 +184,11 @@ WheelEventHandlingResult RemoteScrollingCoordinator::handleWheelEventForScrollin
 
     m_currentWheelGestureInfo = NodeAndGestureState { targetNodeID, gestureState };
     return WheelEventHandlingResult::handled();
+}
+
+void RemoteScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID nodeID, WebCore::ScrollbarOrientation orientation, bool isVisible)
+{
+    AsyncScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange(nodeID, orientation, isVisible);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### a9d8f8b89517139a774a25647ffcbf0e44fc6b8c
<pre>
[UI-side compositing] Have RemoteScrollbarsController keep track of scrollbar visibility for hit testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=255303">https://bugs.webkit.org/show_bug.cgi?id=255303</a>
rdar://107859102

Reviewed by Simon Fraser.

Overlay scrollbars should only participate in hit testing when they are visible. When we do a knob alpha
animation in the UI process, send a visibility change event to the web process, notifying
RemoteScrollbarsController so it can properly report in shouldScrollbarParticipateInHitTesting
whether the scrollbar should participate in hit testing or not.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::scrollingTreeNodeScrollbarVisibilityDidChange):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::scrollbarVisibilityDidChange):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(-[WebScrollerImpDelegateMac scrollerImp:animateKnobAlphaTo:duration:]):
(WebCore::ScrollerMac::visibilityChanged):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
(WebCore::ScrollerPairMac::scrollingNode):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/ScrollbarsController.h:
(WebCore::ScrollbarsController::setScrollbarVisibilityState):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarVisibilityDidChange):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeScrollbarVisibilityDidChange):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm: Renamed from Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.cpp.
(WebKit::RemoteScrollbarsController::RemoteScrollbarsController):
(WebKit::RemoteScrollbarsController::mouseEnteredContentArea):
(WebKit::RemoteScrollbarsController::mouseExitedContentArea):
(WebKit::RemoteScrollbarsController::mouseMovedInContentArea):
(WebKit::RemoteScrollbarsController::mouseEnteredScrollbar const):
(WebKit::RemoteScrollbarsController::mouseExitedScrollbar const):
(WebKit::RemoteScrollbarsController::shouldScrollbarParticipateInHitTesting):
(WebKit::RemoteScrollbarsController::setScrollbarVisibilityState):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange):

Canonical link: <a href="https://commits.webkit.org/263004@main">https://commits.webkit.org/263004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3075b626068395cbfd2c921e6d4a7dd3c7f701ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3264 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4674 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2828 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4494 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/3289 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2900 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2817 "1 flakes 142 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4227 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2659 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2901 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2895 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/386 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->