### PR TITLE
Start using origin directory for DOMCache and ServiceWorkerRegistrations

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -117,7 +117,7 @@ struct NetworkSessionCreationParameters {
 #endif
     bool isBlobRegistryTopOriginPartitioningEnabled { false };
 
-    UnifiedOriginStorageLevel unifiedOriginStorageLevel { UnifiedOriginStorageLevel::Basic };
+    UnifiedOriginStorageLevel unifiedOriginStorageLevel { UnifiedOriginStorageLevel::Standard };
     uint64_t perOriginStorageQuota;
     std::optional<double> originQuotaRatio;
     std::optional<double> totalQuotaRatio;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -425,7 +425,7 @@ WallTime NetworkStorageManager::lastModificationTimeForOrigin(const WebCore::Cli
         FALLTHROUGH;
     }
     case UnifiedOriginStorageLevel::Standard: {
-        auto originFile = manager.path();
+        auto originFile = originFilePath(manager.path());
         auto originFileModificationTime = valueOrDefault(FileSystem::fileModificationTime(originFile));
         lastModificationTime = std::max(originFileModificationTime, lastModificationTime);
     }

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -588,14 +588,10 @@ String OriginStorageManager::StorageBucket::resolvedCacheStoragePath()
         m_resolvedCacheStoragePath = m_customCacheStoragePath;
         break;
     case UnifiedOriginStorageLevel::Standard:
-        auto cacheStorageDirectory = typeStoragePath(StorageType::CacheStorage);
-        RELEASE_LOG(Storage, "%p - StorageBucket::resolvedCacheStoragePath New path '%" PUBLIC_LOG_STRING "'", this, cacheStorageDirectory.utf8().data());
-        if (cacheStorageDirectory.isEmpty() || m_customCacheStoragePath.isEmpty() || !FileSystem::fileExists(m_customCacheStoragePath))
-            m_resolvedCacheStoragePath = emptyString();
-        else {
-            if (!FileSystem::fileExists(cacheStorageDirectory))
-                FileSystem::moveFile(m_customCacheStoragePath, cacheStorageDirectory);
-            m_resolvedCacheStoragePath = cacheStorageDirectory;
+        m_resolvedCacheStoragePath = typeStoragePath(StorageType::CacheStorage);
+        if (!m_resolvedCacheStoragePath.isEmpty() && !m_customCacheStoragePath.isEmpty() && !FileSystem::fileExists(m_resolvedCacheStoragePath) && FileSystem::fileExists(m_customCacheStoragePath)) {
+            RELEASE_LOG(Storage, "%p - StorageBucket::resolvedCacheStoragePath New path '%" PUBLIC_LOG_STRING "'", this, m_resolvedCacheStoragePath.utf8().data());
+            FileSystem::moveFile(m_customCacheStoragePath, m_resolvedCacheStoragePath);
         }
     }
 

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -849,7 +849,7 @@ bool WebsiteDataStore::networkProcessHasEntitlementForTesting(const String& enti
 
 UnifiedOriginStorageLevel WebsiteDataStore::defaultUnifiedOriginStorageLevel()
 {
-    auto defaultUnifiedOriginStorageLevelValue = UnifiedOriginStorageLevel::Basic;
+    auto defaultUnifiedOriginStorageLevelValue = UnifiedOriginStorageLevel::Standard;
     NSString* unifiedOriginStorageLevelKey = @"WebKitDebugUnifiedOriginStorageLevel";
     if ([[NSUserDefaults standardUserDefaults] objectForKey:unifiedOriginStorageLevelKey] == nil)
         return defaultUnifiedOriginStorageLevelValue;


### PR DESCRIPTION
#### b877662f6f561a6cdffee42c6ed5bd2781033ffd
<pre>
Start using origin directory for DOMCache and ServiceWorkerRegistrations
<a href="https://bugs.webkit.org/show_bug.cgi?id=255349">https://bugs.webkit.org/show_bug.cgi?id=255349</a>
rdar://107843591

Reviewed by Youenn Fablet.

By moving to UnifiedOriginStorageLevel::Standard, NetworkStorageManager will migrate existing DOMCache and
ServiceWorkerRegistrations data to origin directory and start using origin directory for storage.

This patch also fixes an issue that DOMCache path is set to be empty string when OriginStorageManager starts using
UnifiedOriginStorageLevel::Standard and there is no existing data to migrate at old path.

* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::lastModificationTimeForOrigin const):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::resolvedCacheStoragePath):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm: Some tests rely on custom CacheStorage and
ServiceWorkerRegistrations and paths, so we keep using UnifiedOriginStorageLevel::Basic for them.
(WebKit::WebsiteDataStore::defaultUnifiedOriginStorageLevel):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm: Ditto.

Canonical link: <a href="https://commits.webkit.org/262941@main">https://commits.webkit.org/262941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1323a50e1099cba5d5ace29dac88759ae7810ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4492 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2685 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4333 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2741 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2718 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4068 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3167 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2524 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2743 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/758 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->