### PR TITLE
EWS bots should upload archives directly to S3

### DIFF
--- a/Tools/CISupport/Shared/generate-s3-url
+++ b/Tools/CISupport/Shared/generate-s3-url
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import argparse
+import boto3
+
+from botocore.config import Config
+
+S3_DEFAULT_BUCKET = 'archives.webkit.org'
+S3_EWS_BUCKET = 'ews-archives.webkit.org'
+
+def generateS3URL(bucket, identifier, revision):
+    key = '/'.join([identifier, revision + '.zip'])
+    print(f'\tS3 Bucket: {bucket}\n\tS3 Key: {key}')
+    config = Config(region_name = 'us-west-2')
+    s3 = boto3.client('s3', config=config)
+    params = {'Bucket': bucket, 'Key': key}
+    url = s3.generate_presigned_url(ClientMethod='put_object', Params=params, ExpiresIn=600)
+    print(f'S3 URL: {url}\n')
+    return url
+
+def main():
+    parser = argparse.ArgumentParser(add_help=True)
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--revision', action="store", help='Revision number or change identifier for the built archive')
+    group.add_argument('--change-id', dest='change_id', action="store", help='patch id or hash of specified change')
+    parser.add_argument('--identifier', action="store", required=True, help='S3 destination identifier, in the form of fullPlatform-architecture-configuration. [mac-mojave-x86_64-release]')
+    args = parser.parse_args()
+
+    s3_bucket = S3_DEFAULT_BUCKET
+    if args.change_id:
+        s3_bucket = S3_EWS_BUCKET
+
+    url = generateS3URL(s3_bucket, args.identifier, args.revision or args.change_id)
+    return url
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### f2d4b23fbdc9f771c30dbb5f4f0df4149a28a4b7
<pre>
EWS bots should upload archives directly to S3
<a href="https://bugs.webkit.org/show_bug.cgi?id=255339">https://bugs.webkit.org/show_bug.cgi?id=255339</a>

Reviewed by Ryan Haddad.

Server will generate a pre-signed url in each build, securely pass it to the
bot, and bot will upload the archive directly to S3. In case the upload fails, we
fallback to previous approach of bot uploading to master and master tranferring to S3.

* Tools/CISupport/Shared/generate-s3-url: Script to generate pre-signed url, runs on master.
* Tools/CISupport/ews-build/steps.py:
(CompileWebKit.evaluateCommand):
(UploadFileToS3): Step to run on bot to upload archive directly to S3.
(GenerateS3URL): Step to generate pre-signed url.

Canonical link: <a href="https://commits.webkit.org/262927@main">https://commits.webkit.org/262927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7010fed803dc1ebc82f1393d79706ca0f507d215

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3062 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/3126 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/3234 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/4474 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit; Failed to upload built product") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/3030 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/3198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/3158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/4474 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit; Failed to upload built product") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3092 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/3198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/3234 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4271 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/3198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/3234 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/3198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/3234 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/3127 "Build was cancelled. Recent messages:OS: Monterey (12.6.1), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/3158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/3021 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/3234 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/356 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->