### PR TITLE
Web Inspector: Support ES2022 Private Fields

### DIFF
--- a/LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt
+++ b/LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt
@@ -132,6 +132,51 @@ Internal Properties:
     "boundThis"       =>  null (object null)  []
     "boundArgs"       =>  "Array" (object array)  []
 
+-- Running test case: Runtime.getDisplayableProperties.Private.Instance
+Evaluating expression...
+Getting displayable properties...
+Properties:
+    "#parentInstancePrivateProperty"  =>  "parentInstancePrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "#childInstancePrivateProperty"   =>  "childInstancePrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "parentInstancePublicProperty"    =>  "parentInstancePublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
+    "childInstancePublicProperty"     =>  "childInstancePublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
+    "__proto__"                       =>  "PrivateMembersTestClassChild" (object)  [writable | configurable | isOwn]
+
+-- Running test case: Runtime.getDisplayableProperties.Private.Constructor
+Evaluating expression...
+Getting displayable properties...
+Properties:
+    "#childClassPrivateProperty"    =>  "childClassPrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "length"                        =>  0 (number)  [configurable | isOwn]
+    "prototype"                     =>  "PrivateMembersTestClassChild" (object)  [isOwn]
+    "childClassPublicMethod"        =>  "function childClassPublicMethod() { }" (function)  [writable | configurable | isOwn]
+    "childClassPublicGetter"        =>  get "function () { }" (function)  [configurable | isOwn]
+    "childClassPublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]
+    "childClassPublicSetter"        =>  get undefined (undefined)  [configurable | isOwn]
+    "childClassPublicSetter"        =>  set "function (x) { }" (function)  [configurable | isOwn]
+    "childClassPublicGetterSetter"  =>  get "function () { }" (function)  [configurable | isOwn]
+    "childClassPublicGetterSetter"  =>  set "function (x) { }" (function)  [configurable | isOwn]
+    "toString"                      =>  "function toString() { return \"<redacted>\"; }" (function)  [writable | configurable | isOwn]
+    "childClassPublicProperty"      =>  "childClassPublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
+    "name"                          =>  "PrivateMembersTestClassChild" (string)  [configurable | isOwn]
+    "arguments"                     =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "caller"                        =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "__proto__"                     =>  "<redacted>" (function class)  [writable | configurable | isOwn]
+
+-- Running test case: Runtime.getDisplayableProperties.Private.Prototype
+Evaluating expression...
+Getting displayable properties...
+Properties:
+    "constructor"                      =>  "<redacted>" (function class)  [writable | configurable | isOwn]
+    "childInstancePublicMethod"        =>  "function childInstancePublicMethod() { }" (function)  [writable | configurable | isOwn]
+    "childInstancePublicGetter"        =>  get "function () { }" (function)  [configurable | isOwn]
+    "childInstancePublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]
+    "childInstancePublicSetter"        =>  get undefined (undefined)  [configurable | isOwn]
+    "childInstancePublicSetter"        =>  set "function (x) { }" (function)  [configurable | isOwn]
+    "childInstancePublicGetterSetter"  =>  get "function () { }" (function)  [configurable | isOwn]
+    "childInstancePublicGetterSetter"  =>  set "function (x) { }" (function)  [configurable | isOwn]
+    "__proto__"                        =>  "PrivateMembersTestClassParent" (object)  [writable | configurable | isOwn]
+
 -- Running test case: Runtime.getDisplayableProperties.Promise.Resolved
 Evaluating expression...
 Getting displayable properties...

--- a/LayoutTests/inspector/runtime/getDisplayableProperties.html
+++ b/LayoutTests/inspector/runtime/getDisplayableProperties.html
@@ -110,6 +110,24 @@ function test()
     });
 
     addTestCase({
+        name: "Runtime.getDisplayableProperties.Private.Instance",
+        expression: `new PrivateMembersTestClassChild`,
+        ownProperties: true,
+    });
+
+    addTestCase({
+        name: "Runtime.getDisplayableProperties.Private.Constructor",
+        expression: `PrivateMembersTestClassChild`,
+        ownProperties: true,
+    });
+
+    addTestCase({
+        name: "Runtime.getDisplayableProperties.Private.Prototype",
+        expression: `PrivateMembersTestClassChild.prototype`,
+        ownProperties: true,
+    });
+
+    addTestCase({
         name: "Runtime.getDisplayableProperties.Promise.Resolved",
         expression: `Promise.resolve(123)`,
     });

