### PR TITLE
[GStreamer] Update minimum required version to 1.18.4

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -122,10 +122,7 @@ AudioSourceProviderGStreamer::AudioSourceProviderGStreamer(MediaStreamTrackPriva
     g_signal_connect_swapped(decodebin, "pad-added", G_CALLBACK(+[](AudioSourceProviderGStreamer* provider, GstPad* pad) {
         auto padCaps = adoptGRef(gst_pad_query_caps(pad, nullptr));
         bool isAudio = doCapsHaveType(padCaps.get(), "audio");
-        if (webkitGstCheckVersion(1, 18, 0))
-            RELEASE_ASSERT(isAudio);
-        else if (!isAudio)
-            return;
+        RELEASE_ASSERT(isAudio);
 
         auto sinkPad = adoptGRef(gst_element_get_static_pad(provider->m_audioSinkBin.get(), "sink"));
         gst_pad_link(pad, sinkPad.get());

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -186,13 +186,12 @@ static void webKitGLVideoSinkGetProperty(GObject* object, guint propertyId, GVal
     WebKitGLVideoSink* sink = WEBKIT_GL_VIDEO_SINK(object);
 
     switch (propertyId) {
-    case PROP_STATS:
-        if (webkitGstCheckVersion(1, 18, 0)) {
-            GUniqueOutPtr<GstStructure> stats;
-            g_object_get(sink->priv->appSink.get(), "stats", &stats.outPtr(), nullptr);
-            gst_value_set_structure(value, stats.get());
-        }
+    case PROP_STATS: {
+        GUniqueOutPtr<GstStructure> stats;
+        g_object_get(sink->priv->appSink.get(), "stats", &stats.outPtr(), nullptr);
+        gst_value_set_structure(value, stats.get());
         break;
+    }
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propertyId, paramSpec);
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
@@ -32,7 +32,7 @@ GST_DEBUG_CATEGORY_STATIC(webkit_media_gst_audio_mixer_debug);
 
 bool GStreamerAudioMixer::isAvailable()
 {
-    return webkitGstCheckVersion(1, 18, 0) && isGStreamerPluginAvailable("inter") && isGStreamerPluginAvailable("audiomixer");
+    return isGStreamerPluginAvailable("inter") && isGStreamerPluginAvailable("audiomixer");
 }
 
 GStreamerAudioMixer& GStreamerAudioMixer::singleton()

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -98,24 +98,6 @@ GstPad* webkitGstGhostPadFromStaticTemplate(GstStaticPadTemplate* staticPadTempl
     return pad;
 }
 
-#if !GST_CHECK_VERSION(1, 18, 0)
-void webkitGstVideoFormatInfoComponent(const GstVideoFormatInfo* info, guint plane, gint components[GST_VIDEO_MAX_COMPONENTS])
-{
-    guint c, i = 0;
-
-    /* Reverse mapping of info->plane. */
-    for (c = 0; c < GST_VIDEO_FORMAT_INFO_N_COMPONENTS(info); c++) {
-        if (GST_VIDEO_FORMAT_INFO_PLANE(info, c) == plane) {
-            components[i] = c;
-            i++;
-        }
-    }
-
-    for (c = i; c < GST_VIDEO_MAX_COMPONENTS; c++)
-        components[c] = -1;
-}
-#endif
-
 #if ENABLE(VIDEO)
 bool getVideoSizeAndFormatFromCaps(const GstCaps* caps, WebCore::IntSize& size, GstVideoFormat& format, int& pixelAspectRatioNumerator, int& pixelAspectRatioDenominator, int& stride)
 {
@@ -727,36 +709,6 @@ String gstStructureToJSONString(const GstStructure* structure)
     return value->toJSONString();
 }
 
-#if !GST_CHECK_VERSION(1, 18, 0)
-GstClockTime webkitGstElementGetCurrentRunningTime(GstElement* element)
-{
-    g_return_val_if_fail(GST_IS_ELEMENT(element), GST_CLOCK_TIME_NONE);
-
-    auto baseTime = gst_element_get_base_time(element);
-    if (!GST_CLOCK_TIME_IS_VALID(baseTime)) {
-        GST_DEBUG_OBJECT(element, "Could not determine base time");
-        return GST_CLOCK_TIME_NONE;
-    }
-
-    auto clock = adoptGRef(gst_element_get_clock(element));
-    if (!clock) {
-        GST_DEBUG_OBJECT(element, "Element has no clock");
-        return GST_CLOCK_TIME_NONE;
-    }
-
-    auto clockTime = gst_clock_get_time(clock.get());
-    if (!GST_CLOCK_TIME_IS_VALID(clockTime))
-        return GST_CLOCK_TIME_NONE;
-
-    if (clockTime < baseTime) {
-        GST_DEBUG_OBJECT(element, "Got negative current running time");
-        return GST_CLOCK_TIME_NONE;
-    }
-
-    return clockTime - baseTime;
-}
-#endif
-
 GstClockTime webkitGstInitTime()
 {
     return s_webkitGstInitTime;
@@ -814,7 +766,6 @@ PlatformVideoColorSpace videoColorSpaceFromInfo(const GstVideoInfo& info)
     case GST_VIDEO_TRANSFER_BT709:
         colorSpace.transfer = PlatformVideoTransferCharacteristics::Bt709;
         break;
-#if GST_CHECK_VERSION(1, 18, 0)
     case GST_VIDEO_TRANSFER_BT601:
         colorSpace.transfer = PlatformVideoTransferCharacteristics::Smpte170m;
         break;
@@ -827,7 +778,6 @@ PlatformVideoColorSpace videoColorSpaceFromInfo(const GstVideoInfo& info)
     case GST_VIDEO_TRANSFER_BT2020_10:
         colorSpace.transfer = PlatformVideoTransferCharacteristics::Bt2020_10bit;
         break;
-#endif
     case GST_VIDEO_TRANSFER_BT2020_12:
         colorSpace.transfer = PlatformVideoTransferCharacteristics::Bt2020_12bit;
         break;
@@ -946,7 +896,6 @@ void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo* info, const PlatformVi
         case PlatformVideoTransferCharacteristics::Bt709:
             GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_BT709;
             break;
-#if GST_CHECK_VERSION(1, 18, 0)
         case PlatformVideoTransferCharacteristics::Smpte170m:
             GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_BT601;
             break;
@@ -959,7 +908,6 @@ void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo* info, const PlatformVi
         case PlatformVideoTransferCharacteristics::Bt2020_10bit:
             GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_BT2020_10;
             break;
-#endif
         case PlatformVideoTransferCharacteristics::Bt2020_12bit:
             GST_VIDEO_INFO_COLORIMETRY(info).transfer = GST_VIDEO_TRANSFER_BT2020_12;
             break;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -56,15 +56,6 @@ inline bool webkitGstCheckVersion(guint major, guint minor, guint micro)
     return true;
 }
 
-// gst_video_format_info_component() is GStreamer 1.18 API, so for older versions we use a local
-// vendored copy of the function.
-#if !GST_CHECK_VERSION(1, 18, 0)
-#define GST_VIDEO_MAX_COMPONENTS 4
-void webkitGstVideoFormatInfoComponent(const GstVideoFormatInfo*, guint, gint components[GST_VIDEO_MAX_COMPONENTS]);
-
-#define gst_video_format_info_component webkitGstVideoFormatInfoComponent
-#endif
-
 #define GST_VIDEO_CAPS_TYPE_PREFIX  "video/"
 #define GST_AUDIO_CAPS_TYPE_PREFIX  "audio/"
 #define GST_TEXT_CAPS_TYPE_PREFIX   "text/"
@@ -331,13 +322,6 @@ GstElement* makeGStreamerElement(const char* factoryName, const char* name);
 GstElement* makeGStreamerBin(const char* description, bool ghostUnlinkedPads);
 
 String gstStructureToJSONString(const GstStructure*);
-
-// gst_element_get_current_running_time() is GStreamer 1.18 API, so for older versions we use a local
-// vendored copy of the function.
-#if !GST_CHECK_VERSION(1, 18, 0)
-GstClockTime webkitGstElementGetCurrentRunningTime(GstElement*);
-#define gst_element_get_current_running_time webkitGstElementGetCurrentRunningTime
-#endif
 
 GstClockTime webkitGstInitTime();
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -807,13 +807,8 @@ GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isAVC1Code
         return checkH264Caps(makeString("video/x-h264, level=(string)", maxLevelString).utf8().data());
     }
 
-    if (webkitGstCheckVersion(1, 18, 0)) {
-        GST_DEBUG("Checking video decoders for constrained caps");
-        return checkH264Caps(makeString("video/x-h264, level=(string)", level, ", profile=(string)", profile).utf8().data());
-    }
-
-    GST_DEBUG("Falling back to unconstrained caps");
-    return checkH264Caps("video/x-h264");
+    GST_DEBUG("Checking video decoders for constrained caps");
+    return checkH264Caps(makeString("video/x-h264, level=(string)", level, ", profile=(string)", profile).utf8().data());
 }
 
 const char* GStreamerRegistryScanner::configurationNameForLogging(Configuration configuration) const

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -580,7 +580,6 @@ private:
     uint64_t m_networkReadPosition { 0 };
     mutable uint64_t m_readPositionAtLastDidLoadingProgress { 0 };
 
-    GRefPtr<GstElement> m_fpsSink { nullptr };
     uint64_t m_totalVideoFrames { 0 };
     uint64_t m_droppedVideoFrames { 0 };
     uint64_t m_decodedVideoFrames { 0 };

--- a/Source/cmake/GStreamerChecks.cmake
+++ b/Source/cmake/GStreamerChecks.cmake
@@ -36,7 +36,7 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
               list(APPEND GSTREAMER_COMPONENTS webrtc)
           endif ()
 
-          find_package(GStreamer 1.16.2 REQUIRED COMPONENTS ${GSTREAMER_COMPONENTS})
+          find_package(GStreamer 1.18.4 REQUIRED COMPONENTS ${GSTREAMER_COMPONENTS})
 
           if (ENABLE_WEB_AUDIO)
               if (NOT PC_GSTREAMER_AUDIO_FOUND OR NOT PC_GSTREAMER_FFT_FOUND)


### PR DESCRIPTION
#### bca3dd735ebf81d8a030ec71f0abd2a4342dec28
<pre>
[GStreamer] Update minimum required version to 1.18.4
<a href="https://bugs.webkit.org/show_bug.cgi?id=255334">https://bugs.webkit.org/show_bug.cgi?id=255334</a>

Reviewed by Xabier Rodriguez-Calvar.

This is the version shipping in Debian 11 (bullseye). Ubuntu 20.04 goes out of support on April
21st, so we can bump the required version.

* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp:
(WebCore::AudioSourceProviderGStreamer::AudioSourceProviderGStreamer):
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(webKitGLVideoSinkGetProperty):
* Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp:
(WebCore::GStreamerAudioMixer::isAvailable):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::videoColorSpaceFromInfo):
(WebCore::fillVideoInfoColorimetryFromColorSpace):
(WebCore::webkitGstVideoFormatInfoComponent): Deleted.
(WebCore::webkitGstElementGetCurrentRunningTime): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::isAVC1CodecSupported const):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::createVideoSink):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoSinkStatistics):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/cmake/GStreamerChecks.cmake:

Canonical link: <a href="https://commits.webkit.org/263218@main">https://commits.webkit.org/263218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eca761ff67738810cfffd76f71c69dce6ba14f8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4266 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2508 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4054 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2529 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2402 "144 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2374 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3799 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2717 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2345 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2925 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2532 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/695 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/945 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2575 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/2996 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/454 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2754 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/824 "Passed tests") | 
<!--EWS-Status-Bubble-End-->