### PR TITLE
Partial Sync SVGTextContentElement.idl with IDL Spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
@@ -1116,13 +1116,13 @@ PASS SVGTextContentElement interface: attribute textLength
 PASS SVGTextContentElement interface: attribute lengthAdjust
 PASS SVGTextContentElement interface: operation getNumberOfChars()
 PASS SVGTextContentElement interface: operation getComputedTextLength()
-FAIL SVGTextContentElement interface: operation getSubStringLength(unsigned long, unsigned long) assert_equals: property has wrong .length expected 2 but got 0
-FAIL SVGTextContentElement interface: operation getStartPositionOfChar(unsigned long) assert_equals: property has wrong .length expected 1 but got 0
-FAIL SVGTextContentElement interface: operation getEndPositionOfChar(unsigned long) assert_equals: property has wrong .length expected 1 but got 0
-FAIL SVGTextContentElement interface: operation getExtentOfChar(unsigned long) assert_equals: property has wrong .length expected 1 but got 0
-FAIL SVGTextContentElement interface: operation getRotationOfChar(unsigned long) assert_equals: property has wrong .length expected 1 but got 0
-FAIL SVGTextContentElement interface: operation getCharNumAtPosition(optional DOMPointInit) assert_equals: property has wrong .length expected 0 but got 1
-FAIL SVGTextContentElement interface: operation selectSubString(unsigned long, unsigned long) assert_equals: property has wrong .length expected 2 but got 0
+PASS SVGTextContentElement interface: operation getSubStringLength(unsigned long, unsigned long)
+PASS SVGTextContentElement interface: operation getStartPositionOfChar(unsigned long)
+PASS SVGTextContentElement interface: operation getEndPositionOfChar(unsigned long)
+PASS SVGTextContentElement interface: operation getExtentOfChar(unsigned long)
+PASS SVGTextContentElement interface: operation getRotationOfChar(unsigned long)
+PASS SVGTextContentElement interface: operation getCharNumAtPosition(optional DOMPointInit)
+PASS SVGTextContentElement interface: operation selectSubString(unsigned long, unsigned long)
 PASS SVGTextPositioningElement interface: existence and properties of interface object
 PASS SVGTextPositioningElement interface object length
 PASS SVGTextPositioningElement interface object name
