### PR TITLE
Add zero-width space before the last filename dot to avoid splitting the extension

### DIFF
--- a/LayoutTests/fast/attachment/attachment-title-with-rtl-expected.html
+++ b/LayoutTests/fast/attachment/attachment-title-with-rtl-expected.html
@@ -2,7 +2,7 @@
 <html>
 <body>
 <attachment title="isolate.ext"></attachment>
-<attachment title="isolate-isolate.ext"></attachment>
+<attachment title="isolate.ext"></attachment>
 <attachment title="long-title-wraps-abc.ext"></attachment>
 </body>
 </html>

--- a/LayoutTests/fast/attachment/attachment-title-with-rtl.html
+++ b/LayoutTests/fast/attachment/attachment-title-with-rtl.html
@@ -2,7 +2,7 @@
 <html>
 <body>
 <attachment title="&#x202E;etalosi.ext"></attachment>
-<attachment title="isolate-&#x202E;etalosi.ext"></attachment>
+<attachment title="iso&#x202E;etal.ext"></attachment>
 <attachment title="long-title-wraps-&#x202E;cba.ext"></attachment>
 </body>
 </html>

--- a/LayoutTests/fast/attachment/mac/wide-attachment-title-with-rtl-expected.html
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-title-with-rtl-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html>
+<body>
+<attachment title="isolate.ext"></attachment>
+<attachment title="isolate.ext"></attachment>
+<attachment title="long-title-should-wrap-abc.ext"></attachment>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/mac/wide-attachment-title-with-rtl.html
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-title-with-rtl.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html>
+<body>
+<attachment title="&#x202E;etalosi.ext"></attachment>
+<attachment title="iso&#x202E;etal.ext"></attachment>
+<attachment title="long-title-should-wrap-&#x202E;cba.ext"></attachment>
+</body>
+</html>

--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -81,7 +81,7 @@ layer at (142,324) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,17) size 230x17 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 52x17
-        text run at (0,0) width 52: "Title.txt"
+        text run at (0,0) width 52: "\x{200E}\x{2068}Title\x{2069}\x{200B}.txt"
 layer at (142,341) size 230x13
   RenderDeprecatedFlexibleBox {DIV} at (0,34) size 230x13 [color=#3C3C4399]
     RenderBlock (anonymous) at (0,0) size 230x13
@@ -93,6 +93,6 @@ layer at (130,410) size 118x24 backgroundClip at (130,410) size 117x24 clip at (
   RenderDeprecatedFlexibleBox {DIV} at (0,7) size 118x26 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 118x17
       RenderText {#text} at (0,0) size 56x17
-        text run at (0,0) width 56: "Title.pdf"
+        text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
 layer at (130,434) size 118x8 backgroundClip at (130,434) size 117x8 clip at (130,434) size 117x8
   RenderDeprecatedFlexibleBox {DIV} at (0,32) size 118x8 [color=#3C3C4399]

--- a/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -81,7 +81,7 @@ layer at (132,282) size 170x16
   RenderDeprecatedFlexibleBox {DIV} at (0,16) size 170x16 [color=#000000D8]
     RenderBlock (anonymous) at (0,0) size 170x16
       RenderText {#text} at (0,0) size 52x16
-        text run at (0,0) width 52: "Title.txt"
+        text run at (0,0) width 52: "\x{200E}\x{2068}Title\x{2069}\x{200B}.txt"
 layer at (132,298) size 170x12
   RenderDeprecatedFlexibleBox {DIV} at (0,32) size 170x12 [color=#0000007F]
     RenderBlock (anonymous) at (0,0) size 170x12
@@ -93,6 +93,6 @@ layer at (120,358) size 94x20 backgroundClip at (120,358) size 93x20 clip at (12
   RenderDeprecatedFlexibleBox {DIV} at (0,4) size 94x20 [color=#000000D8]
     RenderBlock (anonymous) at (0,0) size 94x16
       RenderText {#text} at (0,0) size 56x16
-        text run at (0,0) width 56: "Title.pdf"
+        text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
 layer at (120,378) size 94x4 backgroundClip at (120,378) size 93x4 clip at (120,378) size 93x4
   RenderDeprecatedFlexibleBox {DIV} at (0,24) size 94x4 [color=#0000007F]

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -470,15 +470,15 @@ void HTMLAttachmentElement::attributeChanged(const QualifiedName& name, const At
     switch (name.nodeName()) {
     case AttributeNames::actionAttr:
         if (m_actionTextElement)
-            m_actionTextElement->setTextContent(String(newValue.string()));
+            m_actionTextElement->setTextContent(String(attachmentActionForDisplay()));
         break;
     case AttributeNames::titleAttr:
         if (m_titleElement)
-            m_titleElement->setTextContent(String(newValue.string()));
+            m_titleElement->setTextContent(attachmentTitleForDisplay());
         break;
     case AttributeNames::subtitleAttr:
         if (m_subtitleElement)
-            m_subtitleElement->setTextContent(String(newValue.string()));
+            m_subtitleElement->setTextContent(String(attachmentSubtitleForDisplay()));
         break;
     case AttributeNames::progressAttr:
         updateProgress(newValue);
@@ -535,6 +535,7 @@ String HTMLAttachmentElement::attachmentTitleForDisplay() const
         firstStrongIsolate,
         StringView(title).left(indexOfLastDot),
         popDirectionalIsolate,
+        zeroWidthSpace,
         StringView(title).substring(indexOfLastDot)
     );
 }


### PR DESCRIPTION
#### 07f25ac1ae5727fa1bf2e242ed57e3a4efe3306a
<pre>
Add zero-width space before the last filename dot to avoid splitting the extension
<a href="https://bugs.webkit.org/show_bug.cgi?id=255390">https://bugs.webkit.org/show_bug.cgi?id=255390</a>
rdar://99658593

Reviewed by Cameron McCormack.

This patch also fixes an issue where the LTR isolation characters were missing around updated filenames in wide-layout attachments; added relevant test.

* LayoutTests/fast/attachment/attachment-title-with-rtl-expected.html:
* LayoutTests/fast/attachment/attachment-title-with-rtl.html:
Tweaked test text to avoid wrapping in 2nd attachemnt; it caused sub-pixels differences, and it&apos;s not relevant to this test.
* LayoutTests/fast/attachment/mac/wide-attachment-title-with-rtl-expected.html: Added.
* LayoutTests/fast/attachment/mac/wide-attachment-title-with-rtl.html: Added.
Copy of non-wide tests, updated to exercise wrapping in 3rd attachment.
* LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
Updated to account for added character.
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::attributeChanged):
Actually use attachmentTitleForDisplay when the title changes. Also with action and subtitles for consistency and future-proofing.
(WebCore::HTMLAttachmentElement::attachmentTitleForDisplay const):
Add zero-width spaces before dot and file extension.

Canonical link: <a href="https://commits.webkit.org/263045@main">https://commits.webkit.org/263045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48620bbd41031ec95631980fd817d6e1cbf303fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4744 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3657 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2889 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4566 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2880 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3016 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4312 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2720 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2963 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/836 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3238 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->