### PR TITLE
WebGL creating long dependencies in backboard render times

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1631,7 +1631,7 @@ public:
     WEBCORE_EXPORT static void paintToCanvas(const GraphicsContextGLAttributes&, Ref<PixelBuffer>&&, const IntSize& canvasSize, GraphicsContext&);
 
 protected:
-    WEBCORE_EXPORT void forceContextLost();
+    WEBCORE_EXPORT virtual void forceContextLost();
     WEBCORE_EXPORT void dispatchContextChangedNotification();
 
     int m_currentWidth { 0 };

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -396,9 +396,6 @@ protected:
 #endif
     virtual bool reshapeDisplayBufferBacking() = 0;
 
-    // Returns false if context should be lost due to timeout.
-    bool waitAndUpdateOldestFrame() WARN_UNUSED_RETURN;
-
     static void platformReleaseThreadResources();
 
     virtual void invalidateKnownTextureContent(GCGLuint);
@@ -428,10 +425,6 @@ protected:
     GCGLErrorCodeSet m_errors;
     bool m_isForWebGL2 { false };
     bool m_failNextStatusCheck { false };
-    bool m_useFenceSyncForDisplayRateLimit = false;
-    static constexpr size_t maxPendingFrames = 3;
-    size_t m_oldestFrameCompletionFence { 0 };
-    ScopedGLFence m_frameCompletionFences[maxPendingFrames];
     GraphicsContextGLState m_state;
 
     GCGLDisplay m_displayObj { nullptr };
@@ -459,6 +452,7 @@ inline GCGLConfig GraphicsContextGLANGLE::platformConfig() const
 {
     return m_configObj;
 }
+
 }
 
 #endif

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -203,11 +203,9 @@ public:
     virtual void setContents(CFTypeRef) = 0;
     virtual void clearContents();
 
-    // The subclass will override one variant of both setDelegatedContentsFinishedEvent, setDelegatedContents.
+    // The client will override one of setDelegatedContents().
 
-    virtual void setDelegatedContentsFinishedEvent(const PlatformCALayerDelegatedContentsFinishedEvent&);
     virtual void setDelegatedContents(const PlatformCALayerDelegatedContents&);
-    virtual void setDelegatedContentsFinishedEvent(const PlatformCALayerInProcessDelegatedContentsFinishedEvent&);
     virtual void setDelegatedContents(const PlatformCALayerInProcessDelegatedContents&);
 
     virtual void setContentsRect(const FloatRect&) = 0;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -185,11 +185,6 @@ void PlatformCALayer::clearContents()
     setContents(nullptr);
 }
 
-void PlatformCALayer::setDelegatedContentsFinishedEvent(const PlatformCALayerDelegatedContentsFinishedEvent&)
-{
-    // FIXME: To be implemented.
-}
-
 void PlatformCALayer::setDelegatedContents(const PlatformCALayerDelegatedContents& contents)
 {
     auto surface = WebCore::IOSurface::createFromSendRight(contents.surface.copySendRight());
@@ -197,17 +192,12 @@ void PlatformCALayer::setDelegatedContents(const PlatformCALayerDelegatedContent
         clearContents();
         return;
     }
-    setDelegatedContents({ *surface, contents.finishedIdentifier });
-}
-
-void PlatformCALayer::setDelegatedContentsFinishedEvent(const PlatformCALayerInProcessDelegatedContentsFinishedEvent&)
-{
-    // FIXME: To be implemented.
+    setDelegatedContents({ *surface, contents.finishedFence });
 }
 
 void PlatformCALayer::setDelegatedContents(const PlatformCALayerInProcessDelegatedContents& contents)
 {
-    setDelegatedContents({ contents.surface.createSendRight(), contents.finishedIdentifier });
+    setDelegatedContents({ contents.surface.createSendRight(), contents.finishedFence });
 }
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
@@ -295,6 +285,10 @@ TextStream& operator<<(TextStream& ts, PlatformCALayer::FilterType filterType)
     }
     return ts;
 }
+
+PlatformCALayerDelegatedContentsFence::PlatformCALayerDelegatedContentsFence() = default;
+
+PlatformCALayerDelegatedContentsFence::~PlatformCALayerDelegatedContentsFence() = default;
 
 }
 

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerDelegatedContents.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerDelegatedContents.h
@@ -27,35 +27,30 @@
 
 #include <variant>
 #include <wtf/MachSendRight.h>
+#include <wtf/Noncopyable.h>
 #include <wtf/ObjectIdentifier.h>
