### PR TITLE
Assign to self before returning in init methods

### DIFF
--- a/Source/WebCore/PAL/pal/system/mac/WebPanel.mm
+++ b/Source/WebCore/PAL/pal/system/mac/WebPanel.mm
@@ -37,8 +37,9 @@
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     static NSUInteger styleMask = NSMiniaturizableWindowMask | NSClosableWindowMask | NSResizableWindowMask  | NSTitledWindowMask | NSSmallWindowMask | NSSideUtilityWindowMask | NSUtilityWindowMask;
     ALLOW_DEPRECATED_DECLARATIONS_END
-    
-    return [super initWithContentRect:NSZeroRect styleMask:styleMask backing:NSBackingStoreBuffered defer:YES];
+
+    self = [super initWithContentRect:NSZeroRect styleMask:styleMask backing:NSBackingStoreBuffered defer:YES];
+    return self;
 }
 
 @end

--- a/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
@@ -50,7 +50,8 @@ using namespace WebKit;
 - (instancetype)initWithObjects:(const id [])objects forKeys:(const id <NSCopying> [])keys count:(NSUInteger)count
 {
     ASSERT_NOT_REACHED();
-    return [super initWithObjects:objects forKeys:keys count:count];
+    self = [super initWithObjects:objects forKeys:keys count:count];
+    return self;
 }
 
 - (NSUInteger)count

--- a/Source/WebKit/UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm
@@ -77,7 +77,8 @@
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    return [super init];
+    self = [super init];
+    return self;
 }
 
 + (BOOL)supportsSecureCoding

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm
@@ -223,7 +223,8 @@ struct EraAndYear {
 
 - (instancetype)initWithDelegate:(id <WKQuickboardViewControllerDelegate>)delegate
 {
-    return [super initWithDelegate:delegate];
+    self = [super initWithDelegate:delegate];
+    return self;
 }
 
 - (void)viewDidLoad

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -345,7 +345,8 @@ static const CGFloat kDateTimePickerToolbarHeight = 44;
         return nil;
     }
 
-    return [super initWithView:view control:adoptNS([[WKDateTimePicker alloc] initWithView:view datePickerMode:mode])];
+    self = [super initWithView:view control:adoptNS([[WKDateTimePicker alloc] initWithView:view datePickerMode:mode])];
+    return self;
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -158,7 +158,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (instancetype)initWithView:(WKContentView *)view
 {
     RetainPtr<NSObject <WKFormControl>> control = adoptNS([[WKColorPicker alloc] initWithView:view]);
-    return [super initWithView:view control:WTFMove(control)];
+    self = [super initWithView:view control:WTFMove(control)];
+    return self;
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
@@ -81,7 +81,9 @@ CGFloat adjustedFontSize(CGFloat textWidth, UIFont *font, CGFloat initialFontSiz
             control = adoptNS([[WKSelectMultiplePicker alloc] initWithView:view]);
         else
             control = adoptNS([[WKSelectPicker alloc] initWithView:view]);
-        return [super initWithView:view control:WTFMove(control)];
+
+        self = [super initWithView:view control:WTFMove(control)];
+        return self;
     }
 #endif
 
@@ -92,7 +94,8 @@ CGFloat adjustedFontSize(CGFloat textWidth, UIFont *font, CGFloat initialFontSiz
     else
         control = adoptNS([[WKSelectSinglePicker alloc] initWithView:view]);
 
-    return [super initWithView:view control:WTFMove(control)];
+    self = [super initWithView:view control:WTFMove(control)];
+    return self;
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/forms/WKSelectMenuListViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKSelectMenuListViewController.mm
@@ -138,7 +138,8 @@ static constexpr CGFloat itemCellBaselineToBottom = 8;
 
 - (instancetype)initWithDelegate:(id <WKSelectMenuListViewControllerDelegate>)delegate
 {
-    return [super initWithDelegate:delegate dictationMode:PUICDictationModeText];
+    self = [super initWithDelegate:delegate dictationMode:PUICDictationModeText];
+    return self;
 }
 
 - (void)viewDidLoad

--- a/Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm
@@ -53,7 +53,8 @@ static NSString *timePickerDateFormat = @"HH:mm";
 
 - (instancetype)initWithDelegate:(id <WKQuickboardViewControllerDelegate>)delegate
 {
-    return [super initWithDelegate:delegate];
+    self = [super initWithDelegate:delegate];
+    return self;
 }
 
 - (NSDateFormatter *)dateFormatter

--- a/Source/WebKitLegacy/mac/Misc/WebDownload.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebDownload.mm
@@ -225,12 +225,13 @@ using namespace WebCore;
 - (id)init
 {
     self = [super init];
-    if (self != nil) {
-        // _webInternal can be set up before init by _setRealDelegate
-        if (_webInternal == nil) {
-            _webInternal = [[WebDownloadInternal alloc] init];
-        }
-    }
+    if (self == nil)
+        return nil;
+
+    // _webInternal can be set up before init by _setRealDelegate
+    if (_webInternal == nil)
+        _webInternal = [[WebDownloadInternal alloc] init];
+
     return self;
 }
 

--- a/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
@@ -121,7 +121,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     WebCoreThreadViolationCheckRoundOne();
 
-    return [super init];
+    self = [super init];
+    return self;
 }
 
 - (NSImage *)iconForURL:(NSString *)URL withSize:(NSSize)size cache:(BOOL)cache

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -76,7 +76,8 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
 - (instancetype)init
 {
-    return [super init];
+    self = [super init];
+    return self;
 }
 
 - (instancetype)initWithCoreResource:(Ref<ArchiveResource>&&)passedResource

--- a/Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm
@@ -141,12 +141,16 @@ static std::pair<NSURL *, NSError *> copyFile(NSURL *sourceURL, NSURL *destinati
 
 - (id)initWithImage:(NSImage *)anImage offset:(NSSize)o pasteboard:(NSPasteboard *)pboard source:(id)source
 {
+    self = [super init];
+    if (!self)
+        return nil;
+
     draggedImage = [anImage retain];
     draggingPasteboard = [pboard retain];
     draggingSource = [source retain];
     offset = o;
-    
-    return [super init];
+
+    return self;
 }
 
 - (void)dealloc

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm
@@ -78,7 +78,8 @@ using DecisionPoint = WebCore::MockContentFilterSettings::DecisionPoint;
 
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
-    return [super init];
+    self = [super init];
+    return self;
 }
 
 - (instancetype)initWithDecision:(Decision)decision decisionPoint:(DecisionPoint)decisionPoint

--- a/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
+++ b/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
@@ -175,7 +175,8 @@ using namespace TestWebKitAPI;
     for (NSItemProvider *itemProvider in providers)
         [items addObject:adoptNS([[UIDragItem alloc] initWithItemProvider:itemProvider]).get()];
 
-    return [super initWithItems:items.get() location:locationInWindow window:window allowMove:allowMove];
+    self = [super initWithItems:items.get() location:locationInWindow window:window allowMove:allowMove];
+    return self;
 }
 
 - (BOOL)isLocal
