### PR TITLE
PGM Crash Analysis

### DIFF
--- a/Source/JavaScriptCore/API/PASReportCrashPrivate.cpp
+++ b/Source/JavaScriptCore/API/PASReportCrashPrivate.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "PASReportCrashPrivate.h"
+
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#include <bmalloc/pas_report_crash.h>
+#endif
+
+using namespace JSC;
+
+#ifdef __APPLE__
+kern_return_t PASReportCrashExtractResults(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report *report, crash_reporter_memory_reader_t crm_reader)
+{
+#if TARGET_OS_WATCH
+    UNUSED_PARAM(fault_address);
+    UNUSED_PARAM(pas_dead_root);
+    UNUSED_PARAM(version);
+    UNUSED_PARAM(task);
+    UNUSED_PARAM(report);
+    UNUSED_PARAM(crm_reader);
+
+    return KERN_FAILURE;
+#else
+    return pas_report_crash_extract_pgm_failure(fault_address, pas_dead_root, version, task, report, crm_reader);
+#endif
+}
+#endif /* __APPLE__ */

--- a/Source/JavaScriptCore/API/PASReportCrashPrivate.h
+++ b/Source/JavaScriptCore/API/PASReportCrashPrivate.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/JSBase.h>
+
+#ifdef __APPLE__
+#include <bmalloc/pas_report_crash_pgm_report.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JS_EXPORT kern_return_t PASReportCrashExtractResults(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report *report, crash_reporter_memory_reader_t crm_reader);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __APPLE__ */

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -805,6 +805,7 @@
 		2AACE63D18CA5A0300ED0191 /* GCActivityCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AACE63B18CA5A0300ED0191 /* GCActivityCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2AD2EDFB19799E38004D6478 /* EnumerationMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AD2EDFA19799E38004D6478 /* EnumerationMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2AD8932B17E3868F00668276 /* HeapIterationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AD8932917E3868F00668276 /* HeapIterationScope.h */; };
+		2BDF4F7129E9E8BB0056BF50 /* PASReportCrashPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BDF4F6F29E9E8BB0056BF50 /* PASReportCrashPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D342F36F7244096804ADB24 /* SourceOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = 425BA1337E4344E1B269A671 /* SourceOrigin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		31770C5527B94CE600308091 /* TemporalPlainDateConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C4F27B94CE400308091 /* TemporalPlainDateConstructor.h */; };
 		31770C5727B94CE600308091 /* TemporalPlainDatePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 31770C5127B94CE400308091 /* TemporalPlainDatePrototype.h */; };
@@ -3657,6 +3658,8 @@
 		2AD2EDFA19799E38004D6478 /* EnumerationMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnumerationMode.h; sourceTree = "<group>"; };
 		2AD8932917E3868F00668276 /* HeapIterationScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HeapIterationScope.h; sourceTree = "<group>"; };
 		2ADFA26218EF3540004F9FCC /* GCLogging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GCLogging.cpp; sourceTree = "<group>"; };
+		2BDF4F6E29E9E8BB0056BF50 /* PASReportCrashPrivate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PASReportCrashPrivate.cpp; sourceTree = "<group>"; };
+		2BDF4F6F29E9E8BB0056BF50 /* PASReportCrashPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PASReportCrashPrivate.h; sourceTree = "<group>"; };
 		2E3AF00D28171AC000371A25 /* ShadowRealmPrototype.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = ShadowRealmPrototype.js; sourceTree = "<group>"; };
 		3032175DF1AD47D8998B34E1 /* JSSourceCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSSourceCode.h; sourceTree = "<group>"; };
 		30A5F403F11C4F599CD596D5 /* WasmTypeDefinitionInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmTypeDefinitionInlines.h; sourceTree = "<group>"; };
@@ -6952,6 +6955,8 @@
 				86F3EEB616855A5B0077B92A /* ObjcRuntimeExtras.h */,
 				E124A8F60E555775003091F1 /* OpaqueJSString.cpp */,
 				E124A8F50E555775003091F1 /* OpaqueJSString.h */,