-
-OBJC_PROTOCOL(MTLSharedEvent);
 
 namespace WebCore {
 class IOSurface;
 
-namespace Detail {
-enum PlatformCALayerDelegatedContentsIdentifier { };
-}
+constexpr inline Seconds delegatedContentsFinishedTimeout = 5_s;
 
-struct PlatformCALayerDelegatedContentsFinishedEvent {
-    MachSendRight sharedEvent;
-};
-
-struct PlatformCALayerInProcessDelegatedContentsFinishedEvent {
-    id<MTLSharedEvent> sharedEvent;
+class WEBCORE_EXPORT PlatformCALayerDelegatedContentsFence : public ThreadSafeRefCounted<PlatformCALayerDelegatedContentsFence> {
+    WTF_MAKE_NONCOPYABLE(PlatformCALayerDelegatedContentsFence);
+public:
+    PlatformCALayerDelegatedContentsFence();
+    virtual ~PlatformCALayerDelegatedContentsFence();
+    virtual bool waitFor(Seconds) = 0;
 };
 
 struct PlatformCALayerDelegatedContents {
-    using FinishedIdentifier = ObjectIdentifier<Detail::PlatformCALayerDelegatedContentsIdentifier>;
     MachSendRight surface;
-    FinishedIdentifier finishedIdentifier;
+    RefPtr<PlatformCALayerDelegatedContentsFence> finishedFence;
 };
 
 struct PlatformCALayerInProcessDelegatedContents {
-    using FinishedIdentifier = PlatformCALayerDelegatedContents::FinishedIdentifier;
     const WebCore::IOSurface& surface; 
-    FinishedIdentifier finishedIdentifier;
+    RefPtr<PlatformCALayerDelegatedContentsFence> finishedFence;
 };
 
 }

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
@@ -28,7 +28,6 @@
 #include "PlatformCALayer.h"
 
 OBJC_CLASS NSObject;
-OBJC_PROTOCOL(MTLSharedEvent);
 
 namespace WebCore {
 
@@ -119,7 +118,6 @@ public:
     CFTypeRef contents() const override;
     void setContents(CFTypeRef) override;
     void clearContents() override;
-    void setDelegatedContentsFinishedEvent(const PlatformCALayerInProcessDelegatedContentsFinishedEvent&) override;
     void setDelegatedContents(const PlatformCALayerInProcessDelegatedContents&) override;
 
     void setContentsRect(const FloatRect&) override;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -787,15 +787,10 @@ void PlatformCALayerCocoa::setContents(CFTypeRef value)
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-void PlatformCALayerCocoa::setDelegatedContentsFinishedEvent(const PlatformCALayerInProcessDelegatedContentsFinishedEvent&)
-{
-    // FIXME: To be implemented.
-}
-
 void PlatformCALayerCocoa::setDelegatedContents(const PlatformCALayerInProcessDelegatedContents& contents)
 {
-    setContents(contents.surface.asLayerContents());
-    // FIXME: m_delegatedContentsFinishedIdentifier = contents.finishedIdentifier;
+    if (contents.finishedFence->waitFor(delegatedContentsFinishedTimeout))
+        setContents(contents.surface.asLayerContents());
 }
 
 void PlatformCALayerCocoa::setContentsRect(const FloatRect& value)

--- a/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.h
@@ -40,6 +40,9 @@ void* createPbufferAndAttachIOSurface(GCGLDisplay, GCGLConfig, GCGLenum target, 
 void destroyPbufferAndDetachIOSurface(GCGLDisplay, void* handle);
 
 RetainPtr<MTLSharedEvent> newSharedEventWithMachPort(GCGLDisplay, mach_port_t);
+
+RetainPtr<MTLSharedEvent> newSharedEvent(GCGLDisplay);
+
 }
 
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm
@@ -85,13 +85,26 @@ RetainPtr<MTLSharedEvent> newSharedEventWithMachPort(EGLDisplay display, mach_po
     // FIXME: Check for invalid mach_port_t
     EGLDeviceEXT device = EGL_NO_DEVICE_EXT;
     if (!EGL_QueryDisplayAttribEXT(display, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&device)))
-        return RetainPtr<MTLSharedEvent>();
+        return nullptr;
 
     id<MTLDevice> mtlDevice = nil;
     if (!EGL_QueryDeviceAttribEXT(device, EGL_METAL_DEVICE_ANGLE, reinterpret_cast<EGLAttrib*>(&mtlDevice)))
-        return RetainPtr<MTLSharedEvent>();
+        return nullptr;
 
     return adoptNS([(id<MTLDeviceSPI>)mtlDevice newSharedEventWithMachPort:machPort]);
+}
+
+RetainPtr<MTLSharedEvent> newSharedEvent(EGLDisplay display)
+{
+    EGLDeviceEXT device = EGL_NO_DEVICE_EXT;
+    if (!EGL_QueryDisplayAttribEXT(display, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&device)))
+        return nullptr;
+
+    id<MTLDevice> mtlDevice = nil;
+    if (!EGL_QueryDeviceAttribEXT(device, EGL_METAL_DEVICE_ANGLE, reinterpret_cast<EGLAttrib*>(&mtlDevice)))
+        return nullptr;
+
+    return adoptNS([mtlDevice newSharedEvent]);
 }
 
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -112,7 +112,7 @@ protected:
     void markContextChanged();
     void reshape(int32_t width, int32_t height);
 #if PLATFORM(COCOA)
