### PR TITLE
data: URL base64 handling different from atob()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/navigate.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/navigate.window-expected.txt
@@ -1,0 +1,9 @@
+
+PASS Nothing fancy
+PASS base64
+PASS base64 with code points that differ from base64url
+PASS ASCII whitespace in the input is removed
+PASS base64 with incorrect padding
+PASS base64url is not supported
+PASS Vertical tab in the input leads to an error
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/navigate.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/navigate.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/navigate.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/navigate.window.js
@@ -1,0 +1,75 @@
+// META: timeout=long
+//
+// Test some edge cases around navigation to data: URLs to ensure they use the same code path
+
+[
+  {
+    input: "data:text/html,<script>parent.postMessage(1, '*')</script>",
+    result: 1,
+    name: "Nothing fancy",
+  },
+  {
+    input: "data:text/html;base64,PHNjcmlwdD5wYXJlbnQucG9zdE1lc3NhZ2UoMiwgJyonKTwvc2NyaXB0Pg==",
+    result: 2,
+    name: "base64",
+  },
+  {
+    input: "data:text/html;base64,PHNjcmlwdD5wYXJlbnQucG9zdE1lc3NhZ2UoNCwgJyonKTwvc2NyaXB0Pr+/",
+    result: 4,
+    name: "base64 with code points that differ from base64url"
+  },
+  {
+    input: "data:text/html;base64,PHNjcml%09%20%20%0A%0C%0DwdD5wYXJlbnQucG9zdE1lc3NhZ2UoNiwgJyonKTwvc2NyaXB0Pg==",
+    result: 6,
+    name: "ASCII whitespace in the input is removed"
+  }
+].forEach(({ input, result, name }) => {
+  // Use promise_test so they go sequentially
+  promise_test(async t => {
+    const event = await new Promise((resolve, reject) => {
+      self.addEventListener("message", t.step_func(resolve), { once: true });
+      const frame = document.body.appendChild(document.createElement("iframe"));
+      t.add_cleanup(() => frame.remove());
+
+      // The assumption is that postMessage() is quicker
+      t.step_timeout(reject, 500);
+      frame.src = input;
+    });
+    assert_equals(event.data, result);
+  }, name);
+});
+
+// Failure cases
+[
+  {
+    input: "data:text/html;base64,PHNjcmlwdD5wYXJlbnQucG9zdE1lc3NhZ2UoMywgJyonKTwvc2NyaXB0Pg=",
+    name: "base64 with incorrect padding",
+  },
+  {
+    input: "data:text/html;base64,PHNjcmlwdD5wYXJlbnQucG9zdE1lc3NhZ2UoNSwgJyonKTwvc2NyaXB0Pr-_",
+    name: "base64url is not supported"
+  },
+  {
+    input: "data:text/html;base64,%0BPHNjcmlwdD5wYXJlbnQucG9zdE1lc3NhZ2UoNywgJyonKTwvc2NyaXB0Pg==",
+    name: "Vertical tab in the input leads to an error"
+  }
+].forEach(({ input, name }) => {
+  // Continue to use promise_test so they go sequentially
+  promise_test(async t => {
+    const event = await new Promise((resolve, reject) => {
+      self.addEventListener("message", t.step_func(reject), { once: true });
+      const frame = document.body.appendChild(document.createElement("iframe"));
+      t.add_cleanup(() => frame.remove());
+
+      // The assumption is that postMessage() is quicker
+      t.step_timeout(resolve, 500);
+      frame.src = input;
+    });
+  }, name);
+});
+
+// I found some of the interesting code point cases above through brute force:
+//
+// for (i = 0; i < 256; i++) {
+//   w(btoa("<script>parent.postMessage(5, '*')<\/script>" + String.fromCodePoint(i) + String.fromCodePoint(i)));
+// }

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/w3c-import.log
@@ -16,4 +16,5 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/README.md
 /LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/base64.any.js
+/LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/navigate.window.js
 /LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/processing.any.js

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -294,10 +294,7 @@ void ResourceLoader::loadDataURL()
     if (auto page = m_frame->page())
         scheduleContext.scheduledPairs = *page->scheduledRunLoopPairs();
 #endif