+				2BDF4F6E29E9E8BB0056BF50 /* PASReportCrashPrivate.cpp */,
+				2BDF4F6F29E9E8BB0056BF50 /* PASReportCrashPrivate.h */,
 				5DE3D0F40DD8DDFB00468714 /* WebKitAvailability.h */,
 			);
 			path = API;
@@ -9743,6 +9748,7 @@
 				0F5CF9811E96F17F00C18692 /* AirTmpMap.h in Headers */,
 				0F9C03D51E9476F200CD9125 /* AirTmpSet.h in Headers */,
 				0FE0E4AE1C24C94A002E17B6 /* AirTmpWidth.h in Headers */,
+				DD546FEC29CD2A5D00A5173B /* AirTmpWidthInlines.h in Headers */,
 				0F3730931C0D67EE00052BFA /* AirUseCounts.h in Headers */,
 				0FEC85911BDACDC70080FF74 /* AirValidate.h in Headers */,
 				0FEC3C531F33A41600F59B6C /* AlignedMemoryAllocator.h in Headers */,
@@ -9751,7 +9757,6 @@
 				0F75A063200D261F0038E2CF /* Allocator.h in Headers */,
 				0F30CB5E1FCE4E37004B5323 /* AllocatorForMode.h in Headers */,
 				0F75A062200D261D0038E2CF /* AllocatorInlines.h in Headers */,
-				DD4BEC1129CB85E000398E35 /* B3CanonicalizePrePostIncrements.h in Headers */,
 				0F3730911C0CD70C00052BFA /* AllowMacroScratchRegisterUsage.h in Headers */,
 				A5EA70E919F5B1010098F5EC /* AlternateDispatchableAgent.h in Headers */,
 				2A48D1911772365B00C65A5F /* APICallbackFunction.h in Headers */,
@@ -9812,6 +9817,7 @@
 				DCFDFBD91D1F5D9B00FE3D72 /* B3BottomProvider.h in Headers */,
 				E392E6F924D25FA900B20767 /* B3BottomTupleValue.h in Headers */,
 				0F6B8AE31C4EFE1700969052 /* B3BreakCriticalEdges.h in Headers */,
+				DD4BEC1129CB85E000398E35 /* B3CanonicalizePrePostIncrements.h in Headers */,
 				DC9A0C201D2D9CB30085124E /* B3CaseCollection.h in Headers */,
 				DC9A0C1F1D2D9CB10085124E /* B3CaseCollectionInlines.h in Headers */,
 				0F338DFA1BE96AA80013C88F /* B3CCallValue.h in Headers */,
@@ -9907,7 +9913,6 @@
 				52678F8F1A031009006A306D /* BasicBlockLocation.h in Headers */,
 				147B83AC0E6DB8C9004775A4 /* BatchedTransitionOptimizer.h in Headers */,
 				E35E89FD25C50F870071EE1E /* BigInt64Array.h in Headers */,
-				DD4BEC1329CB952100398E35 /* WasmLLIntPlan.h in Headers */,
 				86976E5F1FA3E8BC00E7C4E1 /* BigIntConstructor.h in Headers */,
 				866739D213BFDE710023D87C /* BigInteger.h in Headers */,
 				861816771FB7924200ECC4EC /* BigIntObject.h in Headers */,
@@ -10185,7 +10190,6 @@
 				86EC9DD01328DF82002B2AD7 /* DFGOperations.h in Headers */,
 				0F7C39FF1C90C55B00480151 /* DFGOpInfo.h in Headers */,
 				A7D89CFE17A0B8CC00773AD8 /* DFGOSRAvailabilityAnalysisPhase.h in Headers */,
-				DD4BEC1229CB950A00398E35 /* WasmEntryPlan.h in Headers */,
 				0FD82E57141DAF1000179C94 /* DFGOSREntry.h in Headers */,
 				0FD8A32617D51F5700CA2C40 /* DFGOSREntrypointCreationPhase.h in Headers */,
 				0FC0976A1468A6F700CF2442 /* DFGOSRExit.h in Headers */,
