### PR TITLE
Web Inspector: Console: internal properties are not greyed out in object previews

### DIFF
--- a/LayoutTests/inspector/runtime/getPreview-expected.txt
+++ b/LayoutTests/inspector/runtime/getPreview-expected.txt
@@ -45,6 +45,12 @@ PASS: RemoteObject.updatePreview should return null for a null RemoteObject.
 -- Running test case: Runtime.getPreview.Function
 {"type":"function","description":"function f() {}","lossless":true}
 
+-- Running test case: Runtime.getPreview.Private
+{"type":"object","description":"Foo","lossless":false,"properties":[{"name":"#value","type":"number","value":"42","isPrivate":true}]}
+
+-- Running test case: Runtime.getPreview.Internal
+{"type":"object","description":"EventTarget","lossless":false,"properties":[{"name":"listeners","type":"object","value":"Object","internal":true},{"name":"addEventListener","type":"function","value":""},{"name":"removeEventListener","type":"function","value":""},{"name":"dispatchEvent","type":"function","value":""}]}
+
 -- Running test case: Runtime.getPreview.InvalidObjectId
 PASS: Should produce an error.
 Error: Missing injected script for given objectId

--- a/LayoutTests/inspector/runtime/getPreview.html
+++ b/LayoutTests/inspector/runtime/getPreview.html
@@ -140,6 +140,30 @@ function test()
         }
     });
 
+    suite.addTestCase({
+        name: "Runtime.getPreview.Private",
+        test(resolve, reject) {
+            InspectorTest.evaluateInPage(`class Foo { #value = 42; } new Foo`, (error, remoteObject) => {
+                RuntimeAgent.getPreview(remoteObject.objectId, (error, result) => {
+                    InspectorTest.log(JSON.stringify(result));
+                    resolve();
+                });
+            });
+        }
+    });
+
+    suite.addTestCase({
+        name: "Runtime.getPreview.Internal",
+        test(resolve, reject) {
+            InspectorTest.evaluateInPage(`var target = new EventTarget; target.addEventListener("click", console.log); target`, (error, remoteObject) => {
+                RuntimeAgent.getPreview(remoteObject.objectId, (error, result) => {
+                    InspectorTest.log(JSON.stringify(result));
+                    resolve();
+                });
+            });
+        }
+    });
+
     // ------
 
     suite.addTestCase({

--- a/Source/JavaScriptCore/inspector/InjectedScriptSource.js
+++ b/Source/JavaScriptCore/inspector/InjectedScriptSource.js
@@ -1310,6 +1310,9 @@ let RemoteObject = class RemoteObject extends PrototypelessObjectBase
                 return InjectedScript.PropertyFetchAction.Stop;
             }
 
+            if (descriptor.isPrivate)
+                property.isPrivate = true;
+
             if (internal)
                 property.internal = true;
 

--- a/Source/JavaScriptCore/inspector/protocol/Runtime.json
+++ b/Source/JavaScriptCore/inspector/protocol/Runtime.json
@@ -49,6 +49,7 @@
                 { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "error", "map", "set", "weakmap", "weakset", "iterator", "class", "proxy"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
                 { "name": "value", "type": "string", "optional": true, "description": "User-friendly property value string." },
                 { "name": "valuePreview", "$ref": "ObjectPreview", "optional": true, "description": "Nested value preview." },
+                { "name": "isPrivate", "type": "boolean", "optional": true, "description": "True if this is a private field." },
                 { "name": "internal", "type": "boolean", "optional": true, "description": "True if this is an internal property." }
             ]
         },