@@ -1155,35 +1155,19 @@ PASS SVGTextContentElement interface: objects.text must inherit property "length
 PASS SVGTextContentElement interface: objects.text must inherit property "getNumberOfChars()" with the proper type
 PASS SVGTextContentElement interface: objects.text must inherit property "getComputedTextLength()" with the proper type
 PASS SVGTextContentElement interface: objects.text must inherit property "getSubStringLength(unsigned long, unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.text with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" threw object "IndexSizeError: The index is not in the allowed range." ("IndexSizeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.text with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.text must inherit property "getStartPositionOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getStartPositionOfChar(unsigned long) on objects.text with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getStartPositionOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.text must inherit property "getEndPositionOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.text with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.text must inherit property "getExtentOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.text with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.text must inherit property "getRotationOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.text with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.text with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.text must inherit property "getCharNumAtPosition(optional DOMPointInit)" with the proper type
 PASS SVGTextContentElement interface: calling getCharNumAtPosition(optional DOMPointInit) on objects.text with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.text must inherit property "selectSubString(unsigned long, unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.text with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" threw object "IndexSizeError: The index is not in the allowed range." ("IndexSizeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.text with too few arguments must throw TypeError
 PASS SVGGraphicsElement interface: objects.text must inherit property "transform" with the proper type
 PASS SVGGraphicsElement interface: objects.text must inherit property "getBBox(optional SVGBoundingBoxOptions)" with the proper type
 PASS SVGGraphicsElement interface: calling getBBox(optional SVGBoundingBoxOptions) on objects.text with too few arguments must throw TypeError
@@ -1217,35 +1201,19 @@ PASS SVGTextContentElement interface: objects.tspan must inherit property "lengt
 PASS SVGTextContentElement interface: objects.tspan must inherit property "getNumberOfChars()" with the proper type
 PASS SVGTextContentElement interface: objects.tspan must inherit property "getComputedTextLength()" with the proper type
 PASS SVGTextContentElement interface: objects.tspan must inherit property "getSubStringLength(unsigned long, unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.tspan with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" threw object "IndexSizeError: The index is not in the allowed range." ("IndexSizeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.tspan with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.tspan must inherit property "getStartPositionOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getStartPositionOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getStartPositionOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.tspan must inherit property "getEndPositionOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.tspan must inherit property "getExtentOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.tspan must inherit property "getRotationOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.tspan with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.tspan must inherit property "getCharNumAtPosition(optional DOMPointInit)" with the proper type
 PASS SVGTextContentElement interface: calling getCharNumAtPosition(optional DOMPointInit) on objects.tspan with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.tspan must inherit property "selectSubString(unsigned long, unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.tspan with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" threw object "IndexSizeError: The index is not in the allowed range." ("IndexSizeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.tspan with too few arguments must throw TypeError
 PASS SVGGraphicsElement interface: objects.tspan must inherit property "transform" with the proper type
 PASS SVGGraphicsElement interface: objects.tspan must inherit property "getBBox(optional SVGBoundingBoxOptions)" with the proper type
 PASS SVGGraphicsElement interface: calling getBBox(optional SVGBoundingBoxOptions) on objects.tspan with too few arguments must throw TypeError
@@ -1300,35 +1268,19 @@ PASS SVGTextContentElement interface: objects.textPath must inherit property "le
 PASS SVGTextContentElement interface: objects.textPath must inherit property "getNumberOfChars()" with the proper type
 PASS SVGTextContentElement interface: objects.textPath must inherit property "getComputedTextLength()" with the proper type
 PASS SVGTextContentElement interface: objects.textPath must inherit property "getSubStringLength(unsigned long, unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.textPath with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" threw object "IndexSizeError: The index is not in the allowed range." ("IndexSizeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS SVGTextContentElement interface: calling getSubStringLength(unsigned long, unsigned long) on objects.textPath with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.textPath must inherit property "getStartPositionOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getStartPositionOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getStartPositionOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.textPath must inherit property "getEndPositionOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getEndPositionOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.textPath must inherit property "getExtentOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getExtentOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.textPath must inherit property "getRotationOfChar(unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGTextContentElement interface: calling getRotationOfChar(unsigned long) on objects.textPath with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.textPath must inherit property "getCharNumAtPosition(optional DOMPointInit)" with the proper type
 PASS SVGTextContentElement interface: calling getCharNumAtPosition(optional DOMPointInit) on objects.textPath with too few arguments must throw TypeError
 PASS SVGTextContentElement interface: objects.textPath must inherit property "selectSubString(unsigned long, unsigned long)" with the proper type
-FAIL SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.textPath with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" threw object "IndexSizeError: The index is not in the allowed range." ("IndexSizeError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS SVGTextContentElement interface: calling selectSubString(unsigned long, unsigned long) on objects.textPath with too few arguments must throw TypeError
 PASS SVGGraphicsElement interface: objects.textPath must inherit property "transform" with the proper type
 PASS SVGGraphicsElement interface: objects.textPath must inherit property "getBBox(optional SVGBoundingBoxOptions)" with the proper type
 PASS SVGGraphicsElement interface: calling getBBox(optional SVGBoundingBoxOptions) on objects.textPath with too few arguments must throw TypeError

--- a/Source/WebCore/svg/SVGTextContentElement.idl
+++ b/Source/WebCore/svg/SVGTextContentElement.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://svgwg.org/svg2-draft/text.html#InterfaceSVGTextContentElement
+
 [
     Exposed=Window
 ] interface SVGTextContentElement : SVGGraphicsElement {
@@ -31,16 +33,17 @@
     const unsigned short LENGTHADJUST_SPACING = 1;
     const unsigned short LENGTHADJUST_SPACINGANDGLYPHS = 2;
 
-    readonly attribute SVGAnimatedLength textLength;
-    readonly attribute SVGAnimatedEnumeration lengthAdjust;
+    [SameObject] readonly attribute SVGAnimatedLength textLength;
+    [SameObject] readonly attribute SVGAnimatedEnumeration lengthAdjust;
 
     long getNumberOfChars();
-    unrestricted float getComputedTextLength();
-    unrestricted float getSubStringLength(optional unsigned long offset = 0, optional unsigned long length = 0);
-    [NewObject] SVGPoint getStartPositionOfChar(optional unsigned long offset = 0);
-    [NewObject] SVGPoint getEndPositionOfChar(optional unsigned long offset = 0);
-    [NewObject] SVGRect getExtentOfChar(optional unsigned long offset = 0);
-    unrestricted float getRotationOfChar(optional unsigned long offset = 0);
-    long getCharNumAtPosition(DOMPointInit point);
-    undefined selectSubString(optional unsigned long offset = 0, optional unsigned long length = 0);
+    float getComputedTextLength();
+    float getSubStringLength(unsigned long charnum, unsigned long nchars);
+    // FIXME: SVGPoint/SVGRect should be DOMPoint/DOMRect as per web-spec.
+    SVGPoint getStartPositionOfChar(unsigned long charnum);
+    SVGPoint getEndPositionOfChar(unsigned long charnum);
+    SVGRect getExtentOfChar(unsigned long charnum);
+    float getRotationOfChar(unsigned long charnum);
+    long getCharNumAtPosition(optional DOMPointInit point = {});
+    undefined selectSubString(unsigned long charnum, unsigned long nchars);
 };


### PR DESCRIPTION
#### 7a9711ddf39ee9a4428602413fc2f4beecbf320c
<pre>
Partial Sync SVGTextContentElement.idl with IDL Spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=120451">https://bugs.webkit.org/show_bug.cgi?id=120451</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with web-spec [1].

[1] <a href="https://svgwg.org/svg2-draft/text.html#InterfaceSVGTextContentElement">https://svgwg.org/svg2-draft/text.html#InterfaceSVGTextContentElement</a>

Further, add FIXME to fully align with web-spec.

* Source/WebCore/svg/SVGTextContentElement.idl:
* LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/262964@main">https://commits.webkit.org/262964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/644920b0b85a41b9602f6046ab75c0bed7492bcf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3527 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3257 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4393 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2823 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2874 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2591 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/768 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->