@@ -10799,7 +10803,6 @@
 				E3BF3C4D2390D1E8008BC752 /* JSWebAssemblyGlobal.h in Headers */,
 				796FB43A1DFF8C3F0039C95D /* JSWebAssemblyHelpers.h in Headers */,
 				AD2FCBE51DB58DAD00B3E736 /* JSWebAssemblyInstance.h in Headers */,
-				DD546FEC29CD2A5D00A5173B /* AirTmpWidthInlines.h in Headers */,
 				ADE802991E08F1DE0058DE78 /* JSWebAssemblyLinkError.h in Headers */,
 				AD2FCBE71DB58DAD00B3E736 /* JSWebAssemblyMemory.h in Headers */,
 				AD2FCC051DB58DAD00B3E736 /* JSWebAssemblyModule.h in Headers */,
@@ -10936,6 +10939,7 @@
 				0FCCAE4516D0CF7400D0C65B /* ParserError.h in Headers */,
 				A77F1825164192C700640A47 /* ParserModes.h in Headers */,
 				65303D641447B9E100D3F904 /* ParserTokens.h in Headers */,
+				2BDF4F7129E9E8BB0056BF50 /* PASReportCrashPrivate.h in Headers */,
 				792CB34A1C4EED5C00D13AF3 /* PCToCodeOriginMap.h in Headers */,
 				A5AB49DD1BEC8086007020FB /* PerGlobalObjectWrapperWorld.h in Headers */,
 				0FE834181A6EF97B00D04847 /* PolymorphicCallStubRoutine.h in Headers */,
@@ -11239,6 +11243,7 @@
 				E3BD2B7622F275020011765C /* WasmCompilationMode.h in Headers */,
 				AD412B341E7B2E9E008AF157 /* WasmContext.h in Headers */,
 				E36CC9472086314F0051FFD6 /* WasmCreationMode.h in Headers */,
+				DD4BEC1229CB950A00398E35 /* WasmEntryPlan.h in Headers */,
 				79DAE27A1E03C82200B526AA /* WasmExceptionType.h in Headers */,
 				5381B9391E60E97D0090F794 /* WasmFaultSignalHandler.h in Headers */,
 				7BC547D31B6959A100959B58 /* WasmFormat.h in Headers */,
@@ -11252,6 +11257,7 @@
 				AD5C36DD1F688B65000BCAAF /* WasmJS.h in Headers */,
 				AD00659E1ECAC812000CA926 /* WasmLimits.h in Headers */,
 				E308A80E294D39340044A109 /* WasmLLIntBuiltin.h in Headers */,
+				DD4BEC1329CB952100398E35 /* WasmLLIntPlan.h in Headers */,
 				1450FA1F2357BEC90093CD4D /* WasmLLIntTierUpCounter.h in Headers */,
 				53E9E0AC1EAE83DF00FEE251 /* WasmMachineThreads.h in Headers */,
 				535557141D9D9EA5006D583B /* WasmMemory.h in Headers */,

--- a/Source/JavaScriptCore/SourcesCocoa.txt
+++ b/Source/JavaScriptCore/SourcesCocoa.txt
@@ -33,5 +33,6 @@ API/JSValue.mm
 API/JSVirtualMachine.mm
 API/JSWrapperMap.mm
 API/ObjCCallbackFunction.mm