--- a/Source/WebInspectorUI/UserInterface/Models/PropertyPreview.js
+++ b/Source/WebInspectorUI/UserInterface/Models/PropertyPreview.js
@@ -25,10 +25,11 @@
 
 WI.PropertyPreview = class PropertyPreview
 {
-    constructor(name, type, subtype, value, valuePreview, isInternalProperty)
+    constructor(name, type, {subtype, value, valuePreview, isPrivateProperty, isInternalProperty} = {})
     {
         console.assert(typeof name === "string");
         console.assert(type);
+        console.assert(!subtype || typeof subtype === "string");
         console.assert(!value || typeof value === "string");
         console.assert(!valuePreview || valuePreview instanceof WI.ObjectPreview);
 
@@ -37,6 +38,7 @@ WI.PropertyPreview = class PropertyPreview
         this._subtype = subtype;
         this._value = value;
         this._valuePreview = valuePreview;
+        this._private = isPrivateProperty;
         this._internal = isInternalProperty;
     }
 
@@ -45,10 +47,13 @@ WI.PropertyPreview = class PropertyPreview
     // Runtime.PropertyPreview.
     static fromPayload(payload)
     {
-        if (payload.valuePreview)
-            payload.valuePreview = WI.ObjectPreview.fromPayload(payload.valuePreview);
-
-        return new WI.PropertyPreview(payload.name, payload.type, payload.subtype, payload.value, payload.valuePreview, payload.internal);
+        return new WI.PropertyPreview(payload.name, payload.type, {
+            subtype: payload.subtype,
+            value: payload.value,
+            valuePreview: payload.valuePreview ? WI.ObjectPreview.fromPayload(payload.valuePreview) : undefined,
+            isPrivateProperty: payload.isPrivate,
+            isInternalProperty: payload.internal,
+        });
     }
 
     // Public
@@ -58,5 +63,6 @@ WI.PropertyPreview = class PropertyPreview
     get subtype() { return this._subtype; }
     get value() { return this._value; }
     get valuePreview() { return this._valuePreview; }
+    get private() { return this._private; }
     get internal() { return this._internal; }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.css
@@ -39,6 +39,10 @@
     color: hsl(295, 76%, 32%);
 }
 
+.object-preview .name:is(.private, .internal) {
+    color: var(--text-color-secondary);
+}
+
 .object-preview > .size {
     font-style: normal;
     color: var(--console-secondary-text-color);

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js
@@ -230,6 +230,11 @@ WI.ObjectPreviewView = class ObjectPreviewView extends WI.Object
                 let nameElement = element.appendChild(document.createElement("span"));
                 nameElement.className = "name";
                 nameElement.textContent = property.name;
+                if (property.private)
+                    nameElement.classList.add("private");
+                if (property.internal)
+                    nameElement.classList.add("internal");
+
                 element.append(": ");
             }
 


### PR DESCRIPTION
#### 6d890dea244d3c6ab908b53ee3cfb52722b38572
<pre>
Web Inspector: Console: internal properties are not greyed out in object previews
<a href="https://bugs.webkit.org/show_bug.cgi?id=255385">https://bugs.webkit.org/show_bug.cgi?id=255385</a>

Reviewed by Patrick Angle.

We should have a consistent style between previews and actual remmote object views.

Otherwise, internal properties appear as regular properties in the preview, but then look different when the object view is expanded.

* Source/JavaScriptCore/inspector/protocol/Runtime.json:
* Source/JavaScriptCore/inspector/InjectedScriptSource.js:
(RemoteObject.prototype._appendPropertyPreview.appendPreview):
* Source/WebInspectorUI/UserInterface/Models/PropertyPreview.js:
(WI.PropertyPreview):
(WI.PropertyPreview.fromPayload):
(WI.PropertyPreview.prototype.get private): Added.
Include an `isPrivate` property in `Runtime.PropertyPreview`.
Drive-by: Refactor `WI.PropertyPreview` to put all optional properties into a `{...} = {}`.

* Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js:
(WI.ObjectPreviewView.prototype._appendPropertyPreviews):
* Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.css:
(.object-preview .name:is(.private, .internal)): Added.
Style private and internal property previews.

* LayoutTests/inspector/runtime/getPreview.html:
* LayoutTests/inspector/runtime/getPreview-expected.txt:

Canonical link: <a href="https://commits.webkit.org/262924@main">https://commits.webkit.org/262924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6c7bcc7c247420aba34a3af41c9ae3f86765d5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4449 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3142 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2652 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3067 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4244 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2705 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/2521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2756 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3979 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2883 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3105 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3106 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2707 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/746 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/743 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2721 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3186 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2924 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/873 "Passed tests") | 
<!--EWS-Status-Bubble-End-->