### PR TITLE
Test freshness page should handle horizontal overflow.

### DIFF
--- a/Websites/perf.webkit.org/public/v3/pages/test-freshness-page.js
+++ b/Websites/perf.webkit.org/public/v3/pages/test-freshness-page.js
@@ -416,11 +416,12 @@ class TestFreshnessPage extends PageWithHeading {
     {
         return `
             .page-with-heading {
-                display: flex;
-                justify-content: center;
+                display: grid;
+                grid-template-columns: 1fr [content] min-content 1fr;
             }
             #test-health {
                 font-size: 1rem;
+                grid-column: content;
             }
             #test-health thead {
                 display: block;
@@ -431,7 +432,7 @@ class TestFreshnessPage extends PageWithHeading {
                 vertical-align: bottom;
             }
             #test-health .row-head {
-                min-width: 18.5rem;
+                min-width: 24rem;
             }
             #test-health th {
                 text-align: left;


### PR DESCRIPTION
#### 27d5d8d5eac4585716683e60660c15a04a7237bb
<pre>
Test freshness page should handle horizontal overflow.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255314">https://bugs.webkit.org/show_bug.cgi?id=255314</a>
rdar://107119770

Reviewed by Patrick Angle.

Update CSS for test freshness table so that it can handle horizontal overflow while
preserving table centering.

* Websites/perf.webkit.org/public/v3/pages/test-freshness-page.js: Update CSS for
CSS table.
(TestFreshnessPage.cssTemplate):

Canonical link: <a href="https://commits.webkit.org/262864@main">https://commits.webkit.org/262864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03778a8926953563ced6223f70e865cf920e9944

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4241 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2937 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2487 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2857 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4024 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2509 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2513 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3765 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2512 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2550 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/331 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->