+API/PASReportCrashPrivate.cpp
 
 // Use inspector/remote/SourcesCocoa.txt for Remote Inspector files

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -149,6 +149,7 @@ set(bmalloc_SOURCES
     libpas/src/libpas/pas_random.c
     libpas/src/libpas/pas_red_black_tree.c
     libpas/src/libpas/pas_redundant_local_allocator_node.c
+    libpas/src/libpas/pas_report_crash.c
     libpas/src/libpas/pas_reserved_memory_provider.c
     libpas/src/libpas/pas_root.c
     libpas/src/libpas/pas_scavenger.c
@@ -567,6 +568,8 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_reallocate_heap_teleport_rule.h
     libpas/src/libpas/pas_red_black_tree.h
     libpas/src/libpas/pas_redundant_local_allocator_node.h
+    libpas/src/libpas/pas_report_crash.h
+    libpas/src/libpas/pas_report_crash_pgm_report.h
     libpas/src/libpas/pas_reserved_memory_provider.h
     libpas/src/libpas/pas_root.h
     libpas/src/libpas/pas_scavenger.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -128,6 +128,9 @@
 		14F271C518EA397E008C152F /* Deallocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 145F6859179DC90200D65598 /* Deallocator.cpp */; };
 		14F271C718EA3990008C152F /* Heap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14DA320E18875D9F007269E0 /* Heap.cpp */; };
 		14F271C818EA3990008C152F /* ObjectType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14105E8318E14374003A106E /* ObjectType.cpp */; };
+		2B6EB7A029EE102E00F10400 /* pas_report_crash_pgm_report.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B6EB79F29EE102E00F10400 /* pas_report_crash_pgm_report.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2BDF4F4C29E8B8BA0056BF50 /* pas_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = 2BDF4F4A29E8B8BA0056BF50 /* pas_report_crash.c */; };
+		2BDF4F4D29E8B8BA0056BF50 /* pas_report_crash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BDF4F4B29E8B8BA0056BF50 /* pas_report_crash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4426E2801C838EE0008EB042 /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4426E27E1C838EE0008EB042 /* Logging.cpp */; };
 		4426E2811C838EE0008EB042 /* Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4426E27F1C838EE0008EB042 /* Logging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		52F47249210BA30200B730BB /* MemoryStatusSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 52F47248210BA2F500B730BB /* MemoryStatusSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1290,6 +1293,9 @@
 		14DA320C18875B09007269E0 /* Heap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Heap.h; path = bmalloc/Heap.h; sourceTree = "<group>"; };
 		14DA320E18875D9F007269E0 /* Heap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Heap.cpp; path = bmalloc/Heap.cpp; sourceTree = "<group>"; };
 		14F271BE18EA3963008C152F /* libbmalloc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libbmalloc.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		2B6EB79F29EE102E00F10400 /* pas_report_crash_pgm_report.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_report_crash_pgm_report.h; path = libpas/src/libpas/pas_report_crash_pgm_report.h; sourceTree = "<group>"; };
+		2BDF4F4A29E8B8BA0056BF50 /* pas_report_crash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_report_crash.c; path = libpas/src/libpas/pas_report_crash.c; sourceTree = "<group>"; };
+		2BDF4F4B29E8B8BA0056BF50 /* pas_report_crash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_report_crash.h; path = libpas/src/libpas/pas_report_crash.h; sourceTree = "<group>"; };
 		2C09D8B92797C6E9005AA15C /* pas_decommit_exclusion_range.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_decommit_exclusion_range.h; path = libpas/src/libpas/pas_decommit_exclusion_range.h; sourceTree = "<group>"; };
 		2C09D8BA2797C6E9005AA15C /* pas_large_virtual_range_min_heap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_large_virtual_range_min_heap.h; path = libpas/src/libpas/pas_large_virtual_range_min_heap.h; sourceTree = "<group>"; };
 		2C09D8BB2797C6E9005AA15C /* pas_committed_pages_vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_committed_pages_vector.h; path = libpas/src/libpas/pas_committed_pages_vector.h; sourceTree = "<group>"; };
@@ -1848,6 +1854,9 @@
 				0FC40AEC2451499300876DA0 /* pas_red_black_tree.h */,
 				0F8E83292492EAF30046D7F8 /* pas_redundant_local_allocator_node.c */,
 				0F8E832A2492EAF30046D7F8 /* pas_redundant_local_allocator_node.h */,
+				2BDF4F4A29E8B8BA0056BF50 /* pas_report_crash.c */,
+				2BDF4F4B29E8B8BA0056BF50 /* pas_report_crash.h */,
+				2B6EB79F29EE102E00F10400 /* pas_report_crash_pgm_report.h */,
 				0FC40A8A2451498C00876DA0 /* pas_reserved_memory_provider.c */,
 				0FC40AE32451499200876DA0 /* pas_reserved_memory_provider.h */,
 				0F87005325AF8A1A000E1ABF /* pas_root.c */,
