### PR TITLE
[WinCairo] Unreviewed test gardening

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -826,6 +826,8 @@ http/tests/cache-storage [ Skip ]
 http/tests/canvas/canvas-slow-font-loading.html [ ImageOnlyFailure ]
 http/tests/canvas/color-fonts [ Skip ]
 
+http/wpt/clear-site-data/partitioning.html [ Skip ] # Not supported yet. This test is slow.
+
 http/tests/contentdispositionattachmentsandbox [ Skip ]
 http/tests/contentfiltering [ Skip ]
 
@@ -862,6 +864,7 @@ http/tests/inspector/network/xhr-response-body.html [ Failure ]
 http/tests/inspector/network/intercept-request-main-resource.html [ Skip ] # Timeout
 
 http/tests/inspector/network/copy-as-fetch.html [ Pass Failure ]
+http/tests/inspector/network/resource-mime-type.html [ Pass Failure ]
 
 http/tests/loading/hidpi-preload-picture-sizes.html [ Failure ]
 http/tests/loading/oauth.html [ Failure ]
@@ -998,8 +1001,9 @@ webkit.org/b/192406 http/tests/inspector/network/resource-security-connection.ht
 webkit.org/b/191498 http/tests/inspector/network/resource-security-certificate.html [ Pass ]
 webkit.org/b/191498 http/tests/inspector/network/getSerializedCertificate.html [ Pass ]
 
+http/wpt/service-workers/mac [ Skip ]
+
 http/wpt/service-workers/fetchEvent.https.html [ Pass Failure ]
-http/wpt/service-workers/mac/throttleable.https.html [ Failure ]
 http/wpt/service-workers/service-worker-networkprocess-crash.html [ Pass Failure ]
 http/wpt/service-workers/service-worker-spinning-activate.https.html [ Pass Failure ]
 http/wpt/service-workers/service-worker-spinning-message.https.html [ Pass Failure ]
@@ -1047,7 +1051,6 @@ http/tests/workers/service/service-worker-download-body.https.html [ Failure ]
 http/tests/workers/service/service-worker-download-stream.https.html [ Failure ]
 http/tests/workers/service/serviceworker-websocket.https.html [ Failure ]
 http/tests/workers/service/shownotification-denied.html [ Failure ]
-http/wpt/clear-site-data/partitioning.html [ Failure ]
 http/wpt/push-api/pushManager.any.html [ Failure ]
 http/wpt/push-api/pushManager.any.serviceworker.html [ Failure ]
 http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https.html [ Failure ]

--- a/LayoutTests/platform/wincairo/fast/text/emphasis-vertical-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/text/emphasis-vertical-expected.txt
@@ -83,7 +83,7 @@ layer at (164,0) size 636x600
         RenderInline {SPAN} at (0,0) size 20x99
           RenderText {#text} at (37,188) size 20x99
             text run at (37,188) width 99: "\x{306F}\x{3042}\x{308A}\x{307E}\x{3059}\x{304B}"
-        RenderInline {SPAN} at (0,0) size 53x355
+        RenderInline {SPAN} at (0,0) size 55x355
           RenderText {#text} at (37,287) size 55x355
             text run at (37,287) width 71: "\x{306A}\x{3089}\x{30BF}\x{30A4}\x{30C8}"
             text run at (72,3) width 32: "\x{30EB}\x{3068}"
@@ -93,7 +93,7 @@ layer at (164,0) size 636x600
         RenderInline {SPAN} at (0,0) size 20x107
           RenderText {#text} at (72,161) size 20x107
             text run at (72,161) width 107: "\x{304F}\x{3001}\x{8A2A}\x{554F}\x{3057}\x{305F}\x{30A6}"
-        RenderInline {SPAN} at (0,0) size 50x344
+        RenderInline {SPAN} at (0,0) size 53x344
           RenderText {#text} at (72,268) size 53x344
             text run at (72,268) width 79: "\x{30A7}\x{30D6}\x{30DA}\x{30FC}\x{30B8}"
             text run at (105,3) width 64: "\x{306E}\x{30B3}\x{30F3}\x{30C6}"


### PR DESCRIPTION
#### dfac4fca21534c38858ca85c5c71df9ce3f82cd1
<pre>
[WinCairo] Unreviewed test gardening

* LayoutTests/platform/wincairo/TestExpectations:
* LayoutTests/platform/wincairo/fast/text/emphasis-vertical-expected.txt:

Canonical link: <a href="https://commits.webkit.org/262925@main">https://commits.webkit.org/262925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa1bc622e866316ca8fc7aa486997eec16a46944

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3391 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2620 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4199 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2515 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2719 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3938 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2457 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2670 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2681 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/354 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2884 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->