### PR TITLE
Apply std::optional to FontMetrics for consistency

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -682,8 +682,8 @@ double CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(CSSUnitType primiti
         return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription->specifiedSize() : fontDescription->computedSize()) * value;
     case CSSUnitType::CSS_EXS:
         ASSERT(fontMetrics);
-        if (fontMetrics->hasXHeight())
-            return fontMetrics->xHeight() * value;
+        if (fontMetrics->xHeight().has_value())
+            return fontMetrics->xHeight().value() * value;
         ASSERT(fontDescription);
         return ((propertyToCompute == CSSPropertyFontSize) ? fontDescription->specifiedSize() : fontDescription->computedSize()) / 2.0 * value;
     case CSSUnitType::CSS_REMS:
@@ -696,7 +696,7 @@ double CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble(CSSUnitType primiti
         return fontMetrics->zeroWidth().value_or(fontDescription->computedSize() / 2) * value;
     case CSSUnitType::CSS_IC:
         ASSERT(fontMetrics);
-        return fontMetrics->ideogramWidth() * value;
+        return fontMetrics->ideogramWidth().value_or(0) * value;
     case CSSUnitType::CSS_PX:
         return value;
     case CSSUnitType::CSS_CM:
@@ -897,7 +897,7 @@ double CSSPrimitiveValue::computeNonCalcLengthDouble(const CSSToLengthConversion
     case CSSUnitType::CSS_LHS:
         if (conversionData.computingLineHeight() || conversionData.computingFontSize()) {
             // Try to get the parent's computed line-height, or fall back to the initial line-height of this element's font spacing.
-            value *= conversionData.parentStyle() ? conversionData.parentStyle()->computedLineHeight() : conversionData.fontCascadeForFontUnits().metricsOfPrimaryFont().lineSpacing();
+            value *= conversionData.parentStyle() ? conversionData.parentStyle()->computedLineHeight() : conversionData.fontCascadeForFontUnits().metricsOfPrimaryFont().intLineSpacing();
         } else
             value *= conversionData.computedLineHeightForFontUnits();
         break;

--- a/Source/WebCore/display/css/DisplayBoxPainter.cpp
+++ b/Source/WebCore/display/css/DisplayBoxPainter.cpp
@@ -75,7 +75,7 @@ void BoxPainter::paintBoxContent(const Box& box, PaintingContext& paintingContex
         paintingContext.context.setFillColor(style.color());
 
         // FIXME: Add non-baseline align painting
-        auto baseline = textRect.y() + style.metricsOfPrimaryFont().ascent();
+        auto baseline = textRect.y() + style.metricsOfPrimaryFont().intAscent();
         auto expansion = textBox.expansion();
 
         auto textRun = TextRun { textBox.text().originalContent(), textRect.x(), expansion.horizontalExpansion, expansion.behavior };

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2588,8 +2588,8 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     location += textOffset(width, textRun.direction());
 
     // The slop built in to this mask rect matches the heuristic used in FontCGWin.cpp for GDI text.
-    FloatRect textRect = FloatRect(location.x() - fontMetrics.height() / 2, location.y() - fontMetrics.ascent() - fontMetrics.lineGap(),
-        width + fontMetrics.height(), fontMetrics.lineSpacing());
+    FloatRect textRect = FloatRect(location.x() - fontMetrics.intHeight() / 2, location.y() - fontMetrics.intAscent() - fontMetrics.intLineGap(),
+        width + fontMetrics.intHeight(), fontMetrics.intLineSpacing());
     if (!fill)
         inflateStrokeRect(textRect);
 
@@ -2708,16 +2708,18 @@ Ref<TextMetrics> CanvasRenderingContext2DBase::measureTextInternal(const TextRun
     metrics->setWidth(fontWidth);
 
     FloatPoint offset = textOffset(fontWidth, textRun.direction());
+    int ascent = fontMetrics.intAscent();
+    int descent = fontMetrics.intDescent();
 
     metrics->setActualBoundingBoxAscent(glyphOverflow.top - offset.y());
     metrics->setActualBoundingBoxDescent(glyphOverflow.bottom + offset.y());
-    metrics->setFontBoundingBoxAscent(fontMetrics.ascent() - offset.y());
-    metrics->setFontBoundingBoxDescent(fontMetrics.descent() + offset.y());
-    metrics->setEmHeightAscent(fontMetrics.ascent() - offset.y());
-    metrics->setEmHeightDescent(fontMetrics.descent() + offset.y());
-    metrics->setHangingBaseline(fontMetrics.ascent() - offset.y());
+    metrics->setFontBoundingBoxAscent(ascent - offset.y());
+    metrics->setFontBoundingBoxDescent(descent + offset.y());
+    metrics->setEmHeightAscent(ascent - offset.y());
+    metrics->setEmHeightDescent(descent + offset.y());
+    metrics->setHangingBaseline(ascent - offset.y());
     metrics->setAlphabeticBaseline(-offset.y());
-    metrics->setIdeographicBaseline(-fontMetrics.descent() - offset.y());
+    metrics->setIdeographicBaseline(-descent - offset.y());
 
     metrics->setActualBoundingBoxLeft(glyphOverflow.left - offset.x());
     metrics->setActualBoundingBoxRight(fontWidth + glyphOverflow.right + offset.x());
@@ -2733,14 +2735,14 @@ FloatPoint CanvasRenderingContext2DBase::textOffset(float width, TextDirection d
     switch (state().textBaseline) {
     case TopTextBaseline:
     case HangingTextBaseline:
-        offset.setY(fontMetrics.ascent());
+        offset.setY(fontMetrics.intAscent());
         break;
     case BottomTextBaseline:
     case IdeographicTextBaseline:
-        offset.setY(-fontMetrics.descent());
+        offset.setY(-fontMetrics.intDescent());
         break;
     case MiddleTextBaseline:
-        offset.setY(fontMetrics.height() / 2 - fontMetrics.descent());
+        offset.setY(fontMetrics.intHeight() / 2 - fontMetrics.intDescent());
         break;
     case AlphabeticTextBaseline:
     default:

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1041,7 +1041,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
 
                 GraphicsContextStateSaver verticalLabelStateSaver(context);
                 context.translate(zoom(x) + 0.5f, scrollY);
-                context.drawText(font, TextRun(String::number(x)), { 2, drawTopEdge ? rulerLabelSize : rulerLabelSize - rulerSize + font.metricsOfPrimaryFont().height() - 1.0f });
+                context.drawText(font, TextRun(String::number(x)), { 2, drawTopEdge ? rulerLabelSize : rulerLabelSize - rulerSize + font.metricsOfPrimaryFont().intHeight() - 1.0f });
             }
         }
 
@@ -1100,7 +1100,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
         const float padding = 2;
         const float radius = 4;
         float fontWidth = font.width(viewportTextRun);
-        float fontHeight = font.metricsOfPrimaryFont().floatHeight();
+        float fontHeight = font.metricsOfPrimaryFont().height();
         FloatRect viewportTextRect(margin, margin, (padding * 2.0f) + fontWidth, (padding * 2.0f) + fontHeight);
         const auto viewportTextRectCenter = viewportTextRect.center();
 
@@ -1138,7 +1138,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
         context.fillRoundedRect(FloatRoundedRect(viewportTextRect, FloatRoundedRect::Radii(radius)), rulerBackgroundColor);
 
         context.setFillColor(Color::black);
-        context.drawText(font, viewportTextRun, { margin +  padding, margin + padding + fontHeight - font.metricsOfPrimaryFont().descent() });
+        context.drawText(font, viewportTextRun, { margin +  padding, margin + padding + fontHeight - font.metricsOfPrimaryFont().intDescent() });
     }
 }
 

--- a/Source/WebCore/inspector/InspectorOverlayLabel.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.cpp
@@ -209,8 +209,8 @@ Path InspectorOverlayLabel::draw(GraphicsContext& context, float maximumLineWidt
     constexpr UChar ellipsis = 0x2026;
 
     auto font = systemFont();
-    float lineHeight = font.metricsOfPrimaryFont().floatHeight();
-    float lineDescent = font.metricsOfPrimaryFont().floatDescent();
+    float lineHeight = font.metricsOfPrimaryFont().height();
+    float lineDescent = font.metricsOfPrimaryFont().descent().value_or(0);
 
     Vector<ComputedContentRun> computedContentRuns;
 
@@ -375,7 +375,7 @@ Path InspectorOverlayLabel::draw(GraphicsContext& context, float maximumLineWidt
 FloatSize InspectorOverlayLabel::expectedSize(const Vector<Content>& contents, Arrow::Direction direction)
 {
     auto font = systemFont();
-    float lineHeight = font.metricsOfPrimaryFont().floatHeight();
+    float lineHeight = font.metricsOfPrimaryFont().height();
 
     float longestLineWidth = 0;
     int currentLine = 0;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingQuirks.cpp
@@ -129,11 +129,11 @@ std::optional<LayoutUnit> InlineFormattingQuirks::initialLetterAlignmentOffset(c
     auto& primaryFontMetrics = lineBoxStyle.fontCascade().metricsOfPrimaryFont();
     auto lineHeight = [&]() -> InlineLayoutUnit {
         if (lineBoxStyle.lineHeight().isNegative())
-            return primaryFontMetrics.ascent() + primaryFontMetrics.descent();
+            return primaryFontMetrics.intAscent() + primaryFontMetrics.intDescent();
         return lineBoxStyle.computedLineHeight();
     };
     auto& floatBoxGeometry = formattingContext().geometryForBox(floatBox);
-    return LayoutUnit { primaryFontMetrics.ascent() + (lineHeight() - primaryFontMetrics.height()) / 2 - primaryFontMetrics.capHeight() - floatBoxGeometry.marginBorderAndPaddingBefore() };
+    return LayoutUnit { primaryFontMetrics.intAscent() + (lineHeight() - primaryFontMetrics.intHeight()) / 2 - primaryFontMetrics.intCapHeight() - floatBoxGeometry.marginBorderAndPaddingBefore() };
 }
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -230,7 +230,7 @@ inline InlineLayoutUnit InlineLevelBox::preferredLineHeight() const
 {
     // FIXME: Remove integral flooring when legacy line layout stops using it.
     if (isPreferredLineHeightFontMetricsBased())
-        return primarymetricsOfPrimaryFont().lineSpacing();
+        return primarymetricsOfPrimaryFont().intLineSpacing();
 
     if (m_style.lineHeight.isPercentOrCalculated())
         return floorf(minimumValueForLength(m_style.lineHeight, fontSize()));

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp
@@ -53,7 +53,7 @@ InlineRect LineBox::logicalRectForTextRun(const Line::Run& run) const
     auto* ancestorInlineBox = &parentInlineBox(run);
     ASSERT(ancestorInlineBox->isInlineBox());
     auto runlogicalTop = ancestorInlineBox->logicalTop() - ancestorInlineBox->inlineBoxContentOffsetForLeadingTrim();
-    InlineLayoutUnit logicalHeight = ancestorInlineBox->primarymetricsOfPrimaryFont().height();
+    InlineLayoutUnit logicalHeight = ancestorInlineBox->primarymetricsOfPrimaryFont().intHeight();
 
     while (ancestorInlineBox != &m_rootInlineBox && !ancestorInlineBox->hasLineBoxRelativeAlignment()) {
         ancestorInlineBox = &parentInlineBox(*ancestorInlineBox);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp
@@ -178,7 +178,7 @@ LineBoxVerticalAligner::LineBoxAlignmentContent LineBoxVerticalAligner::computeL
             logicalTop = parentInlineBoxAscent - layoutBounds.ascent;
             break;
         case VerticalAlign::Middle: {
-            auto logicalTopOffsetFromParentBaseline = layoutBounds.height() / 2 + parentInlineBox.primarymetricsOfPrimaryFont().xHeight() / 2;
+            auto logicalTopOffsetFromParentBaseline = layoutBounds.height() / 2 + parentInlineBox.primarymetricsOfPrimaryFont().xHeight().value_or(0) / 2;
             logicalTop = parentInlineBoxAscent - logicalTopOffsetFromParentBaseline;
             break;
         }
@@ -292,7 +292,7 @@ void LineBoxVerticalAligner::computeRootInlineBoxVerticalPosition(LineBox& lineB
             baselineOffsetFromParentBaseline = { };
             break;
         case VerticalAlign::Middle: {
-            auto logicalTopOffsetFromParentBaseline = (layoutBounds.height() / 2 + parentInlineBox.primarymetricsOfPrimaryFont().xHeight() / 2);
+            auto logicalTopOffsetFromParentBaseline = (layoutBounds.height() / 2 + parentInlineBox.primarymetricsOfPrimaryFont().xHeight().value_or(0) / 2);
             baselineOffsetFromParentBaseline = logicalTopOffsetFromParentBaseline - layoutBounds.ascent;
             break;
         }
@@ -411,7 +411,7 @@ void LineBoxVerticalAligner::alignInlineLevelBoxes(LineBox& lineBox, InlineLayou
             logicalTop = parentInlineBox.ascent() - inlineLevelBox.ascent();
             break;
         case VerticalAlign::Middle: {
-            auto logicalTopOffsetFromParentBaseline = (inlineLevelBox.logicalHeight() / 2 + parentInlineBox.primarymetricsOfPrimaryFont().xHeight() / 2);
+            auto logicalTopOffsetFromParentBaseline = (inlineLevelBox.logicalHeight() / 2 + parentInlineBox.primarymetricsOfPrimaryFont().xHeight().value_or(0) / 2);
             logicalTop = parentInlineBox.ascent() - logicalTopOffsetFromParentBaseline;
             break;
         }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -195,8 +195,8 @@ void InlineDisplayContentBuilder::appendTextDisplayBox(const Line::Run& lineRun,
             auto enclosingAscentAndDescent = TextUtil::enclosingGlyphBoundsForText(StringView(content).substring(text->start, text->length), style);
             // FIXME: Take fallback fonts into account.
             auto& fontMetrics = style.metricsOfPrimaryFont();
-            auto topOverflow = std::max(0.f, ceilf(-enclosingAscentAndDescent.ascent) - fontMetrics.ascent());
-            auto bottomOverflow = std::max(0.f, ceilf(enclosingAscentAndDescent.descent) - fontMetrics.descent());
+            auto topOverflow = std::max(0.f, ceilf(-enclosingAscentAndDescent.ascent) - fontMetrics.intAscent());
+            auto bottomOverflow = std::max(0.f, ceilf(enclosingAscentAndDescent.descent) - fontMetrics.intDescent());
             inkOverflow.inflate(topOverflow, { }, bottomOverflow, { });
         };
         addGlyphOverflow();

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -411,7 +411,7 @@ void LineLayout::updateLayoutBoxDimensions(const RenderBox& replacedOrInlineBloc
         auto baseline = replacedOrInlineBlock.baselinePosition(AlphabeticBaseline, false /* firstLine */, writingMode == WritingMode::TopToBottom ? HorizontalLine : VerticalLine, PositionOnContainingLine);
         if (is<RenderListMarker>(replacedOrInlineBlock)) {
             ASSERT(!downcast<RenderListMarker>(replacedOrInlineBlock).isImage());
-            baseline = replacedOrInlineBlock.style().metricsOfPrimaryFont().ascent();
+            baseline = replacedOrInlineBlock.style().metricsOfPrimaryFont().intAscent();
         }
         layoutBox.setBaselineForIntegration(roundToInt(baseline));
     }

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -111,10 +111,10 @@ void Font::initCharWidths()
 
     // If we can't retrieve the width of a '0', fall back to the x height.
     if (m_avgCharWidth <= 0.f)
-        m_avgCharWidth = m_fontMetrics.xHeight();
+        m_avgCharWidth = m_fontMetrics.xHeight().value_or(0);
 
     if (m_maxCharWidth <= 0.f)
-        m_maxCharWidth = std::max(m_avgCharWidth, m_fontMetrics.floatAscent());
+        m_maxCharWidth = std::max(m_avgCharWidth, m_fontMetrics.ascent().value_or(0));
 }
 
 void Font::platformGlyphInit()
@@ -162,9 +162,9 @@ void Font::platformGlyphInit()
         m_fontMetrics.setIdeogramWidth(platformData().size());
 
     m_spaceWidth = widthForGlyph(m_spaceGlyph, SyntheticBoldInclusion::Exclude); // spaceWidth() handles adding in the synthetic bold.
-    auto amountToAdjustLineGap = std::min(m_fontMetrics.floatLineGap(), 0.0f);
-    m_fontMetrics.setLineGap(m_fontMetrics.floatLineGap() - amountToAdjustLineGap);
-    m_fontMetrics.setLineSpacing(m_fontMetrics.floatLineSpacing() - amountToAdjustLineGap);
+    auto amountToAdjustLineGap = std::min(m_fontMetrics.lineGap().value_or(0), 0.0f);
+    m_fontMetrics.setLineGap(m_fontMetrics.lineGap().value_or(0) - amountToAdjustLineGap);
+    m_fontMetrics.setLineSpacing(m_fontMetrics.lineSpacing().value_or(0) - amountToAdjustLineGap);
     determinePitch();
 }
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1189,7 +1189,7 @@ int FontCascade::emphasisMarkAscent(const AtomString& mark) const
     if (!markFontData)
         return 0;
 
-    return markFontData->fontMetrics().ascent();
+    return markFontData->fontMetrics().intAscent();
 }
 
 int FontCascade::emphasisMarkDescent(const AtomString& mark) const
@@ -1203,7 +1203,7 @@ int FontCascade::emphasisMarkDescent(const AtomString& mark) const
     if (!markFontData)
         return 0;
 
-    return markFontData->fontMetrics().descent();
+    return markFontData->fontMetrics().intDescent();
 }
 
 const Font* FontCascade::fontForEmphasisMark(const AtomString& mark) const
@@ -1219,14 +1219,14 @@ const Font* FontCascade::fontForEmphasisMark(const AtomString& mark) const
 int FontCascade::emphasisMarkHeight(const AtomString& mark) const
 {
     if (auto* font = fontForEmphasisMark(mark))
-        return font->fontMetrics().height();
+        return font->fontMetrics().intHeight();
     return { };
 }
 
 float FontCascade::floatEmphasisMarkHeight(const AtomString& mark) const
 {
     if (auto* font = fontForEmphasisMark(mark))
-        return font->fontMetrics().floatHeight();
+        return font->fontMetrics().height();
     return { };
 }
 
@@ -1396,8 +1396,8 @@ float FontCascade::floatWidthForSimpleText(const TextRun& run, HashSet<const Fon
     it.finalize(glyphBuffer);
 
     if (glyphOverflow) {
-        glyphOverflow->top = std::max<int>(glyphOverflow->top, ceilf(-it.minGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().ascent()));
-        glyphOverflow->bottom = std::max<int>(glyphOverflow->bottom, ceilf(it.maxGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().descent()));
+        glyphOverflow->top = std::max<int>(glyphOverflow->top, ceilf(-it.minGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().intAscent()));
+        glyphOverflow->bottom = std::max<int>(glyphOverflow->bottom, ceilf(it.maxGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().intDescent()));
         glyphOverflow->left = ceilf(it.firstGlyphOverflow());
         glyphOverflow->right = ceilf(it.lastGlyphOverflow());
     }
@@ -1409,8 +1409,8 @@ float FontCascade::floatWidthForComplexText(const TextRun& run, HashSet<const Fo
 {
     ComplexTextController controller(*this, run, true, fallbackFonts);
     if (glyphOverflow) {
-        glyphOverflow->top = std::max<int>(glyphOverflow->top, ceilf(-controller.minGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().ascent()));
-        glyphOverflow->bottom = std::max<int>(glyphOverflow->bottom, ceilf(controller.maxGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().descent()));
+        glyphOverflow->top = std::max<int>(glyphOverflow->top, ceilf(-controller.minGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().intAscent()));
+        glyphOverflow->bottom = std::max<int>(glyphOverflow->bottom, ceilf(controller.maxGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().intDescent()));
         glyphOverflow->left = std::max<int>(0, ceilf(-controller.minGlyphBoundingBoxX()));
         glyphOverflow->right = std::max<int>(0, ceilf(controller.maxGlyphBoundingBoxX() - controller.totalAdvance().width()));
     }

--- a/Source/WebCore/platform/graphics/FontMetrics.h
+++ b/Source/WebCore/platform/graphics/FontMetrics.h
@@ -27,109 +27,101 @@ namespace WebCore {
 
 class FontMetrics {
 public:
-    static const unsigned defaultUnitsPerEm = 1000;
+    static constexpr unsigned defaultUnitsPerEm = 1000;
 
     unsigned unitsPerEm() const { return m_unitsPerEm; }
     void setUnitsPerEm(unsigned unitsPerEm) { m_unitsPerEm = unitsPerEm; }
 
-    float floatAscent(FontBaseline baselineType = AlphabeticBaseline) const
+    float height(FontBaseline baselineType = AlphabeticBaseline) const
+    {
+        return ascent(baselineType).value_or(0) + descent(baselineType).value_or(0);
+    }
+    int intHeight(FontBaseline baselineType = AlphabeticBaseline) const
+    {
+        return intAscent(baselineType) + intDescent(baselineType);
+    }
+
+    std::optional<float> ascent(FontBaseline baselineType = AlphabeticBaseline) const
     {
         if (baselineType == AlphabeticBaseline)
-            return m_floatAscent;
-        return floatHeight() / 2;
+            return m_ascent;
+        return height() / 2;
     }
-
-    void setAscent(float ascent)
-    {
-        m_floatAscent = ascent;
-        m_intAscent = std::max(static_cast<int>(lroundf(ascent)), 0);
-    }
-
-    float floatDescent(FontBaseline baselineType = AlphabeticBaseline) const
-    {
-        if (baselineType == AlphabeticBaseline)
-            return m_floatDescent;
-        return floatHeight() / 2;
-    }
-
-    void setDescent(float descent)
-    {
-        m_floatDescent = descent;
-        m_intDescent = lroundf(descent);
-    }
-
-    float floatHeight(FontBaseline baselineType = AlphabeticBaseline) const
-    {
-        return floatAscent(baselineType) + floatDescent(baselineType);
-    }
-
-    float floatLineGap() const { return m_floatLineGap; }
-    void setLineGap(float lineGap)
-    {
-        m_floatLineGap = lineGap;
-        m_intLineGap = lroundf(lineGap);
-    }
-
-    float floatLineSpacing() const { return m_floatLineSpacing; }
-    void setLineSpacing(float lineSpacing)
-    {
-        m_floatLineSpacing = lineSpacing;
-        m_intLineSpacing = lroundf(lineSpacing);
-    }
-
-    float xHeight() const { return m_xHeight; }
-    void setXHeight(float xHeight) { m_xHeight = xHeight; }
-    bool hasXHeight() const { return m_xHeight > 0; }
-    
-    bool hasCapHeight() const { return m_floatCapHeight > 0; }
-    float floatCapHeight() const { return m_floatCapHeight; }
-    void setCapHeight(float capHeight)
-    {
-        m_floatCapHeight = capHeight;
-        m_intCapHeight = lroundf(capHeight);
-    }
-    
-    // Integer variants of certain metrics, used for HTML rendering.
-    int ascent(FontBaseline baselineType = AlphabeticBaseline) const
+    int intAscent(FontBaseline baselineType = AlphabeticBaseline) const
     {
         if (baselineType == AlphabeticBaseline)
             return m_intAscent;
-        return height() - height() / 2;
+        return intHeight() - intHeight() / 2;
     }
-    
-    int descent(FontBaseline baselineType = AlphabeticBaseline) const
+    void setAscent(float ascent)
+    {
+        m_ascent = ascent;
+        m_intAscent = std::max(static_cast<int>(lroundf(ascent)), 0);
+    }
+
+    std::optional<float> descent(FontBaseline baselineType = AlphabeticBaseline) const
+    {
+        if (baselineType == AlphabeticBaseline)
+            return m_descent;
+        return height() / 2;
+    }
+    int intDescent(FontBaseline baselineType = AlphabeticBaseline) const
     {
         if (baselineType == AlphabeticBaseline)
             return m_intDescent;
-        return height() / 2;
+        return intHeight() / 2;
+    }
+    void setDescent(float descent)
+    {
+        m_descent = descent;
+        m_intDescent = lroundf(descent);
     }
 
-    int height(FontBaseline baselineType = AlphabeticBaseline) const
+    std::optional<float> lineGap() const { return m_lineGap; }
+    int intLineGap() const { return m_intLineGap; }
+    void setLineGap(float lineGap)
     {
-        return ascent(baselineType) + descent(baselineType);
+        m_lineGap = lineGap;
+        m_intLineGap = lroundf(lineGap);
     }
 
-    int lineGap() const { return m_intLineGap; }
-    int lineSpacing() const { return m_intLineSpacing; }
-    
-    int capHeight() const { return m_intCapHeight; }
-    
-    bool hasIdenticalAscentDescentAndLineGap(const FontMetrics& other) const
+    std::optional<float> lineSpacing() const { return m_lineSpacing; }
+    int intLineSpacing() const { return m_intLineSpacing; }
+    void setLineSpacing(float lineSpacing)
     {
-        return ascent() == other.ascent() && descent() == other.descent() && lineGap() == other.lineGap();
+        m_lineSpacing = lineSpacing;
+        m_intLineSpacing = lroundf(lineSpacing);
+    }
+
+    std::optional<float> xHeight() const { return m_xHeight; }
+    void setXHeight(float xHeight) { m_xHeight = xHeight; }
+
+    std::optional<float> capHeight() const { return m_capHeight; }
+    int intCapHeight() const { return m_intCapHeight; }
+    void setCapHeight(float capHeight)
+    {
+        m_capHeight = capHeight;
+        m_intCapHeight = lroundf(capHeight);
     }
 
     std::optional<float> zeroWidth() const { return m_zeroWidth; }
     void setZeroWidth(float zeroWidth) { m_zeroWidth = zeroWidth; }
 
-    float ideogramWidth() const { return m_ideogramWidth; }
+    std::optional<float> ideogramWidth() const { return m_ideogramWidth; }
     void setIdeogramWidth(float ideogramWidth) { m_ideogramWidth = ideogramWidth; }
 
-    float underlinePosition() const { return m_underlinePosition; }
+    std::optional<float> underlinePosition() const { return m_underlinePosition; }
     void setUnderlinePosition(float underlinePosition) { m_underlinePosition = underlinePosition; }
 
-    float underlineThickness() const { return m_underlineThickness; }
+    std::optional<float> underlineThickness() const { return m_underlineThickness; }
     void setUnderlineThickness(float underlineThickness) { m_underlineThickness = underlineThickness; }
+
+    bool hasIdenticalAscentDescentAndLineGap(const FontMetrics& other) const
+    {
+        return intAscent() == other.intAscent()
+            && intDescent() == other.intDescent()
+            && intLineGap() == other.intLineGap();
+    }
 
 private:
     friend class Font;
@@ -137,43 +129,44 @@ private:
     void reset()
     {
         m_unitsPerEm = defaultUnitsPerEm;
-        m_floatAscent = 0;
-        m_floatDescent = 0;
-        m_floatLineGap = 0;
-        m_floatLineSpacing = 0;
-        m_floatCapHeight = 0;
+
+        m_ascent = std::nullopt;
+        m_capHeight = std::nullopt;
+        m_descent = std::nullopt;
+        m_ideogramWidth = std::nullopt;
+        m_lineGap = std::nullopt;
+        m_lineSpacing = std::nullopt;
+        m_underlinePosition = std::nullopt;
+        m_underlineThickness = std::nullopt;
+        m_xHeight = std::nullopt;
+        m_zeroWidth = std::nullopt;
+
         m_intAscent = 0;
         m_intDescent = 0;
         m_intLineGap = 0;
         m_intLineSpacing = 0;
         m_intCapHeight = 0;
-        m_xHeight = 0;
-        m_zeroWidth = std::nullopt;
-        m_ideogramWidth = 0;
-        m_underlinePosition = 0;
-        m_underlineThickness = 0;
     }
 
     unsigned m_unitsPerEm { defaultUnitsPerEm };
 
-    float m_floatAscent { 0 };
-    float m_floatDescent { 0 };
-    float m_floatLineGap { 0 };
-    float m_floatLineSpacing { 0 };
-    float m_floatCapHeight { 0 };
+    std::optional<float> m_ascent;
+    std::optional<float> m_capHeight;
+    std::optional<float> m_descent;
+    std::optional<float> m_ideogramWidth;
+    std::optional<float> m_lineGap;
+    std::optional<float> m_lineSpacing;
+    std::optional<float> m_underlinePosition;
+    std::optional<float> m_underlineThickness;
+    std::optional<float> m_xHeight;
+    std::optional<float> m_zeroWidth;
 
-    // Also cached as integers for performance.
+    // Integer variants of certain metrics are cached for HTML rendering performance.
     int m_intAscent { 0 };
     int m_intDescent { 0 };
     int m_intLineGap { 0 };
     int m_intLineSpacing { 0 };
     int m_intCapHeight { 0 };
-
-    std::optional<float> m_zeroWidth;
-    float m_ideogramWidth { 0 };
-    float m_xHeight { 0 };
-    float m_underlinePosition { 0 };
-    float m_underlineThickness { 0 };
 };
 
 static inline float scaleEmToUnits(float x, unsigned unitsPerEm)

--- a/Source/WebCore/platform/graphics/PositionedGlyphs.cpp
+++ b/Source/WebCore/platform/graphics/PositionedGlyphs.cpp
@@ -36,8 +36,8 @@ FloatRect PositionedGlyphs::computeBounds(const Font& font) const
 
     // FIXME: This code doesn't actually take the extents of the glyphs into consideration. It assumes that
     // the glyph lies entirely within its [(ascent + descent), advance] rect.
-    float ascent = font.fontMetrics().floatAscent();
-    float descent = font.fontMetrics().floatDescent();
+    float ascent = font.fontMetrics().ascent().value_or(0);
+    float descent = font.fontMetrics().descent().value_or(0);
     FloatPoint current = localAnchor;
     for (auto& advance : advances) {
         FloatRect glyphRect = FloatRect(current.x(), current.y() - ascent, width(advance), ascent + descent);

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
@@ -339,7 +339,7 @@ void DrawGlyphsRecorder::recordDrawGlyphs(CGRenderingStateRef, CGGStateRef gstat
     if (font->platformData().orientation() == FontOrientation::Vertical) {
         Vector<CGSize, 256> translations(count);
         CTFontGetVerticalTranslationsForGlyphs(font->platformData().ctFont(), glyphs, translations.data(), count);
-        auto ascentDelta = font->fontMetrics().floatAscent(IdeographicBaseline) - font->fontMetrics().floatAscent();
+        auto ascentDelta = font->fontMetrics().ascent(IdeographicBaseline).value_or(0) - font->fontMetrics().ascent().value_or(0);
         advances = computeVerticalAdvancesFromPositions(translations.data(), positions, count, ascentDelta, textMatrix);
     } else
         advances = computeHorizontalAdvancesFromPositions(positions, count, textMatrix);

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -273,7 +273,7 @@ static void showGlyphsWithAdvances(const FloatPoint& point, const Font& font, CG
         Vector<CGSize, 256> translations(count);
         CTFontGetVerticalTranslationsForGlyphs(platformData.ctFont(), glyphs, translations.data(), count);
 
-        auto ascentDelta = font.fontMetrics().floatAscent(IdeographicBaseline) - font.fontMetrics().floatAscent();
+        auto ascentDelta = font.fontMetrics().ascent(IdeographicBaseline).value_or(0) - font.fontMetrics().ascent().value_or(0);
         fillVectorWithVerticalGlyphPositions(positions, translations.data(), advances, count, point, ascentDelta, CGContextGetTextMatrix(context));
         CTFontDrawGlyphs(platformData.ctFont(), glyphs, positions.data(), count, context);
     } else {

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -217,7 +217,7 @@ void Font::platformInit()
             else
                 xHeight = CTFontGetXHeight(m_platformData.font());
         } else
-            xHeight = verticalRightOrientationFont().fontMetrics().xHeight();
+            xHeight = verticalRightOrientationFont().fontMetrics().xHeight().value_or(0);
     }
 
     m_fontMetrics.setUnitsPerEm(unitsPerEm);

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
@@ -502,7 +502,7 @@ float OpenTypeVerticalData::advanceHeight(const Font* font, Glyph glyph) const
     }
 
     // No vertical info in the font file; use height as advance.
-    return font->fontMetrics().height();
+    return font->fontMetrics().intHeight();
 }
 
 void OpenTypeVerticalData::getVerticalTranslationsForGlyphs(const Font* font, const Glyph* glyphs, size_t count, float* outXYArray) const
@@ -511,7 +511,7 @@ void OpenTypeVerticalData::getVerticalTranslationsForGlyphs(const Font* font, co
     ASSERT(countWidths > 0);
     const FontMetrics& metrics = font->fontMetrics();
     float sizePerUnit = font->sizePerUnit();
-    float ascent = metrics.ascent();
+    float ascent = metrics.intAscent();
     bool useVORG = hasVORG();
     size_t countTopSideBearings = m_topSideBearings.size();
     float defaultVertOriginY = std::numeric_limits<float>::quiet_NaN();

--- a/Source/WebCore/platform/win/DragImageWin.cpp
+++ b/Source/WebCore/platform/win/DragImageWin.cpp
@@ -137,7 +137,7 @@ DragImageRef createDragImageForLink(Element&, URL& url, const String& inLabel, T
     // First step in drawing the link drag image width.
     TextRun labelRun(label);
     TextRun urlRun(urlString);
-    IntSize labelSize(labelFont.width(labelRun), labelFont.metricsOfPrimaryFont().ascent() + labelFont.metricsOfPrimaryFont().descent());
+    IntSize labelSize(labelFont.width(labelRun), labelFont.metricsOfPrimaryFont().intAscent() + labelFont.metricsOfPrimaryFont().intDescent());
 
     if (labelSize.width() > MaxDragLabelStringWidth) {
         labelSize.setWidth(MaxDragLabelStringWidth);
@@ -149,7 +149,7 @@ DragImageRef createDragImageForLink(Element&, URL& url, const String& inLabel, T
 
     if (drawURLString) {
         urlStringSize.setWidth(urlFont.width(urlRun));
-        urlStringSize.setHeight(urlFont.metricsOfPrimaryFont().ascent() + urlFont.metricsOfPrimaryFont().descent()); 
+        urlStringSize.setHeight(urlFont.metricsOfPrimaryFont().intAscent() + urlFont.metricsOfPrimaryFont().intDescent());
         imageSize.setHeight(imageSize.height() + urlStringSize.height());
         if (urlStringSize.width() > MaxDragLabelStringWidth) {
             imageSize.setWidth(MaxDragLabelWidth);
@@ -185,7 +185,7 @@ DragImageRef createDragImageForLink(Element&, URL& url, const String& inLabel, T
     if (drawURLString) {
         if (clipURLString)
             urlString = StringTruncator::rightTruncate(urlString, imageSize.width() - (DragLabelBorderX * 2.0f), urlFont);
-        IntPoint textPos(DragLabelBorderX, imageSize.height() - (LabelBorderYOffset + urlFont.metricsOfPrimaryFont().descent()));
+        IntPoint textPos(DragLabelBorderX, imageSize.height() - (LabelBorderYOffset + urlFont.metricsOfPrimaryFont().intDescent()));
         WebCoreDrawDoubledTextAtPoint(context, urlString, textPos, urlFont, topColor, bottomColor);
     }
     

--- a/Source/WebCore/platform/win/PopupMenuWin.cpp
+++ b/Source/WebCore/platform/win/PopupMenuWin.cpp
@@ -329,7 +329,7 @@ void PopupMenuWin::calculatePositionAndSize(const IntRect& r, LocalFrameView* v)
 
     // First, determine the popup's height
     int itemCount = client()->listSize();
-    m_itemHeight = m_font.metricsOfPrimaryFont().height() + optionSpacingMiddle;
+    m_itemHeight = m_font.metricsOfPrimaryFont().intHeight() + optionSpacingMiddle;
 
     int naturalHeight = m_itemHeight * itemCount;
     int popupHeight = std::min(maxPopupHeight, naturalHeight);
@@ -667,7 +667,7 @@ void PopupMenuWin::paint(const IntRect& damageRect, HDC hdc)
                 if (RenderTheme::singleton().popupOptionSupportsTextIndent())
                     textX -= minimumIntValueForLength(itemStyle.textIndent(), itemRect.width());
             }
-            int textY = itemRect.y() + itemFont.metricsOfPrimaryFont().ascent() + (itemRect.height() - itemFont.metricsOfPrimaryFont().height()) / 2;
+            int textY = itemRect.y() + itemFont.metricsOfPrimaryFont().intAscent() + (itemRect.height() - itemFont.metricsOfPrimaryFont().intHeight()) / 2;
             context.drawBidiText(itemFont, textRun, IntPoint(textX, textY));
         }
     }

--- a/Source/WebCore/rendering/CaretRectComputation.cpp
+++ b/Source/WebCore/rendering/CaretRectComputation.cpp
@@ -113,7 +113,7 @@ static LayoutRect computeCaretRectForEmptyElement(const RenderBoxModelObject& re
     x = std::min(x, std::max<LayoutUnit>(maxX - caretWidth(), 0));
 
     auto lineHeight = renderer.lineHeight(true, currentStyle.isHorizontalWritingMode() ? HorizontalLine : VerticalLine, PositionOfInteriorLineBoxes);
-    auto height = std::min(lineHeight, LayoutUnit { currentStyle.metricsOfPrimaryFont().height() });
+    auto height = std::min(lineHeight, LayoutUnit { currentStyle.metricsOfPrimaryFont().intHeight() });
     auto y = renderer.paddingTop() + renderer.borderTop() + (lineHeight > height ? (lineHeight - height) / 2 : LayoutUnit { });
 
     auto rect = LayoutRect(x, y, caretWidth(), height);
@@ -256,7 +256,7 @@ static LayoutRect computeCaretRectForBox(const RenderBox& renderer, const Inline
     // <rdar://problem/3777804> Deleting all content in a document can result in giant tall-as-window insertion point
     //
     // FIXME: ignoring :first-line, missing good reason to take care of
-    LayoutUnit fontHeight = renderer.style().metricsOfPrimaryFont().height();
+    LayoutUnit fontHeight = renderer.style().metricsOfPrimaryFont().intHeight();
     if (fontHeight > rect.height() || (!renderer.isReplacedOrInlineBlock() && !renderer.isTable()))
         rect.setHeight(fontHeight);
 

--- a/Source/WebCore/rendering/EllipsisBoxPainter.cpp
+++ b/Source/WebCore/rendering/EllipsisBoxPainter.cpp
@@ -70,7 +70,7 @@ void EllipsisBoxPainter::paint()
     
     auto visualRect = m_lineBox.ellipsisVisualRect();
     auto textOrigin = visualRect.location();
-    textOrigin.move(m_paintOffset.x(), m_paintOffset.y() + style.metricsOfPrimaryFont().ascent());
+    textOrigin.move(m_paintOffset.x(), m_paintOffset.y() + style.metricsOfPrimaryFont().intAscent());
     context.drawBidiText(style.fontCascade(), m_lineBox.ellipsisText(), textOrigin);
 
     if (textColor != context.fillColor())

--- a/Source/WebCore/rendering/LegacyEllipsisBox.cpp
+++ b/Source/WebCore/rendering/LegacyEllipsisBox.cpp
@@ -79,7 +79,7 @@ void LegacyEllipsisBox::paintMarkupBox(PaintInfo& paintInfo, const LayoutPoint& 
 
     LayoutPoint adjustedPaintOffset = paintOffset;
     adjustedPaintOffset.move(x() + logicalWidth() - markupBox->x(),
-        y() + style.metricsOfPrimaryFont().ascent() - (markupBox->y() + markupBox->lineStyle().metricsOfPrimaryFont().ascent()));
+        y() + style.metricsOfPrimaryFont().intAscent() - (markupBox->y() + markupBox->lineStyle().metricsOfPrimaryFont().intAscent()));
     markupBox->paint(paintInfo, adjustedPaintOffset, lineTop, lineBottom);
 }
 
@@ -103,7 +103,7 @@ bool LegacyEllipsisBox::nodeAtPoint(const HitTestRequest& request, HitTestResult
     if (LegacyInlineBox* markupBox = this->markupBox()) {
         const RenderStyle& lineStyle = this->lineStyle();
         LayoutUnit mtx { adjustedLocation.x() + logicalWidth() - markupBox->x() };
-        LayoutUnit mty { adjustedLocation.y() + lineStyle.metricsOfPrimaryFont().ascent() - (markupBox->y() + markupBox->lineStyle().metricsOfPrimaryFont().ascent()) };
+        LayoutUnit mty { adjustedLocation.y() + lineStyle.metricsOfPrimaryFont().intAscent() - (markupBox->y() + markupBox->lineStyle().metricsOfPrimaryFont().intAscent()) };
         if (markupBox->nodeAtPoint(request, result, locationInContainer, LayoutPoint(mtx, mty), lineTop, lineBottom, hitTestAction)) {
             blockFlow().updateHitTestResult(result, locationInContainer.point() - LayoutSize(mtx, mty));
             return true;

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -137,14 +137,14 @@ float LegacyInlineBox::logicalHeight() const
 
     const RenderStyle& lineStyle = this->lineStyle();
     if (renderer().isTextOrLineBreak())
-        return lineStyle.metricsOfPrimaryFont().height();
+        return lineStyle.metricsOfPrimaryFont().intHeight();
     if (is<RenderBox>(renderer()) && parent())
         return isHorizontal() ? downcast<RenderBox>(renderer()).height() : downcast<RenderBox>(renderer()).width();
 
     ASSERT(isInlineFlowBox());
     RenderBoxModelObject* flowObject = boxModelObject();
     const FontMetrics& fontMetrics = lineStyle.metricsOfPrimaryFont();
-    float result = fontMetrics.height();
+    float result = fontMetrics.intHeight();
     if (parent())
         result += flowObject->borderAndPaddingLogicalHeight();
     return result;

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -692,7 +692,7 @@ static void placeChildInlineBoxesInBlockDirection(LegacyInlineFlowBox& inlineBox
         const RenderStyle& childLineStyle = child->lineStyle();
         if (child->behavesLikeText() || is<LegacyInlineFlowBox>(*child)) {
             const FontMetrics& fontMetrics = childLineStyle.metricsOfPrimaryFont();
-            newLogicalTop += child->baselinePosition(baselineType) - fontMetrics.ascent(baselineType);
+            newLogicalTop += child->baselinePosition(baselineType) - fontMetrics.intAscent(baselineType);
             if (is<LegacyInlineFlowBox>(*child)) {
                 RenderBoxModelObject& boxObject = downcast<LegacyInlineFlowBox>(*child).renderer();
                 newLogicalTop -= childLineStyle.isHorizontalWritingMode()
@@ -765,7 +765,7 @@ void LegacyInlineFlowBox::placeBoxesInBlockDirection(LayoutUnit top, LayoutUnit 
 {
     bool isRootBox = isRootInlineBox();
     if (isRootBox)
-        setLogicalTop(top + maxAscent - lineStyle().metricsOfPrimaryFont().ascent(baselineType));
+        setLogicalTop(top + maxAscent - lineStyle().metricsOfPrimaryFont().intAscent(baselineType));
 
     placeChildInlineBoxesInBlockDirection(*this, top, maxHeight, maxAscent, strictMode, lineTop, lineBottom, setLineTop, lineTopIncludingMargins, lineBottomIncludingMargins, hasAnnotationsBefore, hasAnnotationsAfter, baselineType);
 

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -467,11 +467,13 @@ static inline void setLogicalWidthForTextRun(LegacyRootInlineBox* lineBox, BidiR
         // If we don't stick out of the root line's font box, then don't bother computing our glyph overflow. This optimization
         // will keep us from computing glyph bounds in nearly all cases.
         bool includeRootLine = lineBox->includesRootLineBoxFontOrLeading();
+        int ascent = font.metricsOfPrimaryFont().intAscent();
+        int descent = font.metricsOfPrimaryFont().intDescent();
         int baselineShift = lineBox->verticalPositionForBox(run->box(), verticalPositionCache);
-        int rootDescent = includeRootLine ? font.metricsOfPrimaryFont().descent() : 0;
-        int rootAscent = includeRootLine ? font.metricsOfPrimaryFont().ascent() : 0;
-        int boxAscent = font.metricsOfPrimaryFont().ascent() - baselineShift;
-        int boxDescent = font.metricsOfPrimaryFont().descent() + baselineShift;
+        int rootDescent = includeRootLine ? descent : 0;
+        int rootAscent = includeRootLine ? ascent : 0;
+        int boxAscent = ascent - baselineShift;
+        int boxDescent = descent + baselineShift;
         if (boxAscent > rootDescent ||  boxDescent > rootAscent)
             glyphOverflow.computeBounds = true; 
     }

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -363,14 +363,14 @@ LayoutUnit LegacyRootInlineBox::lineSnapAdjustment(LayoutUnit delta) const
     if (!roundToInt(gridLineHeight))
         return 0;
 
-    LayoutUnit lineGridFontAscent = lineGrid->style().metricsOfPrimaryFont().ascent(baselineType());
+    LayoutUnit lineGridFontAscent = lineGrid->style().metricsOfPrimaryFont().intAscent(baselineType());
     LayoutUnit lineGridFontHeight { lineGridBox->logicalHeight() };
     LayoutUnit firstTextTop { lineGridBlockOffset + lineGridBox->logicalTop() };
     LayoutUnit firstLineTopWithLeading = lineGridBlockOffset + lineGridBox->lineBoxTop();
     LayoutUnit firstBaselinePosition = firstTextTop + lineGridFontAscent;
 
     LayoutUnit currentTextTop { blockOffset + logicalTop() + delta };
-    LayoutUnit currentFontAscent = blockFlow().style().metricsOfPrimaryFont().ascent(baselineType());
+    LayoutUnit currentFontAscent = blockFlow().style().metricsOfPrimaryFont().intAscent(baselineType());
     LayoutUnit currentBaselinePosition = currentTextTop + currentFontAscent;
 
     LayoutUnit lineGridPaginationOrigin = isHorizontal() ? layoutState->lineGridPaginationOrigin().height() : layoutState->lineGridPaginationOrigin().width();
@@ -708,11 +708,11 @@ void LegacyRootInlineBox::ascentAndDescentForBox(LegacyInlineBox& box, GlyphOver
         usedFonts->append(&boxLineStyle.fontCascade().primaryFont());
         for (auto& font : *usedFonts) {
             auto& fontMetrics = font->fontMetrics();
-            LayoutUnit usedFontAscent { fontMetrics.ascent(baselineType()) };
-            LayoutUnit usedFontDescent { fontMetrics.descent(baselineType()) };
-            LayoutUnit halfLeading { (fontMetrics.lineSpacing() - fontMetrics.height()) / 2 };
+            LayoutUnit usedFontAscent { fontMetrics.intAscent(baselineType()) };
+            LayoutUnit usedFontDescent { fontMetrics.intDescent(baselineType()) };
+            LayoutUnit halfLeading { (fontMetrics.intLineSpacing() - fontMetrics.intHeight()) / 2 };
             LayoutUnit usedFontAscentAndLeading { usedFontAscent + halfLeading };
-            LayoutUnit usedFontDescentAndLeading { fontMetrics.lineSpacing() - usedFontAscentAndLeading };
+            LayoutUnit usedFontDescentAndLeading { fontMetrics.intLineSpacing() - usedFontAscentAndLeading };
             if (includeFont) {
                 setAscentAndDescent(ascent, descent, usedFontAscent, usedFontDescent, ascentDescentSet);
                 setUsedFont = true;
@@ -743,8 +743,8 @@ void LegacyRootInlineBox::ascentAndDescentForBox(LegacyInlineBox& box, GlyphOver
     }
     
     if (includeFontForBox(box) && !setUsedFont) {
-        LayoutUnit fontAscent { boxLineStyle.metricsOfPrimaryFont().ascent(baselineType()) };
-        LayoutUnit fontDescent { boxLineStyle.metricsOfPrimaryFont().descent(baselineType()) };
+        LayoutUnit fontAscent { boxLineStyle.metricsOfPrimaryFont().intAscent(baselineType()) };
+        LayoutUnit fontDescent { boxLineStyle.metricsOfPrimaryFont().intDescent(baselineType()) };
         setAscentAndDescent(ascent, descent, fontAscent, fontDescent, ascentDescentSet);
         affectsAscent = fontAscent - box.logicalTop() > 0;
         affectsDescent = fontDescent + box.logicalTop() > 0;
@@ -754,26 +754,26 @@ void LegacyRootInlineBox::ascentAndDescentForBox(LegacyInlineBox& box, GlyphOver
         setAscentAndDescent(ascent, descent, glyphOverflow->top, glyphOverflow->bottom, ascentDescentSet);
         affectsAscent = glyphOverflow->top - box.logicalTop() > 0;
         affectsDescent = glyphOverflow->bottom + box.logicalTop() > 0;
-        glyphOverflow->top = std::min(glyphOverflow->top, std::max(0_lu, glyphOverflow->top - boxLineStyle.metricsOfPrimaryFont().ascent(baselineType())));
-        glyphOverflow->bottom = std::min(glyphOverflow->bottom, std::max(0_lu, glyphOverflow->bottom - boxLineStyle.metricsOfPrimaryFont().descent(baselineType())));
+        glyphOverflow->top = std::min(glyphOverflow->top, std::max(0_lu, glyphOverflow->top - boxLineStyle.metricsOfPrimaryFont().intAscent(baselineType())));
+        glyphOverflow->bottom = std::min(glyphOverflow->bottom, std::max(0_lu, glyphOverflow->bottom - boxLineStyle.metricsOfPrimaryFont().intDescent(baselineType())));
     }
     
     if (includeInitialLetterForBox(box)) {
         bool canUseGlyphs = glyphOverflow && glyphOverflow->computeBounds;
-        auto letterAscent { baselineType() == AlphabeticBaseline ? LayoutUnit(boxLineStyle.metricsOfPrimaryFont().capHeight()) : (canUseGlyphs ? glyphOverflow->top : LayoutUnit(boxLineStyle.metricsOfPrimaryFont().ascent(baselineType()))) };
-        auto letterDescent { canUseGlyphs ? glyphOverflow->bottom : (box.isRootInlineBox() ? 0_lu : LayoutUnit(boxLineStyle.metricsOfPrimaryFont().descent(baselineType()))) };
+        auto letterAscent { baselineType() == AlphabeticBaseline ? LayoutUnit(boxLineStyle.metricsOfPrimaryFont().intCapHeight()) : (canUseGlyphs ? glyphOverflow->top : LayoutUnit(boxLineStyle.metricsOfPrimaryFont().intAscent(baselineType()))) };
+        auto letterDescent { canUseGlyphs ? glyphOverflow->bottom : (box.isRootInlineBox() ? 0_lu : LayoutUnit(boxLineStyle.metricsOfPrimaryFont().intDescent(baselineType()))) };
         setAscentAndDescent(ascent, descent, letterAscent, letterDescent, ascentDescentSet);
         affectsAscent = letterAscent - box.logicalTop() > 0;
         affectsDescent = letterDescent + box.logicalTop() > 0;
         if (canUseGlyphs) {
-            glyphOverflow->top = std::min(glyphOverflow->top, std::max(0_lu, glyphOverflow->top - boxLineStyle.metricsOfPrimaryFont().ascent(baselineType())));
-            glyphOverflow->bottom = std::min(glyphOverflow->bottom, std::max(0_lu, glyphOverflow->bottom - boxLineStyle.metricsOfPrimaryFont().descent(baselineType())));
+            glyphOverflow->top = std::min(glyphOverflow->top, std::max(0_lu, glyphOverflow->top - boxLineStyle.metricsOfPrimaryFont().intAscent(baselineType())));
+            glyphOverflow->bottom = std::min(glyphOverflow->bottom, std::max(0_lu, glyphOverflow->bottom - boxLineStyle.metricsOfPrimaryFont().intDescent(baselineType())));
         }
     }
 
     if (includeMarginForBox(box)) {
-        LayoutUnit ascentWithMargin = boxLineStyle.metricsOfPrimaryFont().ascent(baselineType());
-        LayoutUnit descentWithMargin = boxLineStyle.metricsOfPrimaryFont().descent(baselineType());
+        LayoutUnit ascentWithMargin = boxLineStyle.metricsOfPrimaryFont().intAscent(baselineType());
+        LayoutUnit descentWithMargin = boxLineStyle.metricsOfPrimaryFont().intDescent(baselineType());
         if (box.parent() && !box.renderer().isTextOrLineBreak()) {
             ascentWithMargin += box.boxModelObject()->borderAndPaddingBefore() + box.boxModelObject()->marginBefore();
             descentWithMargin += box.boxModelObject()->borderAndPaddingAfter() + box.boxModelObject()->marginAfter();
@@ -829,11 +829,11 @@ LayoutUnit LegacyRootInlineBox::verticalPositionForBox(LegacyInlineBox* box, Ver
         else if (verticalAlign == VerticalAlign::Super)
             verticalPosition -= fontSize / 3 + 1;
         else if (verticalAlign == VerticalAlign::TextTop)
-            verticalPosition += renderer->baselinePosition(baselineType(), firstLine, lineDirection) - fontMetrics.ascent(baselineType());
+            verticalPosition += renderer->baselinePosition(baselineType(), firstLine, lineDirection) - fontMetrics.intAscent(baselineType());
         else if (verticalAlign == VerticalAlign::Middle)
-            verticalPosition = (verticalPosition - LayoutUnit(fontMetrics.xHeight() / 2) - renderer->lineHeight(firstLine, lineDirection) / 2 + renderer->baselinePosition(baselineType(), firstLine, lineDirection));
+            verticalPosition = (verticalPosition - LayoutUnit(fontMetrics.xHeight().value_or(0) / 2) - renderer->lineHeight(firstLine, lineDirection) / 2 + renderer->baselinePosition(baselineType(), firstLine, lineDirection));
         else if (verticalAlign == VerticalAlign::TextBottom) {
-            verticalPosition += fontMetrics.descent(baselineType());
+            verticalPosition += fontMetrics.intDescent(baselineType());
             // lineHeight - baselinePosition is always 0 for replaced elements (except inline blocks), so don't bother wasting time in that case.
             if (!renderer->isReplacedOrInlineBlock() || renderer->isInlineBlockOrInlineTable())
                 verticalPosition -= (renderer->lineHeight(firstLine, lineDirection) - renderer->baselinePosition(baselineType(), firstLine, lineDirection));

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2550,7 +2550,7 @@ LayoutUnit RenderBlock::baselinePosition(FontBaseline baselineType, bool firstLi
 
     const RenderStyle& style = firstLine ? firstLineStyle() : this->style();
     const FontMetrics& fontMetrics = style.metricsOfPrimaryFont();
-    return LayoutUnit { fontMetrics.ascent(baselineType) + (lineHeight(firstLine, direction, linePositionMode) - fontMetrics.height()) / 2 }.toInt();
+    return LayoutUnit { fontMetrics.intAscent(baselineType) + (lineHeight(firstLine, direction, linePositionMode) - fontMetrics.intHeight()) / 2 }.toInt();
 }
 
 LayoutUnit RenderBlock::minLineHeightForReplacedRenderer(bool isFirstLine, LayoutUnit replacedHeight) const
@@ -2614,8 +2614,8 @@ std::optional<LayoutUnit> RenderBlock::inlineBlockBaseline(LineDirectionMode lin
 
     if (!haveNormalFlowChild && hasLineIfEmpty()) {
         auto& fontMetrics = firstLineStyle().metricsOfPrimaryFont();
-        return LayoutUnit { LayoutUnit(fontMetrics.ascent()
-            + (lineHeight(true, lineDirection, PositionOfInteriorLineBoxes) - fontMetrics.height()) / 2
+        return LayoutUnit { LayoutUnit(fontMetrics.intAscent()
+            + (lineHeight(true, lineDirection, PositionOfInteriorLineBoxes) - fontMetrics.intHeight()) / 2
             + (lineDirection == HorizontalLine ? borderTop() + paddingTop() : borderRight() + paddingRight())).toInt() };
     }
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2842,14 +2842,14 @@ void RenderBlockFlow::adjustInitialLetterPosition(RenderBox& childBox, LayoutUni
 {
     const RenderStyle& style = firstLineStyle();
     const FontMetrics& fontMetrics = style.metricsOfPrimaryFont();
-    if (!fontMetrics.hasCapHeight())
+    if (!fontMetrics.capHeight().has_value())
         return;
 
     LayoutUnit heightOfLine = lineHeight(true, isHorizontalWritingMode() ? HorizontalLine : VerticalLine, PositionOfInteriorLineBoxes);
     LayoutUnit beforeMarginBorderPadding = childBox.borderAndPaddingBefore() + childBox.marginBefore();
     
     // Make an adjustment to align with the cap height of a theoretical block line.
-    LayoutUnit adjustment = fontMetrics.ascent() + (heightOfLine - fontMetrics.height()) / 2 - fontMetrics.capHeight() - beforeMarginBorderPadding;
+    LayoutUnit adjustment = fontMetrics.intAscent() + (heightOfLine - fontMetrics.intHeight()) / 2 - fontMetrics.intCapHeight() - beforeMarginBorderPadding;
     logicalTopOffset += adjustment;
 
     // For sunken and raised caps, we have to make some adjustments. Test if we're sunken or raised (dropHeightDelta will be
@@ -3395,8 +3395,8 @@ std::optional<LayoutUnit> RenderBlockFlow::firstLineBaseline() const
 
     ASSERT(firstRootBox());
     if (style().isFlippedLinesWritingMode())
-        return LayoutUnit { firstRootBox()->logicalTop() + firstLineStyle().metricsOfPrimaryFont().descent(firstRootBox()->baselineType()) };
-    return LayoutUnit { firstRootBox()->logicalTop() + firstLineStyle().metricsOfPrimaryFont().ascent(firstRootBox()->baselineType()) };
+        return LayoutUnit { firstRootBox()->logicalTop() + firstLineStyle().metricsOfPrimaryFont().intDescent(firstRootBox()->baselineType()) };
+    return LayoutUnit { firstRootBox()->logicalTop() + firstLineStyle().metricsOfPrimaryFont().intAscent(firstRootBox()->baselineType()) };
 }
 
 std::optional<LayoutUnit> RenderBlockFlow::lastLineBaseline() const
@@ -3420,8 +3420,8 @@ std::optional<LayoutUnit> RenderBlockFlow::lastLineBaseline() const
     auto rootBox = lastRootBox();
     const RenderStyle& lastLineBoxStyle = InlineIterator::lastLineBoxFor(*this)->style();
     if (style().isFlippedLinesWritingMode())
-        return LayoutUnit { rootBox->logicalTop() + lastLineBoxStyle.metricsOfPrimaryFont().descent(rootBox->baselineType()) };
-    return LayoutUnit { rootBox->logicalTop() + lastLineBoxStyle.metricsOfPrimaryFont().ascent(rootBox->baselineType()) };
+        return LayoutUnit { rootBox->logicalTop() + lastLineBoxStyle.metricsOfPrimaryFont().intDescent(rootBox->baselineType()) };
+    return LayoutUnit { rootBox->logicalTop() + lastLineBoxStyle.metricsOfPrimaryFont().intAscent(rootBox->baselineType()) };
 }
 
 std::optional<LayoutUnit> RenderBlockFlow::inlineBlockBaseline(LineDirectionMode lineDirection) const
@@ -3452,8 +3452,8 @@ std::optional<LayoutUnit> RenderBlockFlow::inlineBlockBaseline(LineDirectionMode
             if (!hasLineIfEmpty())
                 return std::nullopt;
             const auto& fontMetrics = firstLineStyle().metricsOfPrimaryFont();
-            return LayoutUnit { LayoutUnit(fontMetrics.ascent()
-                + (lineHeight(true, lineDirection, PositionOfInteriorLineBoxes) - fontMetrics.height()) / 2
+            return LayoutUnit { LayoutUnit(fontMetrics.intAscent()
+                + (lineHeight(true, lineDirection, PositionOfInteriorLineBoxes) - fontMetrics.intHeight()) / 2
                 + (lineDirection == HorizontalLine ? borderTop() + paddingTop() : borderRight() + paddingRight())).toInt() };
         }
 
@@ -3461,7 +3461,7 @@ std::optional<LayoutUnit> RenderBlockFlow::inlineBlockBaseline(LineDirectionMode
             bool isFirstLine = lastRootBox() == firstRootBox();
             const auto& style = isFirstLine ? firstLineStyle() : this->style();
             // LegacyInlineFlowBox::placeBoxesInBlockDirection will flip lines in case of verticalLR mode, so we can assume verticalRL for now.
-            lastBaseline = style.metricsOfPrimaryFont().ascent(lastRootBox()->baselineType())
+            lastBaseline = style.metricsOfPrimaryFont().intAscent(lastRootBox()->baselineType())
                 + (style.isFlippedLinesWritingMode() ? logicalHeight() - lastRootBox()->logicalBottom() : lastRootBox()->logicalTop());
         }
         else if (modernLineLayout())

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -259,7 +259,7 @@ void RenderEmbeddedObject::paintReplaced(PaintInfo& paintInfo, const LayoutPoint
 
     const FontMetrics& fontMetrics = font.metricsOfPrimaryFont();
     float labelX = roundf(replacementTextRect.location().x() + replacementTextRoundedRectLeftTextMargin);
-    float labelY = roundf(replacementTextRect.location().y() + (replacementTextRect.size().height() - fontMetrics.height()) / 2 + fontMetrics.ascent() + replacementTextRoundedRectTopTextMargin);
+    float labelY = roundf(replacementTextRect.location().y() + (replacementTextRect.size().height() - fontMetrics.intHeight()) / 2 + fontMetrics.intAscent() + replacementTextRoundedRectTopTextMargin);
     context.setFillColor(replacementTextColor);
     context.drawBidiText(font, run, FloatPoint(labelX, labelY));
 

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -211,7 +211,7 @@ ImageSizeChangeType RenderImage::setImageSizeForAltText(CachedImage* newImage /*
     // we have an alt and the user meant it (its not a text we invented)
     if (!m_altText.isEmpty()) {
         const FontCascade& font = style().fontCascade();
-        IntSize paddedTextSize(paddingWidth + std::min(ceilf(font.width(RenderBlock::constructTextRun(m_altText, style()))), maxAltTextWidth), paddingHeight + std::min(font.metricsOfPrimaryFont().height(), maxAltTextHeight));
+        IntSize paddedTextSize(paddingWidth + std::min(ceilf(font.width(RenderBlock::constructTextRun(m_altText, style()))), maxAltTextWidth), paddingHeight + std::min(font.metricsOfPrimaryFont().intHeight(), maxAltTextHeight));
         imageSize = imageSize.expandedTo(paddedTextSize);
     }
 
@@ -556,7 +556,7 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
                 if (hasRoomForAltText()) {
                     auto altTextLocation = [&]() -> LayoutPoint {
                         auto contentHorizontalOffset = LayoutUnit { leftBorder + leftPadding + (paddingWidth / 2) - missingImageBorderWidth };
-                        auto contentVerticalOffset = LayoutUnit { topBorder + topPadding + fontMetrics.ascent() + (paddingHeight / 2) - missingImageBorderWidth };
+                        auto contentVerticalOffset = LayoutUnit { topBorder + topPadding + fontMetrics.intAscent() + (paddingHeight / 2) - missingImageBorderWidth };
                         if (!style().isLeftToRightDirection())
                             contentHorizontalOffset += contentSize.width() - textWidth;
                         return paintOffset + LayoutPoint { contentHorizontalOffset, contentVerticalOffset };

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -862,7 +862,7 @@ LayoutUnit RenderInline::baselinePosition(FontBaseline baselineType, bool firstL
 {
     const RenderStyle& style = firstLine ? firstLineStyle() : this->style();
     const FontMetrics& fontMetrics = style.metricsOfPrimaryFont();
-    return LayoutUnit { (fontMetrics.ascent(baselineType) + (lineHeight(firstLine, direction, linePositionMode) - fontMetrics.height()) / 2).toInt() };
+    return LayoutUnit { (fontMetrics.intAscent(baselineType) + (lineHeight(firstLine, direction, linePositionMode) - fontMetrics.intHeight()) / 2).toInt() };
 }
 
 LayoutSize RenderInline::offsetForInFlowPositionedInline(const RenderBox* child) const

--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -80,7 +80,7 @@ LayoutUnit RenderLineBreak::baselinePosition(FontBaseline baselineType, bool fir
 {
     const RenderStyle& style = firstLine ? firstLineStyle() : this->style();
     const FontMetrics& fontMetrics = style.metricsOfPrimaryFont();
-    return LayoutUnit { (fontMetrics.ascent(baselineType) + (lineHeight(firstLine, direction, linePositionMode) - fontMetrics.height()) / 2).toInt() };
+    return LayoutUnit { (fontMetrics.intAscent(baselineType) + (lineHeight(firstLine, direction, linePositionMode) - fontMetrics.intHeight()) / 2).toInt() };
 }
 
 std::unique_ptr<LegacyInlineElementBox> RenderLineBreak::createInlineBox()

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -434,7 +434,7 @@ static LayoutSize itemOffsetForAlignment(TextRun textRun, const RenderStyle* ite
     if (actualAlignment == TextAlignMode::Start || actualAlignment == TextAlignMode::Justify)
         actualAlignment = itemStyle->isLeftToRightDirection() ? TextAlignMode::Left : TextAlignMode::Right;
 
-    LayoutSize offset = LayoutSize(0, itemFont.metricsOfPrimaryFont().ascent());
+    LayoutSize offset = LayoutSize(0, itemFont.metricsOfPrimaryFont().intAscent());
     if (actualAlignment == TextAlignMode::Right || actualAlignment == TextAlignMode::WebKitRight) {
         float textWidth = itemFont.width(textRun);
         offset.setWidth(itemBoudingBox.width() - textWidth - optionsSpacingHorizontal);
@@ -758,7 +758,7 @@ void RenderListBox::scrollTo(int newOffset)
 
 LayoutUnit RenderListBox::itemHeight() const
 {
-    return style().metricsOfPrimaryFont().height() + rowSpacing;
+    return style().metricsOfPrimaryFont().intHeight() + rowSpacing;
 }
 
 int RenderListBox::verticalScrollbarWidth() const

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -1655,7 +1655,7 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
         context.translate(-markerRect.x(), -markerRect.maxY());
     }
 
-    FloatPoint textOrigin = FloatPoint(markerRect.x(), markerRect.y() + style().metricsOfPrimaryFont().ascent());
+    FloatPoint textOrigin = FloatPoint(markerRect.x(), markerRect.y() + style().metricsOfPrimaryFont().intAscent());
     textOrigin = roundPointToDevicePixels(LayoutPoint(textOrigin), document().deviceScaleFactor(), style().isLeftToRightDirection());
     context.drawText(style().fontCascade(), textRun(), textOrigin);
 }
@@ -1786,7 +1786,7 @@ void RenderListMarker::layout()
         setHeight(m_image->imageSize(this, style().effectiveZoom()).height());
     } else {
         setLogicalWidth(minPreferredLogicalWidth());
-        setLogicalHeight(style().metricsOfPrimaryFont().height());
+        setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
     }
 
     setMarginStart(0);
@@ -1826,7 +1826,7 @@ void RenderListMarker::updateContent()
     if (isImage()) {
         // FIXME: This is a somewhat arbitrary width.  Generated images for markers really won't become particularly useful
         // until we support the CSS3 marker pseudoclass to allow control over the width and height of the marker box.
-        LayoutUnit bulletWidth = style().metricsOfPrimaryFont().ascent() / 2_lu;
+        LayoutUnit bulletWidth = style().metricsOfPrimaryFont().intAscent() / 2_lu;
         LayoutSize defaultBulletSize(bulletWidth, bulletWidth);
         LayoutSize imageSize = calculateImageIntrinsicDimensions(m_image.get(), defaultBulletSize, DoNotScaleByEffectiveZoom);
         m_image->setContainerContextForRenderer(*this, imageSize, style().effectiveZoom());
@@ -1879,7 +1879,7 @@ void RenderListMarker::computePreferredLogicalWidths()
 
     LayoutUnit logicalWidth;
     if (widthUsesMetricsOfPrimaryFont())
-        logicalWidth = (font.metricsOfPrimaryFont().ascent() * 2 / 3 + 1) / 2 + 2;
+        logicalWidth = (font.metricsOfPrimaryFont().intAscent() * 2 / 3 + 1) / 2 + 2;
     else if (!m_textWithSuffix.isEmpty())
             logicalWidth = font.width(textRun());
 
@@ -1903,13 +1903,13 @@ void RenderListMarker::updateMargins()
             marginEnd = cMarkerPadding;
         else if (widthUsesMetricsOfPrimaryFont()) {
                 marginStart = -1;
-                marginEnd = fontMetrics.ascent() - minPreferredLogicalWidth() + 1;
+                marginEnd = fontMetrics.intAscent() - minPreferredLogicalWidth() + 1;
         }
     } else if (isImage()) {
         marginStart = -minPreferredLogicalWidth() - cMarkerPadding;
         marginEnd = cMarkerPadding;
     } else {
-        int offset = fontMetrics.ascent() * 2 / 3;
+        int offset = fontMetrics.intAscent() * 2 / 3;
         if (widthUsesMetricsOfPrimaryFont()) {
             marginStart = -offset - cMarkerPadding - 1;
             marginEnd = offset + cMarkerPadding + 1 - minPreferredLogicalWidth();
@@ -1961,14 +1961,14 @@ FloatRect RenderListMarker::relativeMarkerRect()
     if (widthUsesMetricsOfPrimaryFont()) {
         // FIXME: Are these particular rounding rules necessary?
         const FontMetrics& fontMetrics = style().metricsOfPrimaryFont();
-        int ascent = fontMetrics.ascent();
+        int ascent = fontMetrics.intAscent();
         int bulletWidth = (ascent * 2 / 3 + 1) / 2;
         relativeRect = FloatRect(1, 3 * (ascent - ascent * 2 / 3) / 2, bulletWidth, bulletWidth);
     } else {
         if (m_textWithSuffix.isEmpty())
             return FloatRect();
         auto& font = style().fontCascade();
-        relativeRect = FloatRect(0, 0, font.width(textRun()), font.metricsOfPrimaryFont().height());
+        relativeRect = FloatRect(0, 0, font.width(textRun()), font.metricsOfPrimaryFont().intHeight());
     }
 
     if (!style().isHorizontalWritingMode()) {

--- a/Source/WebCore/rendering/RenderRubyRun.cpp
+++ b/Source/WebCore/rendering/RenderRubyRun.cpp
@@ -162,7 +162,7 @@ void RenderRubyRun::layoutBlock(bool relayoutChildren, LayoutUnit pageHeight)
         // Bopomofo. We need to move the RenderRubyText over to the right side and center it
         // vertically relative to the base.
         const FontCascade& font = style().fontCascade();
-        float distanceBetweenBase = std::max(font.letterSpacing(), 2.0f * rt->style().fontCascade().metricsOfPrimaryFont().height());
+        float distanceBetweenBase = std::max(font.letterSpacing(), 2.0f * rt->style().fontCascade().metricsOfPrimaryFont().intHeight());
         setWidth(width() + distanceBetweenBase - font.letterSpacing());
         if (RenderRubyBase* rb = rubyBase()) {
             LayoutUnit firstLineTop;
@@ -208,7 +208,7 @@ LayoutUnit RenderRubyRun::baselinePosition(FontBaseline baselineType, bool first
     if (!rubyBase() || rubyBase()->isEmptyOrHasInFlowContent())
         return RenderBlockFlow::baselinePosition(baselineType, firstLine, lineDirectionMode, linePositionMode);
     auto& style = firstLine ? firstLineStyle() : this->style();
-    return LayoutUnit { style.metricsOfPrimaryFont().ascent(baselineType) };
+    return LayoutUnit { style.metricsOfPrimaryFont().intAscent(baselineType) };
 }
 
 static bool shouldOverhang(bool firstLine, const RenderObject* renderer, const RenderRubyBase& rubyBase)

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -445,7 +445,7 @@ void TextBoxPainter<TextBoxPath>::paintForeground(const StyledMarkedText& marked
     float emphasisMarkOffset = 0;
     const AtomString& emphasisMark = m_emphasisMarkExistsAndIsAbove ? m_style.textEmphasisMarkString() : nullAtom();
     if (!emphasisMark.isEmpty())
-        emphasisMarkOffset = *m_emphasisMarkExistsAndIsAbove ? -font.metricsOfPrimaryFont().ascent() - font.emphasisMarkDescent(emphasisMark) : font.metricsOfPrimaryFont().descent() + font.emphasisMarkAscent(emphasisMark);
+        emphasisMarkOffset = *m_emphasisMarkExistsAndIsAbove ? -font.metricsOfPrimaryFont().intAscent() - font.emphasisMarkDescent(emphasisMark) : font.metricsOfPrimaryFont().intDescent() + font.emphasisMarkAscent(emphasisMark);
 
     TextPainter textPainter { context, font };
     textPainter.setStyle(markedText.style.textStyles);
@@ -510,7 +510,7 @@ static inline float computedAutoTextDecorationThickness(const RenderStyle& style
 
 static inline float computedLinethroughCenter(const RenderStyle& styleToUse, float textDecorationThickness, float autoTextDecorationThickness)
 {
-    auto center = 2 * styleToUse.metricsOfPrimaryFont().floatAscent() / 3 + autoTextDecorationThickness / 2;
+    auto center = 2 * styleToUse.metricsOfPrimaryFont().ascent().value_or(0) / 3 + autoTextDecorationThickness / 2;
     return center - textDecorationThickness / 2;
 }
 
@@ -614,7 +614,7 @@ void TextBoxPainter<TextBoxPath>::paintBackgroundDecorations(TextDecorationPaint
                 underlineOffset(),
                 overlineOffset(),
                 computedLinethroughCenter(decoratingBox.style, textDecorationThickness, autoTextDecorationThickness),
-                decoratingBox.style.metricsOfPrimaryFont().ascent() + 2.f,
+                decoratingBox.style.metricsOfPrimaryFont().intAscent() + 2.f,
                 wavyStrokeParameters(decoratingBox.style.computedFontPixelSize())
             };
         };
@@ -670,7 +670,7 @@ void TextBoxPainter<TextBoxPath>::fillCompositionUnderline(float start, float wi
     // All other marked text underlines are 1px thick.
     // If there's not enough space the underline will touch or overlap characters.
     int lineThickness = 1;
-    int baseline = m_style.metricsOfPrimaryFont().ascent();
+    int baseline = m_style.metricsOfPrimaryFont().intAscent();
     if (underline.thick && m_logicalRect.height() - baseline >= 2)
         lineThickness = 2;
 
@@ -873,7 +873,7 @@ FloatRect TextBoxPainter<TextBoxPath>::computePaintRect(const LayoutPoint& paint
 FloatRect calculateDocumentMarkerBounds(const InlineIterator::TextBoxIterator& textBox, const MarkedText& markedText)
 {
     auto& font = textBox->fontCascade();
-    auto ascent = font.metricsOfPrimaryFont().ascent();
+    auto ascent = font.metricsOfPrimaryFont().intAscent();
     auto fontSize = std::min(std::max(font.size(), 10.0f), 40.0f);
     auto y = ascent + 0.11035 * fontSize;
     auto height = 0.13247 * fontSize;
@@ -910,7 +910,7 @@ const FontCascade& TextBoxPainter<TextBoxPath>::fontCascade() const
 template<typename TextBoxPath>
 FloatPoint TextBoxPainter<TextBoxPath>::textOriginFromPaintRect(const FloatRect& paintRect) const
 {
-    FloatPoint textOrigin { paintRect.x(), paintRect.y() + fontCascade().metricsOfPrimaryFont().ascent() };
+    FloatPoint textOrigin { paintRect.x(), paintRect.y() + fontCascade().metricsOfPrimaryFont().intAscent() };
     if (m_isCombinedText) {
         if (auto newOrigin = downcast<RenderCombineText>(m_renderer).computeTextOrigin(paintRect))
             textOrigin = newOrigin.value();

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -200,7 +200,7 @@ void TextPainter::paintTextAndEmphasisMarksIfNeeded(const TextRun& textRun, cons
     updateGraphicsContext(m_context, paintStyle, UseEmphasisMarkColor);
     static NeverDestroyed<TextRun> objectReplacementCharacterTextRun(StringView(&objectReplacementCharacter, 1));
     const TextRun& emphasisMarkTextRun = m_combinedText ? objectReplacementCharacterTextRun.get() : textRun;
-    FloatPoint emphasisMarkTextOrigin = m_combinedText ? FloatPoint(boxOrigin.x() + boxRect.width() / 2, boxOrigin.y() + m_font.metricsOfPrimaryFont().ascent()) : textOrigin;
+    FloatPoint emphasisMarkTextOrigin = m_combinedText ? FloatPoint(boxOrigin.x() + boxRect.width() / 2, boxOrigin.y() + m_font.metricsOfPrimaryFont().intAscent()) : textOrigin;
     if (m_combinedText)
         m_context.concatCTM(rotation(boxRect, Clockwise));
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -79,7 +79,7 @@ static LayoutUnit axisHeight(const RenderStyle& style)
 
     // Otherwise, the idea is to try and use the middle of operators as the math axis which we thus approximate by "half of the x-height".
     // Note that Gecko has a slower but more accurate version that measures half of the height of U+2212 MINUS SIGN.
-    return LayoutUnit(style.metricsOfPrimaryFont().xHeight() / 2);
+    return LayoutUnit(style.metricsOfPrimaryFont().xHeight().value_or(0) / 2);
 }
 
 LayoutUnit RenderMathMLBlock::mathAxisHeight() const
@@ -161,7 +161,7 @@ LayoutUnit toUserUnits(const MathMLElement::Length& length, const RenderStyle& s
     case MathMLElement::LengthType::Em:
         return LayoutUnit(length.value * style.fontCascade().size());
     case MathMLElement::LengthType::Ex:
-        return LayoutUnit(length.value * style.metricsOfPrimaryFont().xHeight());
+        return LayoutUnit(length.value * style.metricsOfPrimaryFont().xHeight().value_or(0));
     case MathMLElement::LengthType::MathUnit:
         return LayoutUnit(length.value * style.fontCascade().size() / 18);
     case MathMLElement::LengthType::Percentage:

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -139,7 +139,7 @@ RenderMathMLRoot::VerticalParameters RenderMathMLRoot::verticalParameters()
         // RadicalDegreeBottomRaisePercent: Suggested value is 60%.
         parameters.ruleThickness = ruleThicknessFallback();
         if (style().mathStyle() == MathStyle::Normal)
-            parameters.verticalGap = parameters.ruleThickness + style().metricsOfPrimaryFont().xHeight() / 4;
+            parameters.verticalGap = parameters.ruleThickness + style().metricsOfPrimaryFont().xHeight().value_or(0) / 4;
         else
             parameters.verticalGap = 5 * parameters.ruleThickness / 4;
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -242,14 +242,15 @@ auto RenderMathMLScripts::verticalParameters() const -> VerticalParameters
         parameters.superscriptBottomMaxWithSubscript = mathData->getMathConstant(primaryFont, OpenTypeMathData::SuperscriptBottomMaxWithSubscript);
     } else {
         // Default heuristic values when you do not have a font.
-        parameters.subscriptShiftDown = style().metricsOfPrimaryFont().xHeight() / 3;
-        parameters.superscriptShiftUp = style().metricsOfPrimaryFont().xHeight();
-        parameters.subscriptBaselineDropMin = style().metricsOfPrimaryFont().xHeight() / 2;
-        parameters.superScriptBaselineDropMax = style().metricsOfPrimaryFont().xHeight() / 2;
+        float xHeight = style().metricsOfPrimaryFont().xHeight().value_or(0);
+        parameters.subscriptShiftDown = xHeight / 3;
+        parameters.superscriptShiftUp = xHeight;
+        parameters.subscriptBaselineDropMin = xHeight / 2;
+        parameters.superScriptBaselineDropMax = xHeight / 2;
         parameters.subSuperscriptGapMin = style().fontCascade().size() / 5;
-        parameters.superscriptBottomMin = style().metricsOfPrimaryFont().xHeight() / 4;
-        parameters.subscriptTopMax = 4 * style().metricsOfPrimaryFont().xHeight() / 5;
-        parameters.superscriptBottomMaxWithSubscript = 4 * style().metricsOfPrimaryFont().xHeight() / 5;
+        parameters.superscriptBottomMin = xHeight / 4;
+        parameters.subscriptTopMax = 4 * xHeight / 5;
+        parameters.superscriptBottomMaxWithSubscript = 4 * xHeight / 5;
     }
     return parameters;
 }

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
@@ -248,7 +248,7 @@ RenderMathMLUnderOver::VerticalParameters RenderMathMLUnderOver::verticalParamet
         parameters.overGapMin = 3 * defaultLineThickness;
         parameters.underExtraDescender = defaultLineThickness;
         parameters.overExtraAscender = defaultLineThickness;
-        parameters.accentBaseHeight = style().metricsOfPrimaryFont().xHeight();
+        parameters.accentBaseHeight = style().metricsOfPrimaryFont().xHeight().value_or(0);
         parameters.useUnderOverBarFallBack = true;
         return parameters;
     }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2068,7 +2068,7 @@ int RenderStyle::computeLineHeight(const Length& lineHeightLength) const
 {
     // Negative value means the line height is not set. Use the font's built-in spacing.
     if (lineHeightLength.isNegative())
-        return metricsOfPrimaryFont().lineSpacing();
+        return metricsOfPrimaryFont().intLineSpacing();
 
     if (lineHeightLength.isPercentOrCalculated())
         return minimumValueForLength(lineHeightLength, computedFontPixelSize());

--- a/Source/WebCore/rendering/style/TextDecorationThickness.h
+++ b/Source/WebCore/rendering/style/TextDecorationThickness.h
@@ -82,7 +82,7 @@ public:
             return fontSize / textDecorationBaseFontSize;
         }
         if (isFromFont())
-            return metrics.underlineThickness();
+            return metrics.underlineThickness().value_or(0);
         ASSERT(isLength());
         return m_length;
     }

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -157,7 +157,7 @@ VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, 
     if (!firstTextBox() || text().isEmpty())
         return createVisiblePosition(0, Affinity::Downstream);
 
-    float baseline = m_scaledFont.metricsOfPrimaryFont().floatAscent();
+    float baseline = m_scaledFont.metricsOfPrimaryFont().ascent().value_or(0);
 
     RenderBlock* containingBlock = this->containingBlock();
     ASSERT(containingBlock);

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -50,9 +50,9 @@ float SVGTextLayoutEngineBaseline::calculateBaselineShift(const SVGRenderStyle& 
     case BaselineShift::Baseline:
         return 0;
     case BaselineShift::Sub:
-        return -m_font.metricsOfPrimaryFont().floatHeight() / 2;
+        return -m_font.metricsOfPrimaryFont().height() / 2;
     case BaselineShift::Super:
-        return m_font.metricsOfPrimaryFont().floatHeight() / 2;
+        return m_font.metricsOfPrimaryFont().height() / 2;
     case BaselineShift::Length:
         break;
     }
@@ -117,26 +117,28 @@ float SVGTextLayoutEngineBaseline::calculateAlignmentBaselineShift(bool isVertic
     }
 
     const FontMetrics& fontMetrics = m_font.metricsOfPrimaryFont();
+    float ascent = fontMetrics.ascent().value_or(0);
+    float descent = fontMetrics.descent().value_or(0);
 
     // Note: http://wiki.apache.org/xmlgraphics-fop/LineLayout/AlignmentHandling
     switch (baseline) {
     case AlignmentBaseline::BeforeEdge:
     case AlignmentBaseline::TextBeforeEdge:
-        return fontMetrics.floatAscent();
+        return ascent;
     case AlignmentBaseline::Middle:
-        return fontMetrics.xHeight() / 2;
+        return fontMetrics.xHeight().value_or(0) / 2;
     case AlignmentBaseline::Central:
-        return (fontMetrics.floatAscent() - fontMetrics.floatDescent()) / 2;
+        return (ascent - descent) / 2;
     case AlignmentBaseline::AfterEdge:
     case AlignmentBaseline::TextAfterEdge:
     case AlignmentBaseline::Ideographic:
-        return -fontMetrics.floatDescent();
+        return -descent;
     case AlignmentBaseline::Alphabetic:
         return 0;
     case AlignmentBaseline::Hanging:
-        return fontMetrics.floatAscent() * 8 / 10.f;
+        return ascent * 8 / 10.f;
     case AlignmentBaseline::Mathematical:
-        return fontMetrics.floatAscent() / 2;
+        return ascent / 2;
     case AlignmentBaseline::Baseline:
         ASSERT_NOT_REACHED();
         return 0;
@@ -198,13 +200,15 @@ float SVGTextLayoutEngineBaseline::calculateGlyphAdvanceAndOrientation(bool isVe
     // 180 degrees, then the current text position is incremented according to the horizontal metrics of the glyph.
 
     const FontMetrics& fontMetrics = m_font.metricsOfPrimaryFont();
+    float ascent = fontMetrics.ascent().value_or(0);
+    float descent = fontMetrics.descent().value_or(0);
 
     // Vertical orientation handling.
     if (isVerticalText) {
-        float ascentMinusDescent = fontMetrics.floatAscent() - fontMetrics.floatDescent();
+        float ascentMinusDescent = ascent - descent;
         if (!angle) {
             xOrientationShift = (ascentMinusDescent - metrics.width()) / 2;
-            yOrientationShift = fontMetrics.floatAscent();
+            yOrientationShift = ascent;
         } else if (angle == 180)
             xOrientationShift = (ascentMinusDescent + metrics.width()) / 2;
         else if (angle == 270) {
@@ -224,7 +228,7 @@ float SVGTextLayoutEngineBaseline::calculateGlyphAdvanceAndOrientation(bool isVe
         yOrientationShift = -metrics.width();
     else if (angle == 180) {
         xOrientationShift = metrics.width();
-        yOrientationShift = -fontMetrics.floatAscent();
+        yOrientationShift = -ascent;
     } else if (angle == 270)
         xOrientationShift = metrics.width();
 

--- a/Source/WebCore/rendering/svg/SVGTextMetrics.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetrics.cpp
@@ -50,7 +50,7 @@ SVGTextMetrics::SVGTextMetrics(RenderSVGInlineText& textRenderer, const TextRun&
     m_width = scaledFont.width(run) / scalingFactor;
     length = run.length();
     m_glyph.name = emptyString();
-    m_height = scaledFont.metricsOfPrimaryFont().floatHeight() / scalingFactor;
+    m_height = scaledFont.metricsOfPrimaryFont().height() / scalingFactor;
 
     m_glyph.unicodeString = run.is8Bit() ? String(run.characters8(), length) : String(run.characters16(), length);
     m_glyph.isValid = true;
@@ -86,7 +86,7 @@ SVGTextMetrics::SVGTextMetrics(RenderSVGInlineText& text, unsigned length, float
     ASSERT(scalingFactor);
 
     m_width = width / scalingFactor;
-    m_height = text.scaledFont().metricsOfPrimaryFont().floatHeight() / scalingFactor;
+    m_height = text.scaledFont().metricsOfPrimaryFont().height() / scalingFactor;
 
     m_length = length;
 }

--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -463,7 +463,7 @@ static inline void calculateGlyphBoundaries(SVGTextQuery::Data* queryData, const
     float scalingFactor = queryData->textRenderer->scalingFactor();
     ASSERT(scalingFactor);
 
-    extent.setLocation(FloatPoint(fragment.x, fragment.y - queryData->textRenderer->scaledFont().metricsOfPrimaryFont().floatAscent() / scalingFactor));
+    extent.setLocation(FloatPoint(fragment.x, fragment.y - queryData->textRenderer->scaledFont().metricsOfPrimaryFont().ascent().value_or(0) / scalingFactor));
 
     if (startPosition) {
         SVGTextMetrics metrics = SVGTextMetrics::measureCharacterRange(*queryData->textRenderer, fragment.characterOffset, startPosition);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -54,7 +54,7 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
 
     // We have to compute the correct font-size for the first-letter if it has an initial letter height set.
     auto* paragraph = firstLetterContainer.isRenderBlockFlow() ? &firstLetterContainer : firstLetterContainer.containingBlock();
-    if (firstLetterStyle.initialLetterHeight() >= 1 && firstLetterStyle.metricsOfPrimaryFont().hasCapHeight() && paragraph->style().metricsOfPrimaryFont().hasCapHeight()) {
+    if (firstLetterStyle.initialLetterHeight() >= 1 && firstLetterStyle.metricsOfPrimaryFont().capHeight().has_value() && paragraph->style().metricsOfPrimaryFont().capHeight().has_value()) {
         // FIXME: For ideographic baselines, we want to go from line edge to line edge. This is equivalent to (N-1)*line-height + the font height.
         // We don't yet support ideographic baselines.
         // For an N-line first-letter and for alphabetic baselines, the cap-height of the first letter needs to equal (N-1)*line-height of paragraph lines + cap-height of the paragraph
@@ -66,22 +66,22 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
         // Set the font to be one line too big and then ratchet back to get to a precise fit. We can't just set the desired font size based off font height metrics
         // because many fonts bake ascent into the font metrics. Therefore we have to look at actual measured cap height values in order to know when we have a good fit.
         auto newFontDescription = firstLetterStyle.fontDescription();
-        float capRatio = firstLetterStyle.metricsOfPrimaryFont().floatCapHeight() / firstLetterStyle.computedFontPixelSize();
-        float startingFontSize = ((firstLetterStyle.initialLetterHeight() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().capHeight()) / capRatio;
+        float capRatio = firstLetterStyle.metricsOfPrimaryFont().capHeight().value() / firstLetterStyle.computedFontPixelSize();
+        float startingFontSize = ((firstLetterStyle.initialLetterHeight() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().intCapHeight()) / capRatio;
         newFontDescription.setSpecifiedSize(startingFontSize);
         newFontDescription.setComputedSize(startingFontSize);
         firstLetterStyle.setFontDescription(WTFMove(newFontDescription));
         firstLetterStyle.fontCascade().update(firstLetterStyle.fontCascade().fontSelector());
 
-        int desiredCapHeight = (firstLetterStyle.initialLetterHeight() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().capHeight();
-        int actualCapHeight = firstLetterStyle.metricsOfPrimaryFont().capHeight();
+        int desiredCapHeight = (firstLetterStyle.initialLetterHeight() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().intCapHeight();
+        int actualCapHeight = firstLetterStyle.metricsOfPrimaryFont().intCapHeight();
         while (actualCapHeight > desiredCapHeight) {
             auto newFontDescription = firstLetterStyle.fontDescription();
             newFontDescription.setSpecifiedSize(newFontDescription.specifiedSize() - 1);
             newFontDescription.setComputedSize(newFontDescription.computedSize() -1);
             firstLetterStyle.setFontDescription(WTFMove(newFontDescription));
             firstLetterStyle.fontCascade().update(firstLetterStyle.fontCascade().fontSelector());
-            actualCapHeight = firstLetterStyle.metricsOfPrimaryFont().capHeight();
+            actualCapHeight = firstLetterStyle.metricsOfPrimaryFont().intCapHeight();
         }
     }
 

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -166,19 +166,20 @@ static float computedUnderlineOffset(const UnderlineOffsetArguments& context)
     auto underlineOffset = context.lineStyle.textUnderlineOffset();
     auto& fontMetrics = context.lineStyle.metricsOfPrimaryFont();
 
-    float computedUnderlineOffset = fontMetrics.ascent() + gap;
+    float ascent = fontMetrics.intAscent();
+    float computedUnderlineOffset = ascent + gap;
     switch (context.resolvedUnderlinePosition) {
     case TextUnderlinePosition::Auto:
-        computedUnderlineOffset = fontMetrics.ascent() + underlineOffset.lengthOr(gap);
+        computedUnderlineOffset = ascent + underlineOffset.lengthOr(gap);
         break;
     case TextUnderlinePosition::FromFont:
-        computedUnderlineOffset = fontMetrics.ascent() + fontMetrics.underlinePosition() + underlineOffset.lengthOr(0.f);
+        computedUnderlineOffset = ascent + fontMetrics.underlinePosition().value_or(0) + underlineOffset.lengthOr(0.f);
         break;
     case TextUnderlinePosition::Under: {
         ASSERT(context.textUnderlinePositionUnder);
         // Position underline relative to the bottom edge of the lowest element's content box.
         auto desiredOffset = context.textUnderlinePositionUnder->textRunLogicalHeight + gap + std::max(context.textUnderlinePositionUnder->textRunOffsetFromBottomMost, 0.f) + underlineOffset.lengthOr(0.f);
-        computedUnderlineOffset = std::max<float>(desiredOffset, fontMetrics.ascent());
+        computedUnderlineOffset = std::max<float>(desiredOffset, ascent);
         break;
     }
     default:
@@ -213,7 +214,7 @@ static GlyphOverflow computedVisualOverflowForDecorations(const RenderStyle& lin
     float wavyOffset = 0;
 
     TextDecorationStyle decorationStyle = lineStyle.textDecorationStyle();
-    float height = lineStyle.fontCascade().metricsOfPrimaryFont().floatHeight();
+    float height = lineStyle.fontCascade().metricsOfPrimaryFont().height();
     GlyphOverflow overflowResult;
 
     if (decorationStyle == TextDecorationStyle::Wavy) {
@@ -251,7 +252,7 @@ static GlyphOverflow computedVisualOverflowForDecorations(const RenderStyle& lin
     if (decoration & TextDecorationLine::LineThrough) {
         FloatRect rect(FloatPoint(), FloatSize(1, strokeThickness));
         float autoTextDecorationThickness = TextDecorationThickness::createWithAuto().resolve(lineStyle.computedFontSize(), lineStyle.metricsOfPrimaryFont());
-        auto center = 2 * lineStyle.metricsOfPrimaryFont().floatAscent() / 3 + autoTextDecorationThickness / 2;
+        auto center = 2 * lineStyle.metricsOfPrimaryFont().ascent().value_or(0) / 3 + autoTextDecorationThickness / 2;
         rect.move(0, center - strokeThickness / 2);
         if (decorationStyle == TextDecorationStyle::Wavy) {
             FloatBoxExtent wavyExpansion;

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -199,16 +199,16 @@ float adjustedFontSize(float size, const FontSizeAdjust& sizeAdjust, const FontM
     // https://github.com/w3c/csswg-drafts/issues/6384
     switch (sizeAdjust.metric) {
     case FontSizeAdjust::Metric::CapHeight:
-        return metrics.hasCapHeight() ? adjustedFontSize(size, *sizeAdjust.value, metrics.floatCapHeight()) : size;
+        return metrics.capHeight() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.capHeight()) : size;
     case FontSizeAdjust::Metric::ChWidth:
         return metrics.zeroWidth() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.zeroWidth()) : size;
     // FIXME: Are ic-height and ic-width the same? Gecko treats them the same.
     case FontSizeAdjust::Metric::IcWidth:
     case FontSizeAdjust::Metric::IcHeight:
-        return metrics.ideogramWidth() > 0 ? adjustedFontSize(size, *sizeAdjust.value, metrics.ideogramWidth()) : size;
+        return metrics.ideogramWidth() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.ideogramWidth()) : size;
     case FontSizeAdjust::Metric::ExHeight:
     default:
-        return metrics.hasXHeight() ? adjustedFontSize(size, *sizeAdjust.value, metrics.xHeight()) : size;
+        return metrics.xHeight() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.xHeight()) : size;
     }
 
     ASSERT_NOT_REACHED();
@@ -220,23 +220,19 @@ std::optional<float> aspectValueOfPrimaryFont(const RenderStyle& style, FontSize
     std::optional<float> metricValue;
     switch (metric) {
     case FontSizeAdjust::Metric::CapHeight:
-        if (metrics.hasCapHeight())
-            metricValue = metrics.floatCapHeight();
+        metricValue = metrics.capHeight();
         break;
     case FontSizeAdjust::Metric::ChWidth:
-        if (metrics.zeroWidth())
-            metricValue = metrics.zeroWidth();
+        metricValue = metrics.zeroWidth();
         break;
     // FIXME: Are ic-height and ic-width the same? Gecko treats them the same.
     case FontSizeAdjust::Metric::IcWidth:
     case FontSizeAdjust::Metric::IcHeight:
-        if (metrics.ideogramWidth() > 0)
-            metricValue = metrics.ideogramWidth();
+        metricValue = metrics.ideogramWidth();
         break;
     case FontSizeAdjust::Metric::ExHeight:
     default:
-        if (metrics.hasXHeight())
-            metricValue = metrics.xHeight();
+        metricValue = metrics.xHeight();
     }
 
     float computedFontSize = style.computedFontSize();

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -265,7 +265,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEXS(float value)
 
     // Use of ceil allows a pixel match to the W3Cs expected output of coords-units-03-b.svg
     // if this causes problems in real world cases maybe it would be best to remove this
-    float xHeight = std::ceil(style->metricsOfPrimaryFont().xHeight());
+    float xHeight = std::ceil(style->metricsOfPrimaryFont().xHeight().value_or(0));
     if (!xHeight)
         return Exception { NotSupportedError };
 
@@ -280,7 +280,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromEXSToUserUnits(float value)
 
     // Use of ceil allows a pixel match to the W3Cs expected output of coords-units-03-b.svg
     // if this causes problems in real world cases maybe it would be best to remove this
-    return value * std::ceil(style->metricsOfPrimaryFont().xHeight());
+    return value * std::ceil(style->metricsOfPrimaryFont().xHeight().value_or(0));
 }
 
 std::optional<FloatSize> SVGLengthContext::viewportSize() const

--- a/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
@@ -48,7 +48,7 @@ void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, Pl
     data.m_clientPaddingRight = m_popupClient->clientPaddingRight();
     data.m_clientInsetLeft = m_popupClient->clientInsetLeft();
     data.m_clientInsetRight = m_popupClient->clientInsetRight();
-    data.m_itemHeight = font.metricsOfPrimaryFont().height() + 1;
+    data.m_itemHeight = font.metricsOfPrimaryFont().intHeight() + 1;
 
     int popupWidth = 0;
     for (size_t i = 0; i < itemCount; ++i) {
@@ -137,7 +137,7 @@ void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, Pl
                 if (RenderTheme::singleton().popupOptionSupportsTextIndent())
                     textX -= minimumIntValueForLength(itemStyle.textIndent(), itemRect.width());
             }
-            int textY = itemRect.y() + itemFontCascade.metricsOfPrimaryFont().ascent() + (itemRect.height() - itemFontCascade.metricsOfPrimaryFont().height()) / 2;
+            int textY = itemRect.y() + itemFontCascade.metricsOfPrimaryFont().intAscent() + (itemRect.height() - itemFontCascade.metricsOfPrimaryFont().intHeight()) / 2;
 
             notSelectedBackingStoreContext->drawBidiText(itemFontCascade, textRun, IntPoint(textX, textY));
             selectedBackingStoreContext->drawBidiText(itemFontCascade, textRun, IntPoint(textX, textY));

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -210,7 +210,7 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
     IntRect rangeRect = frame.view()->contentsToWindow(quads[0].enclosingBoundingBox());
 
     const RenderStyle* style = range.startContainer().renderStyle();
-    float scaledAscent = style ? style->metricsOfPrimaryFont().ascent() * pageScaleFactor() : 0;
+    float scaledAscent = style ? style->metricsOfPrimaryFont().intAscent() * pageScaleFactor() : 0;
     dictionaryPopupInfo.origin = FloatPoint(rangeRect.x(), rangeRect.y() + scaledAscent);
     dictionaryPopupInfo.platformData.options = options;
 

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -519,7 +519,7 @@ static WebCore::IntRect elementBoundingBoxInWindowCoordinatesFromNode(WebCore::N
     }
 
     auto style = range.start.container->renderStyle();
-    float scaledDescent = style ? style->metricsOfPrimaryFont().descent() * frame->page()->pageScaleFactor() : 0;
+    float scaledDescent = style ? style->metricsOfPrimaryFont().intDescent() * frame->page()->pageScaleFactor() : 0;
 
     auto quads = WebCore::RenderObject::absoluteTextQuads(range);
     if (quads.isEmpty()) {


### PR DESCRIPTION
#### 7214c98421996900324baec6492c586c49881927
<pre>
Apply std::optional to FontMetrics for consistency
<a href="https://bugs.webkit.org/show_bug.cgi?id=255378">https://bugs.webkit.org/show_bug.cgi?id=255378</a>

Reviewed by NOBODY (OOPS!).

This change aims at cleaning up the FontMetrics interface. There are three
inconsistencies in this class, which could mislead developers.

1. Inconsistent type of get/set methods. The set methods take float, but the
   corresponding get functions return int.
2. Inconsistent return types of get methods. For example, The height() returns
   an int, but the xHeight() returns a float.
3. Inconsistent validity checks. The xHeight and capHeight use their own has*
   functions, but the zeroWidth uses std::optional. Others font metrics do not
   provide any validity check methods.

This change applies std::optional to FontMetrics and makes its interface
in the following way:

1. Each get method returns a float as default. To get an int value, callers
   should explicitly call the int* methods. (e.g., ascent() returns float and
   intAscent() returns int.)
2. Each font metric value is returned as std::optional. So callers can check
   the validity with the has_value() method.

This patch does not change the existing layout or functionalities.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::computeUnzoomedNonCalcLengthDouble):
(WebCore::CSSPrimitiveValue::computeNonCalcLengthDouble):
* Source/WebCore/display/css/DisplayBoxPainter.cpp:
(WebCore::Display::BoxPainter::paintBoxContent):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
(WebCore::CanvasRenderingContext2DBase::measureTextInternal):
(WebCore::CanvasRenderingContext2DBase::textOffset):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::drawRulers):
* Source/WebCore/inspector/InspectorOverlayLabel.cpp:
(WebCore::InspectorOverlayLabel::draw):
(WebCore::InspectorOverlayLabel::expectedSize):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingQuirks.cpp:
(WebCore::Layout::InlineFormattingQuirks::initialLetterAlignmentOffset const):
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
(WebCore::Layout::InlineLevelBox::preferredLineHeight const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.cpp:
(WebCore::Layout::LineBox::logicalRectForTextRun const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::primaryFontMetricsForInlineBox):
(WebCore::Layout::ascentAndDescentWithTextEdgeForInlineBox):
(WebCore::Layout::LineBoxBuilder::enclosingAscentDescentWithFallbackFonts const):
(WebCore::Layout::LineBoxBuilder::setLayoutBoundsForInlineBox const):
(WebCore::Layout::LineBoxBuilder::setVerticalPropertiesForInlineLevelBox const):
(WebCore::Layout::LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable):
(WebCore::Layout::LineBoxBuilder::computeLineBoxGeometry const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp:
(WebCore::Layout::LineBoxVerticalAligner::computeLineBoxLogicalHeight const):
(WebCore::Layout::LineBoxVerticalAligner::computeRootInlineBoxVerticalPosition const):
(WebCore::Layout::LineBoxVerticalAligner::alignInlineLevelBoxes const):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::appendTextDisplayBox):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateLayoutBoxDimensions):
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::initCharWidths):
(WebCore::Font::platformGlyphInit):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::emphasisMarkAscent const):
(WebCore::FontCascade::emphasisMarkDescent const):
(WebCore::FontCascade::emphasisMarkHeight const):
(WebCore::FontCascade::floatEmphasisMarkHeight const):
(WebCore::FontCascade::floatWidthForSimpleText const):
(WebCore::FontCascade::floatWidthForComplexText const):
* Source/WebCore/platform/graphics/FontMetrics.h:
(WebCore::FontMetrics::height const):
(WebCore::FontMetrics::intHeight const):
(WebCore::FontMetrics::ascent const):
(WebCore::FontMetrics::intAscent const):
(WebCore::FontMetrics::setAscent):
(WebCore::FontMetrics::descent const):
(WebCore::FontMetrics::intDescent const):
(WebCore::FontMetrics::setDescent):
(WebCore::FontMetrics::lineGap const):
(WebCore::FontMetrics::intLineGap const):
(WebCore::FontMetrics::setLineGap):
(WebCore::FontMetrics::lineSpacing const):
(WebCore::FontMetrics::intLineSpacing const):
(WebCore::FontMetrics::setLineSpacing):
(WebCore::FontMetrics::xHeight const):
(WebCore::FontMetrics::capHeight const):
(WebCore::FontMetrics::intCapHeight const):
(WebCore::FontMetrics::setCapHeight):
(WebCore::FontMetrics::ideogramWidth const):
(WebCore::FontMetrics::underlinePosition const):
(WebCore::FontMetrics::underlineThickness const):
(WebCore::FontMetrics::hasIdenticalAscentDescentAndLineGap const):
(WebCore::FontMetrics::reset):
(WebCore::FontMetrics::floatAscent const): Deleted.
(WebCore::FontMetrics::floatDescent const): Deleted.
(WebCore::FontMetrics::floatHeight const): Deleted.
(WebCore::FontMetrics::floatLineGap const): Deleted.
(WebCore::FontMetrics::floatLineSpacing const): Deleted.
(WebCore::FontMetrics::hasXHeight const): Deleted.
(WebCore::FontMetrics::hasCapHeight const): Deleted.
(WebCore::FontMetrics::floatCapHeight const): Deleted.
* Source/WebCore/platform/graphics/PositionedGlyphs.cpp:
(WebCore::PositionedGlyphs::computeBounds const):
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
(WebCore::DrawGlyphsRecorder::recordDrawGlyphs):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::showGlyphsWithAdvances):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::platformInit):
* Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp:
(WebCore::OpenTypeVerticalData::advanceHeight const):
(WebCore::OpenTypeVerticalData::getVerticalTranslationsForGlyphs const):
* Source/WebCore/platform/win/DragImageWin.cpp:
(WebCore::createDragImageForLink):
* Source/WebCore/platform/win/PopupMenuWin.cpp:
(WebCore::PopupMenuWin::calculatePositionAndSize):
(WebCore::PopupMenuWin::paint):
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::computeCaretRectForEmptyElement):
(WebCore::computeCaretRectForBox):
* Source/WebCore/rendering/EllipsisBoxPainter.cpp:
(WebCore::EllipsisBoxPainter::paint):
* Source/WebCore/rendering/LegacyEllipsisBox.cpp:
(WebCore::LegacyEllipsisBox::paintMarkupBox):
(WebCore::LegacyEllipsisBox::nodeAtPoint):
* Source/WebCore/rendering/LegacyInlineBox.cpp:
(WebCore::LegacyInlineBox::logicalHeight const):
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::placeChildInlineBoxesInBlockDirection):
(WebCore::LegacyInlineFlowBox::placeBoxesInBlockDirection):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::setLogicalWidthForTextRun):
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
(WebCore::LegacyRootInlineBox::lineSnapAdjustment const):
(WebCore::LegacyRootInlineBox::ascentAndDescentForBox const):
(WebCore::LegacyRootInlineBox::verticalPositionForBox):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::baselinePosition const):
(WebCore::RenderBlock::inlineBlockBaseline const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::adjustInitialLetterPosition):
(WebCore::RenderBlockFlow::firstLineBaseline const):
(WebCore::RenderBlockFlow::lastLineBaseline const):
(WebCore::RenderBlockFlow::inlineBlockBaseline const):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::paintReplaced):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::setImageSizeForAltText):
(WebCore::RenderImage::paintReplaced):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::baselinePosition const):
* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::RenderLineBreak::baselinePosition const):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::itemOffsetForAlignment):
(WebCore::RenderListBox::itemHeight const):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::paint):
(WebCore::RenderListMarker::layout):
(WebCore::RenderListMarker::updateContent):
(WebCore::RenderListMarker::computePreferredLogicalWidths):
(WebCore::RenderListMarker::updateMargins):
(WebCore::RenderListMarker::relativeMarkerRect):
* Source/WebCore/rendering/RenderRubyRun.cpp:
(WebCore::RenderRubyRun::layoutBlock):
(WebCore::RenderRubyRun::baselinePosition const):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintForeground):
(WebCore::computedLinethroughCenter):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintBackgroundDecorations):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::fillCompositionUnderline const):
(WebCore::calculateDocumentMarkerBounds):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::textOriginFromPaintRect const):
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::paintTextAndEmphasisMarksIfNeeded):
* Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
(WebCore::axisHeight):
(WebCore::toUserUnits):
* Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
(WebCore::RenderMathMLRoot::verticalParameters):
* Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp:
(WebCore::RenderMathMLScripts::verticalParameters const):
* Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp:
(WebCore::RenderMathMLUnderOver::verticalParameters const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::computeLineHeight const):
* Source/WebCore/rendering/style/TextDecorationThickness.h:
(WebCore::TextDecorationThickness::resolve const):
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::positionForPoint):
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::selectionRectForTextFragment const):
(WebCore::positionOffsetForDecoration):
(WebCore::SVGInlineTextBox::paintDecorationWithStyle):
(WebCore::SVGInlineTextBox::paintTextWithShadows):
(WebCore::SVGInlineTextBox::calculateBoundaries const):
(WebCore::SVGInlineTextBox::nodeAtPoint):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::calculateBaselineShift const):
(WebCore::SVGTextLayoutEngineBaseline::calculateAlignmentBaselineShift const):
(WebCore::SVGTextLayoutEngineBaseline::calculateGlyphAdvanceAndOrientation const):
* Source/WebCore/rendering/svg/SVGTextMetrics.cpp:
(WebCore::SVGTextMetrics::SVGTextMetrics):
* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(WebCore::calculateGlyphBoundaries):
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
(WebCore::styleForFirstLetter):
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::computedUnderlineOffset):
(WebCore::computedVisualOverflowForDecorations):
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
(WebCore::Style::adjustedFontSize):
(WebCore::Style::aspectValueOfPrimaryFont):
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::convertValueFromUserUnitsToEXS const):
(WebCore::SVGLengthContext::convertValueFromEXSToUserUnits const):
* Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp:
(WebKit::WebPopupMenu::setUpPlatformData):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::dictionaryPopupInfoForRange):
* Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm:
(+[WebImmediateActionController _dictionaryPopupInfoForRange:inFrame:withLookupOptions:indicatorOptions:transition:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7214c98421996900324baec6492c586c49881927

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4740 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3653 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2885 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4562 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2877 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4303 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2718 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2961 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->