@@ -2548,6 +2557,8 @@
 				DD4BED8C29CBA49700398E35 /* pas_reallocate_heap_teleport_rule.h in Headers */,
 				DD4BEC7929CBA49700398E35 /* pas_red_black_tree.h in Headers */,
 				DD4BED9329CBA49700398E35 /* pas_redundant_local_allocator_node.h in Headers */,
+				2BDF4F4D29E8B8BA0056BF50 /* pas_report_crash.h in Headers */,
+				2B6EB7A029EE102E00F10400 /* pas_report_crash_pgm_report.h in Headers */,
 				DD4BEC6529CBA49700398E35 /* pas_reserved_memory_provider.h in Headers */,
 				DD4BEC8529CBA49700398E35 /* pas_root.h in Headers */,
 				DD4BED4829CBA49700398E35 /* pas_scavenger.h in Headers */,
@@ -2900,6 +2911,7 @@
 				DD4BEC6129CBA49700398E35 /* pas_random.c in Sources */,
 				DD4BECCD29CBA49700398E35 /* pas_red_black_tree.c in Sources */,
 				DD4BEDB329CBA49700398E35 /* pas_redundant_local_allocator_node.c in Sources */,
+				2BDF4F4C29E8B8BA0056BF50 /* pas_report_crash.c in Sources */,
 				DD4BECB829CBA49700398E35 /* pas_reserved_memory_provider.c in Sources */,
 				DD4BEC2C29CBA49700398E35 /* pas_root.c in Sources */,
 				DD4BEC3329CBA49700398E35 /* pas_scavenger.c in Sources */,

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -552,6 +552,8 @@
 		2B2E2FD12949A41100F85C38 /* pas_malloc_stack_logging.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */; };
 		2B2E2FD22949A41100F85C38 /* pas_malloc_stack_logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */; };
 		2B6055E42805368B00C8BDAC /* BmallocTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B6055E32805368B00C8BDAC /* BmallocTests.cpp */; };
+		2BDF4F4529E8B36F0056BF50 /* pas_report_crash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BDF4F4429E8B36F0056BF50 /* pas_report_crash.h */; };
+		2BDF4F4729E8B3AD0056BF50 /* pas_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = 2BDF4F4629E8B3AD0056BF50 /* pas_report_crash.c */; };
 		2BF3F5B529A0051F005361FD /* EnumerationTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2BF3F5B429A0051F005361FD /* EnumerationTests.cpp */; };
 		2C11E88E2728A783002162D0 /* bmalloc_type.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C11E88C2728A783002162D0 /* bmalloc_type.h */; };
 		2C11E88F2728A783002162D0 /* pas_simple_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C11E88D2728A783002162D0 /* pas_simple_type.c */; };
@@ -1257,6 +1259,8 @@
 		2B2E2FCF2949A41100F85C38 /* pas_malloc_stack_logging.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_malloc_stack_logging.c; sourceTree = "<group>"; };
 		2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_malloc_stack_logging.h; sourceTree = "<group>"; };
 		2B6055E32805368B00C8BDAC /* BmallocTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BmallocTests.cpp; sourceTree = "<group>"; };
+		2BDF4F4429E8B36F0056BF50 /* pas_report_crash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_report_crash.h; sourceTree = "<group>"; };
+		2BDF4F4829E8B5510056BF50 /* pas_report_crash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_report_crash.c; sourceTree = "<group>"; };
 		2BF3F5B429A0051F005361FD /* EnumerationTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnumerationTests.cpp; sourceTree = "<group>"; };
 		2C11E88C2728A783002162D0 /* bmalloc_type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bmalloc_type.h; sourceTree = "<group>"; };
 		2C11E88D2728A783002162D0 /* pas_simple_type.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_simple_type.c; sourceTree = "<group>"; };
@@ -1825,6 +1829,8 @@
 				0FF08F3122A58F1200386575 /* pas_red_black_tree.h */,
 				0FA5E4542492D5B900CE962A /* pas_redundant_local_allocator_node.c */,
 				0FA5E4522492D5B900CE962A /* pas_redundant_local_allocator_node.h */,
