### PR TITLE
REGRESSION (261193@main): missing elements on apple-console.lrn.com

### DIFF
--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -397,7 +397,8 @@ void HTMLElement::attributeChanged(const QualifiedName& name, const AtomString& 
         }
     }
 
-    if (document().settings().popoverAttributeEnabled() && name == popoverAttr)
+    bool popoverAttributeEnabled = document().settings().popoverAttributeEnabled() && !document().quirks().shouldDisablePopoverAttributeQuirk();
+    if (popoverAttributeEnabled && name == popoverAttr)
         popoverAttributeChanged(newValue);
 
     auto& eventName = eventNameForEventHandlerAttribute(name);

--- a/Source/WebCore/html/HTMLElement.idl
+++ b/Source/WebCore/html/HTMLElement.idl
@@ -51,10 +51,10 @@
     [CEReactions, Reflect, EnabledBySetting=InertAttributeEnabled] attribute boolean inert;
 
     // The popover API
-    [EnabledBySetting=PopoverAttributeEnabled] undefined showPopover();
-    [EnabledBySetting=PopoverAttributeEnabled] undefined hidePopover();
-    [EnabledBySetting=PopoverAttributeEnabled] undefined togglePopover(optional boolean force);
-    [CEReactions, EnabledBySetting=PopoverAttributeEnabled] attribute [AtomString] DOMString? popover;
+    [EnabledBySetting=PopoverAttributeEnabled, DisabledByQuirk=shouldDisablePopoverAttribute] undefined showPopover();
+    [EnabledBySetting=PopoverAttributeEnabled, DisabledByQuirk=shouldDisablePopoverAttribute] undefined hidePopover();
+    [EnabledBySetting=PopoverAttributeEnabled, DisabledByQuirk=shouldDisablePopoverAttribute] undefined togglePopover(optional boolean force);
+    [CEReactions, EnabledBySetting=PopoverAttributeEnabled, DisabledByQuirk=shouldDisablePopoverAttribute] attribute [AtomString] DOMString? popover;
 
     // Non-standard: IE extension. May get added to the specification (https://github.com/whatwg/html/issues/668).
     [CEReactions] attribute [LegacyNullToEmptyString] DOMString outerText;

--- a/Source/WebCore/html/PopoverInvokerElement.idl
+++ b/Source/WebCore/html/PopoverInvokerElement.idl
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[EnabledBySetting=PopoverAttributeEnabled]
+[EnabledBySetting=PopoverAttributeEnabled, DisabledByQuirk=shouldDisablePopoverAttribute]
 interface mixin PopoverInvokerElement {
     [CEReactions=NotNeeded, Reflect=popovertarget] attribute Element? popoverTargetElement;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString popoverTargetAction;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1575,4 +1575,14 @@ bool Quirks::shouldAdvertiseSupportForHLSSubtitleTypes() const
 }
 #endif
 
+// apple-console.lrn.com (rdar://106779034)
+bool Quirks::shouldDisablePopoverAttributeQuirk() const
+{
+    if (!needsQuirks())
+        return false;
+
+    auto host = m_document->topDocument().url().host();
+    return equalLettersIgnoringASCIICase(host, "apple-console.lrn.com"_s);
+}
+
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -163,6 +163,8 @@ public:
     bool shouldAdvertiseSupportForHLSSubtitleTypes() const;
 #endif
 
+    bool shouldDisablePopoverAttributeQuirk() const;
+
 private:
     bool needsQuirks() const;
 

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -246,7 +246,8 @@ void UserAgentStyle::ensureDefaultStyleSheetsForElement(const Element& element)
     }
 #endif // ENABLE(MATHML)
 
-    if (!popoverStyleSheet && element.document().settings().popoverAttributeEnabled() && element.hasAttributeWithoutSynchronization(popoverAttr)) {
+    bool popoverAttributeEnabled = element.document().settings().popoverAttributeEnabled() && !element.document().quirks().shouldDisablePopoverAttributeQuirk();
+    if (!popoverStyleSheet && popoverAttributeEnabled && element.hasAttributeWithoutSynchronization(popoverAttr)) {
         popoverStyleSheet = parseUASheet(StringImpl::createWithoutCopying(popoverUserAgentStyleSheet, sizeof(popoverUserAgentStyleSheet)));
         addToDefaultStyle(*popoverStyleSheet);
     }


### PR DESCRIPTION
#### 162629a2bccd8d5df744faabcd15577828e53c68
<pre>
REGRESSION (261193@main): missing elements on apple-console.lrn.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=255373">https://bugs.webkit.org/show_bug.cgi?id=255373</a>
rdar://106779034

Reviewed by Brent Fulgham.

The site uses a popover attribute without the intention of using the popover API, causing the display: none; UA styles to apply.
Quirk the site to have the attribute disabled.

* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::parseAttribute):
* Source/WebCore/html/HTMLElement.idl:
* Source/WebCore/html/PopoverInvokerElement.idl:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisablePopoverAttributeQuirk const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::UserAgentStyle::ensureDefaultStyleSheetsForElement):

Canonical link: <a href="https://commits.webkit.org/262921@main">https://commits.webkit.org/262921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a80254439f291d128dd148e77ca332c839dc517

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4369 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2594 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/2992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4161 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2487 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3899 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2433 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2635 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/742 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2650 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2852 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->