--- a/LayoutTests/inspector/runtime/getProperties-expected.txt
+++ b/LayoutTests/inspector/runtime/getProperties-expected.txt
@@ -114,6 +114,49 @@ Internal Properties:
     "boundThis"       =>  null (object null)  []
     "boundArgs"       =>  "Array" (object array)  []
 
+-- Running test case: Runtime.getProperties.Private.Instance
+Evaluating expression...
+Getting own properties...
+Properties:
+    "#parentInstancePrivateProperty"  =>  "parentInstancePrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "#childInstancePrivateProperty"   =>  "childInstancePrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "parentInstancePublicProperty"    =>  "parentInstancePublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
+    "childInstancePublicProperty"     =>  "childInstancePublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
+    "__proto__"                       =>  "PrivateMembersTestClassChild" (object)  [writable | configurable | isOwn]
+
+-- Running test case: Runtime.getProperties.Private.Constructor
+Evaluating expression...
+Getting own properties...
+Properties:
+    "#childClassPrivateProperty"    =>  "childClassPrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "length"                        =>  0 (number)  [configurable | isOwn]
+    "prototype"                     =>  "PrivateMembersTestClassChild" (object)  [isOwn]
+    "childClassPublicMethod"        =>  "function childClassPublicMethod() { }" (function)  [writable | configurable | isOwn]
+    "childClassPublicGetter"        =>  get "function () { }" (function)  [configurable | isOwn]
+    "childClassPublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]
+    "childClassPublicSetter"        =>  get undefined (undefined)  [configurable | isOwn]
+    "childClassPublicSetter"        =>  set "function (x) { }" (function)  [configurable | isOwn]
+    "childClassPublicGetterSetter"  =>  get "function () { }" (function)  [configurable | isOwn]
+    "childClassPublicGetterSetter"  =>  set "function (x) { }" (function)  [configurable | isOwn]
+    "toString"                      =>  "function toString() { return \"<redacted>\"; }" (function)  [writable | configurable | isOwn]
+    "childClassPublicProperty"      =>  "childClassPublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
+    "name"                          =>  "PrivateMembersTestClassChild" (string)  [configurable | isOwn]
+    "__proto__"                     =>  "<redacted>" (function class)  [writable | configurable | isOwn]
+
+-- Running test case: Runtime.getProperties.Private.Prototype
+Evaluating expression...
+Getting own properties...
+Properties:
+    "constructor"                      =>  "<redacted>" (function class)  [writable | configurable | isOwn]
+    "childInstancePublicMethod"        =>  "function childInstancePublicMethod() { }" (function)  [writable | configurable | isOwn]
+    "childInstancePublicGetter"        =>  get "function () { }" (function)  [configurable | isOwn]
+    "childInstancePublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]
+    "childInstancePublicSetter"        =>  get undefined (undefined)  [configurable | isOwn]
+    "childInstancePublicSetter"        =>  set "function (x) { }" (function)  [configurable | isOwn]
+    "childInstancePublicGetterSetter"  =>  get "function () { }" (function)  [configurable | isOwn]
+    "childInstancePublicGetterSetter"  =>  set "function (x) { }" (function)  [configurable | isOwn]
+    "__proto__"                        =>  "PrivateMembersTestClassParent" (object)  [writable | configurable | isOwn]
+
 -- Running test case: Runtime.getProperties.Promise.Resolved
 Evaluating expression...
 Getting own properties...