+				2BDF4F4829E8B5510056BF50 /* pas_report_crash.c */,
+				2BDF4F4429E8B36F0056BF50 /* pas_report_crash.h */,
 				0F5B608F235E88EE00CAE629 /* pas_reserved_memory_provider.c */,
 				0F5B6090235E88EE00CAE629 /* pas_reserved_memory_provider.h */,
 				0F4F60F825979BC7008B4A82 /* pas_root.c */,
@@ -2313,6 +2319,7 @@
 				0FE7EE7D22A1A31C004F4166 /* pas_reallocate_heap_teleport_rule.h in Headers */,
 				0FF08F3322A58F1200386575 /* pas_red_black_tree.h in Headers */,
 				0FA5E4572492D5BA00CE962A /* pas_redundant_local_allocator_node.h in Headers */,
+				2BDF4F4529E8B36F0056BF50 /* pas_report_crash.h in Headers */,
 				0F5B6092235E88EF00CAE629 /* pas_reserved_memory_provider.h in Headers */,
 				0F4F60FB25979BC8008B4A82 /* pas_root.h in Headers */,
 				0F19326C22F73E8500FBA713 /* pas_scavenger.h in Headers */,
@@ -2804,6 +2811,7 @@
 				0FD48B3023A9ABB30026C46D /* pas_random.c in Sources */,
 				0FF08F3422A58F1200386575 /* pas_red_black_tree.c in Sources */,
 				0FA5E4592492D5BA00CE962A /* pas_redundant_local_allocator_node.c in Sources */,
