### PR TITLE
REGRESSION (260399@main): animations flicker on https://payto.com.au

### DIFF
--- a/LayoutTests/webanimations/accelerated-animation-addition-lower-in-effect-stack-expected.html
+++ b/LayoutTests/webanimations/accelerated-animation-addition-lower-in-effect-stack-expected.html
@@ -1,0 +1,14 @@
+<style>
+
+div {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+    translate: 100px;
+}
+
+</style>
+<div></div>

--- a/LayoutTests/webanimations/accelerated-animation-addition-lower-in-effect-stack.html
+++ b/LayoutTests/webanimations/accelerated-animation-addition-lower-in-effect-stack.html
@@ -1,0 +1,50 @@
+<style>
+
+div {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+div.animated {
+    animation: translate 1000s linear forwards;
+}
+
+@keyframes translate {
+    from { translate: 0px }
+    to   { translate: 0px }
+}
+
+</style>
+<div></div>
+<script>
+
+window.testRunner?.waitUntilDone();
+
+(async function () {
+    const target = document.querySelector("div");
+
+    // Start an animation which will remain the highest in composite order.
+    const animation = target.animate({ "translate": ["100px", "100px"] }, { duration: 1000 * 1000, fill: "forwards" })
+
+    // Wait until the animation is committed.
+    await animation.ready;
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+
+    // Start a CSS Animation which will be completely replaced by the script-originated animation.
+    target.classList.add("animated");
+
+    // Wait until the animation is committed.
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+
+    window.testRunner?.notifyDone();
+})();
+
+</script>

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -419,14 +419,32 @@ void DocumentTimeline::applyPendingAcceleratedAnimations()
 
     auto acceleratedAnimationsPendingRunningStateChange = std::exchange(m_acceleratedAnimationsPendingRunningStateChange, { });
 
+    HashSet<KeyframeEffectStack*> keyframeEffectStacksToUpdate;
+
     bool hasForcedLayout = false;
     for (auto& animation : acceleratedAnimationsPendingRunningStateChange) {
         if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect())) {
             if (!hasForcedLayout)
                 hasForcedLayout |= keyframeEffect->forceLayoutIfNeeded();
-            keyframeEffect->applyPendingAcceleratedActions();
+
+            // If the animation is no longer relevant, apply the pending accelerations in isolation.
+            if (!animation->isRelevant()) {
+                keyframeEffect->applyPendingAcceleratedActions();
+                continue;
+            }
+
+            // Otherwise, this accelerated animation exists in the context of an effect stack and we must
+            // update all effects in that stack to ensure their sort order is respected.
+            if (auto target = keyframeEffect->targetStyleable()) {
+                auto* keyframeEffectStack = target ? target->keyframeEffectStack() : nullptr;
+                if (keyframeEffectStack)
+                    keyframeEffectStacksToUpdate.add(keyframeEffectStack);
+            }
         }
     }
+
+    for (auto* keyframeEffectStack : keyframeEffectStacksToUpdate)
+        keyframeEffectStack->applyPendingAcceleratedActions();
 }
 
 void DocumentTimeline::enqueueAnimationEvent(AnimationEventBase& event)

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2002,6 +2002,21 @@ void KeyframeEffect::animationSuspensionStateDidChange(bool animationIsSuspended
         addPendingAcceleratedAction(animationIsSuspended ? AcceleratedAction::Pause : AcceleratedAction::Play);
 }
 
