### PR TITLE
Improve & simplify the HTML entity parsing in the HTML fast parser

### DIFF
--- a/Source/WebCore/platform/text/SegmentedString.cpp
+++ b/Source/WebCore/platform/text/SegmentedString.cpp
@@ -27,7 +27,10 @@ namespace WebCore {
 
 inline void SegmentedString::Substring::appendTo(StringBuilder& builder) const
 {
-    builder.appendSubstring(string, string.length() - length, length);
+    if (is8Bit)
+        builder.appendCharacters(currentCharacter8, length);
+    else
+        builder.appendCharacters(currentCharacter16, length);
 }
 
 SegmentedString& SegmentedString::operator=(SegmentedString&& other)

--- a/Source/WebCore/xml/parser/CharacterReferenceParserInlines.h
+++ b/Source/WebCore/xml/parser/CharacterReferenceParserInlines.h
@@ -32,7 +32,8 @@ namespace WebCore {
 
 inline void unconsumeCharacters(SegmentedString& source, StringBuilder& consumedCharacters)
 {
-    source.pushBack(consumedCharacters.toString());
+    if (!consumedCharacters.isEmpty())
+        source.pushBack(consumedCharacters.toString());
 }
 
 template<typename T> void appendCharacterTo(T& output, UChar32 c)


### PR DESCRIPTION
#### d2928a3c32a3799b66bbdeb863e5f8bbb3c5972b
<pre>
Improve &amp; simplify the HTML entity parsing in the HTML fast parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=255366">https://bugs.webkit.org/show_bug.cgi?id=255366</a>
&lt;rdar://problem/107961494&gt;

Reviewed by Ryosuke Niwa.

Improve &amp; simplify the HTML entity parsing in the HTML fast parser:

Drop a lot of logic in HTMLFastPathParser::scanHTMLCharacterReference()
to try and parse simple HTML entities and instead rely on
solely on consumeHTMLEntity().

This simplifies the code a lot and actually allows the HTML fast parser
to support more input. For example, previously, the fast parser would
fail parsing for &quot;food &amp; water&quot; because it would find an &apos;&amp;&apos; character
and fail to parse an HTML entity. Also, it would fail to parse some
complex cases where the HTML entity doesn&apos;t end with a semicolon
(e.g. &quot;&amp;nbsp&amp;a&quot;). The fast parser now essentially has the same behavior
as the full HTML parser when it comes to HTML entities, since it relies
on the same consumeHTMLEntity() function and uses it in the same way.

Note that extended support is covered by the extended API test. Also
note that we have a pre-existing debug assertion in place to make sure
the fast parser returns the exact same output as the full parser. We
thus have good test coverage for correctness.

For performance reasons and because the HTMLEntityParser currently only
works with SegmentedStrings, I added support for constructing a
SegmentedString from a StringView. This avoids unnecessary String
constructions just for entity parsing.

This is performance neutral on Speedometer but it makes the code simpler
and allows our HTML fast parser to deal with more complex input.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanHTMLCharacterReference):
* Source/WebCore/platform/text/SegmentedString.cpp:
(WebCore::SegmentedString::Substring::appendTo const):
* Source/WebCore/platform/text/SegmentedString.h:
(WebCore::SegmentedString::Substring::Substring):
(WebCore::SegmentedString::Substring::numberOfCharactersConsumed const):
(WebCore::SegmentedString::SegmentedString):
* Source/WebCore/xml/parser/CharacterReferenceParserInlines.h:
(WebCore::unconsumeCharacters):
* Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/262934@main">https://commits.webkit.org/262934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdfd33b001fda66d1274213885068173cb0140da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3377 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2604 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4175 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2646 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2499 "27 flakes 148 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3919 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2442 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2648 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/754 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->