+				2BDF4F4729E8B3AD0056BF50 /* pas_report_crash.c in Sources */,
 				0F5B6091235E88EF00CAE629 /* pas_reserved_memory_provider.c in Sources */,
 				0F4F60FA25979BC8008B4A82 /* pas_root.c in Sources */,
 				0F19326D22F73E8500FBA713 /* pas_scavenger.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c
@@ -77,7 +77,7 @@ static bool pas_hash_map_entry_callback(pas_enumerator* enumerator, pas_ptr_hash
     pas_pgm_storage* allocation = ((pas_pgm_storage*)entry->value);
     size_t mem_to_alloc = (2 * allocation->page_size) + allocation->allocation_size_requested + allocation->mem_to_waste;
     
-    pas_enumerator_record(enumerator, (void*)((char*)entry->key - pas_page_malloc_alignment()), mem_to_alloc, pas_enumerator_object_record);
+    pas_enumerator_record(enumerator, (void*)((char*)entry->key - allocation->mem_to_waste - pas_page_malloc_alignment()), mem_to_alloc, pas_enumerator_object_record);
     pas_enumerator_record(enumerator, (void*)entry->value, sizeof(pas_pgm_storage), pas_enumerator_meta_record);
 
     return true;

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash.c
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "pas_config.h"
+
+#if LIBPAS_ENABLED
+
+#include "pas_ptr_hash_set.h"
+#include "pas_ptr_hash_map.h"
+#include "pas_root.h"
+
+#include "pas_report_crash.h"
+#include "pas_probabilistic_guard_malloc_allocator.h"
+
+#ifdef __APPLE__
+static crash_reporter_memory_reader_t memory_reader;
+
+static kern_return_t memory_reader_adapter(task_t task, vm_address_t address, vm_size_t size, void **local_memory)
+{
+    if (!local_memory)
+        return KERN_FAILURE;
+
+    void *ptr = memory_reader(task, address, size);
+    *local_memory = ptr;
+    return ptr ? KERN_SUCCESS : KERN_FAILURE;
+}
+
+static memory_reader_t * setup_memory_reader(crash_reporter_memory_reader_t crm_reader)
+{
+    memory_reader = crm_reader;
+    return memory_reader_adapter;
+}
+
+
+// This function will be called when a process crashes containing the JavaScriptCore framework.
+// The goal is to determine if the crash was caused by a PGM allocation, and if so whether the crash
+// was a UAF or OOB crash. These details will forwarded back to the Crash Reporter API, which will
+// add the information to the local crash log.
+kern_return_t pas_report_crash_extract_pgm_failure(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report *report, crash_reporter_memory_reader_t crm_reader)
+{
+    if (version != pas_crash_report_version)
+        return KERN_FAILURE;
+
+    memory_reader_t *reader = setup_memory_reader(crm_reader);
+
+    pas_root* read_pas_dead_root = NULL;
+    pas_ptr_hash_map* hash_map = NULL;
+    pas_ptr_hash_map_entry* hash_map_entry = NULL;
+    pas_pgm_storage* pgm_metadata = NULL;
+
+    size_t table_size = 0;
+
+    kern_return_t kr = reader(task, pas_dead_root, sizeof(pas_root), (void **) &read_pas_dead_root);
+    if (kr != KERN_SUCCESS)
+        return KERN_FAILURE;
+
+    kr = reader(task, (vm_address_t) read_pas_dead_root->pas_pgm_hash_map_instance, sizeof(pas_ptr_hash_map), (void **) &hash_map);
+    if (kr != KERN_SUCCESS)
+        return KERN_FAILURE;
+
+    table_size = hash_map->table_size;
+
+    for (size_t i = 0; i < table_size; i++) {
+        kr = reader(task, (vm_address_t) (hash_map->table + i), sizeof(pas_ptr_hash_map_entry), (void **) &hash_map_entry);
+        if (kr != KERN_SUCCESS)
+            return KERN_FAILURE;
+
+        // Skip entry if not there
+        if (hash_map_entry->key == (void*)UINTPTR_MAX)
+            continue;
+
+        kr = reader(task, (vm_address_t) hash_map_entry->value, sizeof(pas_pgm_storage), (void **) &pgm_metadata);
+        if (kr != KERN_SUCCESS)
+            return KERN_FAILURE;
+
+        addr64_t key = (addr64_t) hash_map_entry->key;
+
+        // Lower PGM Bounds Checking
+        addr64_t bottom = (addr64_t) (key - pgm_metadata->mem_to_waste - pgm_metadata->page_size);
+        addr64_t top = (addr64_t) (key - pgm_metadata->mem_to_waste);
+
+        if ((fault_address >= bottom)
+            && (fault_address < top)) {
+            report->error_type = "out-of-bounds";
+            report->confidence = "high";
+            report->fault_address = fault_address;
+            report->allocation_size = pgm_metadata->allocation_size_requested;
+            return KERN_SUCCESS;
+        }
+
+        // Upper PGM Bounds Checking
+        bottom = (addr64_t) (key - pgm_metadata->mem_to_waste + pgm_metadata->size_of_data_pages);
+        top = (addr64_t) (key - pgm_metadata->mem_to_waste + pgm_metadata->size_of_data_pages + pgm_metadata->page_size);
+
+        if ((fault_address >= bottom)
+            && (fault_address < top)) {
+            report->error_type = "out-of-bounds";
+            report->confidence = "high";
+            report->fault_address = fault_address;
+            report->allocation_size = pgm_metadata->allocation_size_requested;
+            return KERN_SUCCESS;
+        }
+
+        // UAF Check
+        bottom = (addr64_t) key;
+        top = (addr64_t) (key - pgm_metadata->mem_to_waste + pgm_metadata->size_of_data_pages);
+
+        if ((fault_address >= bottom)
+            && (fault_address < top)) {
+            report->error_type = "use-after-free";
+            report->confidence = "high";
+            report->fault_address = fault_address;
+            report->allocation_size = pgm_metadata->allocation_size_requested;
+            return KERN_SUCCESS;
+        }
+
+        // UAF + OOB Check
+        bottom = (addr64_t) (key - pgm_metadata->mem_to_waste - pgm_metadata->page_size);
+        top = (addr64_t) key;
+
+        if ((fault_address >= bottom)
+            && (fault_address < top)) {
+            report->error_type = "OOB + UAF";
+            report->confidence = "low";
+            report->fault_address = fault_address;
+            report->allocation_size = pgm_metadata->allocation_size_requested;
+            return KERN_SUCCESS;
+        }
+    }
+
+    return KERN_FAILURE;
+}
+#endif /* __APPLE__ */
+
+#endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef PAS_REPORT_CRASH_H
+#define PAS_REPORT_CRASH_H
+
+/* These functions should never be called directly; they should instead use the SPI
+ * defined in JavaScriptCore PasReportCrashPrivate.h. */
+
+#ifdef __APPLE__
+#include "pas_report_crash_pgm_report.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((visibility("default"))) kern_return_t pas_report_crash_extract_pgm_failure(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report *report, crash_reporter_memory_reader_t crm_reader);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __APPLE__ */
+#endif /* pas_report_crash_h */

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef PAS_REPORT_CRASH_PGM_REPORT_H
+#define PAS_REPORT_CRASH_PGM_REPORT_H
+
+/* This file exposes a SPI between OSAnalytics and libpas ultimately called through
+ * JavaScriptCore. Upon crashing of a process, on Apple platforms, ReportCrash will call
+ * into libpas (through JSC) to inspect whether it was a PGM crash in libpas or not. We will report
+ * back results from libpas with any information about the PGM crash. This will be logged in
+ * the local crash report logs generated on the device. */
+
+#ifdef __APPLE__
+#include <mach/mach_types.h>
+#include <mach/vm_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Read memory from crashed process. */
+typedef void *(*crash_reporter_memory_reader_t)(task_t task, vm_address_t address, size_t size);
+
+/* Crash Report Version number. This must be in sync between ReportCrash and libpas to generate a report. */
+const unsigned pas_crash_report_version = 1;
+
+/* Report sent back to the ReportCrash process. */
+typedef struct {
+    const char *error_type;
+    const char *confidence;
+    vm_address_t fault_address;
+    size_t allocation_size;
+} pas_report_crash_pgm_report;
+#endif /* __APPLE__ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PAS_REPORT_CRASH_PGM_REPORT_H */