@@ -233,7 +234,8 @@ using namespace TestWebKitAPI;
 
 - (instancetype)initWithWindow:(UIWindow *)window allowMove:(BOOL)allowMove
 {
-    return [super initWithItems:@[ ] location:CGPointZero window:window allowMove:allowMove];
+    self = [super initWithItems:@[] location:CGPointZero window:window allowMove:allowMove];
+    return self;
 }
 
 - (NSUInteger)localOperationMask

--- a/Tools/WebKitTestRunner/mac/WebKitTestRunnerWindow.mm
+++ b/Tools/WebKitTestRunner/mac/WebKitTestRunnerWindow.mm
@@ -49,8 +49,12 @@ static Vector<WebKitTestRunnerWindow *> allWindows;
 - (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)windowStyle backing:(NSBackingStoreType)bufferingType defer:(BOOL)deferCreation
 {
     ASSERT(isMainThread());
+    self = [super initWithContentRect:contentRect styleMask:windowStyle backing:bufferingType defer:deferCreation];
+    if (!self)
+        return nil;
+
     allWindows.append(self);
-    return [super initWithContentRect:contentRect styleMask:windowStyle backing:bufferingType defer:deferCreation];
+    return self;
 }
 
 - (void)close


### PR DESCRIPTION
#### 4c8ed9ea14550faa4067caf7e5985a71ee569760
<pre>
Assign to self before returning in init methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=255341">https://bugs.webkit.org/show_bug.cgi?id=255341</a>

Reviewed by Alexey Proskuryakov.

ARC requires this and this is good practice anyway,
even if these files are not being compiled with ARC.

Yes, there were some exceptions simply because reordering
statements in legacy code is too risky/not worth the effort.

* Source/WebCore/PAL/pal/system/mac/WebPanel.mm:
  (-[WebPanel init]):
* Source/WebKit/Shared/Cocoa/WKNSDictionary.mm:
  (-[WKNSDictionary initWithObjects:forKeys:count:]):
* Source/WebKit/UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm:
  (-[WKReloadFrameErrorRecoveryAttempter initWithCoder:]):
* Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm:
  (-[WKDatePickerViewController initWithDelegate:]):
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
  (-[WKDateTimeInputControl initWithView:]):
* Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm:
  (-[WKFormColorControl initWithView:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm:
  (-[WKFormSelectControl initWithView:]):
* Source/WebKit/UIProcess/ios/forms/WKSelectMenuListViewController.mm:
  (-[WKSelectMenuListViewController initWithDelegate:]):
* Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm:
  (-[WKTimePickerViewController initWithDelegate:]):
* Source/WebKitLegacy/mac/Misc/WebDownload.mm:
  (-[WebDownload init:]):
* Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm:
  (-[WebIconDatabase init]):
* Source/WebKitLegacy/mac/WebView/WebResource.mm:
  (-[WebResourcePrivate init]):
* Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm:
  (-[DumpRenderTreeDraggingInfo initWithImage:offset:pasteboard:source:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm:
  (-[MockContentFilterEnabler initWithCoder:]):
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
  (-[MockDropSession initWithProviders:location:window:allowMove:]):
  (-[MockDragSession initWithWindow:allowMove:]):
* Tools/WebKitTestRunner/mac/WebKitTestRunnerWindow.mm:
  (-[WebKitTestRunnerWindow initWithContentRect:styleMask:backing:defer:]):

Canonical link: <a href="https://commits.webkit.org/262971@main">https://commits.webkit.org/262971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/661a9ebd6d04a6aed4092f859a2147edb78849b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4537 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3485 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2715 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4342 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2621 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2828 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4078 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2552 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2779 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/777 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->