+void KeyframeEffect::applyPendingAcceleratedActionsOrUpdateTimingProperties()
+{
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    if (threadedAnimationResolutionEnabled())
+        return;
+#endif
+
+    if (m_pendingAcceleratedActions.isEmpty()) {
+        m_pendingAcceleratedActions.append(AcceleratedAction::UpdateProperties);
+        applyPendingAcceleratedActions();
+        m_pendingAcceleratedActions.clear();
+    } else
+        applyPendingAcceleratedActions();
+}
+
 void KeyframeEffect::applyPendingAcceleratedActions()
 {
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -132,6 +132,7 @@ public:
     enum class RecomputationReason : uint8_t { LogicalPropertyChange, Other };
     std::optional<RecomputationReason> recomputeKeyframesIfNecessary(const RenderStyle* previousUnanimatedStyle, const RenderStyle& unanimatedStyle, const Style::ResolutionContext&);
     void applyPendingAcceleratedActions();
+    void applyPendingAcceleratedActionsOrUpdateTimingProperties();
 
     void willChangeRenderer();
 

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -265,5 +265,10 @@ void KeyframeEffectStack::cascadeDidOverrideProperties(const HashSet<AnimatableP
         effect->acceleratedPropertiesOverriddenByCascadeDidChange();
 }
 
+void KeyframeEffectStack::applyPendingAcceleratedActions() const
+{
+    for (auto& effect : m_effects)
+        effect->applyPendingAcceleratedActionsOrUpdateTimingProperties();
+}
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -72,6 +72,8 @@ public:
 
     const HashSet<AnimatableProperty>& acceleratedPropertiesOverriddenByCascade() const { return m_acceleratedPropertiesOverriddenByCascade; }
 
+    void applyPendingAcceleratedActions() const;
+
 private:
     void ensureEffectsAreSorted();
     bool hasMatchingEffect(const Function<bool(const KeyframeEffect&)>&) const;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3518,6 +3518,9 @@ bool GraphicsLayerCA::createTransformAnimationsFromKeyframes(const KeyframeValue
 
     const auto& primitives = prefix.primitives();
     unsigned numberOfSharedPrimitives = valueList.size() > 1 ? primitives.size() : 0;
+
+    removeAnimation(animationName);
+
     for (unsigned animationIndex = 0; animationIndex < numberOfSharedPrimitives; ++animationIndex) {
         if (!appendToUncommittedAnimations(valueList, primitives[animationIndex], animation, animationName, boxSize, animationIndex, timeOffset, false /* isMatrixAnimation */, keyframesShouldUseAnimationWideTimingFunction))
             return false;
@@ -3580,6 +3583,8 @@ bool GraphicsLayerCA::createFilterAnimationsFromKeyframes(const KeyframeValueLis
         if (operations.at(i)->type() == FilterOperation::Type::DropShadow)
             return false;
     }
+
+    removeAnimation(animationName);
 
     for (int animationIndex = 0; animationIndex < numAnimations; ++animationIndex) {
         if (!appendToUncommittedAnimations(valueList, operations.operations().at(animationIndex).get(), animation, animationName, animationIndex, timeOffset, keyframesShouldUseAnimationWideTimingFunction))


### PR DESCRIPTION
#### d566d000c7a56a384d728aff3dcd30c9ca173e0f
<pre>
REGRESSION (260399@main): animations flicker on <a href="https://payto.com.au">https://payto.com.au</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=255338">https://bugs.webkit.org/show_bug.cgi?id=255338</a>
rdar://107532064

Reviewed by Dean Jackson.

When creating a new animation of any type (CSS Transition, CSS Animation, Web Animations API)
that is accelerated, we add it to the list of animations on GraphicsLayerCA regardless of its
composite order relative to other effects for the given target.

In the case of <a href="https://payto.com.au">https://payto.com.au</a>, a CSS Animation is applied to an element for the &quot;transform&quot;
property, and that property also yields a CSS Transition that is canceled and recreated on each
frame (whether this is the right behavior is discussed in w3c/csswg-drafts#8701
as Firefox, Chrome and Safari all have different behavior).

That perpetually-recreated CSS Transition is lower in the composite order, but since it&apos;s created
after the CSS Animation, due to how we create accelerated animations it would override the CSS Animation.

In this patch we change the behavior of DocumentTimeline::applyPendingAcceleratedAnimations() to
update the entire effect stack with which an effect pending application of an accelerated action
is associated. This guarantees the effect stack&apos;s order to be preserved.

We also ensure we remove any similarly-named animation before adding new animations in GraphicsLayerCA.

* LayoutTests/webanimations/accelerated-animation-addition-lower-in-effect-stack-expected.html: Added.
* LayoutTests/webanimations/accelerated-animation-addition-lower-in-effect-stack.html: Added.
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::applyPendingAcceleratedAnimations):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::applyPendingAcceleratedActionsOrUpdateTimingProperties):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyPendingAcceleratedActions const):
* Source/WebCore/animation/KeyframeEffectStack.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::createTransformAnimationsFromKeyframes):
(WebCore::GraphicsLayerCA::createFilterAnimationsFromKeyframes):

Canonical link: <a href="https://commits.webkit.org/262875@main">https://commits.webkit.org/262875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eba7a1e4437d32ea09932ce983f138cc4ce0be8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2516 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4063 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2538 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2409 "6 flakes 165 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3809 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2351 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2541 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2581 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/335 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->