### PR TITLE
Use String::isNull instead of std::optional<String>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-03.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-03.html
@@ -24,6 +24,7 @@
 	  font-family: fwf;
 	  font-size: 2em;
 	  line-height: 1.1;
+	  font-variant-alternates: character-variant(doesnt-exist) styleset(doesnt-exist);
   }
   .high {
 	 font-variant-alternates: stylistic(foo);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-06.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-06.html
@@ -24,6 +24,7 @@
 	  font-family: fwf;
 	  font-size: 2em;
 	  line-height: 1.1;
+	  font-variant-alternates: styleset(doesnt-exist);
   }
   .high {
 	 font-variant-alternates: styleset(foo);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-09.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-09.html
@@ -24,6 +24,7 @@
 	  font-family: fwf;
 	  font-size: 2em;
 	  line-height: 1.1;
+	  font-variant-alternates: character-variant(doesnt-exist);
   }
   .high {
 	 font-variant-alternates: character-variant(foo);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-12.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-12.html
@@ -24,6 +24,7 @@
 	  font-family: fwf;
 	  font-size: 2em;
 	  line-height: 1.1;
+	  font-variant-alternates: swash(doesnt-exist);
   }
   .high {
 	 font-variant-alternates: swash(foo);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-15.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-15.html
@@ -24,6 +24,7 @@
 	  font-family: fwf;
 	  font-size: 2em;
 	  line-height: 1.1;
+	  font-variant-alternates: ornaments(doesnt-exist);
   }
   .high {
 	 font-variant-alternates: ornaments(foo);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-18.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-18.html
@@ -24,6 +24,7 @@
 	  font-family: fwf;
 	  font-size: 2em;
 	  line-height: 1.1;
+	  font-variant-alternates: annotation(doesnt-exist);
   }
   .high {
 	 font-variant-alternates: annotation(foo);

--- a/Source/WebCore/platform/text/TextFlags.cpp
+++ b/Source/WebCore/platform/text/TextFlags.cpp
@@ -280,11 +280,11 @@ FeaturesMap computeFeatureSettingsFromVariants(const FontVariantSettings& varian
             features.set(fontFeatureTag("hist"), 1);
         
         if (fontFeatureValues) {
-            auto lookupTags = [](const std::optional<String>& name, const auto& tags) -> Span<const unsigned> {
-                if (!name)
+            auto lookupTags = [] (const auto& name, const auto& tags) -> Span<const unsigned> {
+                if (name.isNull())
                     return { };
 
-                auto found = tags.find(*name);
+                auto found = tags.find(name);
                 if (found == tags.end())
                     return { };
 
@@ -308,7 +308,7 @@ FeaturesMap computeFeatureSettingsFromVariants(const FontVariantSettings& varian
             };
 
             // For styleset and character-variant, the tag name itself is the actual conveyor of information.
-            auto addFeatureTags = [&](const Vector<String>& names, const auto& tags, std::array<char, 2> codename) {
+            auto addFeatureTags = [&](const auto& names, const auto& tags, std::array<char, 2> codename) {
                 for (const auto& name : names) {
                     for (unsigned value : lookupTags(name, tags)) {
                         if (value < 1 || value > 99)


### PR DESCRIPTION
#### 3ac8b5512c4dd0473a576ad26d5682c93ee1f721
<pre>
Use String::isNull instead of std::optional&lt;String&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=255337">https://bugs.webkit.org/show_bug.cgi?id=255337</a>
rdar://107758556

Reviewed by Brent Fulgham.

std::optional&lt;String&gt; doesn&apos;t make sense because String
has its own representation of invalid (isNull).
In this case, the optional check was always true, thus
passing a null string to the find() method.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-03.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-06.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-09.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-12.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-15.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-18.html:
* Source/WebCore/platform/text/TextFlags.cpp:
(WebCore::computeFeatureSettingsFromVariants):

Canonical link: <a href="https://commits.webkit.org/262880@main">https://commits.webkit.org/262880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a79eb91533769ba9932420d060dbf1b81864b36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4316 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3328 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3014 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4108 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2581 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2445 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2981 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2584 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/717 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->