-    virtual void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) = 0;
+    virtual void prepareForDisplay(IPC::Semaphore&&, CompletionHandler<void(WTF::MachSendRight&&)>&&) = 0;
 #elif USE(GRAPHICS_LAYER_WC)
     virtual void prepareForDisplay(CompletionHandler<void(std::optional<WCContentBufferIdentifier>)>&&) = 0;
 #elif USE(GBM)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -27,7 +27,7 @@
 messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void Reshape(int32_t width, int32_t height)
 #if PLATFORM(COCOA)
-    void PrepareForDisplay() -> (MachSendRight displayBuffer) Synchronous NotStreamEncodableReply
+    void PrepareForDisplay(IPC::Semaphore finishedFence) -> (MachSendRight displayBuffer) Synchronous NotStreamEncodable NotStreamEncodableReply
 #endif
 #if USE(GRAPHICS_LAYER_WC)
     void PrepareForDisplay() -> (std::optional<WebKit::WCContentBufferIdentifier> contentBuffer) Synchronous

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -93,7 +93,7 @@ public:
 
     // RemoteGraphicsContextGL overrides.
     void platformWorkQueueInitialize(WebCore::GraphicsContextGLAttributes&&) final;
-    void prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&&) final;
+    void prepareForDisplay(IPC::Semaphore&&, CompletionHandler<void(WTF::MachSendRight&&)>&&) final;
 private:
 };
 
@@ -117,12 +117,14 @@ void RemoteGraphicsContextGLCocoa::platformWorkQueueInitialize(WebCore::Graphics
     m_context = WebCore::GraphicsContextGLCocoa::create(WTFMove(attributes), WebCore::ProcessIdentity { m_resourceOwner });
 }
 
