### PR TITLE
[WGSL] Implement comparison operator overload and codegen

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -517,12 +517,29 @@ void FunctionDefinitionWriter::visit(AST::BinaryExpression& binary)
     case AST::BinaryOperation::Xor:
     case AST::BinaryOperation::LeftShift:
     case AST::BinaryOperation::RightShift:
+        // FIXME: Implement these
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+
     case AST::BinaryOperation::Equal:
+        m_stringBuilder.append(" == ");
+        break;
     case AST::BinaryOperation::NotEqual:
+        m_stringBuilder.append(" != ");
+        break;
     case AST::BinaryOperation::GreaterThan:
+        m_stringBuilder.append(" > ");
+        break;
     case AST::BinaryOperation::GreaterEqual:
+        m_stringBuilder.append(" >= ");
+        break;
     case AST::BinaryOperation::LessThan:
+        m_stringBuilder.append(" < ");
+        break;
     case AST::BinaryOperation::LessEqual:
+        m_stringBuilder.append(" <= ");
+        break;
+
     case AST::BinaryOperation::ShortCircuitAnd:
     case AST::BinaryOperation::ShortCircuitOr:
         // FIXME: Implement these

--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -65,12 +65,16 @@ private:
     FixedVector<std::optional<ViableOverload>> considerCandidates();
     std::optional<ViableOverload> considerCandidate(const OverloadCandidate&);
     ConversionRank calculateRank(const AbstractType&, Type*);
+    ConversionRank calculateRank(const AbstractScalarType&, Type*);
     ConversionRank conversionRank(Type*, Type*) const;
 
+    bool unify(const TypeVariable*, Type*);
     bool unify(const AbstractType&, Type*);
+    bool unify(const AbstractScalarType&, Type*);
     bool assign(TypeVariable, Type*);
     Type* resolve(TypeVariable) const;
     Type* materialize(const AbstractType&) const;
+    Type* materialize(const AbstractScalarType&) const;
 
     bool unify(const AbstractValue&, unsigned);
     void assign(NumericVariable, unsigned);
@@ -158,6 +162,17 @@ Type* OverloadResolver::materialize(const AbstractType& abstractType) const
                 return m_types.matrixType(element, columns, rows);
             }
             return nullptr;
+        });
+}
+
+Type* OverloadResolver::materialize(const AbstractScalarType& abstractScalarType) const
+{
+    return WTF::switchOn(abstractScalarType,
+        [&](Type* type) -> Type* {
+            return type;
+        },
+        [&](TypeVariable variable) -> Type* {
+            return resolve(variable);
         });
 }
 
@@ -267,50 +282,66 @@ ConversionRank OverloadResolver::calculateRank(const AbstractType& parameter, Ty
     return conversionRank(argumentType, parameterType);
 }
 
