### PR TITLE
[iOS] ASSERTION FAILED: isMainThread() under WebKit::RemoteGraphicsContextGLProxy::RemoteGraphicsContextGLProxy

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/GraphicsContextGLIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/GraphicsContextGLIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum GraphicsContextGLIdentifierType { };
-using GraphicsContextGLIdentifier = ObjectIdentifier<GraphicsContextGLIdentifierType>;
+using GraphicsContextGLIdentifier = AtomicObjectIdentifier<GraphicsContextGLIdentifierType>;
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 5df7b74b33e3d1493bae3362be2b7ae0019347bc
<pre>
[iOS] ASSERTION FAILED: isMainThread() under WebKit::RemoteGraphicsContextGLProxy::RemoteGraphicsContextGLProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=255307">https://bugs.webkit.org/show_bug.cgi?id=255307</a>
rdar://107905440

Reviewed by Matt Woodrow.

Switch GraphicsContextGLIdentifier to AtomicObjectIdentifier since new
identifiers get generated off the main thread.

* Source/WebKit/WebProcess/GPU/graphics/GraphicsContextGLIdentifier.h:

Canonical link: <a href="https://commits.webkit.org/262846@main">https://commits.webkit.org/262846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ae1ada1e5e3dfc45e2c3849bbc791de8ee2c144

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2785 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/2843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/2931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4200 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/2926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/2882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2811 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/2926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/2931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/3974 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/2926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/2931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/2926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/2931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/2859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/2882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/2931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/325 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2673 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->