### PR DESCRIPTION
#### f209607bc69672c97760e70b3e128cc79d4a704d
<pre>
PGM Crash Analysis
<a href="https://bugs.webkit.org/show_bug.cgi?id=255345">https://bugs.webkit.org/show_bug.cgi?id=255345</a>

Reviewed by Mark Lam, Elliott Williams and David Kilzer.

When a process crashes we will now try to determine whether this crash was caused by
a PGM allocation in WebKit. ReportCrash will call into JSC, which would forward the information
onto libpas. libpas will respond with a report generated from the memory of the now dead process.

libpas will determine whether this was a PGM crash and if so what kind of crash (UAF or OOB).
This information will be added to the local crash log generated.

* Source/JavaScriptCore/API/PASReportCrashPrivate.cpp: Added.
(PASReportCrashExtractResults):
* Source/JavaScriptCore/API/PASReportCrashPrivate.h: Added.
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/SourcesCocoa.txt:
* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c:
(pas_hash_map_entry_callback):
* Source/bmalloc/libpas/src/libpas/pas_report_crash.c: Added.
(memory_reader_adapter):
(setup_memory_reader):
(pas_report_crash_extract_pgm_failure):
* Source/bmalloc/libpas/src/libpas/pas_report_crash.h: Added.
* Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h: Added.

Canonical link: <a href="https://commits.webkit.org/263055@main">https://commits.webkit.org/263055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bb5b510fa07f05259724828b9299003a3990d5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3478 "29 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4900 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3766 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3020 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3520 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4720 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3005 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/2847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3157 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4466 "267 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3260 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3540 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3549 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3096 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/896 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/844 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3106 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3641 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3361 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1007 "Passed tests") | 
<!--EWS-Status-Bubble-End-->