### PR TITLE
[GTK][WPE] Add API to replace and retrieve the entire cookie jar

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -136,6 +136,7 @@ public:
     void setCookieObserverHandler(Function<void ()>&&);
     void getCredentialFromPersistentStorage(const ProtectionSpace&, GCancellable*, Function<void (Credential&&)>&& completionHandler);
     void saveCredentialToPersistentStorage(const ProtectionSpace&, const Credential&);
+    WEBCORE_EXPORT void replaceCookies(const Vector<Cookie>&);
 #elif USE(CURL)
     WEBCORE_EXPORT NetworkStorageSession(PAL::SessionID, const String& alternativeServicesDirectory = nullString());
     WEBCORE_EXPORT ~NetworkStorageSession();

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -84,6 +84,10 @@ private:
     void platformSetHTTPCookieAcceptPolicy(PAL::SessionID, WebCore::HTTPCookieAcceptPolicy, CompletionHandler<void()>&&);
     void getHTTPCookieAcceptPolicy(PAL::SessionID, CompletionHandler<void(WebCore::HTTPCookieAcceptPolicy)>&&);
 
+#if USE(SOUP)
+    void replaceCookies(PAL::SessionID, const Vector<WebCore::Cookie>&, CompletionHandler<void()>&&);
+#endif
+
     void startObservingCookieChanges(PAL::SessionID);
     void stopObservingCookieChanges(PAL::SessionID);
 

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in
@@ -42,6 +42,7 @@ messages -> WebCookieManager NotRefCounted {
     void StopObservingCookieChanges(PAL::SessionID sessionID)
 
 #if USE(SOUP)
+    void ReplaceCookies(PAL::SessionID sessionID, Vector<WebCore::Cookie> cookies) -> ()
     void SetCookiePersistentStorage(PAL::SessionID sessionID, String storagePath, enum:bool WebKit::SoupCookiePersistentStorageType storageType)
 #endif
 }

--- a/Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
@@ -51,4 +51,11 @@ void WebCookieManager::setCookiePersistentStorage(PAL::SessionID sessionID, cons
         static_cast<NetworkSessionSoup&>(*networkSession).setCookiePersistentStorage(storagePath, storageType);
 }
 
+void WebCookieManager::replaceCookies(PAL::SessionID sessionID, const Vector<WebCore::Cookie>& cookies, CompletionHandler<void()>&& completionHandler)
+{
+    if (auto* storageSession = m_process.storageSession(sessionID))
+        storageSession->replaceCookies(cookies);
+    completionHandler();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
@@ -83,6 +83,9 @@ public:
     void filterAppBoundCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&);
 
 #if USE(SOUP)
+    void replaceCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void()>&&);
+    void getAllCookies(CompletionHandler<void(const Vector<WebCore::Cookie>&)>&&);
+
     void setCookiePersistentStorage(const WTF::String& storagePath, WebKit::SoupCookiePersistentStorageType);
 #endif
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
@@ -517,3 +517,106 @@ void webkit_cookie_manager_delete_all_cookies(WebKitCookieManager* manager)
     webkit_website_data_manager_clear(manager->priv->dataManager, WEBKIT_WEBSITE_DATA_COOKIES, 0, nullptr, nullptr, nullptr);
 }
 #endif