+ConversionRank OverloadResolver::calculateRank(const AbstractScalarType& parameter, Type* argumentType)
+{
+    if (auto* variable = std::get_if<TypeVariable>(&parameter)) {
+        auto* resolvedType = resolve(*variable);
+        ASSERT(resolvedType);
+        return conversionRank(argumentType, resolvedType);
+    }
+
+    auto* parameterType = std::get<Type*>(parameter);
+    return conversionRank(argumentType, parameterType);
+}
+
+bool OverloadResolver::unify(const TypeVariable* variable, Type* argumentType)
+{
+    auto* resolvedType = resolve(*variable);
+    if (!resolvedType)
+        return assign(*variable, argumentType);
+
+    logLn("resolved '", *variable, "' to '", *resolvedType, "'");
+
+    // Consider the following:
+    // + :: (T, T) -> T
+    // 1 + 1u
+    //
+    // We first unify `Var(T)` with `Type(AbstractInt)`, and assign `T` to `AbstractInt`
+    // Next, we unify `Var(T) with `Type(u32)`, we look up `T => AbstractInt`,
+    //   and promote `T` to `u32`.
+    //
+    // A few more examples to illustrate it:
+    //
+    // vec3 :: (T, T, T) -> T
+    // vec3(1, 1.0, 1.0f) -> vec3<f32>
+    // 1) unify(Var(T), Type(AbstractInt); T => AbstractInt (assign)
+    // 2) unify(Var(T), Type(AbstractFloat); T => AbstractFloat (promote T)
+    // 3) unify(Var(T), Type(f32); T => f32 (promote T again)
+    //
+    // vec3 :: (T, T, T) -> T
+    // vec3(1.0, 1, 1.0f) -> vec3<f32>
+    // 1) unify(Var(T), Type(AbstractFloat); T => AbstractFloat (assign)
+    // 2) unify(Var(T), Type(AbstractInt); T => AbstractFloat (convert the argument to AbstractInt)
+    // 3) unify(Var(T), Type(f32); T => f32 (promote T)
+    //
+    // vec3 :: (T, T, T) -> T
+    // vec3(1.0, 1u, 1.0f) -> vec3<f32>
+    // 1) unify(Var(T), Type(AbstractInt); T => AbstractFloat (assign)
+    // 2) unify(Var(T), Type(u32); Failed! Can't unify AbstractFloat and u32
+    auto variablePromotionRank = conversionRank(resolvedType, argumentType);
+    auto argumentConversionRank = conversionRank(argumentType, resolvedType);
+    logLn("variablePromotionRank: ", variablePromotionRank.value(), ", argumentConversionRank: ", argumentConversionRank.value());
+    if (variablePromotionRank.value() < argumentConversionRank.value())
+        return assign(*variable, argumentType);
+
+    return !!argumentConversionRank;
+}
+
 bool OverloadResolver::unify(const AbstractType& parameter, Type* argumentType)
 {
     logLn("unify parameter type '", parameter, "' with argument '", *argumentType, "'");
-    if (auto* variable = std::get_if<TypeVariable>(&parameter)) {
-        auto* resolvedType = resolve(*variable);
-        if (!resolvedType)
-            return assign(*variable, argumentType);
-
-        logLn("resolved '", *variable, "' to '", *resolvedType, "'");
-
-        // Consider the following:
-        // + :: (T, T) -> T
-        // 1 + 1u
-        //
-        // We first unify `Var(T)` with `Type(AbstractInt)`, and assign `T` to `AbstractInt`
-        // Next, we unify `Var(T) with `Type(u32)`, we look up `T => AbstractInt`,
-        //   and promote `T` to `u32`.
-        //
-        // A few more examples to illustrate it:
-        //
-        // vec3 :: (T, T, T) -> T
-        // vec3(1, 1.0, 1.0f) -> vec3<f32>
-        // 1) unify(Var(T), Type(AbstractInt); T => AbstractInt (assign)
-        // 2) unify(Var(T), Type(AbstractFloat); T => AbstractFloat (promote T)
-        // 3) unify(Var(T), Type(f32); T => f32 (promote T again)
-        //
-        // vec3 :: (T, T, T) -> T
-        // vec3(1.0, 1, 1.0f) -> vec3<f32>
-        // 1) unify(Var(T), Type(AbstractFloat); T => AbstractFloat (assign)
-        // 2) unify(Var(T), Type(AbstractInt); T => AbstractFloat (convert the argument to AbstractInt)
-        // 3) unify(Var(T), Type(f32); T => f32 (promote T)
-        //
-        // vec3 :: (T, T, T) -> T
-        // vec3(1.0, 1u, 1.0f) -> vec3<f32>
-        // 1) unify(Var(T), Type(AbstractInt); T => AbstractFloat (assign)
-        // 2) unify(Var(T), Type(u32); Failed! Can't unify AbstractFloat and u32
-        auto variablePromotionRank = conversionRank(resolvedType, argumentType);
-        auto argumentConversionRank = conversionRank(argumentType, resolvedType);
-        logLn("variablePromotionRank: ", variablePromotionRank.value(), ", argumentConversionRank: ", argumentConversionRank.value());
-        if (variablePromotionRank.value() < argumentConversionRank.value())
-            return assign(*variable, argumentType);
-
-        return !!argumentConversionRank;
-    }
+    if (auto* variable = std::get_if<TypeVariable>(&parameter))
+        return unify(variable, argumentType);
 
     if (auto* vectorParameter = std::get_if<AbstractVector>(&parameter)) {
         auto* vectorArgument = std::get_if<Types::Vector>(argumentType);
@@ -331,6 +362,16 @@ bool OverloadResolver::unify(const AbstractType& parameter, Type* argumentType)
             return false;
         return unify(matrixParameter->rows, matrixArgument->rows);
     }
+
+    auto* parameterType = std::get<Type*>(parameter);
+    return !!conversionRank(argumentType, parameterType);
+}
+
+bool OverloadResolver::unify(const AbstractScalarType& parameter, Type* argumentType)
+{
+    logLn("unify parameter type '", parameter, "' with argument '", *argumentType, "'");
+    if (auto* variable = std::get_if<TypeVariable>(&parameter))
+        return unify(variable, argumentType);
 
     auto* parameterType = std::get<Type*>(parameter);
     return !!conversionRank(argumentType, parameterType);
@@ -514,6 +555,17 @@ void printInternal(PrintStream& out, const WGSL::AbstractType& type)
             out.print(", ");
             printInternal(out, matrix.rows);
             out.print(">");
+        });
+}
+
+void printInternal(PrintStream& out, const WGSL::AbstractScalarType& type)
+{
+    WTF::switchOn(type,
+        [&](WGSL::Type* type) {
+            printInternal(out, *type);
+        },
+        [&](WGSL::TypeVariable variable) {
+            printInternal(out, variable);
         });
 }
 

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -74,13 +74,18 @@ using AbstractType = std::variant<
     Type*
 >;
 