-    auto mode = DataURLDecoder::Mode::Legacy;
-    if (m_request.requester() == ResourceRequestRequester::Fetch)
-        mode = DataURLDecoder::Mode::ForgivingBase64;
-    DataURLDecoder::decode(url, scheduleContext, mode, [this, protectedThis = Ref { *this }, url](auto decodeResult) mutable {
+    DataURLDecoder::decode(url, scheduleContext, [this, protectedThis = Ref { *this }, url](auto decodeResult) mutable {
         if (this->reachedTerminalState())
             return;
         if (!decodeResult) {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -233,7 +233,7 @@ DataURLResourceMediaLoader::DataURLResourceMediaLoader(WebCoreAVFResourceLoader&
 {
     RELEASE_ASSERT(request.url().protocolIsData());
 
-    if (auto result = DataURLDecoder::decode(request.url(), DataURLDecoder::Mode::ForgivingBase64)) {
+    if (auto result = DataURLDecoder::decode(request.url())) {
         m_response = ResourceResponse::dataURLResponse(request.url(), *result);
         m_buffer = SharedBuffer::create(WTFMove(result->data));
     }

--- a/Source/WebCore/platform/network/DataURLDecoder.h
+++ b/Source/WebCore/platform/network/DataURLDecoder.h
@@ -51,9 +51,8 @@ struct ScheduleContext {
 #endif
 };
 
-enum class Mode { Legacy, ForgivingBase64 };
-void decode(const URL&, const ScheduleContext&, Mode, DecodeCompletionHandler&&);
-WEBCORE_EXPORT std::optional<Result> decode(const URL&, Mode);
+void decode(const URL&, const ScheduleContext&, DecodeCompletionHandler&&);
+WEBCORE_EXPORT std::optional<Result> decode(const URL&);
 
 }
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -340,7 +340,7 @@ void NetworkDataTaskSoup::resume()
     if (m_currentRequest.url().protocolIsData() && !m_cancellable) {
         m_networkLoadMetrics.fetchStart = MonotonicTime::now();
         m_cancellable = adoptGRef(g_cancellable_new());
-        DataURLDecoder::decode(m_currentRequest.url(), { }, DataURLDecoder::Mode::Legacy, [this, protectedThis = WTFMove(protectedThis)](auto decodeResult) mutable {
+        DataURLDecoder::decode(m_currentRequest.url(), { }, [this, protectedThis = WTFMove(protectedThis)](auto decodeResult) mutable {
             if (m_state == State::Canceling || m_state == State::Completed || !m_client) {
                 clearRequest();
                 return;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -651,12 +651,8 @@ static bool shouldClearReferrerOnHTTPSToHTTPRedirect(LocalFrame* frame)
 
 WebLoaderStrategy::SyncLoadResult WebLoaderStrategy::loadDataURLSynchronously(const ResourceRequest& request)
 {
-    auto mode = DataURLDecoder::Mode::Legacy;
-    if (request.requester() == ResourceRequestRequester::Fetch)
-        mode = DataURLDecoder::Mode::ForgivingBase64;
-
     SyncLoadResult result;
-    auto decodeResult = DataURLDecoder::decode(request.url(), mode);
+    auto decodeResult = DataURLDecoder::decode(request.url());
     if (!decodeResult) {
         WEBLOADERSTRATEGY_RELEASE_LOG_BASIC("loadDataURLSynchronously: decoding of data failed");
         result.error = internalError(request.url());


### PR DESCRIPTION
#### 2518c514c679b98cbad35cddfc51d1f3148cea13
<pre>
data: URL base64 handling different from atob()
<a href="https://bugs.webkit.org/show_bug.cgi?id=175568">https://bugs.webkit.org/show_bug.cgi?id=175568</a>
rdar://107982669

Reviewed by Alex Christensen.

We really shouldn&apos;t have different modes of decoding data: URLs.

<a href="https://bugs.webkit.org/show_bug.cgi?id=211671">https://bugs.webkit.org/show_bug.cgi?id=211671</a> fixed a set of web-platform-tests by introducing a new fetch-specific code path. It was not investigated whether the existing code path ought to be changed as well, apart from determining that there was no test coverage for the difference.

This commit adds test coverage and aligns WebKit with other browsers and the Fetch standard by removing the legacy code path altogether.

* LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/navigate.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/navigate.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/navigate.window.js: Added.
(forEach):
(async input):
* LayoutTests/imported/w3c/web-platform-tests/fetch/data-urls/w3c-import.log:

These changes are being upstreamed via <a href="https://github.com/web-platform-tests/wpt/pull/39542.">https://github.com/web-platform-tests/wpt/pull/39542.</a>

* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::loadDataURL):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::DataURLResourceMediaLoader::DataURLResourceMediaLoader):
* Source/WebCore/platform/network/DataURLDecoder.cpp:
(WebCore::DataURLDecoder::decodeSynchronously):
(WebCore::DataURLDecoder::decode):
(WebCore::DataURLDecoder::decodeBase64): Deleted.
* Source/WebCore/platform/network/DataURLDecoder.h:
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::resume):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadDataURLSynchronously):

Canonical link: <a href="https://commits.webkit.org/262976@main">https://commits.webkit.org/262976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5641532a10d54dd3afc73bb54e527bac9907967

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2755 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4387 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1014 "2 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2659 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2871 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4134 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2588 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2822 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/781 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->