### PR TITLE
Web Inspector: Console: non-enumerable properties appear as though they're internal

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -393,6 +393,8 @@ localizedStrings["Compute Shader"] = "Compute Shader";
 localizedStrings["Computed"] = "Computed";
 localizedStrings["Condition"] = "Condition";
 localizedStrings["Conditional expression"] = "Conditional expression";
+/* Part of the tooltip indicating that the hovered property is configurable. */
+localizedStrings["Configurable @ Object Tree Property"] = "Configurable";
 localizedStrings["Conic Gradient"] = "Conic Gradient";
 localizedStrings["Connecting"] = "Connecting";
 localizedStrings["Connection"] = "Connection";
@@ -668,6 +670,8 @@ localizedStrings["Ensure that only one live region is used on the page."] = "Ens
 localizedStrings["Ensure that only one main content section is used on the page."] = "Ensure that only one main content section is used on the page.";
 localizedStrings["Ensure that values for \u201C%s\u201D are valid."] = "Ensure that values for \u201C%s\u201D are valid.";
 localizedStrings["Entire Recording"] = "Entire Recording";
+/* Part of the tooltip indicating that the hovered property is enumerable. */
+localizedStrings["Enumerable @ Object Tree Property"] = "Enumerable";
 localizedStrings["Error"] = "Error";
 /* Title of icon indicating that the selected audit threw an error. */
 localizedStrings["Error @ Audit Tab - Test Case"] = "Error";
@@ -1104,7 +1108,13 @@ localizedStrings["Nodes"] = "Nodes";
 localizedStrings["None"] = "None";
 /* Property value for any `normal` CSS value. */
 localizedStrings["Normal @ Font Details Sidebar Property Value"] = "Normal";
+/* Part of the tooltip indicating that the hovered property is not configurable. */
+localizedStrings["Not configurable @ Object Tree Property"] = "Not configurable";
+/* Part of the tooltip indicating that the hovered property is not enumerable. */
+localizedStrings["Not enumerable @ Object Tree Property"] = "Not enumerable";
 localizedStrings["Not found"] = "Not found";
+/* Part of the tooltip indicating that the hovered property is not writable. */
+localizedStrings["Not writable @ Object Tree Property"] = "Not writable";
 /* Title of icon indicating that the selected audit has not been run yet. */
 localizedStrings["Not yet run @ Audit Tab - Test Case"] = "Not yet run";
 /* Section header for the group of CSS variables with numbers as values */
@@ -1868,6 +1878,8 @@ localizedStrings["Worker: %s"] = "Worker: %s";
 /* Title for list of JavaScript web worker execution contexts */
 localizedStrings["Workers @ Execution Context Picker"] = "Workers";
 localizedStrings["Wrap lines to editor width"] = "Wrap lines to editor width";
+/* Part of the tooltip indicating that the hovered property is writable. */
+localizedStrings["Writable @ Object Tree Property"] = "Writable";
 localizedStrings["XBM"] = "XBM";
 localizedStrings["XHR"] = "XHR";
 localizedStrings["XHR Breakpoint\u2026"] = "XHR Breakpoint\u2026";

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.css
@@ -84,8 +84,8 @@
     font-size: 12px;
 }
 
-.object-tree-property .property-name:is(.private, .not-enumerable) {
-    opacity: 0.6;
+.object-tree-property .property-name:is(.private, .internal) {
+    color: var(--text-color-secondary);
 }
 
 .item.object-tree-property.prototype-property {

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.js
@@ -159,8 +159,27 @@ WI.ObjectTreePropertyTreeElement = class ObjectTreePropertyTreeElement extends W
         if (this._mode === WI.ObjectTreeView.Mode.Properties) {
             if (this.property.isPrivateProperty)
                 nameElement.classList.add("private");
-            if (!this.property.enumerable)
-                nameElement.classList.add("not-enumerable");
+
+            if (this.property.isInternalProperty)
+                nameElement.classList.add("internal");
+            else {
+                nameElement.title += "\n";
+
+                if (this.property.configurable)
+                    nameElement.title += "\n" + WI.UIString("Configurable", "Configurable @ Object Tree Property", "Part of the tooltip indicating that the hovered property is configurable.");
+                else
+                    nameElement.title += "\n" + WI.UIString("Not configurable", "Not configurable @ Object Tree Property", "Part of the tooltip indicating that the hovered property is not configurable.");
+
+                if (this.property.enumerable)
+                    nameElement.title += "\n" + WI.UIString("Enumerable", "Enumerable @ Object Tree Property", "Part of the tooltip indicating that the hovered property is enumerable.");
+                else
+                    nameElement.title += "\n" + WI.UIString("Not enumerable", "Not enumerable @ Object Tree Property", "Part of the tooltip indicating that the hovered property is not enumerable.");
+
+                if (this.property.writable)
+                    nameElement.title += "\n" + WI.UIString("Writable", "Writable @ Object Tree Property", "Part of the tooltip indicating that the hovered property is writable.");
+                else
+                    nameElement.title += "\n" + WI.UIString("Not writable", "Not writable @ Object Tree Property", "Part of the tooltip indicating that the hovered property is not writable.");
+            }
         }
 
         // Value / Getter Value / Getter.


### PR DESCRIPTION
#### 020a590e7acaecf822bce045a637740dbbc5ed1b
<pre>
Web Inspector: Console: non-enumerable properties appear as though they&apos;re internal
<a href="https://bugs.webkit.org/show_bug.cgi?id=255376">https://bugs.webkit.org/show_bug.cgi?id=255376</a>

Reviewed by Patrick Angle.

We currently semi-transparent the text of properties that are not enumerable, but this is most commonly seen as a treatment for internal properties (e.g. `listeners`).

Logging `window` shows all the various builtin constructors (e.g. `AbortController`) with the same treatment, adding further confusion (i.e. &quot;Are these internal properties?  I thought I could access them?&quot;).

We should instead move enumerable, writable, etc. to be part of the `title`.

* Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.js:
(WI.ObjectTreePropertyTreeElement.prototype._createTitlePropertyStyle):
* Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.css:
(.object-tree-property .property-name:is(.private, .internal)): Renamed from `.object-tree-property .property-name:is(.private, .not-enumerable)`.
Drive-by: Use a CSS variable to change the `color` instead of `opacity`.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

Canonical link: <a href="https://commits.webkit.org/262923@main">https://commits.webkit.org/262923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4faf0c67e15de8bdb944a20d1c2a0ab7bd670b5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4446 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3139 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2647 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3064 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4241 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2700 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/2751 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3974 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3102 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2702 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/741 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2921 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->