### PR TITLE
Support JetStream3 in compare-results

### DIFF
--- a/Tools/Scripts/compare-results
+++ b/Tools/Scripts/compare-results
@@ -54,6 +54,7 @@ def readJSONFile(path):
         return result
 
 Speedometer2 = "Speedometer2"
+JetStream3 = "JetStream3"
 JetStream2 = "JetStream2"
 PLT5 = "PLT5"
 CompetitivePLT = "CompetitivePLT"
@@ -107,6 +108,23 @@ def detailedJetStream2Breakdown(jsonObject):
     for test in breakdown._results["JetStream2.0"]["tests"].keys():
         for subtest in breakdown._results["JetStream2.0"]["tests"][test]["tests"]:
             result[test + "-" + subtest] = breakdown._results["JetStream2.0"]["tests"][test]["tests"][subtest]["metrics"]["Time"][None]["current"]
+    return result
+
+def jetStream3Breakdown(jsonObject):
+    breakdown = BenchmarkResults(jsonObject)
+    result = {}
+    result[unitMarker] = "pts"
+    for test in breakdown._results["JetStream3.0"]["tests"].keys():
+        result[test] = breakdown._results["JetStream3.0"]["tests"][test]["metrics"]["Score"][None]["current"]
+    return result
+
+def detailedJetStream3Breakdown(jsonObject):
+    breakdown = BenchmarkResults(jsonObject)
+    result = {}
+    result[unitMarker] = "ms"
+    for test in breakdown._results["JetStream3.0"]["tests"].keys():
+        for subtest in breakdown._results["JetStream3.0"]["tests"][test]["tests"]:
+            result[test + "-" + subtest] = breakdown._results["JetStream3.0"]["tests"][test]["tests"][subtest]["metrics"]["Time"][None]["current"]
     return result
 
 def motionMarkBreakdown(jsonObject):
@@ -321,6 +339,8 @@ def writeCSV(a, b, fileName):
     f.write(result)
     f.close()
 
+def detectJetStream3(payload):
+    return "JetStream3.0" in payload
 
 def detectJetStream2(payload):
     return "JetStream2.0" in payload
@@ -329,6 +349,30 @@ def JetStream2Results(payload):
     assert detectJetStream2(payload)
 
     js = payload["JetStream2.0"]
+
+    iterations = 0
+    if "gaussian-blur" in js["tests"]:
+        iterations = len(js["tests"]["gaussian-blur"]["metrics"]["Score"]["current"])
+    else:
+        obj = js["tests"]
+        first_key = list(obj.keys())[0]
+        iterations = len(obj[first_key]["metrics"]["Score"]["current"])
+
+    results = []
+    for i in range(iterations):
+        scores = []
+        for test in js["tests"].keys():
+            scores.append(js["tests"][test]["metrics"]["Score"]["current"][i])
+        geomean = stats.gmean(scores)
+        
+        results.append(geomean)
+
+    return results
+
+def JetStream3Results(payload):
+    assert detectJetStream3(payload)
+
+    js = payload["JetStream3.0"]
 
     iterations = 0
     if "gaussian-blur" in js["tests"]:
@@ -442,6 +486,8 @@ def motionMarkResults(payload):
     return results
 
 def detectBenchmark(payload):
+    if detectJetStream3(payload):
+        return JetStream3
     if detectJetStream2(payload):
         return JetStream2
     if detectSpeedometer2(payload):
@@ -461,6 +507,8 @@ def detectBenchmark(payload):
     return None
 
 def biggerIsBetter(benchmarkType):
+    if benchmarkType == JetStream3:
+        return True
     if benchmarkType == JetStream2:
         return True
     if benchmarkType == Speedometer2:
@@ -572,6 +620,17 @@ def main():
 
         if args.csv:
             writeCSV(jetStream2Breakdown(a), jetStream2Breakdown(b), args.csv)
+    elif typeA == JetStream3:
+        if args.breakdown:
+            if args.detailed_breakdown:
+                dumpBreakdowns(detailedJetStream3Breakdown(a), detailedJetStream3Breakdown(b))
+            else:
+                dumpBreakdowns(jetStream3Breakdown(a), jetStream3Breakdown(b))
+
+        ttest(typeA, JetStream3Results(a), JetStream3Results(b))
+
+        if args.csv:
+            writeCSV(jetStream3Breakdown(a), jetStream3Breakdown(b), args.csv)
     elif typeA == Speedometer2:
         if args.breakdown:
             if args.detailed_breakdown:


### PR DESCRIPTION
#### 3801cd0aaedc54936f68209dc2ac78a911e72882
<pre>
Support JetStream3 in compare-results
<a href="https://bugs.webkit.org/show_bug.cgi?id=255344">https://bugs.webkit.org/show_bug.cgi?id=255344</a>
rdar://107942609

Reviewed by Justin Michaud.

Script compare-results now supports for JetStream3 results.

* Tools/Scripts/compare-results:
(detailedJetStream2Breakdown):
(jetStream3Breakdown):
(detailedJetStream3Breakdown):
(writeCSV):
(detectJetStream3):
(JetStream2Results):
(JetStream3Results):
(detectBenchmark):
(biggerIsBetter):
(main):

Canonical link: <a href="https://commits.webkit.org/262874@main">https://commits.webkit.org/262874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/033671f0c99f4cc376b72951d04ed3a2df0631d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4296 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3314 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2850 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/2992 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2912 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4086 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2554 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2605 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2961 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2557 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/709 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->