### PR TITLE
Fix PACGA encoding in ARM64EAssembler.h.

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64EAssembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64EAssembler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -83,7 +83,7 @@ protected:
         XPACI  = 1 << 30 | 0b00001 << 16 | 0b10000 << 10,
         XPACD  = 1 << 30 | 0b00001 << 16 | 0b10001 << 10,
 
-        PACGA  = 0 << 30 | 0b01100,
+        PACGA  = 0 << 30 | 0b01100 << 10,
     };
 
     ALWAYS_INLINE static int encodeGroup2(Group2Op op, RegisterID rn, RegisterID rd, RegisterID rm)


### PR DESCRIPTION
#### 6b52f0a0ff9baea675c1b266fcb8fd4a4417593a
<pre>
Fix PACGA encoding in ARM64EAssembler.h.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255362">https://bugs.webkit.org/show_bug.cgi?id=255362</a>
rdar://107956903

Reviewed by Justin Michaud.

The encoding was missing a shift for one of the set of bits.

* Source/JavaScriptCore/assembler/ARM64EAssembler.h:

Canonical link: <a href="https://commits.webkit.org/262884@main">https://commits.webkit.org/262884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18bc9e53d9d4b4db76d2b220b51c5f22e40eb72a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/2989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4329 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/3064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3027 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2952 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/3064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4121 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/3064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/2594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/2415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/3064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/3865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/2770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/2994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/2987 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/2630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/2597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/2619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3065 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/338 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/2815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->