-void RemoteGraphicsContextGLCocoa::prepareForDisplay(CompletionHandler<void(WTF::MachSendRight&&)>&& completionHandler)
+void RemoteGraphicsContextGLCocoa::prepareForDisplay(IPC::Semaphore&& finishedSemaphore, CompletionHandler<void(WTF::MachSendRight&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    m_context->prepareForDisplay();
+    m_context->prepareForDisplayWithFinishedSignal([finishedSemaphore = WTFMove(finishedSemaphore)]() mutable { 
+        finishedSemaphore.signal();
+    });
     MachSendRight sendRight;
-    WebCore::IOSurface* displayBuffer = m_context->displayBuffer();
+    auto displayBuffer = m_context->displayBuffer();
     if (displayBuffer) {
         m_context->markDisplayBufferInUse();
         sendRight = displayBuffer->createSendRight();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -113,7 +113,6 @@ public:
     void setNeedsDisplay(const WebCore::IntRect);
     void setNeedsDisplay();
 
-    void setDelegatedContentsFinishedEvent(const WebCore::PlatformCALayerDelegatedContentsFinishedEvent&);
     void setDelegatedContents(const WebCore::PlatformCALayerDelegatedContents&);
 
     // Returns true if we need to encode the buffer.

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -137,7 +137,6 @@ public:
     bool hasContents() const override;
     CFTypeRef contents() const override;
     void setContents(CFTypeRef) override;
-    void setDelegatedContentsFinishedEvent(const WebCore::PlatformCALayerDelegatedContentsFinishedEvent&) override;
     void setDelegatedContents(const WebCore::PlatformCALayerDelegatedContents&) override;
     void setContentsRect(const WebCore::FloatRect&) override;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -724,13 +724,6 @@ void PlatformCALayerRemote::setContents(CFTypeRef value)
         m_properties.backingStore->clearBackingStore();
 }
 
-void PlatformCALayerRemote::setDelegatedContentsFinishedEvent(const PlatformCALayerDelegatedContentsFinishedEvent& event)
-{
-    ASSERT(m_acceleratesDrawing);
-    ensureBackingStore();
-    m_properties.backingStore->setDelegatedContentsFinishedEvent(event);
-}
-
 void PlatformCALayerRemote::setDelegatedContents(const PlatformCALayerDelegatedContents& contents)
 {
     ASSERT(m_acceleratesDrawing);


### PR DESCRIPTION
#### db0a320e698a2411f40ab61f51e5dcd9f07bc8bf
<pre>
WebGL creating long dependencies in backboard render times
<a href="https://bugs.webkit.org/show_bug.cgi?id=254912">https://bugs.webkit.org/show_bug.cgi?id=254912</a>
rdar://106957008

Reviewed by Simon Fraser.

Before, WebGL would wait for 3rd oldest frame to finish before
continuing to create a new frame. In case the frames were very slow,
they would slow the whole system down as the system compositor
would wait for each submitted frame to finish.

Instead, wait at the WebKit level for the WebGL frames to finish
rendering before submitting the frames to the system compositor.

Wait WebGL rendering to IOSurfaces to finish before setting the surface
as the &quot;delegated contents&quot; of the PlatformCALayer.

Original plan was to wait for the MTLSharedEvent associated with the
context. This is not useful, as waiting has to happen in WP and using
MTLSharedEvent in WP is not possible in full GPUP mode. Instead,
encapsulate the wait fence functionality in new interface
PlatformCALayerDelegatedContentsFence.

The feature has client configurations:
 1. WP-side compositing, WP-side WebGL
 2. WP-side compositing, GPUP-side WebGL
 3. UI-side compositing, GPUP-side WebGL

WP-side compositing:
Background: delegated contents is being set during [CALayer display].

The fence is waited on during the [CALayer display]
when the delegated contents is being set to the PlatformCALayer. This
happens on the main thread.

UI-side compositing:
Background: delegated contents is being set during
RemoteLayerTreeContext::buildTransaction, prepareBackingStoresForDisplay
phase.

When setting the delegated contents, add the fence to the list
of &quot;front buffer flushers&quot;. The fence is wrapped inside a wrapper that
implements the flusher interface.

Waiting happens on the flusher dispatch queue.

WP-side WebGL
Background: During WebPage rendering update, the WebGL context layers
will be &quot;prepared for display&quot;.

As a last ANGLE OpenGL command for the frame, this will insert the EGL
fence that will signal the finishing of the frame. The inserted fence
(ANGLE EGL sync object) encapsulates a MTLSharedEvent signal. Upon
completion of the event signal, Metal will invoke the
MTLSharedEventListener with the pre-set block for the signal value, in
the Metal owned background thread. The block will notify the delegated
contents fence Condition.

GPUP-side WebGL
During prepare for display, send IPC::Semaphore to the GPUP side.
This semaphore will be waited on by the implementation of
PlatformCALayerDelegatedContentsFence.

In GPUP side, insert the semaphore signal into the EGL fence signal,
similar to above.
IPC::Semaphore is used to trampoline the notification, because
WP cannot use MTLSharedEvent directly due to IOKit blocking. IPC
message waits cannot be used because they would spin the message
processing, the IPC connection does not exist at the compositor level,
OffscreenCanvas would have different connection thread, and flusher
dispatch queue doesn&apos;t have the IPC connection.

* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::waitAndUpdateOldestFrame): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
(WebCore::PlatformCALayer::setDelegatedContents):
(WebCore::PlatformCALayer::setDelegatedContentsFinishedEvent): Deleted.
* Source/WebCore/platform/graphics/ca/PlatformCALayerDelegatedContents.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::setDelegatedContents):
(WebCore::PlatformCALayerCocoa::setDelegatedContentsFinishedEvent): Deleted.
* Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm:
(WebCore::newSharedEventWithMachPort):
(WebCore::newSharedEvent):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::MetalFenceSharedState::event):
(WebCore::GraphicsContextGLCocoa::MetalFenceSharedState::listener):
(WebCore::GraphicsContextGLCocoa::MetalFenceSharedState::MetalFenceSharedState):
(WebCore::GraphicsContextGLCocoa::platformInitialize):
(WebCore::GraphicsContextGLANGLE::~GraphicsContextGLANGLE):
(WebCore::GraphicsContextGLCocoa::createSyncWithSharedEvent):
(WebCore::GraphicsContextGLCocoa::clientWaitSyncWithFlush):
(WebCore::GraphicsContextGLCocoa::prepareForDisplay):
(WebCore::GraphicsContextGLCocoa::prepareForDisplayWithFinishedSignal):
(WebCore::GraphicsContextGLCocoa::insertCommandsCompleteSignalOrInvoke):
(WebCore::GraphicsContextGLCocoa::metalFenceSharedState):
(WebCore::GraphicsContextGLCocoa::MetalFenceSharedState::create):
* Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm:
(): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp:
(WebKit::RemoteGraphicsContextGLCocoa::prepareForDisplay):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::setDelegatedContents):
(WebKit::RemoteLayerBackingStore::setDelegatedContentsFinishedEvent): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::setDelegatedContentsFinishedEvent): Deleted.

Canonical link: <a href="https://commits.webkit.org/263427@main">https://commits.webkit.org/263427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82b129bb32c2298e7fa93c49caf82ca974b2bd74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4434 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4795 "1 flakes 143 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5825 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3893 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/7294 "220 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5499 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3549 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3891 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1127 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7943 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->