--- a/LayoutTests/inspector/runtime/getProperties.html
+++ b/LayoutTests/inspector/runtime/getProperties.html
@@ -125,6 +125,24 @@ function test()
     });
 
     addTestCase({
+        name: "Runtime.getProperties.Private.Instance",
+        expression: `new PrivateMembersTestClassChild`.replaceAll(/\s+/g, ' '),
+        ownProperties: true,
+    });
+
+    addTestCase({
+        name: "Runtime.getProperties.Private.Constructor",
+        expression: `PrivateMembersTestClassChild`.replaceAll(/\s+/g, ' '),
+        ownProperties: true,
+    });
+
+    addTestCase({
+        name: "Runtime.getProperties.Private.Prototype",
+        expression: `PrivateMembersTestClassChild.prototype`.replaceAll(/\s+/g, ' '),
+        ownProperties: true,
+    });
+
+    addTestCase({
         name: "Runtime.getProperties.Promise.Resolved",
         expression: `Promise.resolve(123)`,
         ownProperties: true,

--- a/LayoutTests/inspector/runtime/resources/property-descriptor-utilities.js
+++ b/LayoutTests/inspector/runtime/resources/property-descriptor-utilities.js
@@ -1,3 +1,59 @@
+class PrivateMembersTestClassParent {
+    parentInstancePublicProperty = 'parentInstancePublicPropertyValue';
+    #parentInstancePrivateProperty = 'parentInstancePrivatePropertyValue';
+    parentInstancePublicMethod() { }
+    #parentInstancePrivateMethod() { }
+    get parentInstancePublicGetter() { }
+    set parentInstancePublicSetter(x) { }
+    get parentInstancePublicGetterSetter() { }
+    set parentInstancePublicGetterSetter(x) { }
+    get #parentInstancePrivateGetter() { }
+    set #parentInstancePrivateSetter(x) { }
+    get #parentInstancePrivateGetterSetter() { }
+    set #parentInstancePrivateGetterSetter(x) { }
+    static parentClassPublicProperty = 'parentClassPublicPropertyValue';
+    static #parentClassPrivateProperty = 'parentClassPrivatePropertyValue';
+    static parentClassPublicMethod() { }
+    static #parentClassPrivateMethod() { }
+    static get parentClassPublicGetter() { }
+    static set parentClassPublicSetter(x) { }
+    static get parentClassPublicGetterSetter() { }
+    static set parentClassPublicGetterSetter(x) { }
+    static get #parentClassPrivateGetter() { }
+    static set #parentClassPrivateSetter(x) { }
+    static get #parentClassPrivateGetterSetter() { }
+    static set #parentClassPrivateGetterSetter(x) { }
+    static toString() { return "<redacted>"; }
+}
+
+class PrivateMembersTestClassChild extends PrivateMembersTestClassParent {
+    childInstancePublicProperty = 'childInstancePublicPropertyValue';
+    #childInstancePrivateProperty = 'childInstancePrivatePropertyValue';
+    childInstancePublicMethod() { }
+    #childInstancePrivateMethod() { }
+    get childInstancePublicGetter() { }
+    set childInstancePublicSetter(x) { }
+    get childInstancePublicGetterSetter() { }
+    set childInstancePublicGetterSetter(x) { }
+    get #childInstancePrivateGetter() { }
+    set #childInstancePrivateSetter(x) { }
+    get #childInstancePrivateGetterSetter() { }
+    set #childInstancePrivateGetterSetter(x) { }
+    static childClassPublicProperty = 'childClassPublicPropertyValue';
+    static #childClassPrivateProperty = 'childClassPrivatePropertyValue';
+    static childClassPublicMethod() { }
+    static #childClassPrivateMethod() { }
+    static get childClassPublicGetter() { }
+    static set childClassPublicSetter(x) { }
+    static get childClassPublicGetterSetter() { }
+    static set childClassPublicGetterSetter(x) { }
+    static get #childClassPrivateGetter() { }
+    static set #childClassPrivateSetter(x) { }
+    static get #childClassPrivateGetterSetter() { }
+    static set #childClassPrivateGetterSetter(x) { }
+    static toString() { return "<redacted>"; }
+}
+
 function makeArray(length) {
     return Array(length).fill().map((item, i) => {
         let code = (i % 2) ? ("Z".charCodeAt(0) - i) : ("A".charCodeAt(0) + i);
@@ -32,18 +88,23 @@ function makeWeakSet(length) {
 TestPage.registerInitializer(() => {
     ProtocolTest.PropertyDescriptorUtilities = {};
 
-    ProtocolTest.PropertyDescriptorUtilities.logForEach = function({name, value, ...extra}, index, array) {
+    ProtocolTest.PropertyDescriptorUtilities.logForEach = function({name, value, get, set, ...extra}, index, array) {
         let maxPropertyNameLength = array.reduce((max, {name}) => name.length > max ? name.length : max, 0) + 2; // add 2 for the surrounding quotes
         let paddedName = JSON.stringify(name).padEnd(maxPropertyNameLength, " ");
         let descriptorKeys = [];
         for (let [key, value] of Object.entries(extra)) {
             if (value) {
-                ProtocolTest.assert(typeof value === "boolean", `Property descriptor '${key}' has a non-boolean value '${value}'.`);
+                ProtocolTest.assert(typeof value === "boolean", `Property descriptor '${key}' has a non-boolean value '${JSON.stringify(value)}'.`);
                 descriptorKeys.push(key);
             }
         }
 
-        ProtocolTest.log(`    ${paddedName}  =>  ${ProtocolTest.PropertyDescriptorUtilities.stringifyRemoteObject(value)}  [${descriptorKeys.join(" | ")}]`);
+        if (value)
+            ProtocolTest.log(`    ${paddedName}  =>  ${ProtocolTest.PropertyDescriptorUtilities.stringifyRemoteObject(value)}  [${descriptorKeys.join(" | ")}]`);
+        if (get)
+            ProtocolTest.log(`    ${paddedName}  =>  get ${ProtocolTest.PropertyDescriptorUtilities.stringifyRemoteObject(get)}  [${descriptorKeys.join(" | ")}]`);
+        if (set)
+            ProtocolTest.log(`    ${paddedName}  =>  set ${ProtocolTest.PropertyDescriptorUtilities.stringifyRemoteObject(set)}  [${descriptorKeys.join(" | ")}]`);
     };
 
     ProtocolTest.PropertyDescriptorUtilities.stringifyRemoteObject = function(remoteObject) {

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -2848,8 +2848,9 @@ void BytecodeGenerator::emitCreatePrivateBrand(const JSTextPosition& divot, cons
 {
     RefPtr<RegisterID> createPrivateSymbol = moveLinkTimeConstant(nullptr, LinkTimeConstant::createPrivateSymbol);
 
-    CallArguments arguments(*this, nullptr, 0);
+    CallArguments arguments(*this, nullptr, 1);
     emitLoad(arguments.thisRegister(), jsUndefined());
+    emitLoad(arguments.argumentRegister(0), jsEmptyString(m_vm));
     RegisterID* newSymbol = emitCall(finalDestination(nullptr, createPrivateSymbol.get()), createPrivateSymbol.get(), NoExpectedFunction, arguments, divot, divotStart, divotEnd, DebuggableCall::No);
 
     Variable privateBrandVar = variable(propertyNames().builtinNames().privateBrandPrivateName());

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -572,8 +572,9 @@ void PropertyListNode::emitDeclarePrivateFieldNames(BytecodeGenerator& generator
             if (!createPrivateSymbol)
                 createPrivateSymbol = generator.moveLinkTimeConstant(nullptr, LinkTimeConstant::createPrivateSymbol);
 
-            CallArguments arguments(generator, nullptr, 0);
+            CallArguments arguments(generator, nullptr, 1);
             generator.emitLoad(arguments.thisRegister(), jsUndefined());
+            generator.emitLoad(arguments.argumentRegister(0), *node.name());
             RefPtr<RegisterID> symbol = generator.emitCall(generator.finalDestination(nullptr, createPrivateSymbol.get()), createPrivateSymbol.get(), NoExpectedFunction, arguments, position(), position(), position(), DebuggableCall::No);
 
             Variable var = generator.variable(*node.name());

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -31,6 +31,7 @@
 #include "DateInstance.h"
 #include "DeferGCInlines.h"
 #include "DirectArguments.h"
+#include "EnumerationMode.h"
 #include "FunctionPrototype.h"
 #include "HeapAnalyzer.h"
 #include "HeapIterationScope.h"
@@ -56,6 +57,7 @@
 #include "MarkedSpaceInlines.h"
 #include "ObjectConstructor.h"
 #include "PreventCollectionScope.h"
+#include "PropertyNameArray.h"
 #include "ProxyObject.h"
 #include "RegExpObject.h"
 #include "ScopedArguments.h"
@@ -290,6 +292,38 @@ static JSObject* constructInternalProperty(JSGlobalObject* globalObject, const S
     JSObject* result = constructEmptyObject(globalObject);
     result->putDirect(vm, Identifier::fromString(vm, "name"_s), jsString(vm, name));
     result->putDirect(vm, Identifier::fromString(vm, "value"_s), value);
+    return result;
+}
+
+JSValue JSInjectedScriptHost::getOwnPrivatePropertyDescriptors(JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    if (callFrame->argumentCount() < 1)
+        return jsUndefined();
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue value = callFrame->uncheckedArgument(0);
+
+    JSObject* result = constructEmptyObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, JSValue());
+
+    JSObject* object = jsDynamicCast<JSObject*>(value);
+    if (!object)
+        return result;
+
+    PropertyNameArray propertyNames(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+    JSObject::getOwnPropertyNames(object, globalObject, propertyNames, DontEnumPropertiesMode::Include);
+    for (const auto& propertyName : propertyNames) {
+        if (!propertyName.isPrivateName())
+            continue;
+
+        // Authored private properties are indistinguishable from internal private properties except for their use of the `#` prefix.
+        if (!propertyName.string().startsWith('#'))
+            continue;
+
+        result->putDirect(vm, Identifier::fromString(vm, String(propertyName.impl()->isolatedCopy())), objectConstructorGetOwnPropertyDescriptor(globalObject, object, propertyName));
+    }
+
     return result;
 }
 

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.h
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.h
@@ -73,6 +73,7 @@ public:
     JSC::JSValue isPromiseRejectedWithNativeGetterTypeError(JSC::JSGlobalObject*, JSC::CallFrame*);
     JSC::JSValue subtype(JSC::JSGlobalObject*, JSC::CallFrame*);
     JSC::JSValue functionDetails(JSC::JSGlobalObject*, JSC::CallFrame*);
+    JSC::JSValue getOwnPrivatePropertyDescriptors(JSC::JSGlobalObject*, JSC::CallFrame*);
     JSC::JSValue getInternalProperties(JSC::JSGlobalObject*, JSC::CallFrame*);
     JSC::JSValue proxyTargetValue(JSC::CallFrame*);
     JSC::JSValue weakMapSize(JSC::JSGlobalObject*, JSC::CallFrame*);

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp
@@ -35,6 +35,7 @@ using namespace JSC;
 
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionSubtype);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionFunctionDetails);
+static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertyDescriptors);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetInternalProperties);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionInternalConstructorName);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionIsHTMLAllCollection);
@@ -61,6 +62,7 @@ void JSInjectedScriptHostPrototype::finishCreation(VM& vm, JSGlobalObject* globa
     
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("subtype"_s, jsInjectedScriptHostPrototypeFunctionSubtype, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("functionDetails"_s, jsInjectedScriptHostPrototypeFunctionFunctionDetails, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("getOwnPrivatePropertyDescriptors"_s, jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertyDescriptors, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("getInternalProperties"_s, jsInjectedScriptHostPrototypeFunctionGetInternalProperties, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("internalConstructorName"_s, jsInjectedScriptHostPrototypeFunctionInternalConstructorName, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("isHTMLAllCollection"_s, jsInjectedScriptHostPrototypeFunctionIsHTMLAllCollection, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
@@ -286,6 +288,19 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionFunctionDetails, (
         return throwVMTypeError(globalObject, scope);
 
     return JSValue::encode(castedThis->functionDetails(globalObject, callFrame));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertyDescriptors, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = callFrame->thisValue();
+    JSInjectedScriptHost* castedThis = jsDynamicCast<JSInjectedScriptHost*>(thisValue);
+    if (!castedThis)
+        return throwVMTypeError(globalObject, scope);
+
+    return JSValue::encode(castedThis->getOwnPrivatePropertyDescriptors(globalObject, callFrame));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetInternalProperties, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/inspector/protocol/Runtime.json
+++ b/Source/JavaScriptCore/inspector/protocol/Runtime.json
@@ -83,6 +83,7 @@
                 { "name": "enumerable", "type": "boolean", "optional": true, "description": "True if this property shows up during enumeration of the properties on the corresponding object." },
                 { "name": "isOwn", "optional": true, "type": "boolean", "description": "True if the property is owned for the object." },
                 { "name": "symbol", "optional": true, "$ref": "Runtime.RemoteObject", "description": "Property symbol object, if the property is a symbol." },
+                { "name": "isPrivate", "optional": true, "$ref": "boolean", "description": "True if the property is a private field." },
                 { "name": "nativeGetter", "optional": true, "type": "boolean", "description": "True if the property value came from a native getter." }
             ]
         },

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -347,10 +347,14 @@ static JSValue createConsoleProperty(VM& vm, JSObject* object)
 
 // FIXME: use a bytecode or intrinsic for creating a private symbol.
 // https://bugs.webkit.org/show_bug.cgi?id=212782
-JSC_DEFINE_HOST_FUNCTION(createPrivateSymbol, (JSGlobalObject* globalObject, CallFrame*))
+JSC_DEFINE_HOST_FUNCTION(createPrivateSymbol, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
-    return JSValue::encode(Symbol::create(vm, PrivateSymbolImpl::createNullSymbol().get()));
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto description = callFrame->argument(0).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    return JSValue::encode(Symbol::create(vm, PrivateSymbolImpl::create(*description.impl()).get()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsonParse, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -1611,7 +1615,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
 
     // PrivateSymbols / PrivateNames
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::createPrivateSymbol)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "createPrivateSymbol"_s, createPrivateSymbol, ImplementationVisibility::Private));
+            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "createPrivateSymbol"_s, createPrivateSymbol, ImplementationVisibility::Private));
         });
 
     // JSON helpers

--- a/Source/JavaScriptCore/runtime/PrivateName.h
+++ b/Source/JavaScriptCore/runtime/PrivateName.h
@@ -32,11 +32,6 @@ namespace JSC {
 
 class PrivateName {
 public:
-    PrivateName()
-        : m_uid(SymbolImpl::createNullSymbol())
-    {
-    }
-
     explicit PrivateName(SymbolImpl& uid)
         : m_uid(uid)
     {

--- a/Source/JavaScriptCore/runtime/Symbol.cpp
+++ b/Source/JavaScriptCore/runtime/Symbol.cpp
@@ -36,7 +36,7 @@ const ClassInfo Symbol::s_info = { "symbol"_s, nullptr, nullptr, nullptr, CREATE
 
 Symbol::Symbol(VM& vm)
     : Base(vm, vm.symbolStructure.get())
-    , m_privateName()
+    , m_privateName(SymbolImpl::createNullSymbol())
 {
 }
 

--- a/Source/WTF/wtf/text/SymbolImpl.cpp
+++ b/Source/WTF/wtf/text/SymbolImpl.cpp
@@ -65,11 +65,6 @@ Ref<PrivateSymbolImpl> PrivateSymbolImpl::create(StringImpl& rep)
     return adoptRef(*new PrivateSymbolImpl(rep.m_data16, rep.length(), *ownerRep));
 }
 
-Ref<PrivateSymbolImpl> PrivateSymbolImpl::createNullSymbol()
-{
-    return adoptRef(*new PrivateSymbolImpl);
-}
-
 Ref<RegisteredSymbolImpl> RegisteredSymbolImpl::create(StringImpl& rep, SymbolRegistry& symbolRegistry)
 {
     auto* ownerRep = (rep.bufferOwnership() == BufferSubstring) ? rep.substringBuffer() : &rep;

--- a/Source/WTF/wtf/text/SymbolImpl.h
+++ b/Source/WTF/wtf/text/SymbolImpl.h
@@ -126,7 +126,6 @@ static_assert(sizeof(SymbolImpl) == sizeof(SymbolImpl::StaticSymbolImpl));
 
 class PrivateSymbolImpl final : public SymbolImpl {
 public:
-    WTF_EXPORT_PRIVATE static Ref<PrivateSymbolImpl> createNullSymbol();
     WTF_EXPORT_PRIVATE static Ref<PrivateSymbolImpl> create(StringImpl& rep);
 
 private:
@@ -137,11 +136,6 @@ private:
 
     PrivateSymbolImpl(const UChar* characters, unsigned length, Ref<StringImpl>&& base)
         : SymbolImpl(characters, length, WTFMove(base), s_flagIsPrivate)
-    {
-    }
-
-    PrivateSymbolImpl()
-        : SymbolImpl(s_flagIsPrivate)
     {
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Models/PropertyDescriptor.js
+++ b/Source/WebInspectorUI/UserInterface/Models/PropertyDescriptor.js
@@ -25,7 +25,7 @@
 
 WI.PropertyDescriptor = class PropertyDescriptor
 {
-    constructor(descriptor, symbol, isOwnProperty, wasThrown, nativeGetter, isInternalProperty)
+    constructor(descriptor, symbol, isOwnProperty, wasThrown, nativeGetter, isPrivateProperty, isInternalProperty)
     {
         console.assert(descriptor);
         console.assert(descriptor.name);
@@ -48,6 +48,7 @@ WI.PropertyDescriptor = class PropertyDescriptor
         this._own = isOwnProperty || false;
         this._wasThrown = wasThrown || false;
         this._nativeGetterValue = nativeGetter || false;
+        this._private = isPrivateProperty || false;
         this._internal = isInternalProperty || false;
     }
 
@@ -72,7 +73,7 @@ WI.PropertyDescriptor = class PropertyDescriptor
             payload.isOwn = true;
         }
 
-        return new WI.PropertyDescriptor(payload, payload.symbol, payload.isOwn, payload.wasThrown, payload.nativeGetter, internal);
+        return new WI.PropertyDescriptor(payload, payload.symbol, payload.isOwn, payload.wasThrown, payload.nativeGetter, payload.isPrivate, internal);
     }
 
     // Public
@@ -88,6 +89,7 @@ WI.PropertyDescriptor = class PropertyDescriptor
     get isOwnProperty() { return this._own; }
     get wasThrown() { return this._wasThrown; }
     get nativeGetter() { return this._nativeGetterValue; }
+    get isPrivateProperty() { return this._private; }
     get isInternalProperty() { return this._internal; }
 
     hasValue()

--- a/Source/WebInspectorUI/UserInterface/Models/PropertyPath.js
+++ b/Source/WebInspectorUI/UserInterface/Models/PropertyPath.js
@@ -162,6 +162,12 @@ WI.PropertyPath = class PropertyPath
         return new WI.PropertyPath(object, component, this);
     }
 
+    appendPrivatePropertyName(object, propertyName)
+    {
+        let component = WI.PropertyPath.SpecialPathComponent.PrivatePropertyName + "[" + propertyName + "]";
+        return new WI.PropertyPath(object, component, this);
+    }
+
     appendInternalPropertyName(object, propertyName)
     {
         var component = WI.PropertyPath.SpecialPathComponent.InternalPropertyName + "[" + propertyName + "]";
@@ -228,6 +234,8 @@ WI.PropertyPath = class PropertyPath
 
         if (descriptor.isInternalProperty)
             return this.appendInternalPropertyName(object, descriptor.name);
+        if (descriptor.isPrivateProperty)
+            return this.appendPrivatePropertyName(object, descriptor.name);
         if (descriptor.symbol)
             return this.appendSymbolProperty(object);
 
@@ -253,6 +261,7 @@ WI.PropertyPath = class PropertyPath
 };
 
 WI.PropertyPath.SpecialPathComponent = {
+    PrivatePropertyName: "@private",
     InternalPropertyName: "@internal",
     SymbolPropertyName: "@symbol",
     MapKey: "@mapkey",

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.css
@@ -84,7 +84,7 @@
     font-size: 12px;
 }
 
-.object-tree-property .property-name.not-enumerable {
+.object-tree-property .property-name:is(.private, .not-enumerable) {
     opacity: 0.6;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.js
@@ -157,6 +157,8 @@ WI.ObjectTreePropertyTreeElement = class ObjectTreePropertyTreeElement extends W
 
         // Property attributes.
         if (this._mode === WI.ObjectTreeView.Mode.Properties) {
+            if (this.property.isPrivateProperty)
+                nameElement.classList.add("private");
             if (!this.property.enumerable)
                 nameElement.classList.add("not-enumerable");
         }

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.js
@@ -187,6 +187,12 @@ WI.ObjectTreeView = class ObjectTreeView extends WI.Object
         if (propertyB.isInternalProperty && !propertyA.isInternalProperty)
             return 1;
 
+        // Put private properties at the top.
+        if (propertyA.isPrivateProperty && !propertyB.isPrivateProperty)
+            return -1;
+        if (propertyB.isPrivateProperty && !propertyA.isPrivateProperty)
+            return 1;
+
         // Put Symbol properties at the bottom.
         if (propertyA.symbol && !propertyB.symbol)
             return 1;

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2836,7 +2836,7 @@ JSMessageListener::JSMessageListener(JSIPC& jsIPC, Type type, JSContextRef conte
 
     // We can't retain the global context here as that would cause a leak
     // since this object is supposed to live as long as the global object is alive.
-    JSC::PrivateName uniquePrivateName;
+    JSC::PrivateName uniquePrivateName(JSC::PrivateName::Description, "listener"_s);
     globalObject->putDirect(vm, uniquePrivateName, toJS(globalObject, callback));
 
     UNUSED_PARAM(catchScope);


### PR DESCRIPTION
#### 444a3dccd78535db15ac4a8e0164cf8d537a35a5
<pre>
Web Inspector: Support ES2022 Private Fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=254961">https://bugs.webkit.org/show_bug.cgi?id=254961</a>
&lt;rdar://problem/107863310&gt;

Reviewed by Patrick Angle and Justin Michaud.

Web Inspector should show private fields when logging objects in the Console.

As private field usage becomes more and more popular, not being able to see private fields in the Console will become increasingly disruptive to the debugging experience.

* Source/JavaScriptCore/inspector/InjectedScriptSource.js:
(InjectedScript.prototype._forEachPropertyDescriptor):
(InjectedScript.prototype._forEachPropertyDescriptor.processProperty):
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.h:
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::getOwnPrivatePropertyDescriptors): Added.
* Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp:
(Inspector::JSInjectedScriptHostPrototype::finishCreation):
(Inspector::jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertyDescriptors): Added.
Create a `InjectedScriptHost` method similar to `Object.getOwnPropertyDescriptors` but only for private fields.
Use it when fetching property descriptors for the frontend to grab private fields just like all other public fields.

* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::PropertyListNode::emitDeclarePrivateFieldNames):
Pass along the `PropertyNode::name` when creating a private symbol for the private field.

* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitCreatePrivateBrand):
AFAIK there is no name in this scenario, just a private symbol to mark with a private brand, so use an empty string for the name.

* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::createPrivateSymbol):
(JSC::JSGlobalObject::init):
Require a name when calling `@createPrivateSymbol`.

* Source/JavaScriptCore/runtime/PrivateName.h:
(JSC::PrivateName::PrivateName): Deleted.
* Source/JavaScriptCore/runtime/Symbol.cpp:
(JSC::Symbol::Symbol):
* Source/WTF/wtf/text/SymbolImpl.h:
* Source/WTF/wtf/text/SymbolImpl.cpp:
(WTF::PrivateSymbolImpl::createNullSymbol): Deleted.
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSMessageListener::JSMessageListener):
Require that all `PrivateName` and `PrivateSymbolImpl` be created with a name (or at least an empty string).

* Source/JavaScriptCore/inspector/protocol/Runtime.json:
* Source/WebInspectorUI/UserInterface/Models/PropertyDescriptor.js:
(WI.PropertyDescriptor):
(WI.PropertyDescriptor.fromPayload):
(WI.PropertyDescriptor.get isPrivateProperty): Added.
Expose a way for clients to know that this `WI.PropertyDescriptor` is for a private field.

* Source/WebInspectorUI/UserInterface/Models/PropertyPath.js:
(WI.PropertyPath.prototype.appendPrivatePropertyName): Added.
(WI.PropertyPath.prototype.appendPropertyDescriptor):
Make sure that private fields are sufficiently hidden (i.e. do not show &quot;Copy Path to Property&quot; since it won&apos;t work).

* Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.js:
(WI.ObjectTreeView.comparePropertyDescriptors):
Sort private fields above all other non-internal properties.

* Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.js:
(WI.ObjectTreePropertyTreeElement.prototype._createTitlePropertyStyle):
* Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.css:
(.object-tree-property .property-name:is(.private, .not-enumerable)): Renamed from `.object-tree-property .property-name.not-enumerable`.
Display private fields as a greyed out property (similar to internal properties) in order to help emphasize their semi-unreachable nature.

* LayoutTests/inspector/runtime/getDisplayableProperties.html:
* LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt:
* LayoutTests/inspector/runtime/getProperties.html:
* LayoutTests/inspector/runtime/getProperties-expected.txt:
* LayoutTests/inspector/runtime/resources/property-descriptor-utilities.js:
(ProtocolTest.PropertyDescriptorUtilities.logForEach):

Canonical link: <a href="https://commits.webkit.org/262882@main">https://commits.webkit.org/262882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f17c7f6548620ce143f7bbac32961fff3e47af7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2903 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4313 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3049 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/3455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4103 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2575 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2402 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2626 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2756 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/2979 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/3455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2967 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2578 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/712 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/716 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2606 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3044 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2800 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/844 "Passed tests") | 
<!--EWS-Status-Bubble-End-->