+using AbstractScalarType = std::variant<
+    TypeVariable,
+    Type*
+>;
+
 struct AbstractVector {
-    TypeVariable element;
+    AbstractScalarType element;
     AbstractValue size;
 };
 
 struct AbstractMatrix {
-    TypeVariable element;
+    AbstractScalarType element;
     AbstractValue columns;
     AbstractValue rows;
 };
@@ -106,5 +111,6 @@ void printInternal(PrintStream&, const WGSL::NumericVariable&);
 void printInternal(PrintStream&, const WGSL::AbstractValue&);
 void printInternal(PrintStream&, const WGSL::TypeVariable&);
 void printInternal(PrintStream&, const WGSL::AbstractType&);
+void printInternal(PrintStream&, const WGSL::AbstractScalarType&);
 void printInternal(PrintStream&, const WGSL::OverloadCandidate&);
 } // namespace WTF

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -29,6 +29,21 @@ operator :-, {
   [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
 }
 
+# Comparison operations
+["==", "!="].each do |op|
+    operator :"#{op}", {
+        [T < Scalar].(T, T) => Bool,
+        [T < Scalar, N].(Vector[T, N], Vector[T, N]) => Vector[Bool, N],
+    }
+end
+
+["<", "<=", ">", ">="].each do |op|
+    operator :"#{op}", {
+        [T < Number].(T, T) => Bool,
+        [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[Bool, N],
+    }
+end
+
 operator :textureSample, {
     [].(Texture[F32, Texture1d], Sampler, F32) => Vector[F32, 4],
     [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2]) => Vector[F32, 4],

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -98,7 +98,7 @@ class AbstractType
         #    later be promoted to a concrete type once an overload is chosen.
         # 2) A concrete type if it's given a concrete type. Since there are no
         #    variables involved, we can immediately construct a concrete type.
-        if arguments[0].is_a? Variable
+        if arguments.any? do |arg| arg.is_a? Variable end
             ParameterizedAbstractType.new(self, arguments)
         else
             Constructor.new(@name.downcase)[*arguments]

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -341,3 +341,87 @@ fn testBinaryMinus() {
   let x2 = 1 - vec2(1, 1);
   let x3 = vec2(1, 1) - vec2(1, 1);
 }
+
+fn testComparison() {
+  {
+    let x = false == true;
+    let x1 = 0 == 1;
+    let x2 = 0i == 1i;
+    let x3 = 0u == 1u;
+    let x4 = 0.0 == 1.0;
+    let x5 = 0.0f == 1.0f;
+    let x6 = vec2(false) == vec2(true);
+    let x7 = vec2(0) == vec2(1);
+    let x8 = vec2(0i) == vec2(1i);
+    let x9 = vec2(0u) == vec2(1u);
+    let x10 = vec2(0.0) == vec2(1.0);
+    let x11 = vec2(0.0f) == vec2(1.0f);
+  }
+
+  {
+    let x = false != true;
+    let x1 = 0 != 1;
+    let x2 = 0i != 1i;
+    let x3 = 0u != 1u;
+    let x4 = 0.0 != 1.0;
+    let x5 = 0.0f != 1.0f;
+    let x6 = vec2(false) != vec2(true);
+    let x7 = vec2(0) != vec2(1);
+    let x8 = vec2(0i) != vec2(1i);
+    let x9 = vec2(0u) != vec2(1u);
+    let x10 = vec2(0.0) != vec2(1.0);
+    let x11 = vec2(0.0f) != vec2(1.0f);
+  }
+
+  {
+    let x = 0 > 1;
+    let x1 = 0i > 1i;
+    let x2 = 0u > 1u;
+    let x3 = 0.0 > 1.0;
+    let x4 = 0.0f > 1.0f;
+    let x5 = vec2(0) > vec2(1);
+    let x6 = vec2(0i) > vec2(1i);
+    let x7 = vec2(0u) > vec2(1u);
+    let x8 = vec2(0.0) > vec2(1.0);
+    let x9 = vec2(0.0f) > vec2(1.0f);
+  }
+
+  {
+    let x = 0 >= 1;
+    let x1 = 0i >= 1i;
+    let x2 = 0u >= 1u;
+    let x3 = 0.0 >= 1.0;
+    let x4 = 0.0f >= 1.0f;
+    let x5 = vec2(0) >= vec2(1);
+    let x6 = vec2(0i) >= vec2(1i);
+    let x7 = vec2(0u) >= vec2(1u);
+    let x8 = vec2(0.0) >= vec2(1.0);
+    let x9 = vec2(0.0f) >= vec2(1.0f);
+  }
+
+  {
+    let x = 0 < 1;
+    let x1 = 0i < 1i;
+    let x2 = 0u < 1u;
+    let x3 = 0.0 < 1.0;
+    let x4 = 0.0f < 1.0f;
+    let x5 = vec2(0) < vec2(1);
+    let x6 = vec2(0i) < vec2(1i);
+    let x7 = vec2(0u) < vec2(1u);
+    let x8 = vec2(0.0) < vec2(1.0);
+    let x9 = vec2(0.0f) < vec2(1.0f);
+  }
+
+  {
+    let x = 0 <= 1;
+    let x1 = 0i <= 1i;
+    let x2 = 0u <= 1u;
+    let x3 = 0.0 <= 1.0;
+    let x4 = 0.0f <= 1.0f;
+    let x5 = vec2(0) <= vec2(1);
+    let x6 = vec2(0i) <= vec2(1i);
+    let x7 = vec2(0u) <= vec2(1u);
+    let x8 = vec2(0.0) <= vec2(1.0);
+    let x9 = vec2(0.0f) <= vec2(1.0f);
+  }
+}


### PR DESCRIPTION
#### 3a71603352dcd72cfd85c308e4bea671cff8c56a
<pre>
[WGSL] Implement comparison operator overload and codegen
<a href="https://bugs.webkit.org/show_bug.cgi?id=255321">https://bugs.webkit.org/show_bug.cgi?id=255321</a>
rdar://107923257

Reviewed by Tadeu Zagallo.

Implement comparison operator overload and codegen for WGSL.

This change was complicated by needing to teach the overload matching generator
to handle `vecN&lt;bool&gt;`. Adding a constraint type `Boolean` with one valid type
`Bool` didn&apos;t work when using `Vector[S &lt; Boolean, N]` as the return type of an
operator.

To accept `Vector[Bool, N]` aka `vecN&lt;bool&gt;`, A new type `AbstractScalarType` is
introduced that can hold a concrete type or a type variable. `materialize`,
`calculateRank` and `unify` are updated to handle `AbstractType`,
`AbstractScalarType`, and `AbstractValue`. The &quot;hack&quot; in the generator that
selects between `ParameterizedAbstractType` or `Constructor` is extended to
selected `ParameterizedAbstractType` when any argument is a `Variable` to be
able to handle a vector of a concrete type but with a variable number of
elements.

For completeness, `AbstractMatrix` element was also updated.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::materialize const):
(WGSL::OverloadResolver::calculateRank):
(WGSL::OverloadResolver::unify):
(WTF::printInternal):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/262903@main">https://commits.webkit.org/262903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff8e2f17753659de54f0503e36c9beecea253c35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/2992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3268 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/2983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2490 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4028 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2380 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2518 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2562 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3771 "261 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2324 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2514 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/732 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2554 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->