### PR TITLE
Remove remaining Java code in HTMLObjectElement

### DIFF
--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -80,8 +80,6 @@ private:
     // so that we can better share code between <object> and <embed>.
     void parametersForPlugin(Vector<AtomString>& paramNames, Vector<AtomString>& paramValues, String& url, String& serviceType);
 
-    bool hasValidClassId();
-
     void refFormAssociatedElement() const final { ref(); }
     void derefFormAssociatedElement() const final { deref(); }
 

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -630,17 +630,6 @@ bool MIMETypeRegistry::isXMLEntityMIMEType(StringView mimeType)
         || equalLettersIgnoringASCIICase(mimeType, "application/xml-external-parsed-entity"_s);
 }
 
-bool MIMETypeRegistry::isJavaAppletMIMEType(const String& mimeType)
-{
-    // Since this set is very limited and is likely to remain so we won't bother with the overhead
-    // of using a hash set.
-    // Any of the MIME types below may be followed by any number of specific versions of the JVM,
-    // which is why we use startsWith()
-    return startsWithLettersIgnoringASCIICase(mimeType, "application/x-java-applet"_s)
-        || startsWithLettersIgnoringASCIICase(mimeType, "application/x-java-bean"_s)
-        || startsWithLettersIgnoringASCIICase(mimeType, "application/x-java-vm"_s);
-}
-
 bool MIMETypeRegistry::isPDFMIMEType(const String& mimeType)
 {
     static constexpr SortedArraySet set { pdfMIMETypeArray };

--- a/Source/WebCore/platform/MIMETypeRegistry.h
+++ b/Source/WebCore/platform/MIMETypeRegistry.h
@@ -98,9 +98,6 @@ public:
     // Check to see if a MIME type is suitable for being loaded using <track>>.
     WEBCORE_EXPORT static bool isSupportedTextTrackMIMEType(const String& mimeType);
 
-    // Check to see if a MIME type is a valid Java applet mime type.
-    WEBCORE_EXPORT static bool isJavaAppletMIMEType(const String& mimeType);
-
     // Check to see if a MIME type is a plugin implemented by the browser.
     static bool isApplicationPluginMIMEType(const String& mimeType);
 


### PR DESCRIPTION
#### 8159c43f0539d2a714b50f357b6088fc3224c007
<pre>
Remove remaining Java code in HTMLObjectElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=255327">https://bugs.webkit.org/show_bug.cgi?id=255327</a>
rdar://107955360

Reviewed by Chris Dumez.

Java has been gone from the web for a while now.

* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::parametersForPlugin):
(WebCore::HTMLObjectElement::updateWidget):
(WebCore::HTMLObjectElement::hasValidClassId): Deleted.
* Source/WebCore/html/HTMLObjectElement.h:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::isJavaAppletMIMEType): Deleted.
* Source/WebCore/platform/MIMETypeRegistry.h:

Canonical link: <a href="https://commits.webkit.org/263275@main">https://commits.webkit.org/263275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b73f3f7479e78e8610fdd3642bd4ce8d2994b7da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4394 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3383 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/2953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2614 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4187 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5751 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3928 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2448 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2657 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1011 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->