+
+/**
+ * webkit_cookie_manager_replace_cookies:
+ * @cookie_manager: a #WebKitCookieManager
+ * @cookies: (element-type SoupCookie) (transfer none): a #GList of #SoupCookie to be added
+ * @cancellable: (nullable): a #GCancellable or %NULL to ignore
+ * @callback: (scope async): (closure user_data): a #GAsyncReadyCallback to call when the request is satisfied
+ * @user_data: the data to pass to callback function
+ *
+ * Asynchronously replace all cookies in @cookie_manager with the given list of @cookies.
+ *
+ * When the operation is finished, @callback will be called. You can then call
+ * webkit_cookie_manager_replace_cookies_finish() to get the result of the operation.
+ *
+ * Since: 2.42
+ */
+void webkit_cookie_manager_replace_cookies(WebKitCookieManager* manager, GList* cookies, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
+{
+    g_return_if_fail(WEBKIT_IS_COOKIE_MANAGER(manager));
+    g_return_if_fail(cookies);
+
+    Vector<WebCore::Cookie> webCookies;
+    for (GList* it = cookies; it; it = g_list_next(it))
+        webCookies.append(WebCore::Cookie(reinterpret_cast<SoupCookie*>(it->data)));
+
+    GRefPtr<GTask> task = adoptGRef(g_task_new(manager, cancellable, callback, userData));
+    manager->priv->cookieStore().replaceCookies(WTFMove(webCookies), [task = WTFMove(task)]() {
+        g_task_return_boolean(task.get(), TRUE);
+    });
+}
+
+/**
+ * webkit_cookie_manager_replace_cookies_finish:
+ * @cookie_manager: a #WebKitCookieManager
+ * @result: a #GAsyncResult
+ * @error: return location for error or %NULL to ignore
+ *
+ * Finish an asynchronous operation started with webkit_cookie_manager_replace_cookies().
+ *
+ * Returns: %TRUE if the cookies were added or %FALSE in case of error.
+ *
+ * Since: 2.42
+ */
+gboolean webkit_cookie_manager_replace_cookies_finish(WebKitCookieManager* manager, GAsyncResult* result, GError** error)
+{
+    g_return_val_if_fail(WEBKIT_IS_COOKIE_MANAGER(manager), FALSE);
+    g_return_val_if_fail(g_task_is_valid(result, manager), FALSE);
+
+    return g_task_propagate_boolean(G_TASK(result), error);
+}
+
+/**
+ * webkit_cookie_manager_get_all_cookies:
+ * @cookie_manager: a #WebKitCookieManager
+ * @cancellable: (nullable): a #GCancellable or %NULL to ignore
+ * @callback: (scope async): (closure user_data): a #GAsyncReadyCallback to call when the request is satisfied
+ * @user_data: the data to pass to callback function
+ *
+ * Asynchronously get a list of #SoupCookie from @cookie_manager.
+ *
+ * When the operation is finished, @callback will be called. You can then call
+ * webkit_cookie_manager_get_all_cookies_finish() to get the result of the operation.
+ *
+ * Since: 2.42
+ */
+void webkit_cookie_manager_get_all_cookies(WebKitCookieManager* manager, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
+{
+    g_return_if_fail(WEBKIT_IS_COOKIE_MANAGER(manager));
+
+    GRefPtr<GTask> task = adoptGRef(g_task_new(manager, cancellable, callback, userData));
+    manager->priv->cookieStore().getAllCookies([task = WTFMove(task)](const Vector<WebCore::Cookie>& cookies) {
+        GList* cookiesList = nullptr;
+        for (auto& cookie : cookies)
+            cookiesList = g_list_prepend(cookiesList, cookie.toSoupCookie());
+
+        g_task_return_pointer(task.get(), g_list_reverse(cookiesList), [](gpointer data) {
+            g_list_free_full(static_cast<GList*>(data), reinterpret_cast<GDestroyNotify>(soup_cookie_free));
+        });
+    });
+}
+
+/**
+ * webkit_cookie_manager_get_all_cookies_finish:
+ * @cookie_manager: a #WebKitCookieManager
+ * @result: a #GAsyncResult
+ * @error: return location for error or %NULL to ignore
+ *
+ * Finish an asynchronous operation started with webkit_cookie_manager_get_all_cookies().
+ *
+ * The return value is a #GSList of #SoupCookie instances which should be released
+ * with g_list_free_full() and soup_cookie_free().
+ *
+ * Returns: (element-type SoupCookie) (transfer full): A #GList of #SoupCookie instances.
+ *
+ * Since: 2.42
+ */
+GList* webkit_cookie_manager_get_all_cookies_finish(WebKitCookieManager* manager, GAsyncResult* result, GError** error)
+{
+    g_return_val_if_fail(WEBKIT_IS_COOKIE_MANAGER(manager), nullptr);
+    g_return_val_if_fail(g_task_is_valid(result, manager), nullptr);
+
+    return static_cast<GList*>(g_task_propagate_pointer(G_TASK(result), error));
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.h.in
@@ -155,6 +155,30 @@ WEBKIT_DEPRECATED_FOR(webkit_website_data_manager_clear) void
 webkit_cookie_manager_delete_all_cookies              (WebKitCookieManager          *cookie_manager);
 #endif
 
+WEBKIT_API void
+webkit_cookie_manager_replace_cookies                 (WebKitCookieManager          *cookie_manager,
+                                                       GList                        *cookies,
+                                                       GCancellable                 *cancellable,
+                                                       GAsyncReadyCallback           callback,
+                                                       gpointer                      user_data);
+
+WEBKIT_API gboolean
+webkit_cookie_manager_replace_cookies_finish          (WebKitCookieManager          *cookie_manager,
+                                                       GAsyncResult                 *result,
+                                                       GError                      **error);
+
+WEBKIT_API void
+webkit_cookie_manager_get_all_cookies                 (WebKitCookieManager          *cookie_manager,
+                                                       GCancellable                 *cancellable,
+                                                       GAsyncReadyCallback           callback,
+                                                       gpointer                      user_data);
+
+WEBKIT_API GList *
+webkit_cookie_manager_get_all_cookies_finish          (WebKitCookieManager          *cookie_manager,
+                                                       GAsyncResult                 *result,
+                                                       GError                      **error);
+
+
 G_END_DECLS
 
 #endif

--- a/Source/WebKit/UIProcess/API/soup/HTTPCookieStoreSoup.cpp
+++ b/Source/WebKit/UIProcess/API/soup/HTTPCookieStoreSoup.cpp
@@ -39,4 +39,20 @@ void HTTPCookieStore::setCookiePersistentStorage(const WTF::String& storagePath,
         networkProcess->send(Messages::WebCookieManager::SetCookiePersistentStorage(m_sessionID, storagePath, storageType), 0);
 }
 
+void HTTPCookieStore::replaceCookies(Vector<WebCore::Cookie>&& cookies, CompletionHandler<void()>&& completionHandler)
+{
+    if (auto* networkProcess = networkProcessIfExists())
+        networkProcess->sendWithAsyncReply(Messages::WebCookieManager::ReplaceCookies(m_sessionID, cookies), WTFMove(completionHandler));
+    else
+        completionHandler();
+}
+
+void HTTPCookieStore::getAllCookies(CompletionHandler<void(const Vector<WebCore::Cookie>&)>&& completionHandler)
+{
+    if (auto* networkProcess = networkProcessIfExists())
+        networkProcess->sendWithAsyncReply(Messages::WebCookieManager::GetAllCookies(m_sessionID), WTFMove(completionHandler));
+    else
+        completionHandler({ });
+}
+
 } // namespace API


### PR DESCRIPTION
#### 3f2a8e4ebeb1b855e6080f149fc234e5beae567b
<pre>
[GTK][WPE] Add API to replace and retrieve the entire cookie jar
<a href="https://bugs.webkit.org/show_bug.cgi?id=254987">https://bugs.webkit.org/show_bug.cgi?id=254987</a>

Reviewed by Carlos Garcia Campos, Adrian Perez de Castro and Michael Catanzaro.

Add possibility to replace and get all cookies, from each domain via new API.

* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::setCookieJar):
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::setCookieJar):
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.messages.in:
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::HTTPCookieStore::setCookieJar):
(API::HTTPCookieStore::getCookieJar):
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.h:
* Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp:
(webkit_cookie_manager_set_cookie_jar):
(webkit_cookie_manager_set_cookie_jar_finish):
(webkit_cookie_manager_get_cookie_jar):
(webkit_cookie_manager_get_cookie_jar_finish):
* Source/WebKit/UIProcess/API/glib/WebKitCookieManager.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp:
(testCookieManagerSetGetCookieJar):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/265834@main">https://commits.webkit.org/265834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a21c4f44f2048c375477ae1f94e7ac2feb14d4ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9178 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7728 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10610 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9286 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14569 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7360 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10330 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6108 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6816 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2941 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->