### PR TITLE
Fix over-release in ClientConnection::hostAppCodeSigningIdentifier

### DIFF
--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -119,12 +119,12 @@ String ClientConnection::bundleIdentifierFromAuditToken(audit_token_t audit_toke
 #if PLATFORM(MAC)
     LSSessionID sessionID = (LSSessionID)audit_token_to_asid(audit_token);
     auto auditTokenDataRef = adoptCF(CFDataCreate(kCFAllocatorDefault, (const UInt8 *)(&audit_token), sizeof(audit_token)));
-    CFTypeRef keys[] = { auditTokenDataRef.get() };
-    CFTypeRef values[] = { _kLSAuditTokenKey };
+    CFTypeRef keys[] = { _kLSAuditTokenKey };
+    CFTypeRef values[] = { auditTokenDataRef.get() };
     auto matchingAppsRef = adoptCF(_LSCopyMatchingApplicationsWithItems(sessionID, 1, keys, values));
     if (matchingAppsRef && CFArrayGetCount(matchingAppsRef.get())) {
-        auto asnRef = adoptCF((LSASNRef)CFArrayGetValueAtIndex(matchingAppsRef.get(), 0));
-        auto bundleIdentifierRef = adoptCF((CFStringRef)_LSCopyApplicationInformationItem(sessionID, asnRef.get(), kCFBundleIdentifierKey));
+        LSASNRef asnRef = (LSASNRef)CFArrayGetValueAtIndex(matchingAppsRef.get(), 0);
+        auto bundleIdentifierRef = adoptCF((CFStringRef)_LSCopyApplicationInformationItem(sessionID, asnRef, kCFBundleIdentifierKey));
         if (bundleIdentifierRef && CFStringGetLength(bundleIdentifierRef.get()))
             return bundleIdentifierRef.get();
     }


### PR DESCRIPTION
#### e57c4567984bf55aa097a768e4e4c9a20d00aa1a
<pre>
Fix over-release in ClientConnection::hostAppCodeSigningIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=255384">https://bugs.webkit.org/show_bug.cgi?id=255384</a>
rdar://107974725

Reviewed by Simon Fraser.

In rdar://107931346, we introduced a change that wraps the value returned by CFArrayGetValueAtIndex()
using adoptCF. However, since CFArrayGetValueAtIndex() doesn’t return a retained object, our code will
cause an over-release. To resolve this issue, do not wrap the value returned by CFArrayGetValueAtIndex()
using adoptCF.

Additionally, the keys and values array were incorrectly swapped, causing the returned bundleIdentifier
to be loginwindow instead of the belonging app. Fix this by swapping keys and values so they are in the
correct order.

* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::ClientConnection::bundleIdentifierFromAuditToken):
Swap keys and values so they are in the correct order, and do not wrap the value returned by
CFArrayGetValueAtIndex().

Canonical link: <a href="https://commits.webkit.org/262922@main">https://commits.webkit.org/262922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72981a398dfc4fdcff8116f661565cacab4cfabe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4380 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3375 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2603 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4173 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2498 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3917 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2441 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2644 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/744 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->