### PR TITLE
[WGSL] Implement bitwise operator overload and codegen

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -481,12 +481,14 @@ void FunctionDefinitionWriter::visit(AST::CallExpression& call)
 void FunctionDefinitionWriter::visit(AST::UnaryExpression& unary)
 {
     switch (unary.operation()) {
+    case AST::UnaryOperation::Complement:
+        m_stringBuilder.append("~");
+        break;
     case AST::UnaryOperation::Negate:
         m_stringBuilder.append("-");
         break;
 
     case AST::UnaryOperation::AddressOf:
-    case AST::UnaryOperation::Complement:
     case AST::UnaryOperation::Dereference:
     case AST::UnaryOperation::Not:
         // FIXME: Implement these
@@ -512,9 +514,20 @@ void FunctionDefinitionWriter::visit(AST::BinaryExpression& binary)
 
     case AST::BinaryOperation::Divide:
     case AST::BinaryOperation::Modulo:
+        // FIXME: Implement these
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+
     case AST::BinaryOperation::And:
+        m_stringBuilder.append(" & ");
+        break;
     case AST::BinaryOperation::Or:
+        m_stringBuilder.append(" | ");
+        break;
     case AST::BinaryOperation::Xor:
+        m_stringBuilder.append(" ^ ");
+        break;
+
     case AST::BinaryOperation::LeftShift:
     case AST::BinaryOperation::RightShift:
         // FIXME: Implement these

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -44,6 +44,19 @@ end
     }
 end
 
+# Bitwise operations
+operator :~, {
+    [T < Integer].(T) => T,
+    [T < Integer, N].(Vector[T, N]) => Vector[T, N]
+}
+
+["|", "&", "^"].each do |op|
+    operator :"#{op}", {
+        [T < Integer].(T, T) => T,
+        [T < Integer, N].(Vector[T, N], Vector[T, N]) => Vector[T, N]
+    }
+end
+
 operator :textureSample, {
     [].(Texture[F32, Texture1d], Sampler, F32) => Vector[F32, 4],
     [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2]) => Vector[F32, 4],

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -288,6 +288,7 @@ module DSL
         R = Variable.new(:R, @NumericVariable)
 
         Number = Constraint.new(:Number)
+        Integer = Constraint.new(:Integer)
         Float = Constraint.new(:Float)
         Scalar = Constraint.new(:Scalar)
         ConcreteInteger = Constraint.new(:ConcreteInteger)

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -425,3 +425,30 @@ fn testComparison() {
     let x9 = vec2(0.0f) <= vec2(1.0f);
   }
 }
+
+fn testBitwise()
+{
+  {
+    let x = ~0;
+    let x1 = ~0i;
+    let x2 = ~0u;
+  }
+
+  {
+    let x = 0 & 1;
+    let x1 = 0i & 1i;
+    let x2 = 0u & 1u;
+  }
+
+  {
+    let x = 0 | 1;
+    let x1 = 0i | 1i;
+    let x2 = 0u | 1u;
+  }
+
+  {
+    let x = 0 ^ 1;
+    let x1 = 0i ^ 1i;
+    let x2 = 0u ^ 1u;
+  }
+}


### PR DESCRIPTION
#### 5429ef9c32cc440c638fc333e2e1caff7009c58e
<pre>
[WGSL] Implement bitwise operator overload and codegen
<a href="https://bugs.webkit.org/show_bug.cgi?id=255322">https://bugs.webkit.org/show_bug.cgi?id=255322</a>
rdar://problem/107923629

Reviewed by Tadeu Zagallo.

Implement overload and codegen for operators ~, &amp;, |, and ^.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/262906@main">https://commits.webkit.org/262906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21405aff315a1892a0c63bd17d1dafd5ef6e37be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3382 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2610 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4186 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2653 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2704 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3924 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3053 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2447 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/733 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->